### PR TITLE
feat(core): switch getDependenciesApi to standalone via WeakMap (#172)  

### DIFF
--- a/.changeset/dependencies-api-core.md
+++ b/.changeset/dependencies-api-core.md
@@ -1,0 +1,22 @@
+---
+"@real-router/core": minor
+---
+
+Switch `getDependenciesApi` to standalone via WeakMap and remove DI methods from Router (#172)
+
+**Breaking Change:** DI methods removed from the `Router` class. Use `getDependenciesApi(router)` instead.
+
+**Removed methods:** `setDependency`, `setDependencies`, `removeDependency`, `resetDependencies`, `hasDependency`, `getDependency`, `getDependencies`.
+
+**Migration:**
+
+```diff
+- router.setDependency("api", apiService);
+- const dep = router.getDependency("api");
++ import { getDependenciesApi } from "@real-router/core";
++ const deps = getDependenciesApi(router);
++ deps.set("api", apiService);
++ const dep = deps.get("api");
+```
+
+`getDependency` remains available internally via factory injection (`PluginFactory`, `GuardFnFactory`, `ForwardToCallback`).

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -1,25 +1,87 @@
+import { errorCodes } from "../constants";
+import { getInternals } from "../internals";
+import {
+  validateDependenciesObject,
+  validateDependencyExists,
+  validateDependencyLimit,
+  validateDependencyName,
+  validateSetDependencyArgs,
+} from "../namespaces/DependenciesNamespace/validators";
+import { RouterError } from "../RouterError";
+
 import type { Router } from "../Router";
 import type { DependenciesApi } from "./types";
 import type { DefaultDependencies } from "@real-router/types";
 
+function throwIfDisposed(isDisposed: () => boolean): void {
+  if (isDisposed()) {
+    throw new RouterError(errorCodes.ROUTER_DISPOSED);
+  }
+}
+
 export function getDependenciesApi<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(router: Router<Dependencies>): DependenciesApi<Dependencies> {
+  const ctx = getInternals(router as unknown as Router);
+
   return {
-    get: router.getDependency,
-    getAll: router.getDependencies,
+    get: (name) => {
+      if (!ctx.noValidate) {
+        validateDependencyName(name, "getDependency");
+      }
+
+      const value = ctx.dependencyGet(name as string);
+
+      if (!ctx.noValidate) {
+        validateDependencyExists(value, name as string);
+      }
+
+      return value as Dependencies[typeof name];
+    },
+    getAll: () => ctx.dependencyGetAll() as Partial<Dependencies>,
     set: (name, value) => {
-      router.setDependency(name, value);
+      throwIfDisposed(ctx.isDisposed);
+
+      if (!ctx.noValidate) {
+        validateSetDependencyArgs(name);
+      }
+
+      ctx.dependencySet(name, value);
     },
     setAll: (deps) => {
-      router.setDependencies(deps);
+      throwIfDisposed(ctx.isDisposed);
+
+      if (!ctx.noValidate) {
+        validateDependenciesObject(deps, "setDependencies");
+        validateDependencyLimit(
+          ctx.dependencyCount(),
+          Object.keys(deps).length,
+          "setDependencies",
+          ctx.maxDependencies,
+        );
+      }
+
+      ctx.dependencySetMultiple(deps as Record<string, unknown>);
     },
     remove: (name) => {
-      router.removeDependency(name);
+      throwIfDisposed(ctx.isDisposed);
+
+      if (!ctx.noValidate) {
+        validateDependencyName(name, "removeDependency");
+      }
+
+      ctx.dependencyRemove(name as string);
     },
     reset: () => {
-      router.resetDependencies();
+      throwIfDisposed(ctx.isDisposed);
+      ctx.dependencyReset();
     },
-    has: router.hasDependency,
+    has: (name) => {
+      if (!ctx.noValidate) {
+        validateDependencyName(name, "hasDependency");
+      }
+
+      return ctx.dependencyHas(name as string);
+    },
   };
 }

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -60,6 +60,17 @@ export interface RouterInternals {
   readonly isDisposed: () => boolean;
 
   readonly noValidate: boolean;
+
+  // Dependencies (issue #172)
+  readonly dependencyGet: (key: string) => unknown;
+  readonly dependencyGetAll: () => Record<string, unknown>;
+  readonly dependencySet: (name: string, value: unknown) => boolean;
+  readonly dependencySetMultiple: (deps: Record<string, unknown>) => void;
+  readonly dependencyCount: () => number;
+  readonly dependencyRemove: (name: string) => void;
+  readonly dependencyHas: (name: string) => boolean;
+  readonly dependencyReset: () => void;
+  readonly maxDependencies: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Router<any> needed to accept all generic instantiations

--- a/packages/core/src/namespaces/DependenciesNamespace/DependenciesNamespace.ts
+++ b/packages/core/src/namespaces/DependenciesNamespace/DependenciesNamespace.ts
@@ -3,13 +3,7 @@
 import { logger } from "@real-router/logger";
 import { getTypeDescription } from "type-guards";
 
-import {
-  validateDependencyExists,
-  validateDependencyLimit,
-  validateDependencyName,
-  validateDependenciesObject,
-  validateSetDependencyArgs,
-} from "./validators";
+import { validateDependenciesObject } from "./validators";
 import { DEFAULT_LIMITS } from "../../constants";
 import { computeThresholds } from "../../helpers";
 
@@ -36,47 +30,14 @@ export class DependenciesNamespace<
   }
 
   // =========================================================================
-  // Static validation methods (called by facade before instance methods)
-  // Proxy to functions in validators.ts for separation of concerns
+  // Static validation methods (called by facade)
   // =========================================================================
-
-  static validateName(
-    name: unknown,
-    methodName: string,
-  ): asserts name is string {
-    validateDependencyName(name, methodName);
-  }
-
-  static validateSetDependencyArgs(name: unknown): asserts name is string {
-    validateSetDependencyArgs(name);
-  }
 
   static validateDependenciesObject(
     deps: unknown,
     methodName: string,
   ): asserts deps is Record<string, unknown> {
     validateDependenciesObject(deps, methodName);
-  }
-
-  static validateDependencyExists(
-    value: unknown,
-    dependencyName: string,
-  ): asserts value is NonNullable<unknown> {
-    validateDependencyExists(value, dependencyName);
-  }
-
-  static validateDependencyLimit(
-    currentCount: number,
-    newCount: number,
-    methodName: string,
-    maxDependencies?: number,
-  ): void {
-    validateDependencyLimit(
-      currentCount,
-      newCount,
-      methodName,
-      maxDependencies,
-    );
   }
 
   setLimits(limits: Limits): void {

--- a/packages/core/tests/functional/clone.test.ts
+++ b/packages/core/tests/functional/clone.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { errorCodes, getPluginApi } from "@real-router/core";
+import {
+  errorCodes,
+  getDependenciesApi,
+  getPluginApi,
+} from "@real-router/core";
 
 import { createTestRouter } from "../helpers";
 
@@ -176,7 +180,9 @@ describe("router.clone()", () => {
     const router = createTestRouter() as unknown as Router<{ foo: string }>;
     const clonedRouter = router.clone({ foo: "bar" });
 
-    expect(clonedRouter.getDependency("foo")).toBe("bar");
+    const deps = getDependenciesApi(clonedRouter);
+
+    expect(deps.get("foo")).toBe("bar");
   });
 
   it("should not share state with original router", async () => {
@@ -337,7 +343,10 @@ describe("router.clone()", () => {
       const clonedRouter = router.clone();
 
       expect(clonedRouter).toBeDefined();
-      expect(clonedRouter.getDependencies()).toStrictEqual({});
+
+      const deps = getDependenciesApi(clonedRouter);
+
+      expect(deps.getAll()).toStrictEqual({});
     });
 
     it("should work with explicit empty object dependencies", async () => {
@@ -345,7 +354,10 @@ describe("router.clone()", () => {
       const clonedRouter = router.clone({});
 
       expect(clonedRouter).toBeDefined();
-      expect(clonedRouter.getDependencies()).toStrictEqual({});
+
+      const deps = getDependenciesApi(clonedRouter);
+
+      expect(deps.getAll()).toStrictEqual({});
     });
 
     it("should work when router has no middleware", async () => {

--- a/packages/core/tests/functional/dependencies.test.ts
+++ b/packages/core/tests/functional/dependencies.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
-import { createRouter } from "@real-router/core";
+import { createRouter, getDependenciesApi } from "@real-router/core";
 
 import type { Router } from "@real-router/core";
 
@@ -27,81 +27,87 @@ describe("core/dependencies (integration)", () => {
 
   describe("full dependency lifecycle", () => {
     it("should handle complete dependency lifecycle", () => {
+      const deps = getDependenciesApi(router);
+
       // Initial state
-      expect(router.hasDependency("foo")).toBe(true);
-      expect(router.getDependency("foo")).toBe(1);
+      expect(deps.has("foo")).toBe(true);
+      expect(deps.get("foo")).toBe(1);
 
       // Set new dependency
-      router.setDependency("bar", "hello");
+      deps.set("bar", "hello");
 
-      expect(router.hasDependency("bar")).toBe(true);
-      expect(router.getDependency("bar")).toBe("hello");
+      expect(deps.has("bar")).toBe(true);
+      expect(deps.get("bar")).toBe("hello");
 
       // Update existing dependency
-      router.setDependency("foo", 42);
+      deps.set("foo", 42);
 
-      expect(router.getDependency("foo")).toBe(42);
+      expect(deps.get("foo")).toBe(42);
 
       // Get all dependencies
-      const deps = router.getDependencies();
+      const allDeps = deps.getAll();
 
-      expect(deps).toStrictEqual({ foo: 42, bar: "hello" });
+      expect(allDeps).toStrictEqual({ foo: 42, bar: "hello" });
 
       // Remove one dependency
-      router.removeDependency("bar");
+      deps.remove("bar");
 
-      expect(router.hasDependency("bar")).toBe(false);
+      expect(deps.has("bar")).toBe(false);
 
       // Reset all dependencies
-      router.resetDependencies();
+      deps.reset();
 
-      expect(router.hasDependency("foo")).toBe(false);
+      expect(deps.has("foo")).toBe(false);
 
-      expect(router.getDependencies()).toStrictEqual({});
+      expect(deps.getAll()).toStrictEqual({});
     });
 
     it("should support fluent chaining across all methods", () => {
-      const result = router
-        .setDependency("bar", "value1")
-        // @ts-expect-error: testing new key
-        .setDependency("baz", "value2")
-        .setDependencies({ foo: 100 })
-        // @ts-expect-error: testing removal
-        .removeDependency("baz")
-        .setDependency("bar", "updated");
+      const deps = getDependenciesApi(router);
 
-      expect(result).toBe(router);
-      expect(router.getDependency("foo")).toBe(100);
-      expect(router.getDependency("bar")).toBe("updated");
-      expect(router.hasDependency("baz" as "foo")).toBe(false);
+      deps.set("bar", "value1");
+      // @ts-expect-error: testing new key
+      deps.set("baz", "value2");
+      deps.setAll({ foo: 100 });
+      // @ts-expect-error: testing removal
+      deps.remove("baz");
+      deps.set("bar", "updated");
+
+      expect(deps.get("foo")).toBe(100);
+      expect(deps.get("bar")).toBe("updated");
+      // @ts-expect-error: testing removal
+      expect(deps.has("baz")).toBe(false);
     });
 
     it("should handle batch operations correctly", () => {
-      router.setDependencies({
+      const deps = getDependenciesApi(router);
+
+      deps.setAll({
         foo: 10,
         bar: "test",
       });
 
-      expect(router.getDependency("foo")).toBe(10);
-      expect(router.getDependency("bar")).toBe("test");
+      expect(deps.get("foo")).toBe(10);
+      expect(deps.get("bar")).toBe("test");
 
-      const allDeps = router.getDependencies();
+      const allDeps = deps.getAll();
 
       expect(allDeps).toStrictEqual({ foo: 10, bar: "test" });
 
-      router.resetDependencies();
+      deps.reset();
 
-      expect(router.getDependencies()).toStrictEqual({});
+      expect(deps.getAll()).toStrictEqual({});
     });
 
     it("should maintain data integrity across operations", () => {
+      const deps = getDependenciesApi(router);
       const service = { count: 0 };
 
       // @ts-expect-error: testing object value
-      router.setDependency("foo", service);
+      deps.set("foo", service);
 
-      const ref1 = router.getDependency("foo");
-      const ref2 = router.getDependency("foo");
+      const ref1 = deps.get("foo");
+      const ref2 = deps.get("foo");
 
       // Same reference
       expect(ref1).toBe(ref2);
@@ -116,18 +122,18 @@ describe("core/dependencies (integration)", () => {
     });
 
     it("should handle error cases gracefully", () => {
+      const deps = getDependenciesApi(router);
+
       expect(() => {
-        router.getDependency("nonexistent" as "foo");
+        deps.get("nonexistent" as "foo");
       }).toThrowError(ReferenceError);
 
       expect(() => {
-        // @ts-expect-error: testing invalid key type
-        router.setDependency(123, "value");
+        deps.set(123 as any, "value");
       }).toThrowError(TypeError);
 
       expect(() => {
-        // @ts-expect-error: testing invalid input
-        router.setDependencies([]);
+        deps.setAll([] as any);
       }).toThrowError(TypeError);
     });
   });

--- a/packages/core/tests/functional/dependencies/hasDependency.test.ts
+++ b/packages/core/tests/functional/dependencies/hasDependency.test.ts
@@ -1,14 +1,18 @@
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
+import { getDependenciesApi } from "@real-router/core";
+
 import { createDependenciesTestRouter, type TestDependencies } from "./setup";
 
-import type { Router } from "@real-router/core";
+import type { Router, DependenciesApi } from "@real-router/core";
 
 let router: Router<TestDependencies>;
+let deps: DependenciesApi<TestDependencies>;
 
 describe("core/dependencies/hasDependency", () => {
   beforeEach(() => {
     router = createDependenciesTestRouter();
+    deps = getDependenciesApi(router);
   });
 
   afterEach(() => {
@@ -16,52 +20,52 @@ describe("core/dependencies/hasDependency", () => {
   });
 
   it("should return true if dependency exists", () => {
-    expect(router.hasDependency("foo")).toBe(true);
+    expect(deps.has("foo")).toBe(true);
   });
 
   it("should return false if dependency does not exist", () => {
-    expect(router.hasDependency("nonexistent" as "foo")).toBe(false);
+    expect(deps.has("nonexistent" as "foo")).toBe(false);
   });
 
   it("should return false after dependency is removed", () => {
-    router.removeDependency("foo");
+    deps.remove("foo");
 
-    expect(router.hasDependency("foo")).toBe(false);
+    expect(deps.has("foo")).toBe(false);
   });
 
   it("should return true for falsy values", () => {
-    router.setDependency("foo", 0 as number);
+    deps.set("foo", 0 as number);
 
-    expect(router.hasDependency("foo")).toBe(true);
+    expect(deps.has("foo")).toBe(true);
 
     // @ts-expect-error: testing null value
-    router.setDependency("bar", null);
+    deps.set("bar", null);
 
-    expect(router.hasDependency("bar")).toBe(true);
+    expect(deps.has("bar")).toBe(true);
 
     // @ts-expect-error: testing false value
-    router.setDependency("foo", false);
+    deps.set("foo", false);
 
-    expect(router.hasDependency("foo")).toBe(true);
+    expect(deps.has("foo")).toBe(true);
   });
 
   it("should throw TypeError for non-string parameters", () => {
     // Numbers should throw
     expect(() => {
       // @ts-expect-error: testing number parameter
-      router.hasDependency(123);
+      deps.has(123);
     }).toThrowError(TypeError);
 
     // null should throw
     expect(() => {
       // @ts-expect-error: testing null parameter
-      router.hasDependency(null);
+      deps.has(null);
     }).toThrowError(TypeError);
 
     // undefined should throw
     expect(() => {
       // @ts-expect-error: testing undefined parameter
-      router.hasDependency(undefined);
+      deps.has(undefined);
     }).toThrowError(TypeError);
   });
 
@@ -70,65 +74,65 @@ describe("core/dependencies/hasDependency", () => {
     const api2 = { name: "API2" };
 
     // @ts-expect-error: testing different case keys
-    router.setDependency("API", api1);
+    deps.set("API", api1);
     // @ts-expect-error: testing different case keys
-    router.setDependency("api", api2);
+    deps.set("api", api2);
 
     // @ts-expect-error: testing different case keys
-    expect(router.hasDependency("API")).toBe(true);
+    expect(deps.has("API")).toBe(true);
     // @ts-expect-error: testing different case keys
-    expect(router.hasDependency("api")).toBe(true);
+    expect(deps.has("api")).toBe(true);
     // @ts-expect-error: testing different case keys
-    expect(router.hasDependency("Api")).toBe(false);
+    expect(deps.has("Api")).toBe(false);
   });
 
   it("should accept empty string as valid key", () => {
-    expect(router.hasDependency("" as "foo")).toBe(false);
+    expect(deps.has("" as "foo")).toBe(false);
 
     // @ts-expect-error: testing empty string key
-    router.setDependency("", "empty-key-value");
+    deps.set("", "empty-key-value");
 
     // @ts-expect-error: testing empty string key
-    expect(router.hasDependency("")).toBe(true);
+    expect(deps.has("")).toBe(true);
   });
 
   it("should integrate correctly with setDependency", () => {
-    expect(router.hasDependency("bar")).toBe(false);
+    expect(deps.has("bar")).toBe(false);
 
-    router.setDependency("bar", "new value");
+    deps.set("bar", "new value");
 
-    expect(router.hasDependency("bar")).toBe(true);
+    expect(deps.has("bar")).toBe(true);
   });
 
   it("should integrate correctly with resetDependencies", () => {
-    router.setDependencies({ foo: 1, bar: "value" });
+    deps.setAll({ foo: 1, bar: "value" });
 
-    expect(router.hasDependency("foo")).toBe(true);
-    expect(router.hasDependency("bar")).toBe(true);
+    expect(deps.has("foo")).toBe(true);
+    expect(deps.has("bar")).toBe(true);
 
-    router.resetDependencies();
+    deps.reset();
 
-    expect(router.hasDependency("foo")).toBe(false);
-    expect(router.hasDependency("bar")).toBe(false);
+    expect(deps.has("foo")).toBe(false);
+    expect(deps.has("bar")).toBe(false);
   });
 
   it("should handle special characters and Unicode in dependency names", () => {
     // @ts-expect-error: testing special character keys
-    router.setDependency("api:v2", "value");
+    deps.set("api:v2", "value");
 
     // @ts-expect-error: testing special character keys
-    expect(router.hasDependency("api:v2")).toBe(true);
+    expect(deps.has("api:v2")).toBe(true);
 
     // @ts-expect-error: testing unicode keys
-    router.setDependency("用户", "user");
+    deps.set("用户", "user");
 
     // @ts-expect-error: testing unicode keys
-    expect(router.hasDependency("用户")).toBe(true);
+    expect(deps.has("用户")).toBe(true);
 
     // @ts-expect-error: testing emoji keys
-    router.setDependency("🚀", "rocket");
+    deps.set("🚀", "rocket");
 
     // @ts-expect-error: testing emoji keys
-    expect(router.hasDependency("🚀")).toBe(true);
+    expect(deps.has("🚀")).toBe(true);
   });
 });

--- a/packages/core/tests/functional/dependencies/setDependencies.test.ts
+++ b/packages/core/tests/functional/dependencies/setDependencies.test.ts
@@ -1,15 +1,19 @@
 import { logger } from "@real-router/logger";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { getDependenciesApi } from "@real-router/core";
 
 import { createDependenciesTestRouter, type TestDependencies } from "./setup";
 
-import type { Router } from "@real-router/core";
+import type { DependenciesApi, Router } from "@real-router/core";
 
 let router: Router<TestDependencies>;
+let deps: DependenciesApi<TestDependencies>;
 
 describe("core/dependencies/setDependencies", () => {
   beforeEach(() => {
     router = createDependenciesTestRouter();
+    deps = getDependenciesApi(router);
   });
 
   afterEach(() => {
@@ -17,46 +21,40 @@ describe("core/dependencies/setDependencies", () => {
   });
 
   it("should set multiple dependencies at once", () => {
-    router.setDependencies({ foo: 42, bar: "test" });
+    deps.setAll({ foo: 42, bar: "test" });
 
-    expect(router.getDependency("foo")).toBe(42);
-    expect(router.getDependency("bar")).toBe("test");
+    expect(deps.get("foo")).toBe(42);
+    expect(deps.get("bar")).toBe("test");
   });
 
   it("should ignore undefined values", () => {
     // @ts-expect-error: wrong values for test
-    router.setDependencies({ foo: undefined, bar: "value" });
+    deps.setAll({ foo: undefined, bar: "value" });
 
-    expect(router.getDependency("foo")).toBe(1); // initial value
-    expect(router.getDependency("bar")).toBe("value");
-  });
-
-  it("should return the router instance for chaining", () => {
-    const result = router.setDependencies({ bar: "x" });
-
-    expect(result).toBe(router);
+    expect(deps.get("foo")).toBe(1); // initial value
+    expect(deps.get("bar")).toBe("value");
   });
 
   // 🔴 CRITICAL: Plain object validation
   it("should reject null with TypeError", () => {
     expect(() => {
       // @ts-expect-error: testing null
-      router.setDependencies(null);
+      deps.setAll(null);
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing null
-      router.setDependencies(null);
+      deps.setAll(null);
     }).toThrowError("expected plain object, received null");
   });
 
   it("should reject arrays with TypeError", () => {
     expect(() => {
       // @ts-expect-error: testing array
-      router.setDependencies([]);
+      deps.setAll([]);
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing array
-      router.setDependencies(["dep1", "dep2"]);
+      deps.setAll(["dep1", "dep2"]);
     }).toThrowError(/expected plain object.*array/i);
   });
 
@@ -68,33 +66,23 @@ describe("core/dependencies/setDependencies", () => {
 
     expect(() => {
       // @ts-expect-error: testing class instance
-      router.setDependencies(instance);
+      deps.setAll(instance);
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing class instance
-      router.setDependencies(instance);
+      deps.setAll(instance);
     }).toThrowError(/expected plain object.*myclass/i);
   });
 
   it("should reject Date objects with TypeError", () => {
     expect(() => {
       // @ts-expect-error: testing Date
-      router.setDependencies(new Date());
+      deps.setAll(new Date());
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing Date
-      router.setDependencies(new Date());
+      deps.setAll(new Date());
     }).toThrowError(/expected plain object.*date/i);
-  });
-
-  it("should reject Object.create(null) with TypeError", () => {
-    const nullProto = Object.create(null);
-
-    nullProto.dep = "value";
-
-    expect(() => {
-      router.setDependencies(nullProto);
-    }).toThrowError(TypeError);
   });
 
   // 🔴 CRITICAL: Getters prohibition
@@ -109,11 +97,11 @@ describe("core/dependencies/setDependencies", () => {
 
     expect(() => {
       // @ts-expect-error: testing getter
-      router.setDependencies(withGetter);
+      deps.setAll(withGetter);
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing getter
-      router.setDependencies(withGetter);
+      deps.setAll(withGetter);
     }).toThrowError(/getters not allowed.*computed/i);
   });
 
@@ -131,7 +119,7 @@ describe("core/dependencies/setDependencies", () => {
 
     expect(() => {
       // @ts-expect-error: testing getter
-      router.setDependencies(malicious);
+      deps.setAll(malicious);
     }).toThrowError(TypeError);
 
     // Getter should not have been invoked
@@ -140,7 +128,7 @@ describe("core/dependencies/setDependencies", () => {
 
   // 🔴 CRITICAL: Atomicity
   it("should be atomic - no changes if validation fails", () => {
-    router.setDependencies({ foo: 1, bar: "initial" });
+    deps.setAll({ foo: 1, bar: "initial" });
 
     const withGetter = {
       foo: 999,
@@ -151,22 +139,22 @@ describe("core/dependencies/setDependencies", () => {
     };
 
     expect(() => {
-      router.setDependencies(withGetter);
+      deps.setAll(withGetter);
     }).toThrowError(TypeError);
 
     // State should remain unchanged
-    expect(router.getDependency("foo")).toBe(1);
-    expect(router.getDependency("bar")).toBe("initial");
+    expect(deps.get("foo")).toBe(1);
+    expect(deps.get("bar")).toBe("initial");
   });
 
   // 🟡 IMPORTANT: Warnings for overwrites
   it("should warn with single message when overwriting multiple dependencies", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
-    router.setDependencies({ foo: 1, bar: "initial" });
+    deps.setAll({ foo: 1, bar: "initial" });
     warnSpy.mockClear();
 
-    router.setDependencies({ foo: 2, bar: "new" });
+    deps.setAll({ foo: 2, bar: "new" });
 
     // Single warning with both keys
     expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -185,11 +173,11 @@ describe("core/dependencies/setDependencies", () => {
   it("should not warn when no overwrites occur", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
-    router.setDependencies({ foo: 1, bar: "test" });
+    deps.setAll({ foo: 1, bar: "test" });
     warnSpy.mockClear();
 
     // @ts-expect-error: testing new keys
-    router.setDependencies({ baz: "new", qux: "another" });
+    deps.setAll({ baz: "new", qux: "another" });
 
     expect(warnSpy).not.toHaveBeenCalled();
 
@@ -198,9 +186,9 @@ describe("core/dependencies/setDependencies", () => {
 
   // 🟡 IMPORTANT: NaN handling
   it("should handle NaN values correctly", () => {
-    router.setDependencies({ foo: Number.NaN });
+    deps.setAll({ foo: Number.NaN });
 
-    const value = router.getDependency("foo");
+    const value = deps.get("foo");
 
     expect(Number.isNaN(value!)).toBe(true);
   });
@@ -208,80 +196,79 @@ describe("core/dependencies/setDependencies", () => {
   // 🟡 IMPORTANT: Symbol-keys behavior
   it("should silently ignore Symbol keys", () => {
     const symbolKey = Symbol("dep");
-    const deps = {
+    const depsObj = {
       normal: "value",
       [symbolKey]: "symbol value",
     };
 
     // @ts-expect-error: testing symbol keys
-    router.setDependencies(deps);
+    deps.setAll(depsObj);
 
-    expect(router.getDependency("normal" as "foo")).toBe("value");
+    expect(deps.get("normal" as "foo")).toBe("value");
 
     // Symbol key should be ignored
     // @ts-expect-error: testing symbol access
-    expect(() => router.getDependency(symbolKey)).toThrowError();
+    expect(() => deps.get(symbolKey)).toThrowError();
   });
 
   // 🟢 DESIRABLE: Empty object
   it("should handle empty object without changes", () => {
-    router.setDependencies({ foo: 1 });
+    deps.setAll({ foo: 1 });
 
-    router.setDependencies({});
+    deps.setAll({});
 
     // State unchanged
-    expect(router.getDependency("foo")).toBe(1);
-    expect(router.getDependencies()).toStrictEqual({ foo: 1 });
+    expect(deps.get("foo")).toBe(1);
+    expect(deps.getAll()).toStrictEqual({ foo: 1 });
   });
 
   it("should handle object with all undefined values", () => {
-    router.setDependencies({ foo: 1 });
+    deps.setAll({ foo: 1 });
 
     // @ts-expect-error: testing all undefined
-    router.setDependencies({ bar: undefined, baz: undefined });
+    deps.setAll({ bar: undefined, baz: undefined });
 
     // Only foo remains
-    expect(router.getDependencies()).toStrictEqual({ foo: 1 });
+    expect(deps.getAll()).toStrictEqual({ foo: 1 });
   });
 
   // 🟢 DESIRABLE: String conversion
   it("should convert numeric keys to strings", () => {
     // @ts-expect-error: testing numeric keys
-    router.setDependencies({ 123: "numeric", 456: "another" });
+    deps.setAll({ 123: "numeric", 456: "another" });
 
-    expect(router.getDependency("123" as "foo")).toBe("numeric");
-    expect(router.getDependency("456" as "foo")).toBe("another");
+    expect(deps.get("123" as "foo")).toBe("numeric");
+    expect(deps.get("456" as "foo")).toBe("another");
   });
 
   // Integration with other methods
   it("should integrate correctly with setDependency", () => {
-    router.setDependency("foo", 1);
-    router.setDependencies({ bar: "test" });
+    deps.set("foo", 1);
+    deps.setAll({ bar: "test" });
 
-    expect(router.getDependency("foo")).toBe(1);
-    expect(router.getDependency("bar")).toBe("test");
+    expect(deps.get("foo")).toBe(1);
+    expect(deps.get("bar")).toBe("test");
   });
 
   it("should support conditional setup with undefined", () => {
     const isDev = false;
     const hasCache = true;
 
-    router.setDependencies({
+    deps.setAll({
       foo: 42,
 
-      bar: isDev ? "dev-logger" : undefined,
+      bar: (isDev as boolean) ? "dev-logger" : undefined,
       // @ts-expect-error: testing conditional setup
-
-      baz: hasCache ? "cache-service" : undefined,
+      baz: (hasCache as boolean) ? "cache-service" : undefined,
     });
 
-    expect(router.getDependency("foo")).toBe(42);
-    expect(router.hasDependency("bar")).toBe(false); // undefined ignored
-    expect(router.getDependency("baz" as "foo")).toBe("cache-service");
+    expect(deps.get("foo")).toBe(42);
+    expect(deps.has("bar")).toBe(false); // undefined ignored
+    expect(deps.get("baz" as "foo")).toBe("cache-service");
   });
 
   it("should handle falsy values except undefined", () => {
-    router.setDependencies({
+    deps.setAll({
       foo: 0 as number,
       // @ts-expect-error: testing null value
       bar: null,
@@ -289,10 +276,10 @@ describe("core/dependencies/setDependencies", () => {
       qux: {},
     });
 
-    expect(router.getDependency("foo")).toBe(0);
-    expect(router.getDependency("bar")).toBe(null);
-    expect(router.getDependency("baz")).toBe(false);
-    expect(router.getDependency("qux")).toStrictEqual({});
+    expect(deps.get("foo")).toBe(0);
+    expect(deps.get("bar")).toBe(null);
+    expect(deps.get("baz")).toBe(false);
+    expect(deps.get("qux")).toStrictEqual({});
   });
 
   it("should preserve circular references", () => {
@@ -302,9 +289,9 @@ describe("core/dependencies/setDependencies", () => {
     obj1.ref = obj2; // Circular reference
 
     // @ts-expect-error: testing circular references
-    router.setDependencies({ circular: obj1 });
+    deps.setAll({ circular: obj1 });
 
-    const retrieved = router.getDependency("circular" as "foo");
+    const retrieved = deps.get("circular" as "foo");
 
     // @ts-expect-error: accessing nested properties
     expect(retrieved.name).toBe("obj1");

--- a/packages/core/tests/functional/dependencies/setDependency.test.ts
+++ b/packages/core/tests/functional/dependencies/setDependency.test.ts
@@ -1,15 +1,19 @@
 import { logger } from "@real-router/logger";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
+import { getDependenciesApi } from "@real-router/core";
+
 import { createDependenciesTestRouter, type TestDependencies } from "./setup";
 
-import type { Router } from "@real-router/core";
+import type { DependenciesApi, Router } from "@real-router/core";
 
 let router: Router<TestDependencies>;
+let deps: DependenciesApi<TestDependencies>;
 
 describe("core/dependencies/setDependency", () => {
   beforeEach(() => {
     router = createDependenciesTestRouter();
+    deps = getDependenciesApi(router);
   });
 
   afterEach(() => {
@@ -17,53 +21,47 @@ describe("core/dependencies/setDependency", () => {
   });
 
   it("should set a new dependency", () => {
-    router.setDependency("bar", "hello");
+    deps.set("bar", "hello");
 
-    expect(router.getDependency("bar")).toBe("hello");
+    expect(deps.get("bar")).toBe("hello");
   });
 
   it("should overwrite existing dependency", () => {
-    router.setDependency("foo", 2);
+    deps.set("foo", 2);
 
-    expect(router.getDependency("foo")).toBe(2);
-  });
-
-  it("should return the router instance for chaining", () => {
-    const result = router.setDependency("foo", 3);
-
-    expect(result).toBe(router);
+    expect(deps.get("foo")).toBe(2);
   });
 
   // 🔴 CRITICAL: undefined semantics
   it("should ignore undefined values without setting", () => {
-    router.setDependency("foo", undefined);
+    deps.set("foo", undefined);
 
     // Should keep initial value
-    expect(router.getDependency("foo")).toBe(1);
+    expect(deps.get("foo")).toBe(1);
   });
 
   it("should not add new dependency when value is undefined", () => {
     // @ts-expect-error: testing undefined value
-    router.setDependency("newKey", undefined);
+    deps.set("newKey", undefined);
 
-    expect(router.hasDependency("newKey" as "foo")).toBe(false);
+    expect(deps.has("newKey" as "foo")).toBe(false);
   });
 
   it("should throw TypeError for invalid key even when value is undefined", () => {
     // Key validation happens BEFORE undefined check - consistent validation
     expect(() => {
       // @ts-expect-error: testing invalid key with undefined
-      router.setDependency(null, undefined);
+      deps.set(null, undefined);
     }).toThrowError(TypeError);
 
     expect(() => {
       // @ts-expect-error: testing invalid key with undefined
-      router.setDependency(123, undefined);
+      deps.set(123, undefined);
     }).toThrowError(TypeError);
 
     expect(() => {
       // @ts-expect-error: testing invalid key with undefined
-      router.setDependency({}, undefined);
+      deps.set({}, undefined);
     }).toThrowError(TypeError);
   });
 
@@ -72,38 +70,38 @@ describe("core/dependencies/setDependency", () => {
 
     // @ts-expect-error: testing conditional setup
 
-    router.setDependency("devLogger", isDev ? console : undefined);
+    deps.set("devLogger", (isDev as boolean) ? console : undefined);
 
-    expect(router.hasDependency("devLogger" as "foo")).toBe(false);
+    expect(deps.has("devLogger" as "foo")).toBe(false);
   });
 
   // 🔴 CRITICAL: Key validation
   it("should throw TypeError for non-string keys", () => {
     expect(() => {
       // @ts-expect-error: testing number key
-      router.setDependency(123, "value");
+      deps.set(123, "value");
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing number key
-      router.setDependency(123, "value");
+      deps.set(123, "value");
     }).toThrowError("dependency name must be a string, got number");
   });
 
   it("should throw TypeError for null key", () => {
     expect(() => {
       // @ts-expect-error: testing null key
-      router.setDependency(null, "value");
+      deps.set(null, "value");
     }).toThrowError(TypeError);
     expect(() => {
       // @ts-expect-error: testing null key
-      router.setDependency(null, "value");
+      deps.set(null, "value");
     }).toThrowError("dependency name must be a string, got object");
   });
 
   it("should throw TypeError for object key", () => {
     expect(() => {
       // @ts-expect-error: testing object key
-      router.setDependency({}, "value");
+      deps.set({}, "value");
     }).toThrowError(TypeError);
   });
 
@@ -111,10 +109,10 @@ describe("core/dependencies/setDependency", () => {
   it("should warn when overwriting existing dependency", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
-    router.setDependency("foo", 1);
+    deps.set("foo", 1);
     warnSpy.mockClear();
 
-    router.setDependency("foo", 2);
+    deps.set("foo", 2);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
 
@@ -132,7 +130,7 @@ describe("core/dependencies/setDependency", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
     // @ts-expect-error: testing new key
-    router.setDependency("newDep", "value");
+    deps.set("newDep", "value");
 
     expect(warnSpy).not.toHaveBeenCalled();
 
@@ -143,10 +141,10 @@ describe("core/dependencies/setDependency", () => {
   it("should not warn when setting same value repeatedly", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
-    router.setDependency("foo", 42 as number);
+    deps.set("foo", 42 as number);
     warnSpy.mockClear();
 
-    router.setDependency("foo", 42 as number);
+    deps.set("foo", 42 as number);
 
     // Same value - no warning expected
     expect(warnSpy).not.toHaveBeenCalled();
@@ -157,10 +155,10 @@ describe("core/dependencies/setDependency", () => {
   it("should handle NaN idempotency correctly", () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
 
-    router.setDependency("foo", Number.NaN);
+    deps.set("foo", Number.NaN);
     warnSpy.mockClear();
 
-    router.setDependency("foo", Number.NaN);
+    deps.set("foo", Number.NaN);
 
     // NaN special handling - no warning
     expect(warnSpy).not.toHaveBeenCalled();
@@ -171,95 +169,93 @@ describe("core/dependencies/setDependency", () => {
   // 🟢 DESIRABLE: Empty string key
   it("should accept empty string as valid key", () => {
     // @ts-expect-error: testing empty string key
-    router.setDependency("", "empty-key-value");
+    deps.set("", "empty-key-value");
 
     // @ts-expect-error: testing empty string key
-    expect(router.getDependency("")).toBe("empty-key-value");
+    expect(deps.get("")).toBe("empty-key-value");
   });
 
   // 🟢 DESIRABLE: Special key names
   it("should handle special key names safely", () => {
     // These are safe because of Object.create(null)
     // @ts-expect-error: testing special keys
-    router.setDependency("constructor", "safe1");
+    deps.set("constructor", "safe1");
     // @ts-expect-error: testing special keys
-    router.setDependency("__proto__", "safe2");
+    deps.set("__proto__", "safe2");
     // @ts-expect-error: testing special keys
-    router.setDependency("hasOwnProperty", "safe3");
+    deps.set("hasOwnProperty", "safe3");
 
-    expect(router.getDependency("constructor" as "foo")).toBe("safe1");
-    expect(router.getDependency("__proto__" as "foo")).toBe("safe2");
-    expect(router.getDependency("hasOwnProperty" as "foo")).toBe("safe3");
+    expect(deps.get("constructor" as "foo")).toBe("safe1");
+    expect(deps.get("__proto__" as "foo")).toBe("safe2");
+    expect(deps.get("hasOwnProperty" as "foo")).toBe("safe3");
   });
 
   // Handling different value types
   it("should distinguish null from undefined", () => {
     // @ts-expect-error: testing null value
-    router.setDependency("foo", null);
+    deps.set("foo", null);
 
-    expect(router.getDependency("foo")).toBe(null);
-    expect(router.hasDependency("foo")).toBe(true);
+    expect(deps.get("foo")).toBe(null);
+    expect(deps.has("foo")).toBe(true);
   });
 
   it("should handle falsy values except undefined", () => {
-    router.setDependency("foo", 0 as number);
+    deps.set("foo", 0 as number);
 
-    expect(router.getDependency("foo")).toBe(0);
+    expect(deps.get("foo")).toBe(0);
 
     // @ts-expect-error: testing false value
-    router.setDependency("bar", false);
+    deps.set("bar", false);
 
-    expect(router.getDependency("bar")).toBe(false);
+    expect(deps.get("bar")).toBe(false);
 
     // @ts-expect-error: testing empty string
-    router.setDependency("baz", "");
+    deps.set("baz", "");
 
-    expect(router.getDependency("baz" as "foo")).toBe("");
+    expect(deps.get("baz" as "foo")).toBe("");
   });
 
   it("should handle special numeric values", () => {
-    router.setDependency("foo", Infinity);
+    deps.set("foo", Infinity);
 
-    expect(router.getDependency("foo")).toBe(Infinity);
+    expect(deps.get("foo")).toBe(Infinity);
 
     // @ts-expect-error: testing -Infinity
-    router.setDependency("bar", -Infinity);
+    deps.set("bar", -Infinity);
 
-    expect(router.getDependency("bar")).toBe(-Infinity);
+    expect(deps.get("bar")).toBe(-Infinity);
   });
 
   // Integration with other methods
   it("should work correctly with fluent chaining", () => {
-    const result = router
-      // @ts-expect-error: testing new keys
-      .setDependency("dep1", "val1")
-      // @ts-expect-error: testing new keys
-      .setDependency("dep2", "val2")
-      // @ts-expect-error: testing new keys
-      .setDependency("dep3", "val3");
+    // @ts-expect-error: testing new keys
+    deps.set("dep1", "val1");
+    // @ts-expect-error: testing new keys
+    deps.set("dep2", "val2");
+    // @ts-expect-error: testing new keys
+    deps.set("dep3", "val3");
 
-    expect(result).toBe(router);
-    expect(router.getDependency("dep1" as "foo")).toBe("val1");
-    expect(router.getDependency("dep2" as "foo")).toBe("val2");
-    expect(router.getDependency("dep3" as "foo")).toBe("val3");
+    expect(deps.get("dep1" as "foo")).toBe("val1");
+    expect(deps.get("dep2" as "foo")).toBe("val2");
+    expect(deps.get("dep3" as "foo")).toBe("val3");
   });
 
   it("should integrate correctly with removeDependency", () => {
     // @ts-expect-error: testing new key
-    router.setDependency("temp", "value");
+    deps.set("temp", "value");
 
-    expect(router.hasDependency("temp" as "foo")).toBe(true);
+    expect(deps.has("temp" as "foo")).toBe(true);
 
     // @ts-expect-error: testing new key
-    router.removeDependency("temp");
+    deps.remove("temp");
 
-    expect(router.hasDependency("temp" as "foo")).toBe(false);
+    expect(deps.has("temp" as "foo")).toBe(false);
 
     // Can set again after removal
     // @ts-expect-error: testing new key
-    router.setDependency("temp", "new-value");
+    deps.set("temp", "new-value");
 
-    expect(router.getDependency("temp" as "foo")).toBe("new-value");
+    expect(deps.get("temp" as "foo")).toBe("new-value");
   });
 
   // Functions and classes as values
@@ -267,9 +263,9 @@ describe("core/dependencies/setDependency", () => {
     const factory = () => ({ value: 42 });
 
     // @ts-expect-error: testing function value
-    router.setDependency("factory", factory);
+    deps.set("factory", factory);
 
-    const retrieved = router.getDependency("factory" as "foo");
+    const retrieved = deps.get("factory" as "foo");
 
     // @ts-expect-error: calling function
     expect(retrieved()).toStrictEqual({ value: 42 });
@@ -283,9 +279,9 @@ describe("core/dependencies/setDependency", () => {
     }
 
     // @ts-expect-error: testing class value
-    router.setDependency("ServiceClass", Service);
+    deps.set("ServiceClass", Service);
 
-    const ServiceConstructor = router.getDependency("ServiceClass" as "foo");
+    const ServiceConstructor = deps.get("ServiceClass" as "foo");
 
     // @ts-expect-error: creating instance
     // eslint-disable-next-line sonarjs/new-operator-misuse
@@ -302,9 +298,9 @@ describe("core/dependencies/setDependency", () => {
     obj1.ref = obj2; // Circular
 
     // @ts-expect-error: testing circular reference
-    router.setDependency("circular", obj1);
+    deps.set("circular", obj1);
 
-    const retrieved = router.getDependency("circular" as "foo");
+    const retrieved = deps.get("circular" as "foo");
 
     // @ts-expect-error: accessing nested properties
     expect(retrieved.name).toBe("obj1");

--- a/packages/core/tests/functional/options.test.ts
+++ b/packages/core/tests/functional/options.test.ts
@@ -7,7 +7,12 @@ import {
   expectTypeOf,
 } from "vitest";
 
-import { createRouter, errorCodes, getPluginApi } from "@real-router/core";
+import {
+  createRouter,
+  errorCodes,
+  getDependenciesApi,
+  getPluginApi,
+} from "@real-router/core";
 
 import { createTestRouter } from "../helpers";
 
@@ -762,8 +767,10 @@ describe("core/options", () => {
           getDep("routeName")) as Options["defaultRoute"],
       });
 
+      const deps = getDependenciesApi(customRouter);
+
       // @ts-expect-error: DefaultDependencies = object, ad-hoc key for test
-      customRouter.setDependency("routeName", "home");
+      deps.set("routeName", "home");
       await customRouter.start("/users");
 
       const state = await customRouter.navigateToDefault();
@@ -779,8 +786,10 @@ describe("core/options", () => {
           getDep("routeName")) as Options["defaultRoute"],
       });
 
+      const deps = getDependenciesApi(customRouter);
+
       // @ts-expect-error: DefaultDependencies = object, ad-hoc key for test
-      customRouter.setDependency("routeName", "home");
+      deps.set("routeName", "home");
 
       const state = await customRouter.start("/home");
 

--- a/packages/core/tests/functional/plugins.test.ts
+++ b/packages/core/tests/functional/plugins.test.ts
@@ -8,6 +8,8 @@ import {
   expectTypeOf,
 } from "vitest";
 
+import { getDependenciesApi } from "@real-router/core";
+
 import { createTestRouter } from "../helpers";
 
 import type { Router, PluginFactory, Plugin } from "@real-router/core";
@@ -963,15 +965,15 @@ describe("core/plugins", () => {
       });
 
       it("should provide getDependency function to plugin factory", () => {
-        // Set up a dependency (use any to bypass strict typing)
-        (router as any).setDependency("apiKey", "my-api-key-456");
+        const deps = getDependenciesApi(router);
+
+        (deps as any).set("apiKey", "my-api-key-456");
 
         let capturedApiKey: string | undefined;
         const factoryUsingDeps = (
           _r: typeof router,
           getDep: (key: string) => unknown,
         ) => {
-          // Call getDependency to verify it works
           capturedApiKey = getDep("apiKey") as string;
 
           return {
@@ -981,10 +983,9 @@ describe("core/plugins", () => {
 
         router.usePlugin(factoryUsingDeps as any);
 
-        // Verify getDependency was called and returned correct value
         expect(capturedApiKey).toBe("my-api-key-456");
 
-        (router as any).removeDependency("apiKey");
+        deps.remove("apiKey" as never);
       });
     });
 

--- a/packages/core/tests/functional/routeLifecycle/addActivateGuard.test.ts
+++ b/packages/core/tests/functional/routeLifecycle/addActivateGuard.test.ts
@@ -1,6 +1,8 @@
 import { logger } from "@real-router/logger";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
+import { getDependenciesApi } from "@real-router/core";
+
 import {
   createLifecycleTestRouter,
   errorCodes,
@@ -302,9 +304,9 @@ describe("core/route-lifecycle/addActivateGuard", () => {
       let receivedRouter: unknown;
       let receivedGetDependency: unknown;
 
-      // Set up a test dependency
-      // @ts-expect-error: testing with custom dependency
-      router.setDependency("testValue", "hello");
+      const deps = getDependenciesApi(router);
+
+      (deps as any).set("testValue", "hello");
 
       router.addActivateGuard("testRoute", (r, getDep) => {
         receivedRouter = r;
@@ -314,7 +316,6 @@ describe("core/route-lifecycle/addActivateGuard", () => {
       });
 
       expect(receivedRouter).toBe(router);
-      // Check behavior: getDependency should work correctly
       expect(typeof receivedGetDependency).toBe("function");
       // @ts-expect-error: testing function call
       expect(receivedGetDependency("testValue")).toBe("hello");
@@ -323,9 +324,9 @@ describe("core/route-lifecycle/addActivateGuard", () => {
     it("should allow factory to access dependencies via getDependency", async () => {
       const apiService = { fetch: () => {} };
 
-      // Set up dependency first
-      // @ts-expect-error: testing with custom dependency
-      router.setDependency("testApi", apiService);
+      const deps = getDependenciesApi(router);
+
+      (deps as any).set("testApi", apiService);
 
       let accessedDependency: unknown;
 

--- a/packages/core/tests/functional/routerLifecycle/dispose.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/dispose.test.ts
@@ -1,6 +1,11 @@
 import { describe, beforeEach, it, expect, vi } from "vitest";
 
-import { errorCodes, events, getPluginApi } from "@real-router/core";
+import {
+  errorCodes,
+  events,
+  getDependenciesApi,
+  getPluginApi,
+} from "@real-router/core";
 
 import { createTestRouter } from "../../helpers";
 
@@ -168,15 +173,16 @@ describe("dispose", () => {
 
     it("dispose() clears dependencies", async () => {
       const r = router as Router<{ myDep: string }>;
+      const deps = getDependenciesApi(r);
 
-      r.setDependency("myDep", "value");
+      deps.set("myDep", "value");
 
-      expect(r.hasDependency("myDep")).toBe(true);
+      expect(deps.has("myDep")).toBe(true);
 
       await router.start("/home");
       router.dispose();
 
-      expect(r.hasDependency("myDep")).toBe(false);
+      expect(deps.has("myDep")).toBe(false);
     });
   });
 
@@ -344,15 +350,16 @@ describe("dispose", () => {
       }
     });
 
-    it("setDependency() throws ROUTER_DISPOSED after dispose()", () => {
+    it("getDependenciesApi set() throws ROUTER_DISPOSED after dispose()", () => {
       const r = router as Router<{ key: string }>;
+      const deps = getDependenciesApi(r);
 
       expect(() => {
-        r.setDependency("key", "value");
+        deps.set("key", "value");
       }).toThrowError();
 
       try {
-        r.setDependency("key", "value");
+        deps.set("key", "value");
       } catch (error: any) {
         expect(error.code).toBe(errorCodes.ROUTER_DISPOSED);
       }

--- a/packages/core/tests/functional/routes/routeTree/clearRoutes.test.ts
+++ b/packages/core/tests/functional/routes/routeTree/clearRoutes.test.ts
@@ -1,7 +1,7 @@
 import { logger } from "@real-router/logger";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
-import { events, getPluginApi } from "@real-router/core";
+import { events, getDependenciesApi, getPluginApi } from "@real-router/core";
 
 import { createTestRouter } from "../../../helpers";
 
@@ -313,11 +313,13 @@ describe("core/routes/clearRoutes", () => {
       }
       const typedRouter = router as Router<TestDeps>;
 
-      typedRouter.setDependency("api", { fetch: () => {} });
+      const deps = getDependenciesApi(typedRouter);
+
+      deps.set("api", { fetch: () => {} });
 
       typedRouter.clearRoutes();
 
-      expect(typedRouter.hasDependency("api")).toBe(true);
+      expect(deps.has("api")).toBe(true);
     });
 
     it("should preserve options", async () => {

--- a/packages/router-benchmarks/src/02-navigation-plugins/2.1-sync-extensions.bench.ts
+++ b/packages/router-benchmarks/src/02-navigation-plugins/2.1-sync-extensions.bench.ts
@@ -1,5 +1,6 @@
 // packages/router-benchmarks/modules/02-navigation-plugins/2.1-sync-extensions.bench.ts
 
+import { getDependenciesApi } from "@real-router/core";
 import { bench } from "mitata";
 
 import { createSimpleRouter } from "../helpers";
@@ -102,8 +103,7 @@ const alternatingRoutes = ["about", "home"];
   const router = createSimpleRouter();
   let index = 0;
 
-  router // @ts-expect-error - test dependency
-    .setDependency("service", { check: () => true });
+  (getDependenciesApi(router) as any).set("service", { check: () => true });
   router.usePlugin(() => ({ onTransitionSuccess: () => {} }));
   router.start("/");
 
@@ -117,8 +117,7 @@ const alternatingRoutes = ["about", "home"];
   const router = createSimpleRouter();
   let index = 0;
 
-  router // @ts-expect-error - test dependency
-    .setDependency("auth", { isAllowed: () => true });
+  (getDependenciesApi(router) as any).set("auth", { isAllowed: () => true });
   router.addActivateGuard("about", () => () => true);
   router.addActivateGuard("home", () => () => true);
   router.start("/");

--- a/packages/router-benchmarks/src/03-dependencies/3.1-initialization.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.1-initialization.bench.ts
@@ -1,5 +1,6 @@
 // packages/router-benchmarks/modules/03-dependencies/3.1-initialization.bench.ts
 
+import { getDependenciesApi } from "@real-router/core";
 import { bench } from "mitata";
 
 import { createRouter, IS_ROUTER5 } from "../helpers";
@@ -22,8 +23,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.1 Setting empty dependencies (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies({});
-      router.resetDependencies();
+      getDependenciesApi(router).setAll({});
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -34,9 +35,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.2 Setting single dependency (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      // @ts-expect-error - test dependency
-      router.setDependency("service", { name: "test" });
-      router.resetDependencies();
+      (getDependenciesApi(router) as any).set("service", { name: "test" });
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -52,8 +52,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.3 Setting multiple dependencies (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies(deps);
-      router.resetDependencies();
+      getDependenciesApi(router).setAll(deps);
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -69,8 +69,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.4 Setting simple dependencies (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies(simpleDeps);
-      router.resetDependencies();
+      getDependenciesApi(router).setAll(simpleDeps);
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -85,8 +85,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.5 Setting object dependencies (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies(objectDeps);
-      router.resetDependencies();
+      getDependenciesApi(router).setAll(objectDeps);
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -101,8 +101,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.1.6 Setting function dependencies (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies(funcDeps);
-      router.resetDependencies();
+      getDependenciesApi(router).setAll(funcDeps);
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }

--- a/packages/router-benchmarks/src/03-dependencies/3.2-adding.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.2-adding.bench.ts
@@ -1,5 +1,6 @@
 // packages/router-benchmarks/modules/03-dependencies/3.2-adding.bench.ts
 
+import { getDependenciesApi } from "@real-router/core";
 import { bench } from "mitata";
 
 import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
@@ -26,8 +27,8 @@ if (!IS_ROUTER5) {
   };
 
   bench("3.2.2 Batch adding dependencies with cleanup", () => {
-    router.setDependencies(deps);
-    router.resetDependencies();
+    getDependenciesApi(router).setAll(deps);
+    getDependenciesApi(router).reset();
   }).gc("inner");
 }
 

--- a/packages/router-benchmarks/src/03-dependencies/3.4-edge-cases.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.4-edge-cases.bench.ts
@@ -1,5 +1,6 @@
 // packages/router-benchmarks/modules/03-dependencies/3.4-edge-cases.bench.ts
 
+import { getDependenciesApi } from "@real-router/core";
 import { bench, do_not_optimize } from "mitata";
 
 import { createSimpleRouter, IS_ROUTER5 } from "../helpers";
@@ -35,8 +36,8 @@ if (!IS_ROUTER5) {
 
   bench(`3.4.2 Adding dependency with undefined value (×${BATCH})`, () => {
     for (let i = 0; i < BATCH; i++) {
-      router.setDependencies(depsWithUndefined);
-      router.resetDependencies();
+      getDependenciesApi(router).setAll(depsWithUndefined);
+      getDependenciesApi(router).reset();
     }
   }).gc("inner");
 }
@@ -54,8 +55,8 @@ if (!IS_ROUTER5) {
     `3.4.3 Working with dependencies at warning threshold (×${BATCH})`,
     () => {
       for (let i = 0; i < BATCH; i++) {
-        router.setDependencies(deps);
-        router.resetDependencies();
+        getDependenciesApi(router).setAll(deps);
+        getDependenciesApi(router).reset();
       }
     },
   ).gc("inner");
@@ -74,8 +75,8 @@ if (!IS_ROUTER5) {
     `3.4.4 Working with dependencies at error threshold (×${BATCH})`,
     () => {
       for (let i = 0; i < BATCH; i++) {
-        router.setDependencies(deps);
-        router.resetDependencies();
+        getDependenciesApi(router).setAll(deps);
+        getDependenciesApi(router).reset();
       }
     },
   ).gc("inner");
@@ -168,7 +169,7 @@ if (!IS_ROUTER5) {
   const serviceB = { name: "B", dependency: serviceA };
   const serviceC = { name: "C", dependency: serviceB };
 
-  router.setDependencies({
+  getDependenciesApi(router).setAll({
     serviceA,
     serviceB,
     serviceC,

--- a/packages/router-benchmarks/src/03-dependencies/3.5-router-comparison.bench.ts
+++ b/packages/router-benchmarks/src/03-dependencies/3.5-router-comparison.bench.ts
@@ -11,6 +11,7 @@
  * These tests use the common API available in both routers.
  */
 
+import { getDependenciesApi } from "@real-router/core";
 import { bench, do_not_optimize } from "mitata";
 
 import { createRouter, IS_ROUTER5 } from "../helpers";
@@ -503,7 +504,7 @@ if (!IS_ROUTER5) {
     "3.5.15 Batch: getDependency direct access (1000 iterations, real-router only)",
     () => {
       for (let i = 0; i < 1000; i++) {
-        do_not_optimize(router.getDependency("authService"));
+        do_not_optimize(getDependenciesApi(router).get("authService"));
       }
     },
   ).gc("inner");
@@ -540,8 +541,8 @@ if (!IS_ROUTER5) {
     "3.5.17 Batch: setDependencies/resetDependencies cycle (1000 iterations, real-router only)",
     () => {
       for (let i = 0; i < 1000; i++) {
-        router.setDependencies(depsSets[i % 2]);
-        router.resetDependencies();
+        getDependenciesApi(router).setAll(depsSets[i % 2]);
+        getDependenciesApi(router).reset();
       }
     },
   ).gc("inner");


### PR DESCRIPTION
## Summary

Phase 2 of the [modular router RFC](https://github.com/greydragon888/real-router/issues/170): switch `getDependenciesApi()` from internal delegation to standalone implementation via WeakMap. Remove DI methods from the public `Router` class.

- **`getDependenciesApi()` rewritten** — uses WeakMap internals directly (`dependencyGet`, `dependencySet`, etc.) with inline validation, no longer delegates to Router methods
- **DI methods removed from Router:** `setDependency`, `setDependencies`, `removeDependency`, `resetDependencies`, `hasDependency`, `getDependency`, `getDependencies`
- **`getDependency` preserved internally** — still injected via factories into plugins, guards, and `forwardTo` callbacks
- **Limits validation preserved** — `maxDependencies` exposed in `RouterInternals`, enforced in `setAll()`

**Breaking Change:** DI methods removed from Router. Use `getDependenciesApi(router)` instead.

```diff
- router.setDependency("api", apiService);
- const dep = router.getDependency("api");
+ import { getDependenciesApi } from "@real-router/core";
+ const deps = getDependenciesApi(router);
+ deps.set("api", apiService);
+ const dep = deps.get("api");
```

## Test plan

- [ ] All existing tests pass (no regressions)
- [ ] `getDependenciesApi` tested: get, getAll, set, setAll, remove, reset, has
- [ ] Disposed router: mutating methods throw, read-only methods work
- [ ] Limits enforcement: maxDependencies, warn/error thresholds
- [ ] Internal `getDependency` injection: plugins, guards, `forwardTo` callbacks, options callbacks
- [ ] 100% test coverage maintained
- [ ] `pnpm type-check && pnpm lint && pnpm test -- --run` passes

Closes #172