### PR TITLE
refactor(logger-plugin): align with plugin architecture conventions (#250)

### DIFF
--- a/.changeset/logger-plugin-refactor.md
+++ b/.changeset/logger-plugin-refactor.md
@@ -1,0 +1,18 @@
+---
+"@real-router/logger-plugin": minor
+---
+
+Align logger-plugin with plugin architecture conventions (#250)
+
+**BREAKING CHANGE:** Removed `loggerPlugin` singleton export. Use `loggerPluginFactory()` instead.
+
+**Migration:**
+
+```diff
+- import { loggerPlugin } from "@real-router/logger-plugin";
+- router.usePlugin(loggerPlugin);
++ import { loggerPluginFactory } from "@real-router/logger-plugin";
++ router.usePlugin(loggerPluginFactory());
+```
+
+Internal changes: converted closure to `LoggerPlugin` class with `getPlugin()` pattern, extracted factory.ts, added options validation, added LOGGER_CONTEXT/ERROR_PREFIX constants, fixed stale path comments.

--- a/packages/logger-plugin/ARCHITECTURE.md
+++ b/packages/logger-plugin/ARCHITECTURE.md
@@ -13,10 +13,14 @@
 ```
 logger-plugin/
 ├── src/
-│   ├── plugin.ts                      — Plugin factory + lifecycle hooks (242 lines)
+│   ├── factory.ts                     — loggerPluginFactory: validates options, merges defaults,
+│   │                                    returns PluginFactory → new LoggerPlugin(config).getPlugin()
+│   ├── plugin.ts                      — LoggerPlugin class: pre-computes flags in constructor,
+│   │                                    getPlugin() returns Plugin with lifecycle hooks + teardown
+│   ├── validation.ts                  — validateOptions: level, context, boolean flags (TypeError)
 │   ├── types.ts                       — LoggerPluginConfig, LogLevel
-│   ├── constants.ts                   — DEFAULT_CONFIG
-│   ├── index.ts                       — Public API exports
+│   ├── constants.ts                   — LOGGER_CONTEXT, ERROR_PREFIX, DEFAULT_CONFIG
+│   ├── index.ts                       — Public API exports (loggerPluginFactory + types)
 │   └── internal/
 │       ├── console-groups.ts          — Console group manager (74 lines)
 │       ├── formatting.ts             — Route name, timing, label formatting (56 lines)
@@ -39,10 +43,10 @@ graph LR
     end
 ```
 
-| Import source         | What it uses                        | Purpose                                |
-| --------------------- | ----------------------------------- | -------------------------------------- |
-| **@real-router/core** | `PluginFactory` type                | Plugin factory return type             |
-| **@real-router/core** | `State`, `RouterError`, `Params`    | Lifecycle hook parameter types         |
+| Import source         | What it uses                     | Purpose                        |
+| --------------------- | -------------------------------- | ------------------------------ |
+| **@real-router/core** | `PluginFactory` type             | Plugin factory return type     |
+| **@real-router/core** | `State`, `RouterError`, `Params` | Lifecycle hook parameter types |
 
 ## Public API
 
@@ -54,12 +58,6 @@ function loggerPluginFactory(
 ): PluginFactory;
 ```
 
-### loggerPlugin — Default Singleton
-
-```typescript
-const loggerPlugin: PluginFactory; // loggerPluginFactory() with defaults
-```
-
 ### Types
 
 ```typescript
@@ -67,10 +65,10 @@ type LogLevel = "all" | "transitions" | "errors" | "none";
 
 interface LoggerPluginConfig {
   usePerformanceMarks?: boolean; // Performance API marks/measures (default: false)
-  level?: LogLevel;              // Log level filter (default: "all")
-  showTiming?: boolean;          // Transition timing in ms/μs (default: true)
-  showParamsDiff?: boolean;      // Params diff for same-route nav (default: true)
-  context?: string;              // Console prefix (default: "logger-plugin")
+  level?: LogLevel; // Log level filter (default: "all")
+  showTiming?: boolean; // Transition timing in ms/μs (default: true)
+  showParamsDiff?: boolean; // Params diff for same-route nav (default: true)
+  context?: string; // Console prefix (default: "logger-plugin")
 }
 ```
 
@@ -90,42 +88,44 @@ const DEFAULT_CONFIG: Required<LoggerPluginConfig> = {
 
 Not exported — used internally by `loggerPluginFactory` to merge with user options.
 
-**Note:** `showParamsDiff` defaults to `true` in `DEFAULT_CONFIG`, while the JSDoc `@default` says `false`. The runtime default is `true`.
-
 ### Pre-Computed Flags
 
 ```typescript
-// Computed once at factory creation — no runtime condition checks
-const logLifecycle = config.level === "all";
-const logTransition = config.level !== "none" && config.level !== "errors";
-const logWarning = logTransition;
-const logError = config.level !== "none";
-const shouldLogParams = logTransition && config.showParamsDiff;
-const shouldShowTiming = config.showTiming;
-const prefix = `[${config.context}]`;
+// Computed once in LoggerPlugin constructor — no runtime condition checks
+readonly #logLifecycle = config.level === "all";
+readonly #logTransition = config.level !== "none" && config.level !== "errors";
+readonly #logWarning = this.#logTransition;
+readonly #logError = config.level !== "none";
+readonly #shouldLogParams = this.#logTransition && config.showParamsDiff;
+readonly #shouldShowTiming = config.showTiming;
+readonly #prefix = `[${config.context}]`;
 ```
 
-| Level          | logLifecycle | logTransition | logWarning | logError |
-| -------------- | ------------ | ------------- | ---------- | -------- |
-| `"all"`        | true         | true          | true       | true     |
-| `"transitions"`| false        | true          | true       | true     |
-| `"errors"`     | false        | false         | false      | true     |
-| `"none"`       | false        | false         | false      | false    |
+| Level           | logLifecycle | logTransition | logWarning | logError |
+| --------------- | ------------ | ------------- | ---------- | -------- |
+| `"all"`         | true         | true          | true       | true     |
+| `"transitions"` | false        | true          | true       | true     |
+| `"errors"`      | false        | false         | false      | true     |
+| `"none"`        | false        | false         | false      | false    |
 
 ### Plugin Instance State
 
 ```typescript
-// Created per router instance (inside factory return)
-let transitionStartTime: number | null = null; // Timing start
-let transitionLabel = "";                       // "{from}→{to}" for perf marks
-let startMarkName = "";                         // "router:transition-start:{label}"
+// Private fields on LoggerPlugin — created per router instance
+#transitionStartTime: number | null = null;
+#transitionLabel = "";
+#startMarkName = "";
 ```
 
 ### Internal Managers
 
 ```typescript
-const groups: GroupManager = createGroupManager(supportsConsoleGroups());
-const perf: PerformanceTracker = createPerformanceTracker(config.usePerformanceMarks, config.context);
+// Created in LoggerPlugin constructor
+readonly #groups: GroupManager = createGroupManager(supportsConsoleGroups());
+readonly #perf: PerformanceTracker = createPerformanceTracker(
+  config.usePerformanceMarks,
+  config.context,
+);
 ```
 
 Both use the **capability detection + no-op pattern**: if the environment lacks `console.group` or `performance.mark`, all calls become no-ops.
@@ -137,12 +137,14 @@ Both use the **capability detection + no-op pattern**: if the environment lacks 
 ```
 router.usePlugin(loggerPluginFactory(options))
     │
+    ├── validateOptions(options)
     ├── Config merge: { ...DEFAULT_CONFIG, ...options }
-    ├── Pre-compute flags (logLifecycle, logTransition, etc.)
     └── Return factory → called per router instance
             │
-            ├── Create GroupManager + PerformanceTracker
-            └── Return plugin object with 6 hooks:
+            └── new LoggerPlugin(config).getPlugin()
+                    │
+                    ├── Constructor: create GroupManager + PerformanceTracker
+                    └── getPlugin() returns plugin object with 6 hooks:
 
 onStart()
     ├── perf.mark("router:start")
@@ -185,15 +187,15 @@ teardown()
     └── resetTransitionState()
 ```
 
-### resetTransitionState()
+### #resetTransitionState()
 
 ```typescript
-const resetTransitionState = (): void => {
-  groups.close();
-  transitionLabel = "";
-  startMarkName = "";
-  transitionStartTime = null;
-};
+#resetTransitionState(): void {
+  this.#groups.close();
+  this.#transitionLabel = "";
+  this.#startMarkName = "";
+  this.#transitionStartTime = null;
+}
 ```
 
 Called **after** timing is read — preserves `transitionStartTime` until log message is formatted.
@@ -255,36 +257,36 @@ createPerformanceTracker(enabled, context)
 
 When `usePerformanceMarks: true`:
 
-| Event              | Mark name                               | Measure name                              |
-| ------------------ | --------------------------------------- | ----------------------------------------- |
-| Router start       | `router:start`                          | —                                         |
-| Transition start   | `router:transition-start:{from}→{to}`   | —                                         |
-| Transition success | `router:transition-end:{from}→{to}`     | `router:transition:{from}→{to}`           |
-| Transition cancel  | `router:transition-cancel:{from}→{to}`  | `router:transition-cancelled:{from}→{to}` |
-| Transition error   | `router:transition-error:{from}→{to}`   | `router:transition-failed:{from}→{to}`    |
-| Router stop        | `router:stop`                           | `router:lifetime`                         |
+| Event              | Mark name                              | Measure name                              |
+| ------------------ | -------------------------------------- | ----------------------------------------- |
+| Router start       | `router:start`                         | —                                         |
+| Transition start   | `router:transition-start:{from}→{to}`  | —                                         |
+| Transition success | `router:transition-end:{from}→{to}`    | `router:transition:{from}→{to}`           |
+| Transition cancel  | `router:transition-cancel:{from}→{to}` | `router:transition-cancelled:{from}→{to}` |
+| Transition error   | `router:transition-error:{from}→{to}`  | `router:transition-failed:{from}→{to}`    |
+| Router stop        | `router:stop`                          | `router:lifetime`                         |
 
 All marks/measures are visible in browser DevTools Performance tab.
 
 ## Console Output
 
-| Hook                 | Method         | Guard          | Format                                          |
-| -------------------- | -------------- | -------------- | ----------------------------------------------- |
-| `onStart`            | `console.log`  | `logLifecycle` | `[ctx] Router started`                          |
-| `onStop`             | `console.log`  | `logLifecycle` | `[ctx] Router stopped`                          |
-| `onTransitionStart`  | `console.log`  | `logTransition`| `[ctx] Transition: {from} → {to}`               |
-| `onTransitionSuccess`| `console.log`  | `logTransition`| `[ctx] Transition success (Xms)`                |
-| `onTransitionCancel` | `console.warn` | `logWarning`   | `[ctx] Transition cancelled (Xms)`              |
-| `onTransitionError`  | `console.error`| `logError`     | `[ctx] Transition error: {code} (Xms)`          |
-| params diff          | `console.log`  | `shouldLogParams` | `[ctx]  Changed: { ... }, Added: {...}`      |
+| Hook                  | Method          | Guard             | Format                                  |
+| --------------------- | --------------- | ----------------- | --------------------------------------- |
+| `onStart`             | `console.log`   | `logLifecycle`    | `[ctx] Router started`                  |
+| `onStop`              | `console.log`   | `logLifecycle`    | `[ctx] Router stopped`                  |
+| `onTransitionStart`   | `console.log`   | `logTransition`   | `[ctx] Transition: {from} → {to}`       |
+| `onTransitionSuccess` | `console.log`   | `logTransition`   | `[ctx] Transition success (Xms)`        |
+| `onTransitionCancel`  | `console.warn`  | `logWarning`      | `[ctx] Transition cancelled (Xms)`      |
+| `onTransitionError`   | `console.error` | `logError`        | `[ctx] Transition error: {code} (Xms)`  |
+| params diff           | `console.log`   | `shouldLogParams` | `[ctx]  Changed: { ... }, Added: {...}` |
 
 ## Environment Detection
 
-| API                  | Check                                                                   | Fallback                          |
-| -------------------- | ----------------------------------------------------------------------- | --------------------------------- |
-| `console.group`      | `typeof console !== "undefined"` + `group` + `groupEnd` are functions   | Groups disabled (no-op)           |
-| `performance.mark`   | `typeof performance !== "undefined"` + `mark` + `measure` are functions | Marks/measures disabled (no-op)   |
-| `performance.now`    | `typeof performance !== "undefined"` + `now` is a function              | Monotonic `Date.now()` wrapper    |
+| API                | Check                                                                   | Fallback                        |
+| ------------------ | ----------------------------------------------------------------------- | ------------------------------- |
+| `console.group`    | `typeof console !== "undefined"` + `group` + `groupEnd` are functions   | Groups disabled (no-op)         |
+| `performance.mark` | `typeof performance !== "undefined"` + `mark` + `measure` are functions | Marks/measures disabled (no-op) |
+| `performance.now`  | `typeof performance !== "undefined"` + `now` is a function              | Monotonic `Date.now()` wrapper  |
 
 All checks happen once (at manager/provider creation), not per call.
 

--- a/packages/logger-plugin/README.md
+++ b/packages/logger-plugin/README.md
@@ -55,20 +55,12 @@ import { loggerPluginFactory } from "@real-router/logger-plugin";
 router.usePlugin(loggerPluginFactory());
 
 // With custom options
-router.usePlugin(loggerPluginFactory({
-  level: "errors",
-  showTiming: false,
-}));
-```
-
-### `loggerPlugin`
-
-Ready-to-use plugin instance with default settings. Provided for backward compatibility.
-
-```typescript
-import { loggerPlugin } from "@real-router/logger-plugin";
-
-router.usePlugin(loggerPlugin);
+router.usePlugin(
+  loggerPluginFactory({
+    level: "errors",
+    showTiming: false,
+  }),
+);
 ```
 
 ---
@@ -87,28 +79,36 @@ router.usePlugin(loggerPlugin);
 
 ```typescript
 // With custom context for multiple routers
-router.usePlugin(loggerPluginFactory({
-  context: "main-router",
-}));
+router.usePlugin(
+  loggerPluginFactory({
+    context: "main-router",
+  }),
+);
 
 // Performance profiling enabled
-router.usePlugin(loggerPluginFactory({
-  usePerformanceMarks: true,
-  showTiming: true,
-}));
+router.usePlugin(
+  loggerPluginFactory({
+    usePerformanceMarks: true,
+    showTiming: true,
+  }),
+);
 
 // Errors only (for production-like environments)
-router.usePlugin(loggerPluginFactory({
-  level: "errors",
-  showTiming: false,
-}));
+router.usePlugin(
+  loggerPluginFactory({
+    level: "errors",
+    showTiming: false,
+  }),
+);
 
 // Minimal output
-router.usePlugin(loggerPluginFactory({
-  level: "transitions",
-  showParamsDiff: false,
-  showTiming: false,
-}));
+router.usePlugin(
+  loggerPluginFactory({
+    level: "transitions",
+    showParamsDiff: false,
+    showTiming: false,
+  }),
+);
 ```
 
 See [Wiki](https://github.com/greydragon888/real-router/wiki/logger-plugin#3-configuration-options) for detailed descriptions.

--- a/packages/logger-plugin/src/constants.ts
+++ b/packages/logger-plugin/src/constants.ts
@@ -1,11 +1,15 @@
-// packages/logger-plugin/modules/constants.ts
+// packages/logger-plugin/src/constants.ts
 
 import type { LoggerPluginConfig } from "./types";
+
+export const LOGGER_CONTEXT = "logger-plugin";
+
+export const ERROR_PREFIX = `[@real-router/${LOGGER_CONTEXT}]`;
 
 export const DEFAULT_CONFIG: Required<LoggerPluginConfig> = {
   level: "all",
   usePerformanceMarks: false,
   showParamsDiff: true,
   showTiming: true,
-  context: "logger-plugin",
+  context: LOGGER_CONTEXT,
 };

--- a/packages/logger-plugin/src/factory.ts
+++ b/packages/logger-plugin/src/factory.ts
@@ -1,0 +1,21 @@
+// packages/logger-plugin/src/factory.ts
+
+import { DEFAULT_CONFIG } from "./constants";
+import { LoggerPlugin } from "./plugin";
+import { validateOptions } from "./validation";
+
+import type { LoggerPluginConfig } from "./types";
+import type { PluginFactory } from "@real-router/core";
+
+export function loggerPluginFactory(
+  options?: Partial<LoggerPluginConfig>,
+): PluginFactory {
+  validateOptions(options);
+
+  const config: Required<LoggerPluginConfig> = {
+    ...DEFAULT_CONFIG,
+    ...options,
+  };
+
+  return () => new LoggerPlugin(config).getPlugin();
+}

--- a/packages/logger-plugin/src/index.ts
+++ b/packages/logger-plugin/src/index.ts
@@ -1,9 +1,5 @@
-// packages/logger-plugin/modules/index.ts
+// packages/logger-plugin/src/index.ts
 
-// Public API exports for real-router-logger-plugin
+export { loggerPluginFactory } from "./factory";
 
-// Main plugin factory and instance
-export { loggerPluginFactory, loggerPlugin } from "./plugin";
-
-// Types
 export type { LoggerPluginConfig, LogLevel } from "./types";

--- a/packages/logger-plugin/src/internal/console-groups.ts
+++ b/packages/logger-plugin/src/internal/console-groups.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/internal/console-groups.ts
+// packages/logger-plugin/src/internal/console-groups.ts
 
 /**
  * Checks if console.group is supported in the current environment.
@@ -14,7 +14,7 @@ export const supportsConsoleGroups = (): boolean => {
 /**
  * Manager for handling console groups
  */
-interface GroupManager {
+export interface GroupManager {
   /**
    * Opens a group if it's not already open
    */

--- a/packages/logger-plugin/src/internal/formatting.ts
+++ b/packages/logger-plugin/src/internal/formatting.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/internal/formatting.ts
+// packages/logger-plugin/src/internal/formatting.ts
 
 import type { State } from "@real-router/core";
 

--- a/packages/logger-plugin/src/internal/params-diff.ts
+++ b/packages/logger-plugin/src/internal/params-diff.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/internal/params-diff.ts
+// packages/logger-plugin/src/internal/params-diff.ts
 
 import type { Params } from "@real-router/core";
 

--- a/packages/logger-plugin/src/internal/performance-marks.ts
+++ b/packages/logger-plugin/src/internal/performance-marks.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/internal/performance-marks.ts
+// packages/logger-plugin/src/internal/performance-marks.ts
 
 /**
  * Checks if Performance API is supported in the current environment.
@@ -14,7 +14,7 @@ export const supportsPerformanceAPI = (): boolean => {
 /**
  * Performance tracker interface with mark and measure methods.
  */
-interface PerformanceTracker {
+export interface PerformanceTracker {
   mark: (name: string) => void;
   measure: (measureName: string, startMark: string, endMark: string) => void;
 }

--- a/packages/logger-plugin/src/internal/timing.ts
+++ b/packages/logger-plugin/src/internal/timing.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/internal/timing.ts
+// packages/logger-plugin/src/internal/timing.ts
 
 /**
  * Function that returns high-resolution timestamp in milliseconds.

--- a/packages/logger-plugin/src/plugin.ts
+++ b/packages/logger-plugin/src/plugin.ts
@@ -1,6 +1,5 @@
-// packages/logger-plugin/modules/plugin.ts
+// packages/logger-plugin/src/plugin.ts
 
-import { DEFAULT_CONFIG } from "./constants";
 import {
   createGroupManager,
   supportsConsoleGroups,
@@ -14,229 +13,210 @@ import { getParamsDiff, logParamsDiff } from "./internal/params-diff";
 import { createPerformanceTracker } from "./internal/performance-marks";
 import { now } from "./internal/timing";
 
+import type { GroupManager } from "./internal/console-groups";
+import type { PerformanceTracker } from "./internal/performance-marks";
 import type { LoggerPluginConfig } from "./types";
-import type { PluginFactory, RouterError, State } from "@real-router/core";
+import type { Plugin, RouterError, State } from "@real-router/core";
 
-/**
- * Creates a logger-plugin for real-router.
- *
- * @param options - Plugin configuration options
- * @returns Plugin factory function for real-router
- *
- * @example
- * ```ts
- * import { loggerPluginFactory } from "@real-router/logger-plugin";
- *
- * // Use with default configuration
- * router.usePlugin(loggerPluginFactory());
- *
- * // Use with custom configuration
- * router.usePlugin(loggerPluginFactory({
- *   level: 'errors',           // only log errors
- *   usePerformanceMarks: true, // enable Performance API
- *   showTiming: false,         // disable timing info
- *   showParamsDiff: false,     // disable params diff
- *   context: 'my-router',      // custom context name
- * }));
- * ```
- */
-export function loggerPluginFactory(
-  options?: Partial<LoggerPluginConfig>,
-): PluginFactory {
-  // Merge options with defaults
-  const config: Required<LoggerPluginConfig> = {
-    ...DEFAULT_CONFIG,
-    ...options,
-  };
+export class LoggerPlugin {
+  readonly #logLifecycle: boolean;
+  readonly #logTransition: boolean;
+  readonly #logError: boolean;
 
-  // Pre-compute log level flags
-  const logLifecycle = config.level === "all";
-  const logTransition = config.level !== "none" && config.level !== "errors";
-  const logWarning = logTransition;
-  const logError = config.level !== "none";
+  readonly #shouldLogParams: boolean;
+  readonly #shouldShowTiming: boolean;
+  readonly #usePerf: boolean;
 
-  // Pre-compute feature flags
-  const shouldLogParams = logTransition && config.showParamsDiff;
-  const shouldShowTiming = config.showTiming;
+  readonly #prefix: string;
+  readonly #context: string;
 
-  // Cached prefix
-  const prefix = `[${config.context}]`;
+  readonly #groups: GroupManager;
+  readonly #perf: PerformanceTracker;
 
-  return () => {
-    // Create helper managers
-    const groups = createGroupManager(supportsConsoleGroups());
-    const perf = createPerformanceTracker(
+  // Transition state
+  #transitionStartTime: number | null = null;
+  #transitionLabel = "";
+  #startMarkName = "";
+
+  constructor(config: Required<LoggerPluginConfig>) {
+    this.#logLifecycle = config.level === "all";
+    this.#logTransition = config.level !== "none" && config.level !== "errors";
+    this.#logError = config.level !== "none";
+
+    this.#shouldLogParams = this.#logTransition && config.showParamsDiff;
+    this.#shouldShowTiming = config.showTiming;
+    this.#usePerf = config.usePerformanceMarks;
+
+    this.#prefix = `[${config.context}]`;
+    this.#context = config.context;
+
+    this.#groups = createGroupManager(supportsConsoleGroups());
+    this.#perf = createPerformanceTracker(
       config.usePerformanceMarks,
       config.context,
     );
+  }
 
-    // Transition state
-    let transitionStartTime: number | null = null;
-    let transitionLabel = "";
-    let startMarkName = "";
-
-    /**
-     * Logs parameter differences when navigating within the same route.
-     */
-    const logParamsIfNeeded = (toState: State, fromState?: State): void => {
-      if (!shouldLogParams || !fromState) {
-        return;
-      }
-
-      // Show diff only for the same route
-      if (toState.name !== fromState.name) {
-        return;
-      }
-
-      const diff = getParamsDiff(fromState.params, toState.params);
-
-      if (diff) {
-        logParamsDiff(diff, config.context);
-      }
-    };
-
-    /**
-     * Resets transition state. Must be called AFTER timing is read.
-     */
-    const resetTransitionState = (): void => {
-      groups.close();
-      transitionLabel = "";
-      startMarkName = "";
-      transitionStartTime = null;
-    };
-
+  getPlugin(): Plugin {
     return {
-      onStart() {
-        perf.mark("router:start");
+      onStart: () => {
+        this.#perf.mark("router:start");
 
-        if (logLifecycle) {
-          console.log(`${prefix} Router started`);
+        if (this.#logLifecycle) {
+          console.log(`${this.#prefix} Router started`);
         }
       },
 
-      onStop() {
-        groups.close();
+      onStop: () => {
+        this.#groups.close();
 
-        perf.mark("router:stop");
-        perf.measure("router:lifetime", "router:start", "router:stop");
+        this.#perf.mark("router:stop");
+        this.#perf.measure("router:lifetime", "router:start", "router:stop");
 
-        if (logLifecycle) {
-          console.log(`${prefix} Router stopped`);
+        if (this.#logLifecycle) {
+          console.log(`${this.#prefix} Router stopped`);
         }
       },
 
-      onTransitionStart(toState: State, fromState?: State) {
-        groups.open("Router transition");
-        transitionStartTime = now();
+      onTransitionStart: (toState: State, fromState?: State) => {
+        this.#groups.open("Router transition");
+        this.#transitionStartTime = this.#shouldShowTiming ? now() : null;
 
         const fromRoute = formatRouteName(fromState);
         const toRoute = formatRouteName(toState);
 
-        transitionLabel = createTransitionLabel(fromRoute, toRoute);
-        startMarkName = `router:transition-start:${transitionLabel}`;
+        if (this.#usePerf) {
+          this.#transitionLabel = createTransitionLabel(fromRoute, toRoute);
+          this.#startMarkName = `router:transition-start:${this.#transitionLabel}`;
+          this.#perf.mark(this.#startMarkName);
+        }
 
-        perf.mark(startMarkName);
-
-        if (logTransition) {
-          console.log(`${prefix} Transition: ${fromRoute} → ${toRoute}`, {
+        if (this.#logTransition) {
+          console.log(`${this.#prefix} Transition: ${fromRoute} → ${toRoute}`, {
             from: fromState,
             to: toState,
           });
 
-          logParamsIfNeeded(toState, fromState);
+          this.#logParamsIfNeeded(toState, fromState);
         }
       },
 
-      onTransitionSuccess(toState: State, fromState?: State) {
-        const label = transitionLabel;
-        const endMark = `router:transition-end:${label}`;
+      onTransitionSuccess: (toState: State, fromState?: State) => {
+        if (this.#usePerf) {
+          const label = this.#transitionLabel;
+          const endMark = `router:transition-end:${label}`;
 
-        perf.mark(endMark);
-        perf.measure(`router:transition:${label}`, startMarkName, endMark);
+          this.#perf.mark(endMark);
+          this.#perf.measure(
+            `router:transition:${label}`,
+            this.#startMarkName,
+            endMark,
+          );
+        }
 
-        if (logTransition) {
-          const timing = shouldShowTiming
-            ? formatTiming(transitionStartTime, now)
+        if (this.#logTransition) {
+          const timing = this.#shouldShowTiming
+            ? formatTiming(this.#transitionStartTime, now)
             : "";
 
-          console.log(`${prefix} Transition success${timing}`, {
+          console.log(`${this.#prefix} Transition success${timing}`, {
             to: toState,
             from: fromState,
           });
         }
 
-        resetTransitionState();
+        this.#resetTransitionState();
       },
 
-      onTransitionCancel(toState: State, fromState?: State) {
-        const label = transitionLabel;
-        const cancelMark = `router:transition-cancel:${label}`;
+      onTransitionCancel: (toState: State, fromState?: State) => {
+        if (this.#usePerf) {
+          const label = this.#transitionLabel;
+          const cancelMark = `router:transition-cancel:${label}`;
 
-        perf.mark(cancelMark);
-        perf.measure(
-          `router:transition-cancelled:${label}`,
-          startMarkName,
-          cancelMark,
-        );
+          this.#perf.mark(cancelMark);
+          this.#perf.measure(
+            `router:transition-cancelled:${label}`,
+            this.#startMarkName,
+            cancelMark,
+          );
+        }
 
-        if (logWarning) {
-          const timing = shouldShowTiming
-            ? formatTiming(transitionStartTime, now)
+        if (this.#logTransition) {
+          const timing = this.#shouldShowTiming
+            ? formatTiming(this.#transitionStartTime, now)
             : "";
 
-          console.warn(`${prefix} Transition cancelled${timing}`, {
+          console.warn(`${this.#prefix} Transition cancelled${timing}`, {
             to: toState,
             from: fromState,
           });
         }
 
-        resetTransitionState();
+        this.#resetTransitionState();
       },
 
-      onTransitionError(
+      onTransitionError: (
         toState: State | undefined,
         fromState: State | undefined,
         err: RouterError,
-      ) {
-        const label = transitionLabel;
-        const errorMark = `router:transition-error:${label}`;
+      ) => {
+        if (this.#usePerf) {
+          const label = this.#transitionLabel;
+          const errorMark = `router:transition-error:${label}`;
 
-        perf.mark(errorMark);
-        perf.measure(
-          `router:transition-failed:${label}`,
-          startMarkName,
-          errorMark,
-        );
-
-        if (logError) {
-          const timing = shouldShowTiming
-            ? formatTiming(transitionStartTime, now)
-            : "";
-
-          console.error(`${prefix} Transition error: ${err.code}${timing}`, {
-            error: err,
-            stack: err.stack,
-            to: toState,
-            from: fromState,
-          });
+          this.#perf.mark(errorMark);
+          this.#perf.measure(
+            `router:transition-failed:${label}`,
+            this.#startMarkName,
+            errorMark,
+          );
         }
 
-        resetTransitionState();
+        if (this.#logError) {
+          const timing = this.#shouldShowTiming
+            ? formatTiming(this.#transitionStartTime, now)
+            : "";
+
+          console.error(
+            `${this.#prefix} Transition error: ${err.code}${timing}`,
+            {
+              error: err,
+              stack: err.stack,
+              to: toState,
+              from: fromState,
+            },
+          );
+        }
+
+        this.#resetTransitionState();
       },
 
-      teardown() {
-        resetTransitionState();
+      teardown: () => {
+        this.#resetTransitionState();
       },
     };
-  };
-}
+  }
 
-/**
- * Default logger-plugin instance with standard configuration.
- * Provided for backward compatibility with existing code.
- *
- * @example
- * // Use default configuration
- * router.usePlugin(loggerPlugin);
- */
-export const loggerPlugin = loggerPluginFactory();
+  #logParamsIfNeeded(toState: State, fromState?: State): void {
+    if (!this.#shouldLogParams || !fromState) {
+      return;
+    }
+
+    if (toState.name !== fromState.name) {
+      return;
+    }
+
+    const diff = getParamsDiff(fromState.params, toState.params);
+
+    if (diff) {
+      logParamsDiff(diff, this.#context);
+    }
+  }
+
+  #resetTransitionState(): void {
+    this.#groups.close();
+    this.#transitionLabel = "";
+    this.#startMarkName = "";
+    this.#transitionStartTime = null;
+  }
+}

--- a/packages/logger-plugin/src/types.ts
+++ b/packages/logger-plugin/src/types.ts
@@ -1,4 +1,4 @@
-// packages/logger-plugin/modules/types.ts
+// packages/logger-plugin/src/types.ts
 
 /**
  * Logging level for router events.
@@ -53,7 +53,7 @@ export interface LoggerPluginConfig {
    * Only applies when navigating within the same route.
    * Helps identify which parameters changed during navigation.
    *
-   * @default false
+   * @default true
    */
   showParamsDiff?: boolean;
 

--- a/packages/logger-plugin/src/validation.ts
+++ b/packages/logger-plugin/src/validation.ts
@@ -1,0 +1,61 @@
+// packages/logger-plugin/src/validation.ts
+
+import { ERROR_PREFIX } from "./constants";
+
+import type { LoggerPluginConfig } from "./types";
+
+const VALID_LEVELS = new Set(["all", "transitions", "errors", "none"]);
+
+export function validateOptions(options?: Partial<LoggerPluginConfig>): void {
+  if (options === undefined) {
+    return;
+  }
+
+  // Runtime defense: typeof null === "object", so check identity first.
+  // TypeScript excludes null from the parameter type, but JS callers may pass it.
+  if (options === (null as never) || typeof options !== "object") {
+    throw new TypeError(`${ERROR_PREFIX} Options must be an object`);
+  }
+
+  if (options.level !== undefined && !VALID_LEVELS.has(options.level)) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Invalid level: "${options.level}". Expected: ${[...VALID_LEVELS].join(", ")}`,
+    );
+  }
+
+  if (
+    options.context !== undefined &&
+    (typeof options.context !== "string" || options.context.length === 0)
+  ) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Option "context" must be a non-empty string`,
+    );
+  }
+
+  if (
+    options.showTiming !== undefined &&
+    typeof options.showTiming !== "boolean"
+  ) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Option "showTiming" must be a boolean`,
+    );
+  }
+
+  if (
+    options.showParamsDiff !== undefined &&
+    typeof options.showParamsDiff !== "boolean"
+  ) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Option "showParamsDiff" must be a boolean`,
+    );
+  }
+
+  if (
+    options.usePerformanceMarks !== undefined &&
+    typeof options.usePerformanceMarks !== "boolean"
+  ) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Option "usePerformanceMarks" must be a boolean`,
+    );
+  }
+}

--- a/packages/logger-plugin/tests/functional/plugin.test.ts
+++ b/packages/logger-plugin/tests/functional/plugin.test.ts
@@ -1,7 +1,7 @@
 import { createRouter, errorCodes, getLifecycleApi } from "@real-router/core";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
-import { loggerPlugin, loggerPluginFactory } from "../../src";
+import { loggerPluginFactory } from "../../src";
 
 import type { Router, LifecycleApi } from "@real-router/core";
 
@@ -47,7 +47,7 @@ describe("@real-router/logger-plugin", () => {
 
   describe("Basic Functionality", () => {
     beforeEach(() => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
     });
 
     it("should log router start event", async () => {
@@ -145,22 +145,22 @@ describe("@real-router/logger-plugin", () => {
       vi.useRealTimers();
     });
 
-    it("should format route name as (none) when undefined", async () => {
+    it("should format route name as (none) when fromState is undefined", async () => {
       await router.start("/");
-      loggerSpy.mockClear();
-
-      await router.navigate("users");
 
       expect(loggerSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[logger-plugin] Transition: home → users"),
-        expect.any(Object),
+        "[logger-plugin] Transition: (none) → home",
+        expect.objectContaining({
+          from: undefined,
+          to: expect.objectContaining({ name: "home" }),
+        }),
       );
     });
   });
 
   describe("Console Groups", () => {
     it("should open group on transition start", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users");
@@ -169,7 +169,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should close group on transition success", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users");
@@ -178,7 +178,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should close group on transition error", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       try {
         await router.navigate("nonexistent");
@@ -191,7 +191,7 @@ describe("@real-router/logger-plugin", () => {
 
     it("should close group on transition cancel", async () => {
       lifecycle.addDeactivateGuard("home", () => () => false);
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       try {
         await router.navigate("users");
@@ -205,7 +205,7 @@ describe("@real-router/logger-plugin", () => {
     it("should close any open group on router stop", async () => {
       vi.useFakeTimers();
 
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
 
       await router.start("/");
 
@@ -239,7 +239,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should not open multiple groups for same transition", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       consoleGroupSpy.mockClear(); // Clear calls from start
 
@@ -250,7 +250,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should auto-detect console.group support", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users");
@@ -266,7 +266,7 @@ describe("@real-router/logger-plugin", () => {
 
       delete (console as any).group;
 
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users");
@@ -281,7 +281,7 @@ describe("@real-router/logger-plugin", () => {
 
       delete (console as any).groupEnd;
 
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users", {}, {});
@@ -296,25 +296,15 @@ describe("@real-router/logger-plugin", () => {
 
       delete (globalThis as any).console;
 
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
 
       expect(() => router.start("/")).not.toThrowError();
 
       globalThis.console = originalConsole;
     });
 
-    it("should not open group twice for same transition", async () => {
-      router.usePlugin(loggerPlugin);
-      await router.start("/");
-      consoleGroupSpy.mockClear();
-
-      await router.navigate("users");
-
-      expect(consoleGroupSpy).toHaveBeenCalledTimes(1);
-    });
-
     it("should handle rapid transitions correctly", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
 
       await router.navigate("users", {}, {});
@@ -326,7 +316,7 @@ describe("@real-router/logger-plugin", () => {
     it("should cleanup on teardown", async () => {
       vi.useFakeTimers();
 
-      const unsubscribe = router.usePlugin(loggerPlugin);
+      const unsubscribe = router.usePlugin(loggerPluginFactory());
 
       await router.start("/");
 
@@ -368,7 +358,7 @@ describe("@real-router/logger-plugin", () => {
       });
 
       router.usePlugin(customPlugin());
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
 
       await router.start("/");
 
@@ -378,7 +368,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should log nested route transitions", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       loggerSpy.mockClear();
 
@@ -391,7 +381,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should log transitions with parameters", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       loggerSpy.mockClear();
 
@@ -411,7 +401,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should handle router restart", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       router.stop();
       loggerSpy.mockClear();
@@ -424,7 +414,7 @@ describe("@real-router/logger-plugin", () => {
 
   describe("Params Diff Feature", () => {
     it("should show params diff when navigating within same route (default behavior)", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       loggerSpy.mockClear();
 
@@ -441,7 +431,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should not show diff when navigating to different route", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       loggerSpy.mockClear();
 
@@ -459,7 +449,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should not show diff when params are identical", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       await router.navigate("users.view", { id: "123" });
       loggerSpy.mockClear();
@@ -481,8 +471,8 @@ describe("@real-router/logger-plugin", () => {
   });
 
   describe("Backward Compatibility", () => {
-    it("should work with default loggerPlugin export", async () => {
-      router.usePlugin(loggerPlugin);
+    it("should work with default loggerPluginFactory", async () => {
+      router.usePlugin(loggerPluginFactory());
 
       await router.start("/");
 
@@ -490,7 +480,7 @@ describe("@real-router/logger-plugin", () => {
     });
 
     it("should maintain behavior for default usage", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       loggerSpy.mockClear();
       consoleGroupSpy.mockClear();
@@ -508,7 +498,7 @@ describe("@real-router/logger-plugin", () => {
 
   describe("Stress Testing", () => {
     it("should handle 100 transitions without errors", async () => {
-      router.usePlugin(loggerPlugin);
+      router.usePlugin(loggerPluginFactory());
       await router.start("/");
       for (let i = 0; i < 100; i++) {
         await router.navigate(i % 2 ? "users" : "admin");
@@ -756,6 +746,90 @@ describe("@real-router/logger-plugin", () => {
         await router.start("/");
 
         expect(loggerSpy).toHaveBeenCalledWith("[my-router] Router started");
+      });
+    });
+
+    describe("usePerformanceMarks option", () => {
+      let perfMarkSpy: ReturnType<typeof vi.spyOn>;
+      let perfMeasureSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        perfMarkSpy = vi.spyOn(performance, "mark");
+        perfMeasureSpy = vi.spyOn(performance, "measure");
+      });
+
+      it("should create perf marks on successful transition", async () => {
+        router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+        await router.start("/");
+        perfMarkSpy.mockClear();
+        perfMeasureSpy.mockClear();
+
+        await router.navigate("users");
+
+        expect(perfMarkSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-start:"),
+        );
+        expect(perfMarkSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-end:"),
+        );
+        expect(perfMeasureSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition:"),
+          expect.stringContaining("router:transition-start:"),
+          expect.stringContaining("router:transition-end:"),
+        );
+      });
+
+      it("should create perf marks on cancelled transition", async () => {
+        lifecycle.addActivateGuard(
+          "users",
+          () => () => new Promise<boolean>(() => {}),
+        );
+        router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+        await router.start("/");
+        perfMarkSpy.mockClear();
+        perfMeasureSpy.mockClear();
+
+        const navPromise = router.navigate("users");
+
+        await router.navigate("admin");
+
+        try {
+          await navPromise;
+        } catch {
+          // Expected TRANSITION_CANCELLED
+        }
+
+        expect(perfMarkSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-cancel:"),
+        );
+        expect(perfMeasureSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-cancelled:"),
+          expect.stringContaining("router:transition-start:"),
+          expect.stringContaining("router:transition-cancel:"),
+        );
+      });
+
+      it("should create perf marks on errored transition", async () => {
+        lifecycle.addDeactivateGuard("home", () => () => false);
+        router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+        await router.start("/");
+        perfMarkSpy.mockClear();
+        perfMeasureSpy.mockClear();
+
+        try {
+          await router.navigate("users");
+        } catch {
+          // Expected TRANSITION_CANCELLED error
+        }
+
+        expect(perfMarkSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-error:"),
+        );
+        expect(perfMeasureSpy).toHaveBeenCalledWith(
+          expect.stringContaining("router:transition-failed:"),
+          expect.stringContaining("router:transition-start:"),
+          expect.stringContaining("router:transition-error:"),
+        );
       });
     });
   });

--- a/packages/logger-plugin/tests/unit/validation.test.ts
+++ b/packages/logger-plugin/tests/unit/validation.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+
+import { validateOptions } from "../../src/validation";
+
+describe("validateOptions", () => {
+  it("should accept undefined options", () => {
+    expect(() => {
+      validateOptions();
+    }).not.toThrowError();
+  });
+
+  it("should accept empty options object", () => {
+    expect(() => {
+      validateOptions({});
+    }).not.toThrowError();
+  });
+
+  it("should accept all valid options", () => {
+    expect(() => {
+      validateOptions({
+        level: "all",
+        context: "my-router",
+        showTiming: true,
+        showParamsDiff: false,
+        usePerformanceMarks: true,
+      });
+    }).not.toThrowError();
+  });
+
+  it("should throw TypeError for non-object options", () => {
+    expect(() => {
+      validateOptions("string" as never);
+    }).toThrowError(TypeError);
+    expect(() => {
+      validateOptions(42 as never);
+    }).toThrowError(TypeError);
+    expect(() => {
+      validateOptions(true as never);
+    }).toThrowError(TypeError);
+  });
+
+  it("should throw TypeError for null options", () => {
+    expect(() => {
+      validateOptions(null as never);
+    }).toThrowError(TypeError);
+    expect(() => {
+      validateOptions(null as never);
+    }).toThrowError("Options must be an object");
+  });
+
+  describe("level", () => {
+    it.each(["all", "transitions", "errors", "none"] as const)(
+      "should accept valid level '%s'",
+      (level) => {
+        expect(() => {
+          validateOptions({ level });
+        }).not.toThrowError();
+      },
+    );
+
+    it("should throw TypeError for invalid level", () => {
+      expect(() => {
+        validateOptions({ level: "verbose" as never });
+      }).toThrowError(TypeError);
+      expect(() => {
+        validateOptions({ level: "verbose" as never });
+      }).toThrowError('Invalid level: "verbose"');
+    });
+
+    it("should list valid levels in error message", () => {
+      expect(() => {
+        validateOptions({ level: "bad" as never });
+      }).toThrowError("Expected: all, transitions, errors, none");
+    });
+  });
+
+  describe("context", () => {
+    it("should accept valid non-empty string", () => {
+      expect(() => {
+        validateOptions({ context: "my-router" });
+      }).not.toThrowError();
+    });
+
+    it("should throw TypeError for empty string", () => {
+      expect(() => {
+        validateOptions({ context: "" });
+      }).toThrowError(TypeError);
+      expect(() => {
+        validateOptions({ context: "" });
+      }).toThrowError('"context" must be a non-empty string');
+    });
+
+    it("should throw TypeError for non-string", () => {
+      expect(() => {
+        validateOptions({ context: 42 as never });
+      }).toThrowError(TypeError);
+    });
+  });
+
+  describe("boolean options", () => {
+    it("should throw TypeError for non-boolean showTiming", () => {
+      expect(() => {
+        validateOptions({ showTiming: "yes" as never });
+      }).toThrowError(TypeError);
+      expect(() => {
+        validateOptions({ showTiming: "yes" as never });
+      }).toThrowError('"showTiming" must be a boolean');
+    });
+
+    it("should throw TypeError for non-boolean showParamsDiff", () => {
+      expect(() => {
+        validateOptions({ showParamsDiff: "yes" as never });
+      }).toThrowError(TypeError);
+      expect(() => {
+        validateOptions({ showParamsDiff: "yes" as never });
+      }).toThrowError('"showParamsDiff" must be a boolean');
+    });
+
+    it("should throw TypeError for non-boolean usePerformanceMarks", () => {
+      expect(() => {
+        validateOptions({ usePerformanceMarks: "yes" as never });
+      }).toThrowError(TypeError);
+      expect(() => {
+        validateOptions({ usePerformanceMarks: "yes" as never });
+      }).toThrowError('"usePerformanceMarks" must be a boolean');
+    });
+
+    it("should accept boolean values", () => {
+      expect(() => {
+        validateOptions({ showTiming: false });
+      }).not.toThrowError();
+      expect(() => {
+        validateOptions({ showParamsDiff: true });
+      }).not.toThrowError();
+      expect(() => {
+        validateOptions({ usePerformanceMarks: false });
+      }).not.toThrowError();
+    });
+  });
+
+  describe("error prefix", () => {
+    it("should include [@real-router/logger-plugin] prefix in error messages", () => {
+      expect(() => {
+        validateOptions(null as never);
+      }).toThrowError("[@real-router/logger-plugin]");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Aligns `@real-router/logger-plugin` with the unified plugin architecture established in `browser-plugin`, `hash-plugin`, and `persistent-params-plugin`: `factory.ts` / `plugin.ts` separation, `LoggerPlugin` class with `getPlugin()` pattern, options validation, and standardized constants.

**Breaking change:** Removed `loggerPlugin` singleton export. Use `loggerPluginFactory()` instead.

Closes #250

## Changes

### Code

**New file: `src/factory.ts`** — Extracted factory function from `plugin.ts`. Validates options via `validateOptions()`, merges with `DEFAULT_CONFIG`, returns `PluginFactory` that creates `new LoggerPlugin(config).getPlugin()` per router instance.

**Rewritten: `src/plugin.ts`** — Converted closure-based `loggerPluginFactory` to `LoggerPlugin` class with `getPlugin()` pattern. 10 readonly `#private` fields (6 pre-computed flags, 2 managers, prefix, context), 3 mutable transition state fields, 2 private methods (`#logParamsIfNeeded`, `#resetTransitionState`). Arrow functions in `getPlugin()` capture `this` via lexical scope.

**New file: `src/validation.ts`** — `validateOptions()` validates all 5 config fields: `level` (set membership), `context` (non-empty string), `showTiming` / `showParamsDiff` / `usePerformanceMarks` (boolean type checks). Uses `options === (null as never)` guard for `typeof null === "object"`. All errors are `TypeError` with `[@real-router/logger-plugin]` prefix.

**`src/constants.ts`** — Added `LOGGER_CONTEXT` (`"logger-plugin"`) and `ERROR_PREFIX` (`"[@real-router/logger-plugin]"`). `DEFAULT_CONFIG.context` now references `LOGGER_CONTEXT`.

**`src/index.ts`** — Removed `loggerPlugin` singleton re-export. `loggerPluginFactory` now re-exported from `factory.ts`.

**`src/types.ts`** — Fixed JSDoc `@default false` → `@default true` for `showParamsDiff` (matches actual `DEFAULT_CONFIG` value).

**`src/internal/console-groups.ts`** — Exported `GroupManager` interface (needed as class field type in `plugin.ts`).

**`src/internal/performance-marks.ts`** — Exported `PerformanceTracker` interface (needed as class field type in `plugin.ts`).

**`src/internal/*.ts`** — Fixed stale path comments: `modules/...` → `src/...` in all 5 internal files.

### Optimizations (post-refactoring)

Three micro-optimizations discovered during class conversion:

1. **Lazy `now()` call** — `this.#transitionStartTime = this.#shouldShowTiming ? now() : null` — skips high-resolution timer read when `showTiming: false`
2. **Guarded perf mark strings** — All 5 template literal allocations per transition (`router:transition-start:${label}`, etc.) wrapped in `if (this.#usePerf)` — zero allocations when `usePerformanceMarks: false`
3. **Removed redundant `#logWarning` field** — Was always identical to `#logTransition`; `onTransitionCancel` now uses `#logTransition` directly

### Tests

**`tests/functional/plugin.test.ts`** — Replaced all 25 `loggerPlugin` singleton usages with `loggerPluginFactory()`. Fixed test "should format route name as (none) when undefined" to actually assert the `(none)` case (first transition on `router.start()` where `fromState` is `undefined`). Removed duplicate test "should not open group twice for same transition" (identical to "should not open multiple groups for same transition").

**New file: `tests/unit/validation.test.ts`** — 19 tests covering: `undefined`/`null`/non-object rejection, all 4 valid log levels, invalid level with error message listing, empty string context, non-string context, boolean type checks for 3 flags, error prefix format.

### Documentation

**`ARCHITECTURE.md`** — Updated package structure, pre-computed flags section (closure vars → `#private` fields), plugin instance state, internal managers, lifecycle flow diagram (adds `validateOptions` step and `new LoggerPlugin(config).getPlugin()` path), `resetTransitionState` → `#resetTransitionState`. Removed `loggerPlugin` singleton section. Fixed `showParamsDiff` note about mismatched JSDoc.

**`README.md`** — Removed `loggerPlugin` singleton section and usage examples. Reformatted code examples with proper `prettier` style.

## Breaking Change

```diff
- import { loggerPlugin } from "@real-router/logger-plugin";
- router.usePlugin(loggerPlugin);
+ import { loggerPluginFactory } from "@real-router/logger-plugin";
+ router.usePlugin(loggerPluginFactory());
```

The `loggerPlugin` singleton is removed. All other plugins in the monorepo use factory functions exclusively — this aligns `logger-plugin` with that convention. `loggerPluginFactory()` with no arguments produces identical behavior to the former singleton.

## Scope deviation from issue

The issue explicitly excluded class conversion ("Not in Scope: Rewriting closure to class + `getPlugin()`"). During implementation, the closure accumulated 3 `let` variables, 2 inner functions, 6 readonly flags, 2 managers, and 7 methods — effectively a class in disguise. Converted to `LoggerPlugin` class with `getPlugin()` pattern per reviewer request.
