### PR TITLE
fix(config): include transitive workspace sources in build:dist-only inputs (#431) #trivial

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -652,6 +652,54 @@ pnpm test:verbose       # Tests with full output
 }
 ```
 
+### `build:dist-only` Cache Key Correctness (#431)
+
+**Problem:** `dependsOn: ["^build:dist-only"]` controls execution order but **not** cache key computation. With per-package scoped inputs, a package's cache hash includes only its own `src/` — never its workspace dependencies' sources. Turbo documentation confirms:
+
+> `dependsOn` specifies task execution order and dependencies but doesn't automatically feed upstream task outputs into downstream task hashes.
+
+Tracked upstream as [vercel/turborepo#3969](https://github.com/vercel/turborepo/issues/3969) (per-task transitive input hashing).
+
+Flaky CI scenario:
+
+1. PR changes `packages/fsm/src/fsm.ts`
+2. `fsm:build:dist-only` — cache miss, rebuilds ✅
+3. `core:build:dist-only` — remote **cache hit** (core/src/ unchanged) → restores stale `dist/` built against old fsm types
+4. `search-schema-plugin:type-check` uses stale core `.d.ts` → `TS7006: Parameter implicitly has 'any' type`
+
+Alternative manifestation: rolldown `UNRESOLVED_IMPORT` when `core:build:dist-only` has a cache miss but inlines a stale `route-tree/dist/esm/index.mjs` (cache hit) via `alwaysBundle: ["event-emitter", "route-tree"]` in `packages/core/tsdown.config.mts`. Both variants resolve on CI re-run once remote cache is repopulated with fresh artifacts from the failed run's sibling jobs — classic "fails once, passes on retry" symptom.
+
+**Solution:** Use `$TURBO_ROOT$` to include **all** workspace package sources (and the symlinked shared sources introduced by #437) in the `build:dist-only` input glob. Every `src/` change in any package invalidates `build:dist-only` for every package — the cost of correctness.
+
+```json
+// Before
+"inputs": [
+  "src/**/*.{ts,tsx,vue,svelte}",
+  "tsdown.config.*",
+  "tsconfig.json",
+  "package.json"
+]
+
+// After
+"inputs": [
+  "$TURBO_ROOT$/packages/*/src/**/*.{ts,tsx,vue,svelte}",
+  "$TURBO_ROOT$/shared/**/*.{ts,tsx}",
+  "tsdown.config.*",
+  "tsconfig.json",
+  "package.json"
+]
+```
+
+**Why `shared/**`:** #437 migrated `dom-utils`and`browser-env`from workspace packages to a`shared/` directory consumed via git-tracked symlinks (`packages/_/src/{dom-utils,browser-env} → ../../../shared/_`). Turbo hashes symlinked files through the consumer's glob, but explicit `shared/\*\*` makes the dependency unambiguous and protects against future symlink-resolution edge cases.
+
+**Tradeoff:** Any `src/` change in any package (or in `shared/`) invalidates `build:dist-only` for all packages. Cache hit rate drops in exchange for correctness. With 31 packages / ~20K LOC, cold-cache overhead is acceptable. For 300+ packages, per-package transitive input lists (generated from each package's dependency graph) would be the more scalable approach.
+
+**Rejected alternatives:**
+
+- **Disable remote cache for this task** — turbo has no per-task remote-cache toggle; removing `TURBO_TOKEN` would lose all cache benefits.
+- **`--force` flag** — not a per-task flag; would defeat the cache entirely.
+- **Wait for upstream fix** (`vercel/turborepo#3969`) — open since 2023, no timeline.
+
 ### `test:e2e` Task
 
 New turbo task for Playwright e2e tests in example applications:

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,8 @@
       "dependsOn": ["^build:dist-only"],
       "outputs": ["dist/**"],
       "inputs": [
-        "src/**/*.{ts,tsx,vue,svelte}",
+        "$TURBO_ROOT$/packages/*/src/**/*.{ts,tsx,vue,svelte}",
+        "$TURBO_ROOT$/shared/**/*.{ts,tsx}",
         "tsdown.config.*",
         "tsconfig.json",
         "package.json"


### PR DESCRIPTION
## Summary

Fixes #431 — flaky CI `type-check` caused by turbo serving stale `dist/` from remote cache when a workspace dependency's source changes but the consumer's `src/` does not.

## Root Cause (recap)

`build:dist-only.dependsOn: ["^build:dist-only"]` controls execution order but **not** cache key computation. With per-package scoped inputs (`src/**/*.{ts,tsx,vue,svelte}`), a package's cache hash includes only its own `src/` — not its workspace dependencies' sources.

Example flake:
1. PR changes `packages/fsm/src/fsm.ts`
2. `fsm:build:dist-only` — cache miss, rebuilds ✅
3. `core:build:dist-only` — remote cache hit (core/src/ unchanged) → restores stale `dist/` built against old fsm types
4. `search-schema-plugin:type-check` uses stale core `.d.ts` → `TS7006: Parameter implicitly has 'any' type`

Also manifested as rolldown `UNRESOLVED_IMPORT` when `core` inlines a stale `route-tree/dist/esm/index.mjs` via `alwaysBundle: ["event-emitter", "route-tree"]` — see the April 8 CI runs linked in #431 that the reporter provided as reproduction evidence.

Tracked upstream: [vercel/turborepo#3969](https://github.com/vercel/turborepo/issues/3969) (per-task transitive input hashing; open since 2023).

## Fix (Option A from the issue)

Use `$TURBO_ROOT$` to include **all** workspace package sources (plus the symlinked `shared/` sources introduced by #437) in `build:dist-only` inputs:

```diff
"build:dist-only": {
  "dependsOn": ["^build:dist-only"],
  "outputs": ["dist/**"],
  "inputs": [
-   "src/**/*.{ts,tsx,vue,svelte}",
+   "$TURBO_ROOT$/packages/*/src/**/*.{ts,tsx,vue,svelte}",
+   "$TURBO_ROOT$/shared/**/*.{ts,tsx}",
    "tsdown.config.*",
    "tsconfig.json",
    "package.json"
  ]
}
```

### Why `shared/**`

#437 migrated `dom-utils` and `browser-env` from workspace packages to `shared/` consumed via git-tracked symlinks (`packages/*/src/{dom-utils,browser-env} → ../../../shared/*`). Turbo hashes symlinked files through the consumer glob, but the explicit `shared/**` entry makes the dependency unambiguous and protects against future symlink-resolution edge cases.

## Tradeoff

Any `src/` change in any package (or in `shared/`) now invalidates `build:dist-only` for **all** packages. Cache hit rate drops in exchange for correctness. With 31 packages / ~20K LOC, cold-cache overhead is ~10s on CI — acceptable for a 30-package monorepo. For 300+ packages, per-package transitive input lists generated from each package's dependency graph would be the more scalable approach.

## Rejected Alternatives (from the issue)

- **Disable remote cache for this task** — turbo has no per-task remote-cache toggle; removing `TURBO_TOKEN` would lose all cache benefits.
- **`--force` flag** — not a per-task flag; would defeat the cache entirely.
- **Wait for upstream fix** (vercel/turborepo#3969) — open since 2023, no timeline.

## Local Verification

Empirical hash check — touching `packages/fsm/src/index.ts` correctly invalidates `@real-router/core#build:dist-only` (the exact scenario described in the issue):

| Package | Hash (clean state) | Hash (after editing `fsm/src/index.ts`) | Invalidated? |
| --- | --- | --- | --- |
| `@real-router/core` | `90b048a65867fc9d` | `e36e9b13b51460bd` | ✅ |
| `@real-router/fsm` | `78168a3167605b30` | `5ca28cf2afa9fa98` | ✅ |
| `@real-router/logger` | `620a7d31811a0938` | `64e4bf4b417f0cd5` | ✅ |

Also verified locally:

- `turbo dry-run` — `$TURBO_ROOT$` resolves correctly, `Inputs Files Considered = 409` for every `build:dist-only` task
- `turbo run build:dist-only --filter=@real-router/core` — 8/8 success (3.5s)
- `turbo run type-check --filter='...^@real-router/sources'` — 31/31 success (all framework adapters pass)
- `pnpm test -- --run` — **179/179 tasks success, 0 failed** (2m14s)
- Pre-commit hook (tests + knip + jscpd + lint:e2e) — passed

## Notes

- `#trivial` in the title because only `turbo.json` + `IMPLEMENTATION_NOTES.md` change — no public package source files → no changeset needed per `.changeset/README.md` escape-hatch rules.
- Draft until CI verification on this PR is complete.
- Follow-up probe commit touching `packages/fsm/src/index.ts` may land on this branch temporarily to empirically demonstrate on CI that `core:build:dist-only` correctly misses the remote cache when fsm sources change. It will be reverted before the PR is marked ready.

## See Also

- #431 — original bug report with reproduction evidence
- #437 / #440 — shared sources migration (motivates the `$TURBO_ROOT$/shared/**` entry)
- [vercel/turborepo#3969](https://github.com/vercel/turborepo/issues/3969) — upstream tracking issue