### PR TITLE
fix(browser-env): enforce segment boundary in extractPath (#446)

### DIFF
--- a/.changeset/extractpath-segment-boundary-browser-fix.md
+++ b/.changeset/extractpath-segment-boundary-browser-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix `extractPath` matching non-segment-boundary base prefix (#446)
+
+`extractPath("/application/users", "/app")` incorrectly stripped the base, returning `/lication/users`. Now enforces `/`-delimited segment boundaries: only exact match (`pathname === base`) or segment-boundary match (`pathname.startsWith(base + "/")`) triggers stripping.

--- a/.changeset/extractpath-segment-boundary-navigation-fix.md
+++ b/.changeset/extractpath-segment-boundary-navigation-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix `extractPath` matching non-segment-boundary base prefix (#446)
+
+`extractPath("/application/users", "/app")` incorrectly stripped the base, returning `/lication/users`. Now enforces `/`-delimited segment boundaries: only exact match (`pathname === base`) or segment-boundary match (`pathname.startsWith(base + "/")`) triggers stripping.

--- a/packages/browser-plugin/tests/functional/url.test.ts
+++ b/packages/browser-plugin/tests/functional/url.test.ts
@@ -154,20 +154,14 @@ describe("Browser Plugin — URL", () => {
         });
       });
 
-      it("handles base path where stripped path needs leading slash (line 174)", async () => {
+      it("does not strip base when match is not at segment boundary", async () => {
         router = createRouter(routerConfig, { defaultRoute: "home" });
-        // Base matches exactly, stripped path will be empty or not start with /
         router.usePlugin(browserPluginFactory({ base: "/app" }));
 
-        // When base is exactly stripped, pathname becomes "users/list" (no leading /)
-        // The code adds "/" prefix when stripped doesn't start with "/"
+        // "/appusers/list" should NOT match base "/app" — not a segment boundary
         const state = router.matchUrl("https://example.com/appusers/list");
 
-        // This path doesn't match after stripping because it becomes "users/list" not "/users/list"
-        // Actually let me reconsider - /appusers/list with base /app would strip to "users/list"
-        // which needs a leading slash added
-        expect(state).toBeDefined();
-        // Or it might be undefined if route doesn't match - but the branch is exercised
+        expect(state).toBeUndefined();
       });
     });
   });

--- a/packages/browser-plugin/tests/property/browserPlugin.properties.ts
+++ b/packages/browser-plugin/tests/property/browserPlugin.properties.ts
@@ -211,7 +211,10 @@ describe("Browser Plugin URL Invariants", () => {
             fc.stringMatching(/^\/[a-z]{1,4}$/),
             fc.stringMatching(/^[a-z]{1,6}$/),
           )
-          .map(([base, suffix]) => ({ base, pathname: `${base}${suffix}/page` })),
+          .map(([base, suffix]) => ({
+            base,
+            pathname: `${base}${suffix}/page`,
+          })),
       ],
       { numRuns: NUM_RUNS.standard },
     )(

--- a/packages/browser-plugin/tests/property/browserPlugin.properties.ts
+++ b/packages/browser-plugin/tests/property/browserPlugin.properties.ts
@@ -203,6 +203,25 @@ describe("Browser Plugin URL Invariants", () => {
         expect(result).toStrictEqual(path);
       },
     );
+
+    test.prop(
+      [
+        fc
+          .tuple(
+            fc.stringMatching(/^\/[a-z]{1,4}$/),
+            fc.stringMatching(/^[a-z]{1,6}$/),
+          )
+          .map(([base, suffix]) => ({ base, pathname: `${base}${suffix}/page` })),
+      ],
+      { numRuns: NUM_RUNS.standard },
+    )(
+      "extractPath never strips a partial segment prefix (#446)",
+      ({ base, pathname }) => {
+        const result = extractPath(pathname, base);
+
+        expect(result).toBe(pathname);
+      },
+    );
   });
 
   describe("matchUrl — non-matching URLs", () => {

--- a/packages/navigation-plugin/tests/functional/url.test.ts
+++ b/packages/navigation-plugin/tests/functional/url.test.ts
@@ -30,6 +30,24 @@ describe("extractPath", () => {
   it("returns original path when base is empty", () => {
     expect(extractPath("/users/list", "")).toBe("/users/list");
   });
+
+  it("does not strip partial segment match", () => {
+    expect(extractPath("/application/users", "/app")).toBe(
+      "/application/users",
+    );
+  });
+
+  it("does not strip when base is prefix of segment", () => {
+    expect(extractPath("/app-v2/users", "/app")).toBe("/app-v2/users");
+  });
+
+  it("strips exact segment match", () => {
+    expect(extractPath("/app/users", "/app")).toBe("/users");
+  });
+
+  it("returns / for exact base match", () => {
+    expect(extractPath("/app", "/app")).toBe("/");
+  });
 });
 
 describe("buildUrl", () => {

--- a/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
+++ b/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
@@ -217,7 +217,10 @@ describe("Navigation Plugin URL Invariants", () => {
             fc.stringMatching(/^\/[a-z]{1,4}$/),
             fc.stringMatching(/^[a-z]{1,6}$/),
           )
-          .map(([base, suffix]) => ({ base, pathname: `${base}${suffix}/page` })),
+          .map(([base, suffix]) => ({
+            base,
+            pathname: `${base}${suffix}/page`,
+          })),
       ],
       { numRuns: NUM_RUNS.standard },
     )(

--- a/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
+++ b/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
@@ -209,6 +209,25 @@ describe("Navigation Plugin URL Invariants", () => {
         expect(result).toStrictEqual(path);
       },
     );
+
+    test.prop(
+      [
+        fc
+          .tuple(
+            fc.stringMatching(/^\/[a-z]{1,4}$/),
+            fc.stringMatching(/^[a-z]{1,6}$/),
+          )
+          .map(([base, suffix]) => ({ base, pathname: `${base}${suffix}/page` })),
+      ],
+      { numRuns: NUM_RUNS.standard },
+    )(
+      "extractPath never strips a partial segment prefix (#446)",
+      ({ base, pathname }) => {
+        const result = extractPath(pathname, base);
+
+        expect(result).toBe(pathname);
+      },
+    );
   });
 
   describe("matchUrl — non-matching URLs", () => {

--- a/shared/browser-env/url-utils.ts
+++ b/shared/browser-env/url-utils.ts
@@ -1,7 +1,7 @@
 import { safeParseUrl } from "./url-parsing.js";
 
 export function extractPath(pathname: string, base: string): string {
-  if (base && pathname.startsWith(base)) {
+  if (base && (pathname === base || pathname.startsWith(base + "/"))) {
     const stripped = pathname.slice(base.length);
 
     return stripped.startsWith("/") ? stripped : `/${stripped}`;

--- a/shared/browser-env/url-utils.ts
+++ b/shared/browser-env/url-utils.ts
@@ -1,7 +1,7 @@
 import { safeParseUrl } from "./url-parsing.js";
 
 export function extractPath(pathname: string, base: string): string {
-  if (base && (pathname === base || pathname.startsWith(base + "/"))) {
+  if (base && (pathname === base || pathname.startsWith(`${base}/`))) {
     const stripped = pathname.slice(base.length);
 
     return stripped.startsWith("/") ? stripped : `/${stripped}`;


### PR DESCRIPTION
## Summary

- Fix `extractPath` incorrectly stripping base prefix when base is a non-segment-boundary prefix of the pathname (e.g., `/app` matching `/application/users`)
- Replace `pathname.startsWith(base)` with `pathname === base || pathname.startsWith(base + "/")` to enforce `/`-delimited segment boundaries
- Update existing browser-plugin test that asserted the buggy behavior
- Add unit tests and property-based tests (PBT) to both browser-plugin and navigation-plugin

Closes #446

## What was broken

`extractPath("/application/users", "/app")` returned `/lication/users` instead of `/application/users`. Any app with base `/app` would incorrectly strip the base from URLs like `/application`, `/app-v2`, `/appended`, etc.

## Test plan

- [x] 4 new functional unit tests in navigation-plugin (`url.test.ts`): partial segment match, segment prefix, exact segment match, exact base match
- [x] 1 browser-plugin test updated: now asserts `/appusers/list` with base `/app` returns `undefined` (was incorrectly asserting `toBeDefined()`)
- [x] 1 new PBT property in each plugin: generates random base paths and pathnames where base is a prefix but NOT at a segment boundary, verifies `extractPath` returns the original pathname
- [x] All existing tests pass (151 turbo tasks, 0 failures)