### PR TITLE
feat(router-benchmarks): add router6 support and improve stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,7 +279,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - type-guards@0.1.0
   - @real-router/core@0.1.0
 
-### @real-router/react@1.0.0
+### @real-router/react@0.1.0
 
 ### Minor Changes
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -25,7 +25,7 @@ export const SCOPES = [
   "logger-plugin",
   "persistent-params-plugin",
   "react",
-  "benchmarks",
+  "router-benchmarks",
   "deps",
   "config",
   "ci",

--- a/cz.config.js
+++ b/cz.config.js
@@ -36,6 +36,7 @@ export default {
       "logger-plugin",
       "persistent-params-plugin",
       "react",
+      "router-benchmarks",
     ].map((name) => ({ name })),
   },
   allowEmptyScopes: true,

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,6 @@
         "scripts/*.{sh,mjs,ts}",
         "*.mts",
         "cz.config.js",
-        "dangerfile.ts",
         ".changeset/*.md"
       ],
       "project": ["*.{ts,mts,js,mjs}"],
@@ -35,6 +34,6 @@
     "@stryker-mutator/api",
     "jsdom"
   ],
-  "ignoreBinaries": ["tree", "tsx", "open"],
+  "ignoreBinaries": ["tree", "tsx", "open", "ps", "awk"],
   "ignoreExportsUsedInFile": true
 }

--- a/packages/router-benchmarks/package.json
+++ b/packages/router-benchmarks/package.json
@@ -1,18 +1,21 @@
 {
   "name": "router-benchmarks",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "private": true,
   "description": "Benchmark tests for @real-router/core",
   "scripts": {
     "prebench": "pnpm --filter @real-router/core build",
     "bench": "BENCH_ROUTER=real-router NODE_OPTIONS='--expose-gc --max-old-space-size=8192' npx tsx src/index.ts",
+    "bench:router6": "BENCH_ROUTER=router6 NODE_OPTIONS='--expose-gc --max-old-space-size=8192' npx tsx src/index.ts",
     "bench:baseline": "BENCH_ROUTER=router5 NODE_OPTIONS='--expose-gc --max-old-space-size=8192' npx tsx src/index.ts",
     "bench:current": "pnpm prebench && BENCH_ROUTER=real-router NODE_OPTIONS='--expose-gc --max-old-space-size=8192' npx tsx src/index.ts",
+    "cpu": "ps -Ao %cpu,comm -r | awk '$1 > 10 && !/webstorm/ && !/claude/ && !/WindowServer/ {print $2 \" (\" $1 \"%)\"}' | head -10",
     "type-check": "tsc --noEmit",
     "lint": "eslint --cache src/ --fix --max-warnings 0"
   },
   "dependencies": {
     "router5": "8.0.1",
+    "router6": "1.0.2",
     "@real-router/core": "workspace:^"
   },
   "devDependencies": {

--- a/packages/router-benchmarks/src/01-navigation-basic/1.2-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/01-navigation-basic/1.2-edge-cases.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench } from "mitata";
 
-import { createRouter, createSimpleRouter } from "../helpers";
+import { createRouter, createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // Helper: routes to alternate between to avoid same-state short-circuit
 const alternatingRoutes = ["about", "home"];

--- a/packages/router-benchmarks/src/02-navigation-plugins/2.3-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/02-navigation-plugins/2.3-edge-cases.bench.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { bench } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // Helper: routes to alternate between to avoid same-state short-circuit
 const alternatingRoutes = ["about", "home"];
@@ -169,8 +169,6 @@ const alternatingRoutes = ["about", "home"];
 // 2.3.11 Cancelling navigation during middleware execution
 // router5: navigate() does not reliably return a cancel function
 // real-router: navigate() always returns a cancel function
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
-
 if (!IS_ROUTER5) {
   const router = createSimpleRouter();
   let index = 0;

--- a/packages/router-benchmarks/src/03-dependencies/3.1-initialization.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.1-initialization.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench } from "mitata";
 
-import { createRouter } from "../helpers";
+import { createRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 const routes: Route[] = [
   { name: "home", path: "/" },

--- a/packages/router-benchmarks/src/03-dependencies/3.2-adding.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.2-adding.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // 3.2.1 Adding single dependency with cleanup
 if (!IS_ROUTER5) {

--- a/packages/router-benchmarks/src/03-dependencies/3.3-getting.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.3-getting.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // 3.3.1 Getting single dependency
 if (!IS_ROUTER5) {

--- a/packages/router-benchmarks/src/03-dependencies/3.4-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.4-edge-cases.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // 3.4.1 Checking existence of non-existent dependency
 if (!IS_ROUTER5) {

--- a/packages/router-benchmarks/src/03-dependencies/3.5-router-comparison.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.5-router-comparison.bench.ts
@@ -13,11 +13,9 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createRouter } from "../helpers";
+import { createRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 /**
  * API Compatibility:

--- a/packages/router-benchmarks/src/04-plugins-management/4.1-adding.bench.ts
+++ b/packages/router-benchmarks/src/04-plugins-management/4.1-adding.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // 4.1.1 Adding single plugin with cleanup
 {

--- a/packages/router-benchmarks/src/10-start-stop/10.4-lifecycle-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/10-start-stop/10.4-lifecycle-edge-cases.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createRouter, createSimpleRouter } from "../helpers";
+import { createRouter, createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 10.4.1 Starting immediately after router creation with stop
 {

--- a/packages/router-benchmarks/src/11-events/11.4-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/11-events/11.4-edge-cases.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
 
 // 11.4.1 Adding listener during dispatch
 {

--- a/packages/router-benchmarks/src/12-stress-testing/12.1-high-load-sequential.bench.ts
+++ b/packages/router-benchmarks/src/12-stress-testing/12.1-high-load-sequential.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter, createNestedRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, createNestedRouter, IS_ROUTER5 } from "../helpers";
 
 // 12.1.1 Thousand sequential navigations between two routes
 {

--- a/packages/router-benchmarks/src/12-stress-testing/12.2-route-scaling.bench.ts
+++ b/packages/router-benchmarks/src/12-stress-testing/12.2-route-scaling.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter, createNestedRouter } from "../helpers";
+import { createSimpleRouter, createNestedRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 12.2.1 Navigation in router with 100 routes
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/12-stress-testing/12.3-extension-scaling.bench.ts
+++ b/packages/router-benchmarks/src/12-stress-testing/12.3-extension-scaling.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter, createNestedRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, createNestedRouter, IS_ROUTER5 } from "../helpers";
 
 // 12.3.1 Navigation with 50 synchronous middleware
 {

--- a/packages/router-benchmarks/src/12-stress-testing/12.4-auto-cleanup.bench.ts
+++ b/packages/router-benchmarks/src/12-stress-testing/12.4-auto-cleanup.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench } from "mitata";
 
-import { createNestedRouter } from "../helpers";
+import { createNestedRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 12.4.1 Navigation with auto-cleanup of 10 canDeactivate guards
 {

--- a/packages/router-benchmarks/src/12-stress-testing/12.5-comparative.bench.ts
+++ b/packages/router-benchmarks/src/12-stress-testing/12.5-comparative.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter, createNestedRouter } from "../helpers";
+import { createSimpleRouter, createNestedRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 12.5.1 Comparison: parameter count impact (0/5/10 parameters)
 {

--- a/packages/router-benchmarks/src/13-cloning/13.1-ssr-scenarios.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.1-ssr-scenarios.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter, cloneRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, cloneRouter, IS_ROUTER5 } from "../helpers";
 
 // JIT Warmup: Pre-warm cloning code paths to avoid cold-start bias
 // Without this, the first benchmarks would be significantly slower due to JIT compilation

--- a/packages/router-benchmarks/src/13-cloning/13.2-testing-scenarios.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.2-testing-scenarios.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter, cloneRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, cloneRouter, IS_ROUTER5 } from "../helpers";
 
 // 13.2.1 Cloning with mock dependencies
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/13-cloning/13.3-clone-scaling.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.3-clone-scaling.bench.ts
@@ -6,11 +6,10 @@ import {
   createSimpleRouter,
   createNestedRouter,
   cloneRouter,
+  IS_ROUTER5,
 } from "../helpers";
 
 import type { Route } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 13.3.1 Cloning router with 10 routes
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/13-cloning/13.4-configuration.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.4-configuration.bench.ts
@@ -2,11 +2,9 @@
 
 import { bench } from "mitata";
 
-import { createSimpleRouter, cloneRouter } from "../helpers";
+import { createSimpleRouter, cloneRouter, IS_ROUTER5 } from "../helpers";
 
 import type { Params } from "router5/dist/types/base";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
 
 // 13.4.1 Clone preserves defaultParams
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/13-cloning/13.5-isolation.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.5-isolation.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter, cloneRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, cloneRouter, IS_ROUTER5 } from "../helpers";
 
 // 13.5.1 Clone state changes do not affect the original
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/13-cloning/13.6-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/13-cloning/13.6-edge-cases.bench.ts
@@ -2,9 +2,7 @@
 
 import { bench, do_not_optimize } from "mitata";
 
-import { createSimpleRouter, cloneRouter } from "../helpers";
-
-const IS_ROUTER5 = process.env.BENCH_ROUTER === "router5";
+import { createSimpleRouter, cloneRouter, IS_ROUTER5 } from "../helpers";
 
 // 13.6.1 Chain of clones (clone -> clone -> clone)
 if (IS_ROUTER5) {

--- a/packages/router-benchmarks/src/helpers/constants.ts
+++ b/packages/router-benchmarks/src/helpers/constants.ts
@@ -1,0 +1,35 @@
+// packages/router-benchmarks/src/helpers/constants.ts
+
+import type { Options } from "@real-router/core";
+
+/**
+ * Current router being benchmarked.
+ * Set via BENCH_ROUTER environment variable.
+ */
+export const ROUTER_NAME = process.env.BENCH_ROUTER ?? "real-router";
+
+/**
+ * Router detection constants.
+ * Use these to conditionally skip benchmarks that don't apply to certain routers.
+ */
+export const IS_ROUTER5 = ROUTER_NAME === "router5";
+
+/** @public Will be used for router6-specific benchmarks */
+export const IS_ROUTER6 = ROUTER_NAME === "router6";
+
+/** @public Will be used for real-router-specific benchmarks */
+export const IS_REAL_ROUTER = ROUTER_NAME === "real-router";
+
+/**
+ * Unified options for fair benchmarking between router5, router6, and real-router.
+ *
+ * These options normalize the behavior differences between routers:
+ * - queryParamsMode: router5 defaults to "default", real-router to "loose"
+ * - allowNotFound: router5 defaults to false, real-router to true
+ *
+ * Using router5 defaults as baseline for comparison.
+ */
+export const UNIFIED_OPTIONS: Partial<Options> = {
+  queryParamsMode: "default",
+  allowNotFound: false,
+};

--- a/packages/router-benchmarks/src/helpers/index.ts
+++ b/packages/router-benchmarks/src/helpers/index.ts
@@ -1,8 +1,10 @@
-// packages/router-benchmarks/modules/helpers/index.ts
+// packages/router-benchmarks/src/helpers/index.ts
 
 export { do_not_optimize } from "mitata";
 
-export { createRouter, cloneRouter, UNIFIED_OPTIONS } from "./router-adapter";
+export { createRouter, cloneRouter } from "./router-adapter";
+
+export { ROUTER_NAME, IS_ROUTER5, UNIFIED_OPTIONS } from "./constants";
 
 export type { Route, Router } from "@real-router/core";
 

--- a/packages/router-benchmarks/src/helpers/router-adapter.ts
+++ b/packages/router-benchmarks/src/helpers/router-adapter.ts
@@ -1,4 +1,6 @@
-// packages/router-benchmarks/modules/helpers/router-adapter.ts
+// packages/router-benchmarks/src/helpers/router-adapter.ts
+
+import { ROUTER_NAME, UNIFIED_OPTIONS } from "./constants";
 
 import type {
   Router,
@@ -7,26 +9,21 @@ import type {
   DefaultDependencies,
 } from "@real-router/core";
 
-const ROUTER_NAME = process.env.BENCH_ROUTER ?? "real-router";
-
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment */
-const routerModule =
-  ROUTER_NAME === "router5" ? require("router5") : require("@real-router/core");
-/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment */
-
-/**
- * Unified options for fair benchmarking between router5 and real-router.
- *
- * These options normalize the behavior differences between routers:
- * - queryParamsMode: router5 defaults to "default", real-router to "loose"
- * - allowNotFound: router5 defaults to false, real-router to true
- *
- * Using router5 defaults as baseline for comparison.
- */
-export const UNIFIED_OPTIONS: Partial<Options> = {
-  queryParamsMode: "default",
-  allowNotFound: false,
-};
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
+const routerModule = (() => {
+  switch (ROUTER_NAME) {
+    case "router5": {
+      return require("router5");
+    }
+    case "router6": {
+      return require("router6");
+    }
+    default: {
+      return require("@real-router/core");
+    }
+  }
+})();
+/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
 
 type CreateRouterFn = <Dependencies extends DefaultDependencies = object>(
   routes?: Route<Dependencies>[],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       router5:
         specifier: 8.0.1
         version: 8.0.1
+      router6:
+        specifier: 1.0.2
+        version: 1.0.2
     devDependencies:
       mitata:
         specifier: 1.0.34
@@ -4206,6 +4209,12 @@ packages:
 
   router5@8.0.1:
     resolution: {integrity: sha512-LBLQAYd2ZI1FiiBqGf82oC+LRD0PUABrZqTzd6OmyK+t5N8wRs3hbIxeiy/9Zy+xI8Fdf/0WM68P41W6MH8pdQ==}
+
+  router6-types@1.0.2:
+    resolution: {integrity: sha512-H8hhVP6KpKCg3YYhYz6+CMSgHjw7M8WqRivmmGKUCvX5OL4eyeOcNr94wFe9/kNvGr9aSGMiaPHdIf/UjyJC9w==}
+
+  router6@1.0.2:
+    resolution: {integrity: sha512-SLzG04xajopnNuph/hFw3pgaJk6rhfGsId30dD+1rUT/uD5OdRwodd71qeLNa6VPHlWdCdxUyTVYquEdxpBx4w==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -9257,6 +9266,12 @@ snapshots:
       route-node: 4.1.1
       router5-transition-path: 8.0.1(router5@8.0.1)
       symbol-observable: 1.2.0
+
+  router6-types@1.0.2: {}
+
+  router6@1.0.2:
+    dependencies:
+      router6-types: 1.0.2
 
   run-parallel@1.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - 'packages/*'
   - 'tools/*'
+
+minimumReleaseAgeExclude:
+  - router6
+  - router6-types


### PR DESCRIPTION
## Summary

Adds router6 as a third benchmark target for three-way performance comparison (router5 → router6 → real-router). Also significantly improves benchmark stability on Apple Silicon (M3 Pro).

## Changes

### router6 Support
- Add `router6` dependency to router-benchmarks
- Update `router-adapter.ts` to support router5/router6/real-router via `BENCH_ROUTER` env
- Add `pnpm bench:router6` npm script
- Update `compare.mjs` to handle three routers
- Update `bench-compare.sh` to run all three routers sequentially

### Code Refactoring
- Extract shared constants to `helpers/constants.ts`:
  - `ROUTER_NAME`, `IS_ROUTER5`, `IS_ROUTER6`, `IS_REAL_ROUTER`
  - `UNIFIED_OPTIONS` (moved from router-adapter.ts)
- Update 21 benchmark files to use shared `IS_ROUTER5` import instead of local definition

### Benchmark Stability (Apple Silicon)
- Add power source check (warns if running on battery)
- Add thermal pressure monitoring (`powermetrics --samplers thermal`)
- Add check for distracting apps (Chrome, Telegram, Slack, Discord, Spotify)
- Add check for heavy CPU processes (>10%)
- Add system optimizations:
  - Disable Spotlight indexing during benchmarks
  - Disable Time Machine during benchmarks
  - Purge file system caches before each run
- Add smart cooldown based on thermal pressure level (waits for "Nominal")
- Add `pnpm cpu` script to check heavy processes

### Documentation
- Update README.md with system requirements and Apple Silicon notes
- Add `router-benchmarks` scope to commitlint and commitizen configs

### Minor Fixes
- Fix `@real-router/react` version typo in CHANGELOG (1.0.0 → 0.1.0)
- Add `ps`, `awk` to knip ignoreBinaries

## Test Plan

- [x] `pnpm bench` — real-router benchmarks run successfully
- [x] `pnpm bench:baseline` — router5 benchmarks run successfully
- [x] `pnpm bench:router6` — router6 benchmarks run successfully
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` — all pass
- [x] `pnpm lint:unused` (knip) — no unused exports

Closes #17
