### PR TITLE
perf(cache-manager): replace LRU with FIFO eviction in KeyIndexCache (#165)

### DIFF
--- a/.changeset/cache-manager-fifo-perf.md
+++ b/.changeset/cache-manager-fifo-perf.md
@@ -1,0 +1,13 @@
+---
+"@real-router/cache-manager": patch
+---
+
+Replace LRU with FIFO eviction in KeyIndexCache (#165)
+
+FIFO eliminates `Map.delete()` + `Map.set()` on every cache hit (LRU refresh).
+Hit path is now a single `Map.get()` — 2–3.4× faster than LRU in benchmarks.
+
+Other optimizations:
+- Inline `#store()` into `get()` (one fewer function call on miss)
+- Replace `#stats` object with separate `#hits`/`#misses` counters (no object allocation on `clear()`)
+- Handle `undefined` as a valid cached value (disambiguate from cache miss)

--- a/packages/cache-manager/src/CacheManager.ts
+++ b/packages/cache-manager/src/CacheManager.ts
@@ -3,7 +3,7 @@ import { KeyIndexCache } from "./KeyIndexCache.js";
 import type { CacheMetrics, CacheOptions } from "./types.js";
 
 export class CacheManager {
-  #caches = new Map<
+  readonly #caches = new Map<
     string,
     { cache: KeyIndexCache<unknown>; options: CacheOptions<unknown> }
   >();

--- a/packages/cache-manager/tests/benchmarks/cache-manager.bench.ts
+++ b/packages/cache-manager/tests/benchmarks/cache-manager.bench.ts
@@ -1,0 +1,554 @@
+import { bench, boxplot, do_not_optimize, run, summary } from "mitata";
+
+import { KeyIndexCache, CacheManager } from "../../src/index";
+
+// --- Section 1: KeyIndexCache — get() performance ---
+
+boxplot(() => {
+  summary(() => {
+    // Cache hit: same key repeated (best case)
+    {
+      const cache = new KeyIndexCache<number>(100);
+
+      cache.get("warmKey", () => 42);
+
+      bench("KIC get() hit — same key repeated", () => {
+        do_not_optimize(cache.get("warmKey", () => 42));
+      }).gc("inner");
+    }
+
+    // Cache hit: cycling 10 keys (realistic pattern)
+    {
+      const cache = new KeyIndexCache<number>(100);
+      const keys = Array.from({ length: 10 }, (_, i) => `key${i}`);
+
+      for (const key of keys) {
+        cache.get(key, () => 1);
+      }
+
+      let index = 0;
+
+      bench("KIC get() hit — cycling 10 keys", () => {
+        const key = keys[index++ % 10];
+
+        do_not_optimize(cache.get(key, () => 1));
+      }).gc("inner");
+    }
+
+    // Cache miss: unique keys (always computes)
+    {
+      const cache = new KeyIndexCache<number>(100_000);
+      const keys = Array.from({ length: 10_000 }, (_, i) => `miss${i}`);
+      let index = 0;
+
+      bench("KIC get() miss — unique keys", () => {
+        const key = keys[index++ % keys.length];
+
+        do_not_optimize(cache.get(key, () => index));
+      }).gc("inner");
+    }
+
+    // Cache miss with eviction: maxSize=100, unique keys force LRU eviction
+    {
+      const cache = new KeyIndexCache<number>(100);
+      const keys = Array.from({ length: 10_000 }, (_, i) => `evict${i}`);
+      let index = 0;
+
+      bench("KIC get() miss + eviction (maxSize=100)", () => {
+        const key = keys[index++ % keys.length];
+
+        do_not_optimize(cache.get(key, () => index));
+      }).gc("inner");
+    }
+  });
+});
+
+// Compute cost comparison
+boxplot(() => {
+  summary(() => {
+    {
+      const cache = new KeyIndexCache<number>(100);
+
+      bench("KIC get() miss — cheap compute (() => 1)", () => {
+        cache.clear();
+        do_not_optimize(cache.get("k", () => 1));
+      }).gc("inner");
+    }
+
+    {
+      const cache = new KeyIndexCache<string>(100);
+
+      bench("KIC get() miss — expensive compute (array join)", () => {
+        cache.clear();
+        do_not_optimize(
+          cache.get("k", () =>
+            Array.from({ length: 50 }, (_, i) => `s${i}`).join("."),
+          ),
+        );
+      }).gc("inner");
+    }
+  });
+});
+
+// --- Section 2: KeyIndexCache — mutation operations ---
+
+boxplot(() => {
+  summary(() => {
+    // invalidateMatching: 10% match
+    {
+      const cache = new KeyIndexCache<number>(1000);
+
+      for (let i = 0; i < 1000; i++) {
+        cache.get(`route${i}`, () => i);
+      }
+
+      bench("KIC invalidateMatching — 10% match (100/1000)", () => {
+        cache.invalidateMatching((key) => key.startsWith("route9"));
+        // Refill evicted entries for next iteration
+        for (let i = 900; i < 1000; i++) {
+          cache.get(`route${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+
+    // invalidateMatching: 50% match
+    {
+      const cache = new KeyIndexCache<number>(1000);
+
+      for (let i = 0; i < 1000; i++) {
+        cache.get(`${i < 500 ? "a" : "b"}.route${i}`, () => i);
+      }
+
+      bench("KIC invalidateMatching — 50% match (500/1000)", () => {
+        cache.invalidateMatching((key) => key.startsWith("a."));
+        // Refill evicted entries
+        for (let i = 0; i < 500; i++) {
+          cache.get(`a.route${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+
+    // invalidateMatching: 100% match
+    {
+      const cache = new KeyIndexCache<number>(1000);
+
+      for (let i = 0; i < 1000; i++) {
+        cache.get(`route${i}`, () => i);
+      }
+
+      bench("KIC invalidateMatching — 100% match (1000/1000)", () => {
+        cache.invalidateMatching(() => true);
+        // Refill all entries
+        for (let i = 0; i < 1000; i++) {
+          cache.get(`route${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+  });
+});
+
+// clear benchmarks
+boxplot(() => {
+  summary(() => {
+    {
+      const cache = new KeyIndexCache<number>(100);
+
+      for (let i = 0; i < 50; i++) {
+        cache.get(`key${i}`, () => i);
+      }
+
+      bench("KIC clear — small cache (50 entries)", () => {
+        cache.clear();
+        // Refill for next iteration
+        for (let i = 0; i < 50; i++) {
+          cache.get(`key${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+
+    {
+      const cache = new KeyIndexCache<number>(5000);
+
+      for (let i = 0; i < 5000; i++) {
+        cache.get(`key${i}`, () => i);
+      }
+
+      bench("KIC clear — large cache (5000 entries)", () => {
+        cache.clear();
+        // Refill for next iteration
+        for (let i = 0; i < 5000; i++) {
+          cache.get(`key${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+  });
+});
+
+// --- Section 3: CacheManager — registry operations ---
+
+boxplot(() => {
+  summary(() => {
+    // register + unregister (fallback pattern)
+    {
+      const manager = new CacheManager();
+
+      bench("CM register + unregister", () => {
+        manager.register("bench", { maxSize: 100 });
+        manager.unregister("bench");
+      }).gc("inner");
+    }
+
+    // invalidateForNewRoutes: 1 cache
+    {
+      const manager = new CacheManager();
+      const cache = manager.register<number>("path", {
+        maxSize: 500,
+        onInvalidate: (c, names) => {
+          c.invalidateMatching((key) => names.some((n) => key.includes(n)));
+        },
+      });
+
+      for (let i = 0; i < 200; i++) {
+        cache.get(`users.route${i}`, () => i);
+      }
+
+      const newRoutes = ["users.settings", "users.profile"];
+
+      bench("CM invalidateForNewRoutes — 1 cache", () => {
+        manager.invalidateForNewRoutes(newRoutes);
+      }).gc("inner");
+    }
+
+    // invalidateForNewRoutes: 5 caches
+    {
+      const manager = new CacheManager();
+
+      for (let i = 0; i < 5; i++) {
+        const cache = manager.register<number>(`cache${i}`, {
+          maxSize: 200,
+          onInvalidate: (c, names) => {
+            c.invalidateMatching((key) => names.some((n) => key.includes(n)));
+          },
+        });
+
+        for (let j = 0; j < 100; j++) {
+          cache.get(`route${j}`, () => j);
+        }
+      }
+
+      const newRoutes = ["route50", "route75"];
+
+      bench("CM invalidateForNewRoutes — 5 caches", () => {
+        manager.invalidateForNewRoutes(newRoutes);
+      }).gc("inner");
+    }
+
+    // clear: 1 cache
+    {
+      const manager = new CacheManager();
+      const cache = manager.register<number>("single", { maxSize: 500 });
+
+      for (let i = 0; i < 200; i++) {
+        cache.get(`key${i}`, () => i);
+      }
+
+      bench("CM clear — 1 cache", () => {
+        manager.clear();
+        // Refill for next iteration
+        for (let i = 0; i < 200; i++) {
+          cache.get(`key${i}`, () => i);
+        }
+      }).gc("inner");
+    }
+
+    // clear: 5 caches
+    {
+      const manager = new CacheManager();
+      const caches: KeyIndexCache<number>[] = [];
+
+      for (let i = 0; i < 5; i++) {
+        const cache = manager.register<number>(`c${i}`, { maxSize: 200 });
+
+        for (let j = 0; j < 100; j++) {
+          cache.get(`key${j}`, () => j);
+        }
+
+        caches.push(cache);
+      }
+
+      bench("CM clear — 5 caches", () => {
+        manager.clear();
+        // Refill for next iteration
+        for (const cache of caches) {
+          for (let j = 0; j < 100; j++) {
+            cache.get(`key${j}`, () => j);
+          }
+        }
+      }).gc("inner");
+    }
+
+    // getMetrics: 1 cache
+    {
+      const manager = new CacheManager();
+      const cache = manager.register<number>("metrics1", { maxSize: 500 });
+
+      for (let i = 0; i < 100; i++) {
+        cache.get(`key${i}`, () => i);
+      }
+
+      bench("CM getMetrics — 1 cache", () => {
+        do_not_optimize(manager.getMetrics());
+      }).gc("inner");
+    }
+
+    // getMetrics: 5 caches
+    {
+      const manager = new CacheManager();
+
+      for (let i = 0; i < 5; i++) {
+        const cache = manager.register<number>(`m${i}`, { maxSize: 200 });
+
+        for (let j = 0; j < 100; j++) {
+          cache.get(`key${j}`, () => j);
+        }
+      }
+
+      bench("CM getMetrics — 5 caches", () => {
+        do_not_optimize(manager.getMetrics());
+      }).gc("inner");
+    }
+  });
+});
+
+// --- Section 4: Stress tests ---
+
+// 100K sustained cache hits
+{
+  const cache = new KeyIndexCache<number>(500);
+  const keys = Array.from({ length: 500 }, (_, i) => `warm${i}`);
+
+  for (const key of keys) {
+    cache.get(key, () => 1);
+  }
+
+  bench("Stress: 100K cache hits on warm cache (500 entries)", () => {
+    for (let i = 0; i < 100_000; i++) {
+      cache.get(keys[i % 500], () => 1);
+    }
+  }).gc("inner");
+}
+
+// 100K unique keys with maxSize=100 (cache thrashing / eviction storm)
+{
+  const cache = new KeyIndexCache<number>(100);
+
+  bench("Stress: 100K unique keys, maxSize=100 (99.9% eviction)", () => {
+    for (let i = 0; i < 100_000; i++) {
+      cache.get(`thrash${i}`, () => i);
+    }
+
+    cache.clear();
+  }).gc("inner");
+}
+
+// 100K mixed workload: 70% hits, 30% misses
+{
+  const cache = new KeyIndexCache<number>(1000);
+  const hitKeys = Array.from({ length: 700 }, (_, i) => `hit${i}`);
+  const missKeys = Array.from({ length: 10_000 }, (_, i) => `miss${i}`);
+
+  for (const key of hitKeys) {
+    cache.get(key, () => 1);
+  }
+
+  let missIndex = 0;
+
+  bench("Stress: 100K mixed workload (70% hit, 30% miss)", () => {
+    for (let i = 0; i < 100_000; i++) {
+      if (i % 10 < 7) {
+        cache.get(hitKeys[i % 700], () => 1);
+      } else {
+        cache.get(missKeys[missIndex++ % 10_000], () => i);
+      }
+    }
+  }).gc("inner");
+}
+
+// Rapid register/dispose cycles (GC pressure)
+{
+  bench("Stress: 1000 register/dispose cycles (GC pressure)", () => {
+    for (let i = 0; i < 1000; i++) {
+      const manager = new CacheManager();
+
+      for (let j = 0; j < 5; j++) {
+        const cache = manager.register<number>(`c${j}`, { maxSize: 50 });
+
+        for (let k = 0; k < 50; k++) {
+          cache.get(`key${k}`, () => k);
+        }
+      }
+
+      manager.dispose();
+    }
+  }).gc("inner");
+}
+
+// --- Section 5: Memory benchmarks (manual, after mitata) ---
+
+const gc = globalThis.gc;
+
+async function measureMemory(
+  _label: string,
+  fn: () => void,
+  iterations: number,
+): Promise<{ heapDelta: number; timeMs: number }> {
+  // Warm up
+  for (let i = 0; i < 100; i++) {
+    fn();
+  }
+
+  if (gc) {
+    gc();
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const heapBefore = process.memoryUsage().heapUsed;
+  const start = performance.now();
+
+  for (let i = 0; i < iterations; i++) {
+    fn();
+  }
+
+  const end = performance.now();
+
+  if (gc) {
+    gc();
+  }
+
+  const heapAfter = process.memoryUsage().heapUsed;
+
+  return {
+    heapDelta: heapAfter - heapBefore,
+    timeMs: end - start,
+  };
+}
+
+function formatBytes(bytes: number): string {
+  const abs = Math.abs(bytes);
+
+  if (abs < 1024) {
+    return `${bytes} B`;
+  }
+  if (abs < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(2)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+const memoryTests = async () => {
+  console.log(`\n${"=".repeat(70)}`);
+  console.log("  MEMORY BENCHMARKS");
+  console.log("=".repeat(70));
+
+  const tests = [
+    {
+      name: "100K hits on warm cache (500)",
+      fn: (() => {
+        const cache = new KeyIndexCache<number>(500);
+        const keys = Array.from({ length: 500 }, (_, i) => `warm${i}`);
+
+        for (const key of keys) {
+          cache.get(key, () => 1);
+        }
+
+        return () => {
+          for (let i = 0; i < 100; i++) {
+            cache.get(keys[i % 500], () => 1);
+          }
+        };
+      })(),
+      iterations: 1000,
+    },
+    {
+      name: "100K evictions (maxSize=100)",
+      fn: (() => {
+        const cache = new KeyIndexCache<number>(100);
+        let counter = 0;
+
+        return () => {
+          for (let i = 0; i < 100; i++) {
+            cache.get(`ev${counter++}`, () => counter);
+          }
+        };
+      })(),
+      iterations: 1000,
+    },
+    {
+      name: "Sustained invalidation cycles",
+      fn: (() => {
+        const manager = new CacheManager();
+        const cache = manager.register<number>("inv", {
+          maxSize: 500,
+          onInvalidate: (c, names) => {
+            c.invalidateMatching((key) => names.some((n) => key.includes(n)));
+          },
+        });
+
+        return () => {
+          for (let i = 0; i < 100; i++) {
+            cache.get(`route${i}`, () => i);
+          }
+
+          manager.invalidateForNewRoutes(["route5", "route10"]);
+        };
+      })(),
+      iterations: 1000,
+    },
+    {
+      name: "GC pressure: register/dispose",
+      fn: () => {
+        const manager = new CacheManager();
+
+        for (let j = 0; j < 3; j++) {
+          const cache = manager.register<number>(`c${j}`, { maxSize: 20 });
+
+          for (let k = 0; k < 20; k++) {
+            cache.get(`k${k}`, () => k);
+          }
+        }
+
+        manager.dispose();
+      },
+      iterations: 10_000,
+    },
+  ];
+
+  console.log(
+    `\n${"Test".padEnd(40)}${"Heap Δ".padStart(12)}${"Time".padStart(12)}${"Ops/s".padStart(14)}`,
+  );
+  console.log("-".repeat(78));
+
+  for (const test of tests) {
+    if (gc) {
+      gc();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const result = await measureMemory(test.name, test.fn, test.iterations);
+    const opsPerSec = Math.round(test.iterations / (result.timeMs / 1000));
+
+    console.log(
+      test.name.padEnd(40) +
+        formatBytes(result.heapDelta).padStart(12) +
+        `${result.timeMs.toFixed(2)}ms`.padStart(12) +
+        `${(opsPerSec / 1000).toFixed(0)}K`.padStart(14),
+    );
+  }
+
+  console.log(`\n${"=".repeat(70)}`);
+};
+
+void run().then(() => memoryTests());

--- a/packages/core/tests/benchmarks/transitionPath/cache-overhead-isolation.bench.ts
+++ b/packages/core/tests/benchmarks/transitionPath/cache-overhead-isolation.bench.ts
@@ -1,0 +1,408 @@
+/**
+ * Cache overhead isolation benchmark
+ *
+ * Compares three caching strategies on identical data to isolate
+ * whether regressions come from CacheManager implementation overhead
+ * or from the fundamental cost of multi-entry caching vs single-entry.
+ *
+ * Strategies:
+ * 1. single-entry — original: 2× reference `===`, 3 variable writes
+ * 2. raw-map      — bare Map<string, T>, no LRU, no stats, no abstraction
+ * 3. KeyIndexCache — full CacheManager with LRU, stats, hasMetaParams
+ *
+ * Each strategy wraps the SAME computeTransitionPath call.
+ */
+
+import { bench, boxplot, run, summary } from "mitata";
+
+import { KeyIndexCache } from "../../../../cache-manager/src/KeyIndexCache";
+
+import type { State } from "@real-router/types";
+
+interface TransitionPath {
+  intersection: string;
+  toActivate: string[];
+  toDeactivate: string[];
+}
+
+// ============================================================================
+// Minimal computeTransitionPath (same logic as real one, inlined)
+// ============================================================================
+
+const EMPTY_INTERSECTION = "";
+
+function nameToIDs(name: string): string[] {
+  const ids: string[] = [];
+  let idx = 0;
+  let dot: number;
+
+  while ((dot = name.indexOf(".", idx)) !== -1) {
+    ids.push(name.slice(0, dot));
+    idx = dot + 1;
+  }
+
+  ids.push(name);
+
+  return ids;
+}
+
+function computeTransitionPath(
+  toState: State,
+  fromState?: State,
+): TransitionPath {
+  if (!fromState) {
+    return {
+      intersection: EMPTY_INTERSECTION,
+      toActivate: nameToIDs(toState.name),
+      toDeactivate: [],
+    };
+  }
+
+  const toStateIds = nameToIDs(toState.name);
+  const fromStateIds = nameToIDs(fromState.name);
+  const maxI = Math.min(fromStateIds.length, toStateIds.length);
+
+  let i = 0;
+
+  while (i < maxI && fromStateIds[i] === toStateIds[i]) {
+    i++;
+  }
+
+  const toDeactivate: string[] = [];
+
+  for (let j = fromStateIds.length - 1; j >= i; j--) {
+    toDeactivate.push(fromStateIds[j]);
+  }
+
+  return {
+    intersection: i > 0 ? fromStateIds[i - 1] : EMPTY_INTERSECTION,
+    toDeactivate,
+    toActivate: toStateIds.slice(i),
+  };
+}
+
+// ============================================================================
+// Strategy 1: Single-entry cache (original — reference equality)
+// ============================================================================
+
+let cachedFromState: State | undefined;
+let cachedToState: State | undefined;
+let cachedResult: TransitionPath | null = null;
+
+function getTransitionPath_singleEntry(
+  toState: State,
+  fromState?: State,
+): TransitionPath {
+  if (
+    cachedResult !== null &&
+    toState === cachedToState &&
+    fromState === cachedFromState
+  ) {
+    return cachedResult;
+  }
+
+  const result = computeTransitionPath(toState, fromState);
+
+  cachedToState = toState;
+  cachedFromState = fromState;
+  cachedResult = result;
+
+  return result;
+}
+
+// ============================================================================
+// Strategy 2: Raw Map (multi-entry, no LRU, no stats, no abstraction)
+// ============================================================================
+
+const rawMap = new Map<string, TransitionPath>();
+
+function getTransitionPath_rawMap(
+  toState: State,
+  fromState?: State,
+): TransitionPath {
+  if (!fromState) {
+    return computeTransitionPath(toState, fromState);
+  }
+
+  const key = `${fromState.name}\u2192${toState.name}`;
+  let result = rawMap.get(key);
+
+  if (result !== undefined) {
+    return result;
+  }
+
+  result = computeTransitionPath(toState, fromState);
+  rawMap.set(key, result);
+
+  return result;
+}
+
+// ============================================================================
+// Strategy 3: KeyIndexCache (full CacheManager abstraction)
+// ============================================================================
+
+const lruCache = new KeyIndexCache<TransitionPath>(500);
+
+function hasMetaParams(state: State): boolean {
+  const params = state.meta?.params;
+
+  if (params === undefined) {
+    return false;
+  }
+
+  for (const segmentName of Object.keys(params)) {
+    const segmentParams = params[segmentName];
+
+    if (
+      segmentParams !== null &&
+      segmentParams !== undefined &&
+      typeof segmentParams === "object" &&
+      !Array.isArray(segmentParams) &&
+      Object.keys(segmentParams).length > 0
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getTransitionPath_keyIndexCache(
+  toState: State,
+  fromState?: State,
+): TransitionPath {
+  if (
+    !fromState ||
+    toState.meta?.options.reload ||
+    hasMetaParams(toState) ||
+    hasMetaParams(fromState)
+  ) {
+    return computeTransitionPath(toState, fromState);
+  }
+
+  const key = `${fromState.name}\u2192${toState.name}`;
+
+  return lruCache.get(key, () => computeTransitionPath(toState, fromState));
+}
+
+// ============================================================================
+// Test data
+// ============================================================================
+
+function makeState(
+  name: string,
+  params: Record<string, unknown> = {},
+  metaParams: Record<string, Record<string, unknown>> = {},
+): State {
+  return {
+    name,
+    params,
+    path: `/${name.replaceAll(".", "/")}`,
+    meta: {
+      id: 1,
+      params: metaParams,
+      options: {},
+      redirected: false,
+    },
+  } as State;
+}
+
+// Scenario 1: single-pair repeated (shouldUpdateNode pattern)
+const stateA = makeState("users", {}, { users: {} });
+const stateB = makeState(
+  "users.profile",
+  {},
+  { users: {}, "users.profile": {} },
+);
+
+// Scenario 2: 3-route cycling
+const routes3 = [
+  [makeState("home", {}, { home: {} }), makeState("users", {}, { users: {} })],
+  [
+    makeState("users", {}, { users: {} }),
+    makeState("admin", {}, { admin: {} }),
+  ],
+  [makeState("admin", {}, { admin: {} }), makeState("home", {}, { home: {} })],
+] as const;
+
+// Scenario 3: 10-route SPA
+const routeNames = [
+  "home",
+  "users",
+  "users.profile",
+  "admin",
+  "admin.settings",
+  "docs",
+  "docs.getting-started",
+  "blog",
+  "blog.post",
+  "about",
+];
+const spaStates = routeNames.map((n) => {
+  const parts = n.split(".");
+  const mp: Record<string, Record<string, unknown>> = {};
+  let acc = "";
+
+  for (const p of parts) {
+    acc = acc ? `${acc}.${p}` : p;
+    mp[acc] = {};
+  }
+
+  return makeState(n, {}, mp);
+});
+
+// ============================================================================
+// Benchmarks
+// ============================================================================
+
+// --- SCENARIO 1: Single pair repeated ×10 (shouldUpdateNode hot path) ---
+boxplot(() => {
+  summary(() => {
+    bench("single-pair ×10: single-entry", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath_singleEntry(stateB, stateA);
+      }
+    });
+
+    bench("single-pair ×10: raw Map", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath_rawMap(stateB, stateA);
+      }
+    });
+
+    bench("single-pair ×10: KeyIndexCache", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath_keyIndexCache(stateB, stateA);
+      }
+    });
+  });
+});
+
+// --- SCENARIO 2: 3-route cycling ×30 ---
+boxplot(() => {
+  summary(() => {
+    bench("3-route cycling ×30: single-entry", () => {
+      for (let i = 0; i < 30; i++) {
+        const [from, to] = routes3[i % 3];
+
+        getTransitionPath_singleEntry(to, from);
+      }
+    });
+
+    bench("3-route cycling ×30: raw Map", () => {
+      for (let i = 0; i < 30; i++) {
+        const [from, to] = routes3[i % 3];
+
+        getTransitionPath_rawMap(to, from);
+      }
+    });
+
+    bench("3-route cycling ×30: KeyIndexCache", () => {
+      for (let i = 0; i < 30; i++) {
+        const [from, to] = routes3[i % 3];
+
+        getTransitionPath_keyIndexCache(to, from);
+      }
+    });
+  });
+});
+
+// --- SCENARIO 3: 10-route SPA cycling ×100 ---
+boxplot(() => {
+  summary(() => {
+    bench("10-route SPA ×100: single-entry", () => {
+      for (let i = 0; i < 100; i++) {
+        const from = spaStates[i % 10];
+        const to = spaStates[(i + 1) % 10];
+
+        getTransitionPath_singleEntry(to, from);
+      }
+    });
+
+    bench("10-route SPA ×100: raw Map", () => {
+      for (let i = 0; i < 100; i++) {
+        const from = spaStates[i % 10];
+        const to = spaStates[(i + 1) % 10];
+
+        getTransitionPath_rawMap(to, from);
+      }
+    });
+
+    bench("10-route SPA ×100: KeyIndexCache", () => {
+      for (let i = 0; i < 100; i++) {
+        const from = spaStates[i % 10];
+        const to = spaStates[(i + 1) % 10];
+
+        getTransitionPath_keyIndexCache(to, from);
+      }
+    });
+  });
+});
+
+// --- SCENARIO 4: shouldUpdateNode — 5 components, 1 navigation ---
+boxplot(() => {
+  summary(() => {
+    bench("shouldUpdateNode 5×1: single-entry", () => {
+      // 1 navigation
+      getTransitionPath_singleEntry(stateB, stateA);
+      // 5 shouldUpdateNode checks (same pair)
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath_singleEntry(stateB, stateA);
+      }
+    });
+
+    bench("shouldUpdateNode 5×1: raw Map", () => {
+      getTransitionPath_rawMap(stateB, stateA);
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath_rawMap(stateB, stateA);
+      }
+    });
+
+    bench("shouldUpdateNode 5×1: KeyIndexCache", () => {
+      getTransitionPath_keyIndexCache(stateB, stateA);
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath_keyIndexCache(stateB, stateA);
+      }
+    });
+  });
+});
+
+// --- SCENARIO 5: shouldUpdateNode — 5 components, 3 navigations cycling ---
+boxplot(() => {
+  summary(() => {
+    bench("shouldUpdateNode 5×3 cycling: single-entry", () => {
+      for (let n = 0; n < 3; n++) {
+        const [from, to] = routes3[n % 3];
+
+        getTransitionPath_singleEntry(to, from);
+        for (let c = 0; c < 5; c++) {
+          getTransitionPath_singleEntry(to, from);
+        }
+      }
+    });
+
+    bench("shouldUpdateNode 5×3 cycling: raw Map", () => {
+      for (let n = 0; n < 3; n++) {
+        const [from, to] = routes3[n % 3];
+
+        getTransitionPath_rawMap(to, from);
+        for (let c = 0; c < 5; c++) {
+          getTransitionPath_rawMap(to, from);
+        }
+      }
+    });
+
+    bench("shouldUpdateNode 5×3 cycling: KeyIndexCache", () => {
+      for (let n = 0; n < 3; n++) {
+        const [from, to] = routes3[n % 3];
+
+        getTransitionPath_keyIndexCache(to, from);
+        for (let c = 0; c < 5; c++) {
+          getTransitionPath_keyIndexCache(to, from);
+        }
+      }
+    });
+  });
+});
+
+void run();

--- a/packages/core/tests/benchmarks/transitionPath/getTransitionPath-cache.bench.ts
+++ b/packages/core/tests/benchmarks/transitionPath/getTransitionPath-cache.bench.ts
@@ -1,0 +1,345 @@
+/**
+ * getTransitionPath cache benchmark
+ *
+ * Measures the performance difference between single-entry cache (baseline)
+ * and LRU KeyIndexCache (post-implementation) for getTransitionPath.
+ *
+ * Key scenarios:
+ * 1. Single-pair repeated calls (shouldUpdateNode pattern) — both should be fast
+ * 2. Multi-route cycling (3-5 routes) — single-entry misses, LRU should hit
+ * 3. Dashboard tabs pattern (alternating between N tabs)
+ * 4. Memory: heap growth under sustained load
+ * 5. Parameterized navigation (cache bypass — should be identical)
+ *
+ * Run: NODE_OPTIONS='--expose-gc' npx tsx tests/benchmarks/transitionPath/getTransitionPath-cache.bench.ts
+ */
+
+import { bench, boxplot, run, summary } from "mitata";
+
+import { getTransitionPath } from "../../../src/transitionPath";
+
+import type { State } from "@real-router/types";
+
+// ============================================================================
+// Test data factory
+// ============================================================================
+
+function makeState(
+  name: string,
+  params: Record<string, any> = {},
+  metaParams: Record<string, any> = {},
+  options: Record<string, any> = {},
+): State {
+  return {
+    name,
+    params,
+    path: `/${name.replaceAll(".", "/")}`,
+    meta: {
+      id: 1,
+      params: metaParams,
+      options,
+    },
+  };
+}
+
+// ============================================================================
+// Pre-generated test data
+// ============================================================================
+
+// --- Scenario 1: Single-pair repeated (shouldUpdateNode pattern) ---
+// shouldUpdateNode calls getTransitionPath N times per navigation with same states
+const singlePair = {
+  from: makeState("users.list"),
+  to: makeState("users.profile"),
+};
+
+// --- Scenario 2: 3-route cycling (A→B, B→C, C→A, repeat) ---
+const threeRoutes = {
+  a: makeState("home"),
+  b: makeState("users.list"),
+  c: makeState("settings.general"),
+};
+
+// --- Scenario 3: 5-tab dashboard (user switches between tabs) ---
+const tabs = {
+  t1: makeState("dashboard.overview"),
+  t2: makeState("dashboard.analytics"),
+  t3: makeState("dashboard.reports"),
+  t4: makeState("dashboard.settings"),
+  t5: makeState("dashboard.users"),
+};
+
+// --- Scenario 4: 10-route SPA (realistic app with many pages) ---
+const spaRoutes = Array.from({ length: 10 }, (_, i) =>
+  makeState(`app.section${i}.page`),
+);
+
+// --- Scenario 5: parameterized navigation (cache bypass) ---
+const paramNav = {
+  from: makeState(
+    "users.profile",
+    { id: "1" },
+    { "users.profile": { id: "url" } },
+  ),
+  to: makeState(
+    "users.profile",
+    { id: "2" },
+    { "users.profile": { id: "url" } },
+  ),
+};
+
+// --- Scenario 6: deep routes (4 levels) ---
+const deepRoutes = {
+  from: makeState("app.module.section.page"),
+  to: makeState("app.module.section.detail"),
+};
+
+// ============================================================================
+// Category 1: Speed benchmarks — Cache hit patterns
+// ============================================================================
+
+boxplot(() => {
+  summary(() => {
+    // Single-entry cache wins here: same pair repeated
+    bench("single-pair repeated ×10 (shouldUpdateNode)", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath(singlePair.to, singlePair.from);
+      }
+    });
+
+    // Single-entry cache MISSES on every call (always different pair)
+    // LRU cache should hit after warmup
+    bench("3-route cycling ×30 (A→B, B→C, C→A)", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath(threeRoutes.b, threeRoutes.a);
+        getTransitionPath(threeRoutes.c, threeRoutes.b);
+        getTransitionPath(threeRoutes.a, threeRoutes.c);
+      }
+    });
+
+    // Dashboard tabs: user clicks between 5 tabs
+    // 5 unique pairs, single-entry caches only the last one
+    bench("5-tab dashboard ×50", () => {
+      for (let i = 0; i < 10; i++) {
+        getTransitionPath(tabs.t2, tabs.t1);
+        getTransitionPath(tabs.t3, tabs.t2);
+        getTransitionPath(tabs.t4, tabs.t3);
+        getTransitionPath(tabs.t5, tabs.t4);
+        getTransitionPath(tabs.t1, tabs.t5);
+      }
+    });
+
+    // 10-route SPA: cycling through all pages
+    bench("10-route SPA cycling ×100", () => {
+      for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 10; j++) {
+          const next = (j + 1) % 10;
+
+          getTransitionPath(spaRoutes[next], spaRoutes[j]);
+        }
+      }
+    });
+  });
+});
+
+// ============================================================================
+// Category 2: Parameterized navigation (cache bypass — control group)
+// ============================================================================
+
+boxplot(() => {
+  summary(() => {
+    // Both implementations should bypass cache for parameterized routes
+    bench("parameterized: same route, different params", () => {
+      getTransitionPath(paramNav.to, paramNav.from);
+    });
+
+    // No fromState — always computes (initial load)
+    bench("initial load: no fromState", () => {
+      getTransitionPath(singlePair.to);
+    });
+
+    // Deep route with no params — cacheable
+    bench("deep route: 4 levels, no params (cacheable)", () => {
+      getTransitionPath(deepRoutes.to, deepRoutes.from);
+    });
+  });
+});
+
+// ============================================================================
+// Category 3: shouldUpdateNode simulation
+// N components each calling getTransitionPath with same state pair per navigation
+// ============================================================================
+
+boxplot(() => {
+  summary(() => {
+    bench("shouldUpdateNode: 5 components, 1 navigation", () => {
+      // 5 route-node subscribers check the same transition
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath(singlePair.to, singlePair.from);
+      }
+    });
+
+    bench("shouldUpdateNode: 20 components, 1 navigation", () => {
+      for (let i = 0; i < 20; i++) {
+        getTransitionPath(singlePair.to, singlePair.from);
+      }
+    });
+
+    bench("shouldUpdateNode: 5 components, 3 navigations (cycling)", () => {
+      // 3 different navigations, each checked by 5 components
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath(threeRoutes.b, threeRoutes.a);
+      }
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath(threeRoutes.c, threeRoutes.b);
+      }
+      for (let i = 0; i < 5; i++) {
+        getTransitionPath(threeRoutes.a, threeRoutes.c);
+      }
+    });
+  });
+});
+
+// ============================================================================
+// Category 4: Memory — heap delta under sustained load
+// ============================================================================
+
+const gc = globalThis.gc;
+
+async function measureMemory(
+  _label: string,
+  fn: () => void,
+  iterations: number,
+): Promise<{ heapDelta: number; rssDelta: number; timeMs: number }> {
+  // Warm up
+  for (let i = 0; i < 100; i++) {
+    fn();
+  }
+
+  if (gc) {
+    gc();
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const before = process.memoryUsage();
+  const start = performance.now();
+
+  for (let i = 0; i < iterations; i++) {
+    fn();
+  }
+
+  const end = performance.now();
+  const after = process.memoryUsage();
+
+  return {
+    heapDelta: after.heapUsed - before.heapUsed,
+    rssDelta: after.rss - before.rss,
+    timeMs: end - start,
+  };
+}
+
+function formatBytes(bytes: number): string {
+  const abs = Math.abs(bytes);
+
+  if (abs < 1024) {
+    return `${bytes} B`;
+  }
+  if (abs < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(2)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+// Memory tests run after mitata benchmarks
+const memoryTests = async () => {
+  console.log(`\n${"=".repeat(70)}`);
+  console.log("  MEMORY BENCHMARKS");
+  console.log("=".repeat(70));
+
+  const tests = [
+    {
+      name: "single-pair repeated ×100K",
+      fn: () => getTransitionPath(singlePair.to, singlePair.from),
+      iterations: 100_000,
+    },
+    {
+      name: "3-route cycling ×100K",
+      fn: () => {
+        getTransitionPath(threeRoutes.b, threeRoutes.a);
+        getTransitionPath(threeRoutes.c, threeRoutes.b);
+        getTransitionPath(threeRoutes.a, threeRoutes.c);
+      },
+      iterations: 33_334,
+    },
+    {
+      name: "10-route SPA ×100K",
+      fn: () => {
+        for (let j = 0; j < 10; j++) {
+          const next = (j + 1) % 10;
+
+          getTransitionPath(spaRoutes[next], spaRoutes[j]);
+        }
+      },
+      iterations: 10_000,
+    },
+    {
+      name: "5-tab dashboard ×100K",
+      fn: () => {
+        getTransitionPath(tabs.t2, tabs.t1);
+        getTransitionPath(tabs.t3, tabs.t2);
+        getTransitionPath(tabs.t4, tabs.t3);
+        getTransitionPath(tabs.t5, tabs.t4);
+        getTransitionPath(tabs.t1, tabs.t5);
+      },
+      iterations: 20_000,
+    },
+    {
+      name: "parameterized (bypass) ×100K",
+      fn: () => getTransitionPath(paramNav.to, paramNav.from),
+      iterations: 100_000,
+    },
+  ];
+
+  console.log(
+    `\n${"Test".padEnd(35)}${"Heap Δ".padStart(12)}${"RSS Δ".padStart(
+      12,
+    )}${"Time".padStart(12)}${"Ops/s".padStart(14)}`,
+  );
+  console.log("-".repeat(85));
+
+  for (const test of tests) {
+    if (gc) {
+      gc();
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const result = await measureMemory(test.name, test.fn, test.iterations);
+    let multiplier = 1;
+
+    if (test.name.includes("10-route")) {
+      multiplier = 10;
+    } else if (test.name.includes("3-route")) {
+      multiplier = 3;
+    } else if (test.name.includes("cycling") || test.name.includes("SPA")) {
+      multiplier = 5;
+    }
+
+    const totalOps = test.iterations * multiplier;
+    const opsPerSec = Math.round(totalOps / (result.timeMs / 1000));
+
+    console.log(
+      test.name.padEnd(35) +
+        formatBytes(result.heapDelta).padStart(12) +
+        formatBytes(result.rssDelta).padStart(12) +
+        `${result.timeMs.toFixed(2)}ms`.padStart(12) +
+        `${(opsPerSec / 1000).toFixed(0)}K`.padStart(14),
+    );
+  }
+
+  console.log(`\n${"=".repeat(70)}`);
+};
+
+void run().then(() => memoryTests());


### PR DESCRIPTION
## Summary

- Replace LRU eviction with FIFO in `KeyIndexCache` — eliminates `Map.delete()` + `Map.set()` on every cache hit
- Inline `#store()` into `get()`, split `#stats` object into separate `#hits`/`#misses` counters
- Handle `undefined` as a valid cached value (disambiguate from cache miss)
- Add FIFO eviction tests and `undefined`-value edge cases

## Context

During investigation of #165 (integrating cache-manager into core), benchmarks revealed that LRU's `delete+set` refresh on every hit was the dominant overhead. Switching to FIFO makes the hit path a single `Map.get()` — **2–3.4× faster than LRU**.

Core integration was ultimately reverted (single-entry `===` cache is optimal for `transitionPath`), but these optimizations improve `@real-router/cache-manager` as a standalone package for plugin use cases.

## Benchmark Results (Apple M3 Pro, Node 24.11.1)

| Operation | LRU | FIFO | Improvement |
|---|---|---|---|
| Cache hit (existing key) | ~45ns | ~15ns | **3× faster** |
| Cache miss (compute + store) | ~60ns | ~55ns | ~1.1× faster |

## Changes

| File | Change |
|---|---|
| `KeyIndexCache.ts` | LRU → FIFO, inline `#store`, separate counters, `undefined` handling |
| `CacheManager.ts` | `readonly` on `#caches` (cosmetic) |
| `KeyIndexCache.test.ts` | FIFO eviction tests, `undefined`-value edge cases (+80 lines) |
| `cache-manager.bench.ts` | New benchmark file |
| `core/tests/benchmarks/` | transitionPath cache isolation benchmarks (research artifacts) |

## Test Results

- cache-manager: **66/66 passed** ✅
- core: **2034/2034 passed** ✅
- Type-check: clean ✅
- Lint: clean ✅