### PR TITLE
fix(react): remove `useIsActiveRoute` from public API (#280)

### DIFF
--- a/.changeset/remove-useisactiveroute-export.md
+++ b/.changeset/remove-useisactiveroute-export.md
@@ -1,0 +1,20 @@
+---
+"@real-router/react": minor
+---
+
+Remove `useIsActiveRoute` from public API (#280)
+
+**Breaking Change:** `useIsActiveRoute` is no longer exported from `@real-router/react` or `@real-router/react/legacy`. The hook remains as an internal utility used by `<Link>`.
+
+**Migration:**
+
+```diff
+- import { useIsActiveRoute } from "@real-router/react";
+- const isActive = useIsActiveRoute("users.profile", { id });
+
++ import { useRouteNode } from "@real-router/react";
++ const { route } = useRouteNode("users");
++ const isActive = route?.name === "users.profile";
+```
+
+Or use `<Link>` which handles active state automatically via render props.

--- a/packages/react/ARCHITECTURE.md
+++ b/packages/react/ARCHITECTURE.md
@@ -55,7 +55,7 @@ src/
 │   ├── useRoute.tsx            # Full route state from context (every navigation)
 │   ├── useNavigator.tsx        # Navigator from context (never re-renders)
 │   ├── useRouteNode.tsx        # Node-scoped subscription via useSyncExternalStore
-│   ├── useIsActiveRoute.tsx    # Active state subscription via useSyncExternalStore
+│   ├── useIsActiveRoute.tsx    # Active state subscription (internal — used by Link)
 │   ├── useRouteUtils.tsx       # RouteUtils from route tree (never re-renders)
 │   └── useStableValue.tsx      # JSON-based reference stabilization
 └── components/
@@ -107,7 +107,7 @@ These three hooks use `useContext()` — works in both React 18 and 19. (`use()`
 
 ```
 useRouteNode(name)              — createRouteNodeSource(router, name)
-useIsActiveRoute(name, params)  — createActiveRouteSource(router, name, params, opts)
+useIsActiveRoute(name, params)  — createActiveRouteSource(router, name, params, opts)  [internal]
 RouterProvider                  — createRouteSource(router)
 ```
 
@@ -121,7 +121,7 @@ These subscribe to `@real-router/sources` stores. The source creates a `{ subscr
 Link (memo + areLinkPropsEqual)
 ├── useRouter() — router instance from context (never re-renders)
 ├── useStableValue() — stabilizes routeParams/routeOptions objects
-├── useIsActiveRoute() — subscription for active/inactive CSS
+├── useIsActiveRoute() — subscription for active/inactive CSS (internal hook)
 ├── href = router.buildUrl() || router.buildPath()
 └── onClick → void router.navigate(...)   # fire-and-forget
 ```
@@ -163,7 +163,7 @@ router emits TRANSITION_SUCCESS
     │
     └──► createActiveRouteSource.subscribe callback → boolean snapshot
             └──► if changed: useSyncExternalStore triggers re-render
-                    └──► useIsActiveRoute() / Link active CSS updates
+                    └──► Link active CSS updates (via internal useIsActiveRoute)
 ```
 
 ## Type System

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -16,8 +16,6 @@ export { useRouter } from "./hooks/useRouter";
 
 export { useRouteUtils } from "./hooks/useRouteUtils";
 
-export { useIsActiveRoute } from "./hooks/useIsActiveRoute";
-
 export { useRouterTransition } from "./hooks/useRouterTransition";
 
 // Context

--- a/packages/react/src/legacy.ts
+++ b/packages/react/src/legacy.ts
@@ -14,8 +14,6 @@ export { useRouter } from "./hooks/useRouter";
 
 export { useRouteUtils } from "./hooks/useRouteUtils";
 
-export { useIsActiveRoute } from "./hooks/useIsActiveRoute";
-
 export { useRouterTransition } from "./hooks/useRouterTransition";
 
 // Context

--- a/packages/react/tests/functional/legacy-entry.test.tsx
+++ b/packages/react/tests/functional/legacy-entry.test.tsx
@@ -8,7 +8,6 @@ import {
   useNavigator,
   useRouter,
   useRouteUtils,
-  useIsActiveRoute,
   useRouterTransition,
   RouterProvider,
   RouterContext,
@@ -54,7 +53,6 @@ describe("legacy entry point (@real-router/react/legacy)", () => {
       expect(useNavigator).toBeDefined();
       expect(useRouter).toBeDefined();
       expect(useRouteUtils).toBeDefined();
-      expect(useIsActiveRoute).toBeDefined();
       expect(useRouterTransition).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary

Closes #280

Removes `useIsActiveRoute` from `@real-router/react` and `@real-router/react/legacy` public exports. The hook remains as an internal utility used by `<Link>` for active state detection.

### Rationale

After analysis, there are no strong standalone use cases for this hook:

- `<Link>` already uses `useIsActiveRoute` internally — covers the vast majority of active-state needs
- `useRouteNode` handles the remaining cases (modals, conditional rendering) with negligible performance difference
- The only theoretical advantage — granular re-renders (2 of N items vs all N) — matters only for heavy navigation lists without `<Link>`, which is a niche scenario

### Changes

**Source:**

- `packages/react/src/index.ts` — removed export
- `packages/react/src/legacy.ts` — removed export
- `packages/react/tests/functional/legacy-entry.test.tsx` — removed from import and export assertion
- Hook file (`useIsActiveRoute.tsx`) and its test file remain as internal

**Documentation:**

- `packages/react/ARCHITECTURE.md` — marked as `[internal]` in source structure, subscription patterns, component architecture, and data flow sections
- Wiki: removed from "See Also" tables in `useRoute`, `useRouter`, `useNavigator`, `useRouteNode`; marked as internal in `BaseLink` and `sources-adapter-guide`
