### PR TITLE
fix(react): replace use() with useContext() for React 18 compatibility

### DIFF
--- a/.changeset/react-use-context-fix.md
+++ b/.changeset/react-use-context-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": patch
+---
+
+Replace `use()` with `useContext()` in hooks for React 18 compatibility (#288)
+
+`useRouter`, `useRoute`, and `useNavigator` used React 19's `use()` API, breaking the `@real-router/react/legacy` entry point on React 18. Replaced with `useContext()` which is available in both React 18 and 19.

--- a/packages/react/src/hooks/useNavigator.tsx
+++ b/packages/react/src/hooks/useNavigator.tsx
@@ -1,13 +1,13 @@
 // packages/react/modules/hooks/useNavigator.tsx
 
-import { use } from "react";
+import { useContext } from "react";
 
 import { NavigatorContext } from "../context";
 
 import type { Navigator } from "@real-router/core";
 
 export const useNavigator = (): Navigator => {
-  const navigator = use(NavigatorContext);
+  const navigator = useContext(NavigatorContext);
 
   if (!navigator) {
     throw new Error("useNavigator must be used within a RouterProvider");

--- a/packages/react/src/hooks/useRoute.tsx
+++ b/packages/react/src/hooks/useRoute.tsx
@@ -1,13 +1,13 @@
 // packages/react/modules/hooks/useRoute.tsx
 
-import { use } from "react";
+import { useContext } from "react";
 
 import { RouteContext } from "../context";
 
 import type { RouteContext as RouteContextType } from "../types";
 
 export const useRoute = (): RouteContextType => {
-  const routeContext = use(RouteContext);
+  const routeContext = useContext(RouteContext);
 
   if (!routeContext) {
     throw new Error("useRoute must be used within a RouteProvider");

--- a/packages/react/src/hooks/useRouter.tsx
+++ b/packages/react/src/hooks/useRouter.tsx
@@ -1,13 +1,13 @@
 // packages/react/modules/hooks/useRouter.tsx
 
-import { use } from "react";
+import { useContext } from "react";
 
 import { RouterContext } from "../context";
 
 import type { Router } from "@real-router/core";
 
 export const useRouter = (): Router => {
-  const router = use(RouterContext);
+  const router = useContext(RouterContext);
 
   if (!router) {
     throw new Error("useRouter must be used within a RouterProvider");


### PR DESCRIPTION
## Summary

Closes #288

- Replace `use(Context)` with `useContext(Context)` in `useRouter`, `useRoute`, and `useNavigator` hooks
- These hooks are shared between main (`index.ts`, React 19.2+) and legacy (`legacy.ts`, React 18+) entry points — `use()` only exists in React 19, breaking the legacy entry point

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test --filter=@real-router/react -- --run` passes (307 tests)