### PR TITLE
fix(navigation-plugin): computeDirection returns "unknown" for equal indices

### DIFF
--- a/.changeset/compute-direction-equal-indices-fix.md
+++ b/.changeset/compute-direction-equal-indices-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix `computeDirection` returning "back" for traverse with equal indices (#448)
+
+`computeDirection("traverse", i, i)` now correctly returns `"unknown"` instead of `"back"` when destination and current indices are equal.

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -31,6 +31,10 @@ export function computeDirection(
   currentIndex: number,
 ): NavigationDirection {
   if (navigationType === "traverse") {
+    if (destinationIndex === currentIndex) {
+      return "unknown";
+    }
+
     return destinationIndex > currentIndex ? "forward" : "back";
   }
 

--- a/packages/navigation-plugin/tests/functional/navigation-meta.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigation-meta.test.ts
@@ -348,6 +348,21 @@ describe("Navigation Plugin — NavigationMeta", () => {
     });
   });
 
+  describe("direction for traverse with equal indices", () => {
+    it('direction is "unknown" when traversing to the current entry (equal indices)', async () => {
+      await router.start();
+
+      const currentKey = mockNav.currentEntry!.key;
+      const result = mockNav.traverseTo(currentKey);
+
+      await result.finished;
+
+      const state = router.getState()!;
+
+      expect(state.context.navigation?.direction).toBe("unknown");
+    });
+  });
+
   describe("direction for browser-initiated navigation", () => {
     it('direction is "unknown" for browser replace navigation', async () => {
       await router.start();

--- a/packages/navigation-plugin/tests/property/history-model.properties.ts
+++ b/packages/navigation-plugin/tests/property/history-model.properties.ts
@@ -249,7 +249,9 @@ class AssertCanGoBackToCommand implements fc.AsyncCommand<
   }
 
   async run(m: HistoryModel, r: HistoryReal) {
-    const backNames = new Set(m.stack.slice(0, m.cursor).map((entry) => entry.name));
+    const backNames = new Set(
+      m.stack.slice(0, m.cursor).map((entry) => entry.name),
+    );
 
     for (const routeName of LEAF_ROUTE_NAMES) {
       const expected = backNames.has(routeName);

--- a/packages/navigation-plugin/tests/property/pure-functions.properties.ts
+++ b/packages/navigation-plugin/tests/property/pure-functions.properties.ts
@@ -54,6 +54,13 @@ describe("computeDirection Properties", () => {
     );
   });
 
+  test.prop([arbIndex], { numRuns: NUM_RUNS.fast })(
+    "traverse direction is unknown for equal indices",
+    (index) => {
+      expect(computeDirection("traverse", index, index)).toBe("unknown");
+    },
+  );
+
   test.prop([arbIndex, arbIndex], { numRuns: NUM_RUNS.fast })(
     "push direction is always forward",
     (destination, curr) => {


### PR DESCRIPTION
## Summary
- Fix `computeDirection("traverse", i, i)` returning `"back"` instead of `"unknown"` when destination and current indices are equal
- Add functional test for traverse to current entry via `mockNav.traverseTo(currentKey)`
- Add property-based test asserting `computeDirection("traverse", index, index) === "unknown"`

Closes #448

## Test plan
- [x] Functional test: traverse to current entry returns `direction: "unknown"`
- [x] Property test: equal indices always produce `"unknown"` for traverse
- [x] Existing antisymmetry property test still passes (distinct indices)
- [x] Full build passes (234/234 tasks, 100% coverage)