### PR TITLE
refactor(path-matcher): pre-compute buildParamNamesSet at registration time

### DIFF
--- a/.changeset/buildpath-precompute-set.md
+++ b/.changeset/buildpath-precompute-set.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Pre-compute `buildParamNamesSet` at route registration time (#142)
+
+Eliminate per-call `Set` and `Array` allocations in `buildPath()` loose mode by pre-computing URL param names during route registration.

--- a/packages/path-matcher/src/SegmentMatcher.ts
+++ b/packages/path-matcher/src/SegmentMatcher.ts
@@ -262,33 +262,30 @@ export class SegmentMatcher {
       return "";
     }
 
-    const queryParamNames = [...route.declaredQueryParams];
+    const queryObj: Record<string, unknown> = {};
+    let hasKeys = false;
+
+    for (const name of route.declaredQueryParams) {
+      if (name in params) {
+        queryObj[name] = params[name];
+        hasKeys = true;
+      }
+    }
 
     if (queryParamsMode === "loose") {
-      const urlParamNames = new Set(
-        route.buildParamSlots.map((s) => s.paramName),
-      );
-
       for (const p in params) {
         if (
           Object.hasOwn(params, p) &&
           !route.declaredQueryParamsSet.has(p) &&
-          !urlParamNames.has(p)
+          !route.buildParamNamesSet.has(p)
         ) {
-          queryParamNames.push(p);
+          queryObj[p] = params[p];
+          hasKeys = true;
         }
       }
     }
 
-    const queryObj: Record<string, unknown> = {};
-
-    for (const name of queryParamNames) {
-      if (name in params) {
-        queryObj[name] = params[name];
-      }
-    }
-
-    if (Object.keys(queryObj).length === 0) {
+    if (!hasKeys) {
       return "";
     }
 

--- a/packages/path-matcher/src/registration.ts
+++ b/packages/path-matcher/src/registration.ts
@@ -141,6 +141,7 @@ function compileAndRegisterRoute(
     hasConstraints: constraintPatterns.size > 0,
     buildStaticParts,
     buildParamSlots,
+    buildParamNamesSet: new Set(buildParamSlots.map((s) => s.paramName)),
   };
 
   state.routesByName.set(node.fullName, compiled);

--- a/packages/path-matcher/src/types.ts
+++ b/packages/path-matcher/src/types.ts
@@ -138,6 +138,7 @@ export interface CompiledRoute {
 
   readonly buildStaticParts: readonly string[];
   readonly buildParamSlots: readonly BuildParamSlot[];
+  readonly buildParamNamesSet: ReadonlySet<string>;
 
   readonly forwardTo?: string;
   readonly defaultParams?: Readonly<Record<string, unknown>>;

--- a/packages/path-matcher/tests/unit/SegmentMatcher.test.ts
+++ b/packages/path-matcher/tests/unit/SegmentMatcher.test.ts
@@ -118,6 +118,7 @@ describe("type compilation", () => {
       hasConstraints: false,
       buildStaticParts: ["/"],
       buildParamSlots: [],
+      buildParamNamesSet: new Set(),
     };
 
     expect(route.name).toBe("home");


### PR DESCRIPTION
## Summary

Pre-compute `buildParamNamesSet` at route registration time and refactor `#buildQueryStringForBuild()` to eliminate per-call allocations.

Closes #142

## Problem

Every `buildPath()` call in loose mode created:
- `new Set(route.buildParamSlots.map(s => s.paramName))` — new Set + new Array via `.map()`
- `[...route.declaredQueryParams]` — new Array via spread

These collections depend only on the route definition, not on runtime parameters — they should be computed once at registration time.

Additionally, `Object.keys(queryObj).length === 0` allocated a temporary keys array just to check emptiness.

## Solution

1. **Pre-compute `buildParamNamesSet`** as a field on `CompiledRoute` during route registration (one-time cost)
2. **Eliminate spread** — iterate `route.declaredQueryParams` directly instead of copying to intermediate array
3. **Eliminate intermediate `queryParamNames` array** — build `queryObj` directly in a single pass
4. **Replace `Object.keys().length === 0`** with a boolean `hasKeys` flag

```diff
- const queryParamNames = [...route.declaredQueryParams];
- if (queryParamsMode === "loose") {
-   const urlParamNames = new Set(
-     route.buildParamSlots.map((s) => s.paramName),
-   );
-   for (const p in params) {
-     if (!route.declaredQueryParamsSet.has(p) && !urlParamNames.has(p)) {
-       queryParamNames.push(p);
-     }
-   }
- }
- const queryObj = {};
- for (const name of queryParamNames) { ... }
- if (Object.keys(queryObj).length === 0) return "";

+ const queryObj = {};
+ let hasKeys = false;
+ for (const name of route.declaredQueryParams) {
+   if (name in params) { queryObj[name] = params[name]; hasKeys = true; }
+ }
+ if (queryParamsMode === "loose") {
+   for (const p in params) {
+     if (!route.declaredQueryParamsSet.has(p) && !route.buildParamNamesSet.has(p)) {
+       queryObj[p] = params[p]; hasKeys = true;
+     }
+   }
+ }
+ if (!hasKeys) return "";
```

## Benchmarks

This is primarily a **code quality improvement** — static data should be computed at registration time, not on every call. Performance deltas are within noise because `buildPath` is called 1-2× per navigation and the allocations were already cheap (~50ns).

### Speed (avg, lower is better)

| Scenario | Before | After | Change |
|---|---|---|---|
| 3 query, default mode | 349 ns | 365 ns | ±5% (noise) |
| 3 query, loose mode | 422 ns | 422 ns | 0% |
| 3 query + 2 extra, loose | 642 ns | 653 ns | ±2% (noise) |
| heavy 10 query, loose | 1.47 µs | 1.50 µs | ±2% (noise) |
| heavy 10 query + 5 extra, loose | 2.13 µs | 2.15 µs | ±1% (noise) |
| nested + extra, loose (×10) | 6.24 µs | 6.34 µs | ±2% (noise) |
| nested, default (×10) | 3.16 µs | 3.21 µs | ±2% (noise) |

### Memory (heap avg, lower is better)

| Scenario | Before | After | Change |
|---|---|---|---|
| 3 query, default mode | 916 B | 917 B | 0% |
| 3 query, loose mode | 1.40 KB | 1.37 KB | −2% |
| 3 query + 2 extra, loose | 1.84 KB | 1.84 KB | 0% |
| heavy 10 query, loose | 2.90 KB | 2.90 KB | 0% |
| heavy 10 query + 5 extra, loose | 4.12 KB | 4.12 KB | 0% |

No measurable performance change — confirms this is a zero-cost refactor with correctness improvement (static data computed at the right time).

## Verification

- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm test -- --run` ✅ (all 60 tasks, 100% coverage)
