### PR TITLE
fix(browser-env): add null guard in shouldReplaceHistory (#447)

### DIFF
--- a/.changeset/shouldReplaceHistory-browser-plugin-fix.md
+++ b/.changeset/shouldReplaceHistory-browser-plugin-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix TypeError in `shouldReplaceHistory` when `replace:false` + `fromState:undefined` (#447)
+
+Added optional chaining (`fromState?.path`) to prevent crash when the `??` operator preserves an explicit `false` for `replace`, bypassing the `!fromState` null guard and reaching `fromState.path` with `undefined`.

--- a/.changeset/shouldReplaceHistory-hash-plugin-fix.md
+++ b/.changeset/shouldReplaceHistory-hash-plugin-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Fix TypeError in `shouldReplaceHistory` when `replace:false` + `fromState:undefined` (#447)
+
+Added optional chaining (`fromState?.path`) to prevent crash when the `??` operator preserves an explicit `false` for `replace`, bypassing the `!fromState` null guard and reaching `fromState.path` with `undefined`.

--- a/.changeset/shouldReplaceHistory-navigation-plugin-fix.md
+++ b/.changeset/shouldReplaceHistory-navigation-plugin-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix TypeError in `shouldReplaceHistory` when `replace:false` + `fromState:undefined` (#447)
+
+Added optional chaining (`fromState?.path`) to prevent crash when the `??` operator preserves an explicit `false` for `replace`, bypassing the `!fromState` null guard and reaching `fromState.path` with `undefined`.

--- a/packages/browser-env/tests/property/shouldReplaceHistory.properties.ts
+++ b/packages/browser-env/tests/property/shouldReplaceHistory.properties.ts
@@ -66,4 +66,40 @@ describe("shouldReplaceHistory Properties", () => {
       },
     );
   });
+
+  describe("G4: domain completeness — never throws for any valid input", () => {
+    test.prop(
+      [arbNavigationOptions, arbState, fc.option(arbState, { nil: undefined })],
+      { numRuns: NUM_RUNS.standard },
+    )(
+      "returns boolean for all (replace, reload, fromState) combinations",
+      (
+        navOptions: NavigationOptions,
+        toState: State,
+        fromState: State | undefined,
+      ) => {
+        const result = shouldReplaceHistory(navOptions, toState, fromState);
+
+        expect(typeof result).toBe("boolean");
+      },
+    );
+
+    test.prop(
+      [
+        fc.record({
+          replace: fc.constantFrom(true, false, undefined),
+          reload: fc.constantFrom(true, false, undefined),
+        }),
+        arbState,
+      ],
+      { numRuns: NUM_RUNS.standard },
+    )(
+      "fromState=undefined never crashes regardless of replace/reload values",
+      (navOptions: NavigationOptions, toState: State) => {
+        const result = shouldReplaceHistory(navOptions, toState, undefined);
+
+        expect(typeof result).toBe("boolean");
+      },
+    );
+  });
 });

--- a/packages/browser-env/tests/unit/plugin-utils.test.ts
+++ b/packages/browser-env/tests/unit/plugin-utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+
+import { shouldReplaceHistory } from "../../src";
+
+import type { State } from "@real-router/core";
+
+const STUB_TRANSITION = Object.freeze({
+  phase: "activating",
+  reason: "success",
+  segments: Object.freeze({
+    deactivated: Object.freeze([]),
+    activated: Object.freeze([]),
+    intersection: "",
+  }),
+}) as unknown as State["transition"];
+
+function makeState(path: string): State {
+  return {
+    name: "test",
+    params: {},
+    path,
+    transition: STUB_TRANSITION,
+    context: {},
+  };
+}
+
+describe("shouldReplaceHistory", () => {
+  describe("replace option", () => {
+    it("returns true when replace:true", () => {
+      const toState = makeState("/a");
+      const fromState = makeState("/b");
+
+      expect(
+        shouldReplaceHistory({ replace: true }, toState, fromState),
+      ).toBe(true);
+    });
+
+    it("returns true when replace:true even with fromState undefined", () => {
+      const toState = makeState("/a");
+
+      expect(
+        shouldReplaceHistory({ replace: true }, toState, undefined),
+      ).toBe(true);
+    });
+  });
+
+  describe("fromState undefined (initial navigation)", () => {
+    it("returns true when replace is undefined and fromState is undefined", () => {
+      const toState = makeState("/a");
+
+      expect(
+        shouldReplaceHistory({}, toState, undefined),
+      ).toBe(true);
+    });
+
+    it("returns false when replace:false and fromState is undefined (no crash)", () => {
+      const toState = makeState("/a");
+
+      expect(
+        shouldReplaceHistory({ replace: false }, toState, undefined),
+      ).toBe(false);
+    });
+  });
+
+  describe("reload with same path", () => {
+    it("returns true for reload:true + same path when replace:false", () => {
+      const state = makeState("/users");
+
+      expect(
+        shouldReplaceHistory({ reload: true, replace: false }, state, state),
+      ).toBe(true);
+    });
+
+    it("returns false for reload:true + different path when replace:false", () => {
+      expect(
+        shouldReplaceHistory(
+          { reload: true, replace: false },
+          makeState("/users"),
+          makeState("/home"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("regression: #447 — replace:false + fromState:undefined + reload:true", () => {
+    it("does not crash when replace:false + reload:true + fromState:undefined", () => {
+      // Before fix: TypeError — accessing fromState.path when fromState is undefined
+      // After fix: false — replace:false is preserved by ??, reload path comparison safe via ?.
+      expect(
+        shouldReplaceHistory(
+          { reload: true, replace: false },
+          makeState("/a"),
+          undefined,
+        ),
+      ).toBe(false);
+    });
+
+    it("does not crash when replace:false + reload:false + fromState:undefined", () => {
+      expect(
+        shouldReplaceHistory(
+          { reload: false, replace: false },
+          makeState("/a"),
+          undefined,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("normal navigation", () => {
+    it("returns false for non-replace, non-reload with different states", () => {
+      expect(
+        shouldReplaceHistory(
+          { replace: false, reload: false },
+          makeState("/users"),
+          makeState("/home"),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for non-replace, non-reload with same path", () => {
+      const state = makeState("/users");
+
+      expect(
+        shouldReplaceHistory({ replace: false, reload: false }, state, state),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/browser-env/tests/unit/plugin-utils.test.ts
+++ b/packages/browser-env/tests/unit/plugin-utils.test.ts
@@ -30,17 +30,17 @@ describe("shouldReplaceHistory", () => {
       const toState = makeState("/a");
       const fromState = makeState("/b");
 
-      expect(
-        shouldReplaceHistory({ replace: true }, toState, fromState),
-      ).toBe(true);
+      expect(shouldReplaceHistory({ replace: true }, toState, fromState)).toBe(
+        true,
+      );
     });
 
     it("returns true when replace:true even with fromState undefined", () => {
       const toState = makeState("/a");
 
-      expect(
-        shouldReplaceHistory({ replace: true }, toState, undefined),
-      ).toBe(true);
+      expect(shouldReplaceHistory({ replace: true }, toState, undefined)).toBe(
+        true,
+      );
     });
   });
 
@@ -48,17 +48,15 @@ describe("shouldReplaceHistory", () => {
     it("returns true when replace is undefined and fromState is undefined", () => {
       const toState = makeState("/a");
 
-      expect(
-        shouldReplaceHistory({}, toState, undefined),
-      ).toBe(true);
+      expect(shouldReplaceHistory({}, toState, undefined)).toBe(true);
     });
 
     it("returns false when replace:false and fromState is undefined (no crash)", () => {
       const toState = makeState("/a");
 
-      expect(
-        shouldReplaceHistory({ replace: false }, toState, undefined),
-      ).toBe(false);
+      expect(shouldReplaceHistory({ replace: false }, toState, undefined)).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/core/tests/functional/api/getPluginApi/claimContextNamespace.test.ts
+++ b/packages/core/tests/functional/api/getPluginApi/claimContextNamespace.test.ts
@@ -348,17 +348,15 @@ describe("State.context", () => {
     });
 
     it("transition.segments is frozen", () => {
-      expect(Object.isFrozen(state.transition!.segments)).toBe(true);
+      expect(Object.isFrozen(state.transition.segments)).toBe(true);
     });
 
     it("transition.segments.activated is frozen", () => {
-      expect(Object.isFrozen(state.transition!.segments.activated)).toBe(true);
+      expect(Object.isFrozen(state.transition.segments.activated)).toBe(true);
     });
 
     it("transition.segments.deactivated is frozen", () => {
-      expect(Object.isFrozen(state.transition!.segments.deactivated)).toBe(
-        true,
-      );
+      expect(Object.isFrozen(state.transition.segments.deactivated)).toBe(true);
     });
   });
 

--- a/packages/core/tests/property/shouldUpdateNode.properties.ts
+++ b/packages/core/tests/property/shouldUpdateNode.properties.ts
@@ -12,7 +12,7 @@ describe("shouldUpdateNode Properties", () => {
 
       await router.navigate("admin.settings");
       const toState = router.getState()!;
-      const { deactivated, activated } = toState.transition!.segments;
+      const { deactivated, activated } = toState.transition.segments;
 
       for (const segment of [...deactivated, ...activated]) {
         expect(router.shouldUpdateNode(segment)(toState, fromState)).toBe(true);
@@ -53,7 +53,7 @@ describe("shouldUpdateNode Properties", () => {
     const toState = router.getState()!;
     const fromState = router.getPreviousState()!;
 
-    expect(toState.transition!.segments.intersection).toBe("users");
+    expect(toState.transition.segments.intersection).toBe("users");
     expect(router.shouldUpdateNode("users")(toState, fromState)).toBe(true);
 
     router.stop();

--- a/packages/core/tests/property/transitionSegments.properties.ts
+++ b/packages/core/tests/property/transitionSegments.properties.ts
@@ -41,7 +41,7 @@ describe("navigate() → transition.segments Properties", () => {
       await router.navigate(toRoute, getParamsForRoute(toRoute));
 
       const { deactivated, activated, intersection } =
-        router.getState()!.transition!.segments;
+        router.getState()!.transition.segments;
 
       const fromParts = fromRoute.split(".");
       const toParts = toRoute.split(".");
@@ -72,7 +72,7 @@ describe("navigate() → transition.segments Properties", () => {
       );
       await router.navigate(toRoute, getParamsForRoute(toRoute));
 
-      const { intersection } = router.getState()!.transition!.segments;
+      const { intersection } = router.getState()!.transition.segments;
 
       if (intersection) {
         expect(fromRoute.startsWith(intersection)).toBe(true);
@@ -97,7 +97,7 @@ describe("navigate() → transition.segments Properties", () => {
       );
       await router.navigate(toRoute, getParamsForRoute(toRoute));
 
-      const { deactivated } = router.getState()!.transition!.segments;
+      const { deactivated } = router.getState()!.transition.segments;
 
       for (let i = 0; i < deactivated.length - 1; i++) {
         expect(deactivated[i].length).toBeGreaterThanOrEqual(
@@ -123,7 +123,7 @@ describe("navigate() → transition.segments Properties", () => {
       );
       await router.navigate(toRoute, getParamsForRoute(toRoute));
 
-      const { activated } = router.getState()!.transition!.segments;
+      const { activated } = router.getState()!.transition.segments;
 
       for (let i = 0; i < activated.length - 1; i++) {
         expect(activated[i].length).toBeLessThanOrEqual(
@@ -137,7 +137,7 @@ describe("navigate() → transition.segments Properties", () => {
 
   it("first navigation: deactivated is empty", async () => {
     const router = await createStartedRouter("/users/abc");
-    const { deactivated } = router.getState()!.transition!.segments;
+    const { deactivated } = router.getState()!.transition.segments;
 
     expect(deactivated).toStrictEqual([]);
 

--- a/packages/navigation-plugin/tests/property/history-model.properties.ts
+++ b/packages/navigation-plugin/tests/property/history-model.properties.ts
@@ -21,15 +21,18 @@ import type { PluginApi } from "@real-router/core/api";
 // Model
 // =============================================================================
 
+interface StackEntry {
+  name: string;
+  params: Record<string, string>;
+}
+
 interface HistoryModel {
-  /** Route names in the history stack (ordered) */
-  stack: string[];
+  /** Route names and params in the history stack (ordered) */
+  stack: StackEntry[];
   /** Current position in the stack */
   cursor: number;
   /** Whether the router has been started */
   started: boolean;
-  /** Current route params (for SAME_STATES prevention) */
-  currentParams: Record<string, string>;
 }
 
 interface HistoryReal {
@@ -54,13 +57,15 @@ class NavigateCommand implements fc.AsyncCommand<HistoryModel, HistoryReal> {
       return false;
     }
 
-    if (m.stack[m.cursor] !== this.routeName) {
+    const current = m.stack[m.cursor];
+
+    if (current.name !== this.routeName) {
       return true;
     }
 
     // Same route — check if params differ
     if (this.params) {
-      return this.params.id !== m.currentParams.id;
+      return this.params.id !== current.params.id;
     }
 
     // Same leaf route, same params — skip to prevent SAME_STATES
@@ -71,9 +76,11 @@ class NavigateCommand implements fc.AsyncCommand<HistoryModel, HistoryReal> {
     await r.router.navigate(this.routeName, this.params ?? {});
 
     m.stack = m.stack.slice(0, m.cursor + 1);
-    m.stack.push(this.routeName);
+    m.stack.push({
+      name: this.routeName,
+      params: this.params ? { ...this.params } : {},
+    });
     m.cursor = m.stack.length - 1;
-    m.currentParams = this.params ? { ...this.params } : {};
   }
 
   toString() {
@@ -92,7 +99,6 @@ class BackCommand implements fc.AsyncCommand<HistoryModel, HistoryReal> {
     await r.mockNav.goBack();
     await new Promise((resolve) => setTimeout(resolve, 10));
     m.cursor--;
-    m.currentParams = {};
   }
 
   toString() {
@@ -109,7 +115,6 @@ class ForwardCommand implements fc.AsyncCommand<HistoryModel, HistoryReal> {
     await r.mockNav.goForward();
     await new Promise((resolve) => setTimeout(resolve, 10));
     m.cursor++;
-    m.currentParams = {};
   }
 
   toString() {
@@ -168,7 +173,7 @@ class AssertPeekBackCommand implements fc.AsyncCommand<
 
     if (m.cursor > 0) {
       expect(peeked).toBeDefined();
-      expect(peeked!.name).toBe(m.stack[m.cursor - 1]);
+      expect(peeked!.name).toBe(m.stack[m.cursor - 1].name);
     } else {
       expect(peeked).toBeUndefined();
     }
@@ -192,7 +197,7 @@ class AssertPeekForwardCommand implements fc.AsyncCommand<
 
     if (m.cursor < m.stack.length - 1) {
       expect(peeked).toBeDefined();
-      expect(peeked!.name).toBe(m.stack[m.cursor + 1]);
+      expect(peeked!.name).toBe(m.stack[m.cursor + 1].name);
     } else {
       expect(peeked).toBeUndefined();
     }
@@ -212,7 +217,7 @@ class AssertVisitedCommand implements fc.AsyncCommand<
   }
 
   async run(m: HistoryModel, r: HistoryReal) {
-    const uniqueRoutes = [...new Set(m.stack)];
+    const uniqueRoutes = [...new Set(m.stack.map((entry) => entry.name))];
     const visited = r.router.getVisitedRoutes();
 
     for (const route of uniqueRoutes) {
@@ -224,7 +229,7 @@ class AssertVisitedCommand implements fc.AsyncCommand<
     );
 
     for (const route of uniqueRoutes) {
-      const expected = m.stack.filter((name) => name === route).length;
+      const expected = m.stack.filter((entry) => entry.name === route).length;
 
       expect(r.router.getRouteVisitCount(route)).toBe(expected);
     }
@@ -244,10 +249,10 @@ class AssertCanGoBackToCommand implements fc.AsyncCommand<
   }
 
   async run(m: HistoryModel, r: HistoryReal) {
-    const backEntries = new Set(m.stack.slice(0, m.cursor));
+    const backNames = new Set(m.stack.slice(0, m.cursor).map((entry) => entry.name));
 
     for (const routeName of LEAF_ROUTE_NAMES) {
-      const expected = backEntries.has(routeName);
+      const expected = backNames.has(routeName);
 
       expect(r.router.canGoBackTo(routeName)).toBe(expected);
     }
@@ -300,7 +305,7 @@ class AssertFindLastEntryForRouteCommand implements fc.AsyncCommand<
       let expectedIndex = -1;
 
       for (let i = m.stack.length - 1; i >= 0; i--) {
-        if (i !== m.cursor && m.stack[i] === routeName) {
+        if (i !== m.cursor && m.stack[i].name === routeName) {
           expectedIndex = i;
 
           break;
@@ -469,10 +474,9 @@ describe("Navigation Plugin History Model", () => {
 
       const setup = (): { model: HistoryModel; real: HistoryReal } => ({
         model: {
-          stack: [initialRoute],
+          stack: [{ name: initialRoute, params: {} }],
           cursor: 0,
           started: true,
-          currentParams: {},
         },
         real: { router, mockNav, browser, api },
       });

--- a/shared/browser-env/plugin-utils.ts
+++ b/shared/browser-env/plugin-utils.ts
@@ -53,6 +53,7 @@ export function shouldReplaceHistory(
 ): boolean {
   return (
     (navOptions.replace ?? !fromState) ||
-    (!!navOptions.reload && toState.path === fromState.path)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- fromState is NOT narrowed when replace is false (#447)
+    (!!navOptions.reload && toState.path === fromState?.path)
   );
 }


### PR DESCRIPTION
## Summary
- Fixed `TypeError: Cannot read properties of undefined (reading 'path')` in `shouldReplaceHistory()` when called with `replace: false` and `fromState: undefined`
- The `??` operator preserves explicit `false` (it is not nullish), bypassing the `!fromState` null guard and reaching `fromState.path` with `undefined`. Added optional chaining (`fromState?.path`) to prevent the crash
- Added unit tests, property-based tests (G4 domain completeness invariant), and changesets for all three consuming plugins

## Root cause
In `shared/browser-env/plugin-utils.ts`, line 56:
```typescript
(!!navOptions.reload && toState.path === fromState.path)
```
When `navOptions.replace` is `false`, the `??` operator in `(navOptions.replace ?? !fromState)` evaluates to `false` (since `false` is not nullish), so the second operand of `||` is reached. There, `fromState.path` crashes if `fromState` is `undefined`.

## Fix
```diff
-(!!navOptions.reload && toState.path === fromState.path)
+(!!navOptions.reload && toState.path === fromState?.path)
```

## Test plan
- [x] Unit tests: 10 new tests covering all branches of `shouldReplaceHistory` including the regression scenario
- [x] Property-based tests: 2 new properties for G4 domain completeness — never throws for any valid input combination
- [x] All 151 turbo tasks pass (type-check, lint, test, build)
- [x] Pre-commit hooks pass (tests + knip + jscpd + lint:e2e)

Closes #447