### PR TITLE
fix(navigation-plugin): entryToState query string + hot-path optimization (#449, #450)

### DIFF
--- a/.changeset/navigation-plugin-entrytostate-fix.md
+++ b/.changeset/navigation-plugin-entrytostate-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix entryToState discarding query string and remove redundant shouldReplaceHistory call (#449, #450)
+
+**Bug fix (#449):** `entryToState` now includes `url.search` when matching history entries, aligning with `traverseToLast` and `handleNavigateEvent` which already preserved query strings. Previously, history extensions like `peekBack`, `hasVisited`, `canGoBackTo`, and `getVisitedRoutes` would fail to match entries whose URLs contained query parameters.
+
+**Performance (#450):** `onTransitionSuccess` no longer calls `shouldReplaceHistory()` a second time — the push/replace decision is derived from the already-computed `navigationType` on `capturedMeta`.

--- a/packages/navigation-plugin/src/history-extensions.ts
+++ b/packages/navigation-plugin/src/history-extensions.ts
@@ -20,8 +20,8 @@ export function entryToState(
     return undefined;
   }
 
-  const pathname = new URL(entry.url).pathname;
-  const path = extractPath(pathname, base);
+  const url = new URL(entry.url);
+  const path = extractPath(url.pathname, base) + url.search;
 
   return api.matchPath(path) ?? undefined;
 }

--- a/packages/navigation-plugin/src/plugin.ts
+++ b/packages/navigation-plugin/src/plugin.ts
@@ -228,6 +228,8 @@ export class NavigationPlugin {
           };
         }
 
+        const { navigationType } = this.#capturedMeta;
+
         this.#claim.write(toState, Object.freeze(this.#capturedMeta));
         this.#capturedMeta = undefined;
 
@@ -252,11 +254,7 @@ export class NavigationPlugin {
           if (toState.name === UNKNOWN_ROUTE) {
             this.#browser.updateCurrentEntry({ state: historyState });
           } else {
-            const replace = shouldReplaceHistory(
-              navOptions,
-              toState,
-              fromState,
-            );
+            const replace = navigationType !== "push";
 
             this.#browser.navigate(finalUrl, {
               state: historyState,

--- a/packages/navigation-plugin/tests/functional/history-extensions.test.ts
+++ b/packages/navigation-plugin/tests/functional/history-extensions.test.ts
@@ -267,8 +267,10 @@ describe("Navigation Plugin — History Extensions", () => {
       unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
       await router.start();
 
+      // With query string preserved in entryToState (#449), strict mode
+      // rejects ?undeclared=1 during entry matching — no entry is found
       await expect(router.traverseToLast("users.list")).rejects.toThrow(
-        "No matching route",
+        "No history entry",
       );
     });
 
@@ -291,6 +293,28 @@ describe("Navigation Plugin — History Extensions", () => {
 
       await expect(router.traverseToLast("users.list")).rejects.toThrow(
         'No matching route for entry URL "null"',
+      );
+    });
+
+    it("throws when entry URL exists but does not match any route", async () => {
+      await router.start();
+      await router.navigate("users.list");
+      await router.navigate("home");
+
+      const entries = browser.entries();
+      const userListEntry = entries[1];
+      const entryWithUnknownUrl = Object.assign(
+        Object.create(Object.getPrototypeOf(userListEntry)),
+        userListEntry,
+        { url: "http://localhost/no-such-route" },
+      );
+
+      vi.spyOn(historyExtensions, "findLastEntryForRoute").mockReturnValue(
+        entryWithUnknownUrl as NavigationHistoryEntry,
+      );
+
+      await expect(router.traverseToLast("users.list")).rejects.toThrow(
+        "No matching route",
       );
     });
   });
@@ -460,6 +484,56 @@ describe("Navigation Plugin — History Extensions", () => {
       vi.spyOn(browser, "entries").mockReturnValue(entriesWithNull);
 
       expect(router.canGoBackTo("users.list")).toBe(true);
+    });
+  });
+
+  describe("entryToState — query string preservation (#449)", () => {
+    it("hasVisited recognizes entries with query params", async () => {
+      mockNav.navigate("http://localhost/users/list?tab=active");
+
+      await router.start();
+
+      expect(router.hasVisited("users.list")).toBe(true);
+    });
+
+    it("getVisitedRoutes includes routes reached via URLs with query params", async () => {
+      mockNav.navigate("http://localhost/users/list?tab=active");
+
+      await router.start();
+
+      const visited = router.getVisitedRoutes();
+
+      expect(visited).toContain("users.list");
+    });
+
+    it("getRouteVisitCount counts entries with query params", async () => {
+      mockNav.navigate("http://localhost/users/list?tab=active");
+      mockNav.navigate("http://localhost/users/list?tab=inactive");
+
+      await router.start();
+
+      expect(router.getRouteVisitCount("users.list")).toBe(2);
+    });
+
+    it("canGoBackTo finds routes in back entries with query params", async () => {
+      mockNav.navigate("http://localhost/users/list?tab=active");
+      mockNav.navigate("http://localhost/home");
+
+      await router.start();
+
+      expect(router.canGoBackTo("users.list")).toBe(true);
+    });
+
+    it("peekBack returns state for entry with query params in URL", async () => {
+      mockNav.navigate("http://localhost/users/list?tab=active");
+      mockNav.navigate("http://localhost/home");
+
+      await router.start();
+
+      const prev = router.peekBack();
+
+      expect(prev).toBeDefined();
+      expect(prev!.name).toBe("users.list");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **#449 — entryToState discards query string:** `entryToState()` in `history-extensions.ts` was extracting only `pathname` from the entry URL, discarding the query string. All history extensions (`peekBack`, `peekForward`, `hasVisited`, `getVisitedRoutes`, `getRouteVisitCount`, `canGoBackTo`, `findLastEntryForRoute`) failed to match entries whose URLs contained query parameters. Fixed by appending `url.search` to the extracted path, consistent with `traverseToLast` and `handleNavigateEvent`.

- **#450 — redundant `shouldReplaceHistory` call:** `onTransitionSuccess` called `shouldReplaceHistory()` twice — once inside `deriveNavigationType()` and again directly to decide push vs replace. Replaced the second call with a derivation from the already-computed `navigationType` on `capturedMeta` (`navigationType !== "push"`).

## Test plan

- [x] 5 new tests for query string preservation in `entryToState` (`hasVisited`, `getVisitedRoutes`, `getRouteVisitCount`, `canGoBackTo`, `peekBack` with query params)
- [x] 1 new test for `traverseToLast` when entry URL exists but does not match any route (coverage for defensive guard)
- [x] Updated existing stale route test expectation (now throws "No history entry" instead of "No matching route" — correct behavior since strict mode rejects undeclared query params during entry matching)
- [x] All 168 tests pass (162 original + 6 new)
- [x] 100% code coverage maintained

Closes #449
Closes #450