### PR TITLE
feat!: remove clearMiddleware() method (#91)

### DIFF
--- a/.changeset/remove-clear-middleware.md
+++ b/.changeset/remove-clear-middleware.md
@@ -1,0 +1,21 @@
+---
+"@real-router/core": minor
+---
+
+feat!: remove `clearMiddleware()` method (#91)
+
+BREAKING CHANGE: `clearMiddleware()` has been removed. Use the `Unsubscribe` function returned by `useMiddleware()` instead.
+
+Before:
+```ts
+router.useMiddleware(myMiddleware);
+// later...
+router.clearMiddleware();
+```
+
+After:
+```ts
+const unsub = router.useMiddleware(myMiddleware);
+// later...
+unsub();
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -203,12 +203,6 @@ router.useMiddleware((router) => (toState, fromState, done) => {
 });
 ```
 
-#### `router.clearMiddleware()`
-
-Clear all middleware.\
-Returns: `void`\
-[Wiki](https://github.com/greydragon888/real-router/wiki/clearMiddleware)
-
 ---
 
 ## Advanced API

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -232,8 +232,6 @@ export class Router<
 
     // Middleware
     this.useMiddleware = this.useMiddleware.bind(this);
-    this.clearMiddleware = this.clearMiddleware.bind(this);
-
     // Dependencies
     this.setDependency = this.setDependency.bind(this);
     this.setDependencies = this.setDependencies.bind(this);
@@ -851,12 +849,6 @@ export class Router<
 
     // 6. Commit
     return this.#middleware.commit(initialized);
-  }
-
-  clearMiddleware(): this {
-    this.#middleware.clear();
-
-    return this;
   }
 
   // ============================================================================

--- a/packages/core/src/namespaces/MiddlewareNamespace/MiddlewareNamespace.ts
+++ b/packages/core/src/namespaces/MiddlewareNamespace/MiddlewareNamespace.ts
@@ -182,14 +182,6 @@ export class MiddlewareNamespace<
   }
 
   /**
-   * Removes all registered middleware.
-   */
-  clear(): void {
-    this.#factories.clear();
-    this.#factoryToMiddleware.clear();
-  }
-
-  /**
    * Returns a copy of registered middleware factories.
    * Preserves insertion order.
    */

--- a/packages/core/tests/functional/navigation/navigate/concurrent-navigation.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/concurrent-navigation.test.ts
@@ -37,7 +37,6 @@ describe("router.navigate() - concurrent navigation", () => {
     });
 
     afterEach(() => {
-      router.clearMiddleware();
       vi.restoreAllMocks();
     });
 
@@ -54,7 +53,7 @@ describe("router.navigate() - concurrent navigation", () => {
     it("should cancel navigation via router.stop() and reject with TRANSITION_CANCELLED error", async () => {
       vi.useFakeTimers();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -70,7 +69,7 @@ describe("router.navigate() - concurrent navigation", () => {
         code: errorCodes.TRANSITION_CANCELLED,
       });
 
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -80,7 +79,7 @@ describe("router.navigate() - concurrent navigation", () => {
 
       const onCancel = vi.fn();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -110,7 +109,7 @@ describe("router.navigate() - concurrent navigation", () => {
       );
 
       unsubCancel();
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -158,8 +157,8 @@ describe("router.navigate() - concurrent navigation", () => {
         await new Promise((resolve) => setTimeout(resolve, 30));
       });
 
-      router.useMiddleware(middleware1);
-      router.useMiddleware(middleware2);
+      const unsub1 = router.useMiddleware(middleware1);
+      const unsub2 = router.useMiddleware(middleware2);
 
       const promise = router.navigate("settings");
 
@@ -175,7 +174,8 @@ describe("router.navigate() - concurrent navigation", () => {
 
       expect(middleware1).toHaveBeenCalledTimes(1);
 
-      router.clearMiddleware();
+      unsub1();
+      unsub2();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -213,7 +213,7 @@ describe("router.navigate() - concurrent navigation", () => {
     it("should not affect already completed navigation when router stops", async () => {
       vi.useFakeTimers();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
 
@@ -229,14 +229,14 @@ describe("router.navigate() - concurrent navigation", () => {
       // State was set before stop
       expect(router.getState()?.name).toBe("users");
 
-      router.clearMiddleware();
+      unsub();
       vi.useRealTimers();
     });
 
     it("should handle router.stop() called multiple times", async () => {
       vi.useFakeTimers();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -254,7 +254,7 @@ describe("router.navigate() - concurrent navigation", () => {
         code: errorCodes.TRANSITION_CANCELLED,
       });
 
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -265,7 +265,7 @@ describe("router.navigate() - concurrent navigation", () => {
       const onSuccess = vi.fn();
       const onCancel = vi.fn();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 60));
       });
 
@@ -296,7 +296,7 @@ describe("router.navigate() - concurrent navigation", () => {
 
       unsubSuccess();
       unsubCancel();
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -306,7 +306,7 @@ describe("router.navigate() - concurrent navigation", () => {
 
       const onCancel = vi.fn();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -339,7 +339,7 @@ describe("router.navigate() - concurrent navigation", () => {
       );
 
       unsubCancel();
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -347,7 +347,7 @@ describe("router.navigate() - concurrent navigation", () => {
     it("should handle cancellation when router is stopped during navigation", async () => {
       vi.useFakeTimers();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -363,7 +363,7 @@ describe("router.navigate() - concurrent navigation", () => {
         code: errorCodes.TRANSITION_CANCELLED,
       });
 
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });
@@ -373,7 +373,7 @@ describe("router.navigate() - concurrent navigation", () => {
 
       vi.useFakeTimers();
 
-      router.useMiddleware(() => async () => {
+      const unsub = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
       });
 
@@ -397,7 +397,7 @@ describe("router.navigate() - concurrent navigation", () => {
         code: errorCodes.TRANSITION_CANCELLED,
       });
 
-      router.clearMiddleware();
+      unsub();
       await router.start("/home");
       vi.useRealTimers();
     });

--- a/packages/core/tests/functional/navigation/navigate/events-transition-start.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/events-transition-start.test.ts
@@ -112,7 +112,6 @@ describe("router.navigate() - events transition start", () => {
       expect(startCallTime).toBeLessThan(middlewareCallTime);
 
       unsubStart();
-      router.clearMiddleware();
     });
 
     it("should emit TRANSITION_START even when transition is later cancelled", async () => {
@@ -167,7 +166,6 @@ describe("router.navigate() - events transition start", () => {
       // Cleanup
       unsubStart();
       unsubCancel();
-      router.clearMiddleware();
       vi.useRealTimers();
     });
 

--- a/packages/core/tests/functional/navigation/navigate/events-transition-success.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/events-transition-success.test.ts
@@ -203,8 +203,6 @@ describe("router.navigate() - events transition success", () => {
       expect(middlewareCallTime).toBeLessThan(successCallTime);
 
       unsubSuccess();
-
-      router.clearMiddleware();
     });
 
     it("should not emit TRANSITION_SUCCESS when transition fails", async () => {
@@ -256,7 +254,7 @@ describe("router.navigate() - events transition success", () => {
       );
 
       // Set up async middleware to allow cancellation
-      router.useMiddleware(() => async () => {
+      const unsubMiddleware = router.useMiddleware(() => async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
@@ -284,7 +282,7 @@ describe("router.navigate() - events transition success", () => {
       unsubSuccess();
       unsubCancel();
 
-      router.clearMiddleware();
+      unsubMiddleware();
       await router.start("/home");
       vi.useRealTimers();
     });

--- a/packages/core/tests/functional/navigation/navigate/route-not-found.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/route-not-found.test.ts
@@ -208,8 +208,6 @@ describe("router.navigate() - route not found", () => {
 
       expect(guard).not.toHaveBeenCalled();
       expect(middleware).not.toHaveBeenCalled();
-
-      router.clearMiddleware();
     });
 
     it("should handle multiple invalid route navigations", async () => {

--- a/packages/core/tests/functional/navigation/navigate/router-not-started.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/router-not-started.test.ts
@@ -154,8 +154,6 @@ describe("router.navigate() - router not started", () => {
 
       expect(guard).not.toHaveBeenCalled();
       expect(middleware).not.toHaveBeenCalled();
-
-      router.clearMiddleware();
     });
 
     it("should handle invalid route names when router not started", async () => {

--- a/packages/core/tests/functional/navigation/navigate/transitions-and-cancellation.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/transitions-and-cancellation.test.ts
@@ -43,7 +43,6 @@ describe("router.navigate() - transitions and cancellation", () => {
       );
 
     await router.navigate("users");
-    router.clearMiddleware();
 
     await Promise.all(promises);
   });

--- a/packages/core/tests/functional/navigation/navigateToDefault.test.ts
+++ b/packages/core/tests/functional/navigation/navigateToDefault.test.ts
@@ -236,8 +236,6 @@ describe("navigateToDefault", () => {
         );
         expect(blockingMiddleware).toHaveBeenCalledTimes(1);
       }
-
-      router.clearMiddleware();
     });
 
     it("should respect navigation options when navigating to defaultRoute", async () => {
@@ -362,8 +360,6 @@ describe("navigateToDefault", () => {
 
       expect(canActivateGuard).toHaveBeenCalledTimes(1);
       expect(middleware).toHaveBeenCalledTimes(1);
-
-      router.clearMiddleware();
     });
   });
 
@@ -856,7 +852,6 @@ describe("navigateToDefault", () => {
         expect(error).toStrictEqual(customError);
       }
 
-      router.clearMiddleware();
       vi.useRealTimers();
     });
   });
@@ -957,7 +952,6 @@ describe("navigateToDefault", () => {
 
       expect(state).toBeDefined();
 
-      router.clearMiddleware();
       vi.useRealTimers();
     });
 

--- a/packages/core/tests/functional/observable/observable.test.ts
+++ b/packages/core/tests/functional/observable/observable.test.ts
@@ -129,7 +129,6 @@ describe("core/observable", () => {
         // because navigations don't cancel each other in the new API
         expect(cb).toHaveBeenCalledTimes(0);
 
-        router.clearMiddleware();
         vi.useRealTimers();
       });
 

--- a/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
@@ -291,7 +291,7 @@ describe("router.start() - error handling", () => {
       it("should allow start() after failed async transition resets isActive", async () => {
         // Issue #50: When async transition fails, isActive is reset
         // Next start() call should be allowed
-        router.useMiddleware(
+        const unsubMiddleware = router.useMiddleware(
           () => () => Promise.reject(new Error("Middleware error")),
         );
 
@@ -305,7 +305,7 @@ describe("router.start() - error handling", () => {
         expect(router.isActive()).toBe(false);
 
         // Clear middleware for second attempt
-        router.clearMiddleware();
+        unsubMiddleware();
 
         // Second start should now work
         await router.start("/users");

--- a/packages/logger-plugin/tests/functional/plugin.test.ts
+++ b/packages/logger-plugin/tests/functional/plugin.test.ts
@@ -138,7 +138,6 @@ describe("@real-router/logger-plugin", () => {
         expect.any(Object),
       );
 
-      router.clearMiddleware();
       vi.useRealTimers();
     });
 
@@ -235,7 +234,6 @@ describe("@real-router/logger-plugin", () => {
         // Expected error
       }
 
-      router.clearMiddleware();
       vi.useRealTimers();
     });
 
@@ -360,7 +358,6 @@ describe("@real-router/logger-plugin", () => {
         // Expected error
       }
 
-      router.clearMiddleware();
       vi.useRealTimers();
     });
   });
@@ -557,13 +554,15 @@ describe("@real-router/logger-plugin", () => {
         await router.start("/");
         warnSpy.mockClear();
 
-        router.useMiddleware(() => (_toState, _fromState) => {
-          return new Promise((resolve) =>
-            setTimeout(() => {
-              resolve(true);
-            }, 200),
-          );
-        });
+        const unsubMiddleware = router.useMiddleware(
+          () => (_toState, _fromState) => {
+            return new Promise((resolve) =>
+              setTimeout(() => {
+                resolve(true);
+              }, 200),
+            );
+          },
+        );
 
         const navPromise = router.navigate("users");
 
@@ -581,7 +580,7 @@ describe("@real-router/logger-plugin", () => {
 
         expect(warnSpy).not.toHaveBeenCalled();
 
-        router.clearMiddleware();
+        unsubMiddleware();
         await router.start("/");
         vi.useRealTimers();
       });
@@ -593,13 +592,15 @@ describe("@real-router/logger-plugin", () => {
         await router.start("/");
         warnSpy.mockClear();
 
-        router.useMiddleware(() => (_toState, _fromState) => {
-          return new Promise((resolve) =>
-            setTimeout(() => {
-              resolve(true);
-            }, 200),
-          );
-        });
+        const unsubMiddleware = router.useMiddleware(
+          () => (_toState, _fromState) => {
+            return new Promise((resolve) =>
+              setTimeout(() => {
+                resolve(true);
+              }, 200),
+            );
+          },
+        );
 
         const navPromise = router.navigate("users");
 
@@ -617,7 +618,7 @@ describe("@real-router/logger-plugin", () => {
 
         expect(warnSpy).not.toHaveBeenCalled();
 
-        router.clearMiddleware();
+        unsubMiddleware();
         await router.start("/");
         vi.useRealTimers();
       });


### PR DESCRIPTION
## Summary

- Remove `clearMiddleware()` from `Router` and `MiddlewareNamespace.clear()` — no production use case; the `Unsubscribe` pattern from `useMiddleware()` covers all real scenarios
- Replace all ~80 test usages: redundant cleanup lines deleted (fresh router per `beforeEach`), mid-test calls replaced with captured `unsub()`
- Remove from docs (README, wiki pages)

## Breaking Change

`clearMiddleware()` has been removed. Use the `Unsubscribe` function returned by `useMiddleware()` instead:

```ts
// Before
router.useMiddleware(myMiddleware);
router.clearMiddleware();

// After
const unsub = router.useMiddleware(myMiddleware);
unsub();
```

Test plan

- pnpm type-check passes
- pnpm lint passes
- pnpm test -- --run passes (all 49 tasks, 2233+ tests)
- No remaining clearMiddleware references in source/tests/docs

Closes #91