### PR TITLE
chore: add changesets for RouterErrorBoundary (#366)

### DIFF
--- a/.changeset/error-boundary-preact-feature.md
+++ b/.changeset/error-boundary-preact-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preact": minor
+---
+
+Add `RouterErrorBoundary` component for declarative navigation error handling (#366)
+
+New component that shows a fallback alongside children when a navigation error occurs. Auto-resets on successful navigation. Supports `resetError()` for manual dismiss and `onError` callback for logging.

--- a/.changeset/error-boundary-react-feature.md
+++ b/.changeset/error-boundary-react-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": minor
+---
+
+Add `RouterErrorBoundary` component for declarative navigation error handling (#366)
+
+New component that shows a fallback **alongside** children when a navigation error occurs (guard rejection, route not found). Auto-resets on successful navigation. Supports manual dismiss via `resetError()` and side-effect logging via `onError` callback. Available from both `@real-router/react` and `@real-router/react/legacy`.

--- a/.changeset/error-boundary-solid-feature.md
+++ b/.changeset/error-boundary-solid-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/solid": minor
+---
+
+Add `RouterErrorBoundary` component for declarative navigation error handling (#366)
+
+New component that shows a fallback alongside children when a navigation error occurs. Uses Solid signals (`createSignal`, `createMemo`, `createEffect`) for fine-grained reactivity. Auto-resets on successful navigation.

--- a/.changeset/error-boundary-svelte-feature.md
+++ b/.changeset/error-boundary-svelte-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/svelte": minor
+---
+
+Add `RouterErrorBoundary` component for declarative navigation error handling (#366)
+
+New Svelte 5 component using Runes (`$state`, `$derived`, `$effect`) and Snippets for typed fallback rendering. Shows a fallback alongside children when a navigation error occurs. Uses `untrack()` for `onError` callback stability. Auto-resets on successful navigation.

--- a/.changeset/error-boundary-vue-feature.md
+++ b/.changeset/error-boundary-vue-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/vue": minor
+---
+
+Add `RouterErrorBoundary` component for declarative navigation error handling (#366)
+
+New `defineComponent` that shows a fallback alongside slot children when a navigation error occurs. Uses `watch({ immediate: true })` for `onError` callback, `computed` for visible error, and `shallowRef` for dismissed state. Auto-resets on successful navigation.

--- a/.changeset/error-source-feature.md
+++ b/.changeset/error-source-feature.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": minor
+---
+
+Add `createErrorSource` factory for navigation error tracking (#366)
+
+New eager-subscription source that tracks `TRANSITION_ERROR` events. Provides `RouterErrorSnapshot` with `error`, `toRoute`, `fromRoute`, and `version` fields. Resets on `TRANSITION_SUCCESS`. Skips update when no error exists (avoids unnecessary re-renders).


### PR DESCRIPTION
## Summary

Add changeset files for the RouterErrorBoundary feature implemented in `4ffda6ff`.

6 changesets (all `minor`):
- `@real-router/sources` — `createErrorSource` factory
- `@real-router/react` — `RouterErrorBoundary` component
- `@real-router/preact` — `RouterErrorBoundary` component
- `@real-router/solid` — `RouterErrorBoundary` component
- `@real-router/vue` — `RouterErrorBoundary` component
- `@real-router/svelte` — `RouterErrorBoundary` component

Closes #366