### PR TITLE
feat(core)!: extract getNavigator into standalone function (#83)

### DIFF
--- a/.changeset/extract-get-navigator-core.md
+++ b/.changeset/extract-get-navigator-core.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": minor
+---
+
+Extract `getNavigator` into standalone function (#83)
+
+Extract `getNavigator` into standalone function. BREAKING: `Router.getNavigator()` method removed. Use `import { getNavigator } from '@real-router/core'` and call `getNavigator(router)` instead.

--- a/.changeset/extract-get-navigator-react.md
+++ b/.changeset/extract-get-navigator-react.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": minor
+---
+
+Update to use standalone `getNavigator` function (#83)
+
+Update to use standalone `getNavigator` function. Fix `useRouteNode` navigator memoization bug.

--- a/.changeset/extract-get-navigator-types.md
+++ b/.changeset/extract-get-navigator-types.md
@@ -1,0 +1,7 @@
+---
+"@real-router/types": minor
+---
+
+Remove `getNavigator` from Router interface (#83)
+
+Remove `getNavigator` from Router interface.

--- a/packages/core-types/src/router.ts
+++ b/packages/core-types/src/router.ts
@@ -293,14 +293,4 @@ export interface Router {
    * @returns true if navigation is allowed, false otherwise
    */
   canNavigateTo: (name: string, params?: Params) => boolean;
-
-  /**
-   * Get a minimal, safe Navigator interface for passing to components.
-   *
-   * The returned Navigator object is frozen and includes only essential methods:
-   * navigate, getState, isActiveRoute, canNavigateTo, subscribe.
-   *
-   * @returns Frozen Navigator object
-   */
-  getNavigator: () => Navigator;
 }

--- a/packages/core/codemods/get-navigator-standalone.ts
+++ b/packages/core/codemods/get-navigator-standalone.ts
@@ -1,0 +1,105 @@
+/**
+ * Codemod: Transform router.getNavigator() to getNavigator(router)
+ *
+ * USAGE:
+ *   npx jscodeshift -t packages/core/codemods/get-navigator-standalone.ts \
+ *     --extensions=ts,tsx,js,jsx <target-dir>
+ *
+ * EXAMPLES:
+ *   npx jscodeshift -t packages/core/codemods/get-navigator-standalone.ts \
+ *     --extensions=ts,tsx src/
+ *
+ *   npx jscodeshift -t packages/core/codemods/get-navigator-standalone.ts \
+ *     --extensions=ts,tsx --dry src/
+ *
+ * LIMITATIONS:
+ *   - Does NOT handle aliased variables (const r = router; r.getNavigator())
+ *   - Does NOT handle computed property access (router['getNavigator']())
+ *   - Does NOT handle dynamic references (router[method]())
+ *
+ * @see RFC-10 lines 146-147
+ * @see Issue #83 checklist item 12
+ */
+
+export const parser = "tsx";
+
+export default function transformer(file: any, api: any, _options: any) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasModifications = false;
+
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: "MemberExpression",
+        property: {
+          type: "Identifier",
+          name: "getNavigator",
+        },
+      },
+    })
+    .forEach((path: any) => {
+      const callExpr = path.node;
+      const memberExpr = callExpr.callee;
+      const objectExpr = memberExpr.object;
+
+      const newCallExpr = j.callExpression(j.identifier("getNavigator"), [
+        objectExpr,
+      ]);
+
+      j(path).replaceWith(newCallExpr);
+      hasModifications = true;
+    });
+
+  if (hasModifications) {
+    addGetNavigatorImport(j, root);
+  }
+
+  return hasModifications ? root.toSource() : undefined;
+}
+
+function addGetNavigatorImport(j: any, root: any) {
+  const importSource = "@real-router/core";
+  const importName = "getNavigator";
+
+  const existingImports = root.find(j.ImportDeclaration, {
+    source: { value: importSource },
+  });
+
+  if (existingImports.length > 0) {
+    let alreadyImported = false;
+
+    existingImports.forEach((path: any) => {
+      const importDecl = path.node;
+      const specifiers = importDecl.specifiers || [];
+
+      const hasGetNavigator = specifiers.some(
+        (spec: any) =>
+          spec.type === "ImportSpecifier" &&
+          spec.imported.type === "Identifier" &&
+          spec.imported.name === importName,
+      );
+
+      if (hasGetNavigator) {
+        alreadyImported = true;
+        return;
+      }
+
+      if (!alreadyImported) {
+        const newSpecifier = j.importSpecifier(j.identifier(importName));
+        importDecl.specifiers = [...specifiers, newSpecifier];
+        alreadyImported = true;
+      }
+    });
+  } else {
+    const newImport = j.importDeclaration(
+      [j.importSpecifier(j.identifier(importName))],
+      j.literal(importSource),
+    );
+
+    const firstNode = root.find(j.Program).get("body", 0);
+    if (firstNode) {
+      j(firstNode).insertBefore(newImport);
+    }
+  }
+}

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -50,7 +50,6 @@ import type {
   DoneFn,
   EventName,
   NavigationOptions,
-  Navigator,
   Options,
   Params,
   Plugin,
@@ -102,11 +101,6 @@ export class Router<
   readonly #navigation: NavigationNamespace;
   readonly #lifecycle: RouterLifecycleNamespace;
   readonly #clone: CloneNamespace<Dependencies>;
-
-  /**
-   * Cached Navigator instance. Lazily created on first getNavigator() call.
-   */
-  #navigator: Navigator | null = null;
 
   /**
    * When true, skips argument validation in public methods for production performance.
@@ -265,7 +259,6 @@ export class Router<
 
     // Cloning
     this.clone = this.clone.bind(this);
-    this.getNavigator = this.getNavigator.bind(this);
   }
 
   // ============================================================================
@@ -1072,18 +1065,6 @@ export class Router<
       (routes, options, deps) =>
         new Router<Dependencies>(routes, options, deps),
     );
-  }
-
-  getNavigator(): Navigator {
-    this.#navigator ??= Object.freeze({
-      navigate: this.navigate,
-      getState: this.getState,
-      isActiveRoute: this.isActiveRoute,
-      canNavigateTo: this.canNavigateTo,
-      subscribe: this.subscribe,
-    });
-
-    return this.#navigator;
   }
 
   // ============================================================================

--- a/packages/core/src/getNavigator.ts
+++ b/packages/core/src/getNavigator.ts
@@ -1,0 +1,15 @@
+import type { Router } from "./Router";
+import type { Navigator, DefaultDependencies } from "@real-router/types";
+
+export const getNavigator = <
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+>(
+  router: Router<Dependencies>,
+): Navigator =>
+  Object.freeze({
+    navigate: router.navigate,
+    getState: router.getState,
+    isActiveRoute: router.isActiveRoute,
+    canNavigateTo: router.canNavigateTo,
+    subscribe: router.subscribe,
+  });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,3 +44,5 @@ export { events, constants, errorCodes } from "./constants";
 export { RouterError } from "./RouterError";
 
 export { createRouter } from "./createRouter";
+
+export { getNavigator } from "./getNavigator";

--- a/packages/react/src/RouterProvider.tsx
+++ b/packages/react/src/RouterProvider.tsx
@@ -1,5 +1,6 @@
 // packages/react/modules/RouterProvider.tsx
 
+import { getNavigator } from "@real-router/core";
 import { useMemo, useSyncExternalStore } from "react";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
@@ -18,7 +19,7 @@ export const RouterProvider: FC<RouteProviderProps> = ({
   children,
 }) => {
   // Get navigator instance from router
-  const navigator = useMemo(() => router.getNavigator(), [router]);
+  const navigator = useMemo(() => getNavigator(router), [router]);
 
   // Local store state to hold route information
   const store = useMemo(() => {

--- a/packages/react/src/hooks/useRouteNode.tsx
+++ b/packages/react/src/hooks/useRouteNode.tsx
@@ -1,5 +1,6 @@
 // packages/react/modules/hooks/useRouteNode.tsx
 
+import { getNavigator } from "@real-router/core";
 import { useCallback, useMemo } from "react";
 
 import { useRouter } from "@real-router/react";
@@ -61,7 +62,7 @@ export function useRouteNode(nodeName: string): RouteContext {
   );
 
   // Return memoized context - useMemo ensures stable reference when deps unchanged
-  const navigator = router.getNavigator();
+  const navigator = useMemo(() => getNavigator(router), [router]);
 
   return useMemo(
     (): RouteContext => ({


### PR DESCRIPTION
## Summary

- Extract `getNavigator()` from Router class into a standalone tree-shakeable pure function `getNavigator(router)`
- Remove `Router.getNavigator()` method, `#navigator` field, and interface declaration
- Fix latent memoization bug in `useRouteNode` — navigator was created on every render instead of being memoized

## Breaking change

```typescript
// Before
const navigator = router.getNavigator();

// After
import { getNavigator } from "@real-router/core";
const navigator = getNavigator(router);
```

## Changes

- **@real-router/core**: new `getNavigator(router)` export, Router class cleanup (-19 lines)
- **@real-router/types**: `getNavigator` removed from Router interface (-10 lines)
- **@real-router/react**: `RouterProvider` and `useRouteNode` updated to use standalone function with explicit `useMemo`

## Bug fix

`useRouteNode.tsx` called `router.getNavigator()` outside `useMemo`, relying on internal caching for reference stability. Now properly wrapped in `useMemo(() => getNavigator(router), [router])`.

## Test plan

- [x] 100% test coverage maintained
- [x] No remaining `router.getNavigator()` calls in source code