### PR TITLE
refactor(sources): deduplicate all sources via BaseSource composition

### DIFF
--- a/.changeset/sources-base-source-refactor.md
+++ b/.changeset/sources-base-source-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": patch
+---
+
+Deduplicate all source implementations via `BaseSource` composition (#287)
+
+Replaced all 4 wrapper classes (`RouteSource`, `RouteNodeSource`, `ActiveRouteSource`, `TransitionSource`) with factory functions that compose `BaseSource` directly. Added `onFirstSubscribe`/`onLastUnsubscribe`/`onDestroy` lifecycle hooks and auto-bound methods to `BaseSource`, eliminating all jscpd-reported code clones in the package.

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -32,7 +32,7 @@ export const SCOPES = [
   "rx",
   "event-emitter",
   "route-utils",
-  "stores",
+  "sources",
   "router-benchmarks",
   "deps",
   "config",

--- a/packages/sources/src/BaseSource.ts
+++ b/packages/sources/src/BaseSource.ts
@@ -1,11 +1,27 @@
+export interface BaseSourceOptions {
+  onFirstSubscribe?: () => void;
+  onLastUnsubscribe?: () => void;
+  onDestroy?: () => void;
+}
+
 export class BaseSource<T> {
   #currentSnapshot: T;
   #destroyed = false;
 
   readonly #listeners = new Set<() => void>();
+  readonly #onFirstSubscribe: (() => void) | undefined;
+  readonly #onLastUnsubscribe: (() => void) | undefined;
+  readonly #onDestroy: (() => void) | undefined;
 
-  constructor(initialSnapshot: T) {
+  constructor(initialSnapshot: T, options?: BaseSourceOptions) {
     this.#currentSnapshot = initialSnapshot;
+    this.#onFirstSubscribe = options?.onFirstSubscribe;
+    this.#onLastUnsubscribe = options?.onLastUnsubscribe;
+    this.#onDestroy = options?.onDestroy;
+
+    this.subscribe = this.subscribe.bind(this);
+    this.getSnapshot = this.getSnapshot.bind(this);
+    this.destroy = this.destroy.bind(this);
   }
 
   subscribe(listener: () => void): () => void {
@@ -13,10 +29,22 @@ export class BaseSource<T> {
       return () => {};
     }
 
+    if (this.#listeners.size === 0 && this.#onFirstSubscribe) {
+      this.#onFirstSubscribe();
+    }
+
     this.#listeners.add(listener);
 
     return () => {
       this.#listeners.delete(listener);
+
+      if (
+        !this.#destroyed &&
+        this.#listeners.size === 0 &&
+        this.#onLastUnsubscribe
+      ) {
+        this.#onLastUnsubscribe();
+      }
     };
   }
 
@@ -42,6 +70,7 @@ export class BaseSource<T> {
     }
 
     this.#destroyed = true;
+    this.#onDestroy?.();
     this.#listeners.clear();
   }
 }

--- a/packages/sources/src/createActiveRouteSource.ts
+++ b/packages/sources/src/createActiveRouteSource.ts
@@ -5,73 +5,49 @@ import { BaseSource } from "./BaseSource";
 import type { ActiveRouteSourceOptions, RouterSource } from "./types.js";
 import type { Params, Router } from "@real-router/core";
 
-class ActiveRouteSource implements RouterSource<boolean> {
-  readonly #source: BaseSource<boolean>;
-  readonly #unsubscribe: () => void;
-
-  constructor(
-    router: Router,
-    routeName: string,
-    params?: Params,
-    options?: ActiveRouteSourceOptions,
-  ) {
-    const strict = options?.strict ?? false;
-    const ignoreQueryParams = options?.ignoreQueryParams ?? true;
-
-    const initialValue = router.isActiveRoute(
-      routeName,
-      params,
-      strict,
-      ignoreQueryParams,
-    );
-
-    this.#source = new BaseSource(initialValue);
-
-    this.#unsubscribe = router.subscribe((next) => {
-      const isNewRelated = areRoutesRelated(routeName, next.route.name);
-      const isPrevRelated =
-        next.previousRoute &&
-        areRoutesRelated(routeName, next.previousRoute.name);
-
-      if (!isNewRelated && !isPrevRelated) {
-        return;
-      }
-
-      // If new route is not related, we know the route is inactive —
-      // avoid calling isActiveRoute for the optimization
-      const newValue = isNewRelated
-        ? router.isActiveRoute(routeName, params, strict, ignoreQueryParams)
-        : false;
-
-      if (!Object.is(this.#source.getSnapshot(), newValue)) {
-        this.#source.updateSnapshot(newValue);
-      }
-    });
-
-    this.subscribe = this.subscribe.bind(this);
-    this.getSnapshot = this.getSnapshot.bind(this);
-    this.destroy = this.destroy.bind(this);
-  }
-
-  subscribe(listener: () => void): () => void {
-    return this.#source.subscribe(listener);
-  }
-
-  getSnapshot(): boolean {
-    return this.#source.getSnapshot();
-  }
-
-  destroy(): void {
-    this.#unsubscribe();
-    this.#source.destroy();
-  }
-}
-
 export function createActiveRouteSource(
   router: Router,
   routeName: string,
   params?: Params,
   options?: ActiveRouteSourceOptions,
 ): RouterSource<boolean> {
-  return new ActiveRouteSource(router, routeName, params, options);
+  const strict = options?.strict ?? false;
+  const ignoreQueryParams = options?.ignoreQueryParams ?? true;
+
+  const initialValue = router.isActiveRoute(
+    routeName,
+    params,
+    strict,
+    ignoreQueryParams,
+  );
+
+  const source = new BaseSource(initialValue, {
+    onDestroy: () => {
+      unsubscribe();
+    },
+  });
+
+  // Eager connection: subscribe to router immediately
+  const unsubscribe = router.subscribe((next) => {
+    const isNewRelated = areRoutesRelated(routeName, next.route.name);
+    const isPrevRelated =
+      next.previousRoute &&
+      areRoutesRelated(routeName, next.previousRoute.name);
+
+    if (!isNewRelated && !isPrevRelated) {
+      return;
+    }
+
+    // If new route is not related, we know the route is inactive —
+    // avoid calling isActiveRoute for the optimization
+    const newValue = isNewRelated
+      ? router.isActiveRoute(routeName, params, strict, ignoreQueryParams)
+      : false;
+
+    if (!Object.is(source.getSnapshot(), newValue)) {
+      source.updateSnapshot(newValue);
+    }
+  });
+
+  return source;
 }

--- a/packages/sources/src/createRouteNodeSource.ts
+++ b/packages/sources/src/createRouteNodeSource.ts
@@ -1,105 +1,9 @@
+import { BaseSource } from "./BaseSource";
 import { computeSnapshot } from "./computeSnapshot.js";
 import { getCachedShouldUpdate } from "./shouldUpdateCache.js";
 
 import type { RouteNodeSnapshot, RouterSource } from "./types.js";
 import type { Router } from "@real-router/core";
-
-class RouteNodeSource implements RouterSource<RouteNodeSnapshot> {
-  #routerUnsubscribe: (() => void) | null = null;
-  #currentSnapshot: RouteNodeSnapshot;
-  #destroyed = false;
-
-  readonly #listeners = new Set<() => void>();
-  readonly #router: Router;
-  readonly #nodeName: string;
-  readonly #shouldUpdate: ReturnType<typeof getCachedShouldUpdate>;
-
-  constructor(router: Router, nodeName: string) {
-    this.#router = router;
-    this.#nodeName = nodeName;
-    this.#shouldUpdate = getCachedShouldUpdate(router, nodeName);
-
-    const initialSnapshot: RouteNodeSnapshot = {
-      route: undefined,
-      previousRoute: undefined,
-    };
-
-    this.#currentSnapshot = computeSnapshot(initialSnapshot, router, nodeName);
-
-    this.subscribe = this.subscribe.bind(this);
-    this.getSnapshot = this.getSnapshot.bind(this);
-    this.destroy = this.destroy.bind(this);
-  }
-
-  subscribe(listener: () => void): () => void {
-    if (this.#destroyed) {
-      return () => {};
-    }
-
-    if (this.#listeners.size === 0) {
-      // Reconcile snapshot with current router state before connecting.
-      // Covers reconnection after Activity hide/show cycles where the
-      // source was disconnected and missed navigation events.
-      this.#currentSnapshot = computeSnapshot(
-        this.#currentSnapshot,
-        this.#router,
-        this.#nodeName,
-      );
-
-      // Connect to router on first subscription
-      this.#routerUnsubscribe = this.#router.subscribe((next) => {
-        if (!this.#shouldUpdate(next.route, next.previousRoute)) {
-          return;
-        }
-
-        const newSnapshot = computeSnapshot(
-          this.#currentSnapshot,
-          this.#router,
-          this.#nodeName,
-          next,
-        );
-
-        /* v8 ignore next 3 -- @preserve: dedup guard; shouldUpdateNode filters accurately so computeSnapshot always returns new ref */
-        if (!Object.is(this.#currentSnapshot, newSnapshot)) {
-          this.#currentSnapshot = newSnapshot;
-          this.#listeners.forEach((cb) => {
-            cb();
-          });
-        }
-      });
-    }
-
-    this.#listeners.add(listener);
-
-    return () => {
-      this.#listeners.delete(listener);
-
-      if (this.#listeners.size === 0 && this.#routerUnsubscribe) {
-        this.#routerUnsubscribe();
-        this.#routerUnsubscribe = null;
-      }
-    };
-  }
-
-  getSnapshot(): RouteNodeSnapshot {
-    return this.#currentSnapshot;
-  }
-
-  destroy(): void {
-    if (this.#destroyed) {
-      return;
-    }
-
-    this.#destroyed = true;
-
-    if (this.#routerUnsubscribe) {
-      this.#routerUnsubscribe();
-      this.#routerUnsubscribe = null;
-    }
-
-    this.#listeners.clear();
-  }
-}
 
 /**
  * Creates a source scoped to a specific route node.
@@ -112,5 +16,56 @@ export function createRouteNodeSource(
   router: Router,
   nodeName: string,
 ): RouterSource<RouteNodeSnapshot> {
-  return new RouteNodeSource(router, nodeName);
+  let routerUnsubscribe: (() => void) | null = null;
+
+  const shouldUpdate = getCachedShouldUpdate(router, nodeName);
+
+  const initialSnapshot: RouteNodeSnapshot = {
+    route: undefined,
+    previousRoute: undefined,
+  };
+
+  const disconnect = (): void => {
+    const unsub = routerUnsubscribe;
+
+    routerUnsubscribe = null;
+    unsub?.();
+  };
+
+  const source = new BaseSource<RouteNodeSnapshot>(
+    computeSnapshot(initialSnapshot, router, nodeName),
+    {
+      onFirstSubscribe: () => {
+        // Reconcile snapshot with current router state before connecting.
+        // Covers reconnection after Activity hide/show cycles where the
+        // source was disconnected and missed navigation events.
+        source.updateSnapshot(
+          computeSnapshot(source.getSnapshot(), router, nodeName),
+        );
+
+        // Connect to router on first subscription
+        routerUnsubscribe = router.subscribe((next) => {
+          if (!shouldUpdate(next.route, next.previousRoute)) {
+            return;
+          }
+
+          const newSnapshot = computeSnapshot(
+            source.getSnapshot(),
+            router,
+            nodeName,
+            next,
+          );
+
+          /* v8 ignore next 3 -- @preserve: dedup guard; shouldUpdateNode filters accurately so computeSnapshot always returns new ref */
+          if (!Object.is(source.getSnapshot(), newSnapshot)) {
+            source.updateSnapshot(newSnapshot);
+          }
+        });
+      },
+      onLastUnsubscribe: disconnect,
+      onDestroy: disconnect,
+    },
+  );
+
+  return source;
 }

--- a/packages/sources/src/createRouteSource.ts
+++ b/packages/sources/src/createRouteSource.ts
@@ -1,76 +1,7 @@
+import { BaseSource } from "./BaseSource";
+
 import type { RouteSnapshot, RouterSource } from "./types.js";
 import type { Router } from "@real-router/core";
-
-class RouteSource implements RouterSource<RouteSnapshot> {
-  #routerUnsubscribe: (() => void) | null = null;
-  #currentSnapshot: RouteSnapshot;
-  #destroyed = false;
-
-  readonly #listeners = new Set<() => void>();
-  readonly #router: Router;
-
-  constructor(router: Router) {
-    this.#router = router;
-
-    this.#currentSnapshot = {
-      route: router.getState(),
-      previousRoute: undefined,
-    };
-
-    this.subscribe = this.subscribe.bind(this);
-    this.destroy = this.destroy.bind(this);
-    this.getSnapshot = this.getSnapshot.bind(this);
-  }
-
-  subscribe(listener: () => void): () => void {
-    if (this.#destroyed) {
-      return () => {};
-    }
-
-    if (this.#listeners.size === 0) {
-      // Connect to router on first subscription
-      this.#routerUnsubscribe = this.#router.subscribe((next) => {
-        this.#currentSnapshot = {
-          route: next.route,
-          previousRoute: next.previousRoute,
-        };
-        this.#listeners.forEach((cb) => {
-          cb();
-        });
-      });
-    }
-
-    this.#listeners.add(listener);
-
-    return () => {
-      this.#listeners.delete(listener);
-
-      if (this.#listeners.size === 0 && this.#routerUnsubscribe) {
-        this.#routerUnsubscribe();
-        this.#routerUnsubscribe = null;
-      }
-    };
-  }
-
-  getSnapshot(): RouteSnapshot {
-    return this.#currentSnapshot;
-  }
-
-  destroy(): void {
-    if (this.#destroyed) {
-      return;
-    }
-
-    this.#destroyed = true;
-
-    if (this.#routerUnsubscribe) {
-      this.#routerUnsubscribe();
-      this.#routerUnsubscribe = null;
-    }
-
-    this.#listeners.clear();
-  }
-}
 
 /**
  * Creates a source for the full route state.
@@ -80,5 +11,33 @@ class RouteSource implements RouterSource<RouteSnapshot> {
  * This is compatible with React's useSyncExternalStore and Strict Mode.
  */
 export function createRouteSource(router: Router): RouterSource<RouteSnapshot> {
-  return new RouteSource(router);
+  let routerUnsubscribe: (() => void) | null = null;
+
+  const disconnect = (): void => {
+    const unsub = routerUnsubscribe;
+
+    routerUnsubscribe = null;
+    unsub?.();
+  };
+
+  const source = new BaseSource<RouteSnapshot>(
+    {
+      route: router.getState(),
+      previousRoute: undefined,
+    },
+    {
+      onFirstSubscribe: () => {
+        routerUnsubscribe = router.subscribe((next) => {
+          source.updateSnapshot({
+            route: next.route,
+            previousRoute: next.previousRoute,
+          });
+        });
+      },
+      onLastUnsubscribe: disconnect,
+      onDestroy: disconnect,
+    },
+  );
+
+  return source;
 }

--- a/packages/sources/src/createTransitionSource.ts
+++ b/packages/sources/src/createTransitionSource.ts
@@ -11,58 +11,39 @@ const IDLE_SNAPSHOT: RouterTransitionSnapshot = {
   fromRoute: null,
 };
 
-class TransitionSource implements RouterSource<RouterTransitionSnapshot> {
-  readonly #source: BaseSource<RouterTransitionSnapshot>;
-  readonly #unsubs: (() => void)[];
-
-  constructor(router: Router) {
-    this.#source = new BaseSource(IDLE_SNAPSHOT);
-
-    const api = getPluginApi(router);
-
-    const resetToIdle = (): void => {
-      this.#source.updateSnapshot(IDLE_SNAPSHOT);
-    };
-
-    this.#unsubs = [
-      api.addEventListener(
-        events.TRANSITION_START,
-        (toState: State, fromState?: State) => {
-          this.#source.updateSnapshot({
-            isTransitioning: true,
-            toRoute: toState,
-            fromRoute: fromState ?? null,
-          });
-        },
-      ),
-      api.addEventListener(events.TRANSITION_SUCCESS, resetToIdle),
-      api.addEventListener(events.TRANSITION_ERROR, resetToIdle),
-      api.addEventListener(events.TRANSITION_CANCEL, resetToIdle),
-    ];
-
-    this.subscribe = this.subscribe.bind(this);
-    this.getSnapshot = this.getSnapshot.bind(this);
-    this.destroy = this.destroy.bind(this);
-  }
-
-  subscribe(listener: () => void): () => void {
-    return this.#source.subscribe(listener);
-  }
-
-  getSnapshot(): RouterTransitionSnapshot {
-    return this.#source.getSnapshot();
-  }
-
-  destroy(): void {
-    this.#unsubs.forEach((u) => {
-      u();
-    });
-    this.#source.destroy();
-  }
-}
-
 export function createTransitionSource(
   router: Router,
 ): RouterSource<RouterTransitionSnapshot> {
-  return new TransitionSource(router);
+  const source = new BaseSource(IDLE_SNAPSHOT, {
+    onDestroy: () => {
+      unsubs.forEach((u) => {
+        u();
+      });
+    },
+  });
+
+  const api = getPluginApi(router);
+
+  const resetToIdle = (): void => {
+    source.updateSnapshot(IDLE_SNAPSHOT);
+  };
+
+  // Eager connection: subscribe to router events immediately
+  const unsubs = [
+    api.addEventListener(
+      events.TRANSITION_START,
+      (toState: State, fromState?: State) => {
+        source.updateSnapshot({
+          isTransitioning: true,
+          toRoute: toState,
+          fromRoute: fromState ?? null,
+        });
+      },
+    ),
+    api.addEventListener(events.TRANSITION_SUCCESS, resetToIdle),
+    api.addEventListener(events.TRANSITION_ERROR, resetToIdle),
+    api.addEventListener(events.TRANSITION_CANCEL, resetToIdle),
+  ];
+
+  return source;
 }


### PR DESCRIPTION
## Summary

Closes #287

- Replaced all 4 wrapper classes (`RouteSource`, `RouteNodeSource`, `ActiveRouteSource`, `TransitionSource`) with factory functions that compose `BaseSource` directly
- Added `onFirstSubscribe`/`onLastUnsubscribe`/`onDestroy` lifecycle hooks and auto-bound methods to `BaseSource`
- Eliminated all 4 jscpd-reported code clones in `packages/sources/src/` (−93 lines net)

## Test plan

- [x] All existing unit tests pass (53 tests across 5 test files)
- [x] 100% code coverage maintained
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` green
- [x] `pnpm run lint:duplicates` reports 0 clones in `packages/sources/`