### PR TITLE
feat(lifecycle-plugin): add onNavigate hook (combined onEnter + onStay) (#463)

### DIFF
--- a/.changeset/onnavigate-feature.md
+++ b/.changeset/onnavigate-feature.md
@@ -1,0 +1,31 @@
+---
+"@real-router/lifecycle-plugin": minor
+---
+
+Add `onNavigate` lifecycle hook — combined `onEnter` + `onStay` fallback (#463)
+
+New route-level hook that fires on every successful navigation to the route,
+regardless of whether the route was entered or params changed. Replaces the
+common pattern of duplicating the same function in both `onEnter` and `onStay`.
+
+```typescript
+// Before — duplication:
+{
+  name: "services.catalog",
+  path: "/catalog?q&sort&dir",
+  onEnter: loadServices,
+  onStay: loadServices,
+}
+
+// After — one declaration:
+{
+  name: "services.catalog",
+  path: "/catalog?q&sort&dir",
+  onNavigate: loadServices,
+}
+```
+
+**Priority:** `onEnter` / `onStay` take precedence over `onNavigate` for their
+respective case. `onNavigate` acts as a fallback for whichever specific hook is
+not defined. This enables hybrid declarations — shared data loading in
+`onNavigate`, entry-specific initialization in `onEnter`.

--- a/.changeset/onnavigate-feature.md
+++ b/.changeset/onnavigate-feature.md
@@ -2,7 +2,7 @@
 "@real-router/lifecycle-plugin": minor
 ---
 
-Add `onNavigate` lifecycle hook — combined `onEnter` + `onStay` fallback (#463)
+Add `onNavigate` lifecycle hook — orthogonal to `onEnter` / `onStay` (#463)
 
 New route-level hook that fires on every successful navigation to the route,
 regardless of whether the route was entered or params changed. Replaces the
@@ -25,7 +25,8 @@ common pattern of duplicating the same function in both `onEnter` and `onStay`.
 }
 ```
 
-**Priority:** `onEnter` / `onStay` take precedence over `onNavigate` for their
-respective case. `onNavigate` acts as a fallback for whichever specific hook is
-not defined. This enables hybrid declarations — shared data loading in
-`onNavigate`, entry-specific initialization in `onEnter`.
+**Orthogonal dispatch:** `onEnter` / `onStay` / `onNavigate` fire
+independently — if both `onEnter` and `onNavigate` are defined, both fire on
+entry. Each hook reacts to its own condition, so you can compose shared logic
+(`onNavigate`) with case-specific setup (`onEnter` / `onStay`) without either
+silencing the other.

--- a/packages/lifecycle-plugin/ARCHITECTURE.md
+++ b/packages/lifecycle-plugin/ARCHITECTURE.md
@@ -58,11 +58,13 @@ onTransitionLeaveApprove(toState, fromState)
 onTransitionSuccess(toState, fromState)
     │
     ├── toState.name === fromState.name?
-    │   ├── YES → compileHook("onStay", "users.view") ?? compileHook("onNavigate", "users.view") → call if resolved
-    │   └── NO  → compileHook("onEnter", "users.view") ?? compileHook("onNavigate", "users.view") → call if resolved
+    │   ├── YES → compileHook("onStay", "users.view") → call if resolved
+    │   └── NO  → compileHook("onEnter", "users.view") → call if resolved
+    │
+    └── compileHook("onNavigate", "users.view") → call if resolved (orthogonal — always consulted)
 ```
 
-`onNavigate` is consulted only when the case-specific hook (`onStay` or `onEnter`) is not defined for the target route. If both are defined, the specific hook wins and `onNavigate` does not fire for that case.
+`onNavigate` fires independently of `onEnter` / `onStay` — if both are defined, both fire. Each hook is dispatched based on its own condition.
 
 ### Lazy Compile + Cache Pattern
 
@@ -111,14 +113,21 @@ Hooks fire only for `toState.name` / `fromState.name`, not for all segments in `
 - No loops, no Set allocations — just a property lookup
 - Parent route hooks would fire on every child navigation, which is rarely desired
 
-### Why `onNavigate` as fallback, not additional
+### Why `onNavigate` is orthogonal, not a fallback
 
-`onNavigate` is the most common pattern: run the same side-effect on both route entry and same-route param change (data loading, analytics, UI reset). Two design options were considered:
+`onNavigate` covers the most common pattern: run the same side-effect whenever the route is the navigation target (data loading, analytics, UI reset). Two design options were considered:
 
-1. **Additive** — fire `onNavigate` in addition to `onEnter` / `onStay` when both are defined.
-2. **Fallback** — fire `onNavigate` only when the case-specific hook (`onEnter` or `onStay`) is absent.
+1. **Orthogonal** — fire `onNavigate` on every success, independently of `onEnter` / `onStay`.
+2. **Fallback** — fire `onNavigate` only when the case-specific hook (`onEnter` or `onStay`) is absent for the current case.
 
-The fallback design wins: it lets users mix shared logic (`onNavigate`) with case-specific overrides (`onEnter` to connect WebSocket, `onStay` falls back to `onNavigate` to reload data). The additive design would double-fire effects when users declare both, forcing defensive guards inside hooks.
+The orthogonal design wins:
+
+- **Matches the real-world hybrid example.** Chat route: `onEnter` connects the WebSocket, `onNavigate` loads messages. Under fallback semantics, `onNavigate` would not fire on entry (since `onEnter` is defined), forcing the user to duplicate `loadMessages` inside `onEnter` — exactly the duplication `onNavigate` was introduced to eliminate.
+- **Mirrors global plugin hooks.** `onTransitionStart` and `onTransitionSuccess` coexist — neither silences the other. Route-level hooks follow the same model.
+- **Simpler mental model.** Each hook fires based on its own condition. No priority rules, no fallback chains, no hidden interactions.
+- **Composable.** Declaring `onEnter` alongside `onNavigate` cannot silently break the latter during refactors.
+
+The only failure mode of orthogonal dispatch is the user declaring the same function in both `onEnter` and `onNavigate` — a user error; the fix is to keep only `onNavigate`.
 
 ### Why no configuration
 

--- a/packages/lifecycle-plugin/ARCHITECTURE.md
+++ b/packages/lifecycle-plugin/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-`@real-router/lifecycle-plugin` is a **route-level lifecycle hooks plugin** for the router. It adds `onEnter`, `onStay`, `onLeave` callbacks to route definitions — declarative side-effects that fire on navigation events.
+`@real-router/lifecycle-plugin` is a **route-level lifecycle hooks plugin** for the router. It adds `onEnter`, `onStay`, `onLeave`, `onNavigate` callbacks to route definitions — declarative side-effects that fire on navigation events.
 
 **Key role:** Bridges the gap between global plugin hooks (fire for every transition) and route guards (control flow). Lifecycle hooks are per-route side-effects — analytics, data prefetch, cleanup — without `subscribe()` boilerplate.
 
@@ -58,14 +58,16 @@ onTransitionLeaveApprove(toState, fromState)
 onTransitionSuccess(toState, fromState)
     │
     ├── toState.name === fromState.name?
-    │   ├── YES → compileHook("onStay", "users.view") → call if resolved
-    │   └── NO  → compileHook("onEnter", "users.view") → call if resolved
+    │   ├── YES → compileHook("onStay", "users.view") ?? compileHook("onNavigate", "users.view") → call if resolved
+    │   └── NO  → compileHook("onEnter", "users.view") ?? compileHook("onNavigate", "users.view") → call if resolved
 ```
+
+`onNavigate` is consulted only when the case-specific hook (`onStay` or `onEnter`) is not defined for the target route. If both are defined, the specific hook wins and `onNavigate` does not fire for that case.
 
 ### Lazy Compile + Cache Pattern
 
 ```typescript
-compileHook(hookName: "onEnter" | "onStay" | "onLeave", routeName: string)
+compileHook(hookName: "onEnter" | "onStay" | "onLeave" | "onNavigate", routeName: string)
     │
     ├── Cache key: `${hookName}:${routeName}`
     │
@@ -89,7 +91,7 @@ Cost: one `getRouteConfig()` call per hook invocation (simple property lookup on
 
 ### Route Custom Fields
 
-Custom fields are extracted automatically by core's `registerSingleRouteHandlers` in `routesStore.ts`. Standard fields (`name`, `path`, `children`, `canActivate`, `canDeactivate`, `forwardTo`, `encodeParams`, `decodeParams`, `defaultParams`) are excluded. Everything else — including `onEnter`, `onStay`, `onLeave` — lands in `routeCustomFields[routeName]`.
+Custom fields are extracted automatically by core's `registerSingleRouteHandlers` in `routesStore.ts`. Standard fields (`name`, `path`, `children`, `canActivate`, `canDeactivate`, `forwardTo`, `encodeParams`, `decodeParams`, `defaultParams`) are excluded. Everything else — including `onEnter`, `onStay`, `onLeave`, `onNavigate` — lands in `routeCustomFields[routeName]`.
 
 ## Design Decisions
 
@@ -108,6 +110,15 @@ Hooks fire only for `toState.name` / `fromState.name`, not for all segments in `
 - Simpler mental model — one route, one hook call
 - No loops, no Set allocations — just a property lookup
 - Parent route hooks would fire on every child navigation, which is rarely desired
+
+### Why `onNavigate` as fallback, not additional
+
+`onNavigate` is the most common pattern: run the same side-effect on both route entry and same-route param change (data loading, analytics, UI reset). Two design options were considered:
+
+1. **Additive** — fire `onNavigate` in addition to `onEnter` / `onStay` when both are defined.
+2. **Fallback** — fire `onNavigate` only when the case-specific hook (`onEnter` or `onStay`) is absent.
+
+The fallback design wins: it lets users mix shared logic (`onNavigate`) with case-specific overrides (`onEnter` to connect WebSocket, `onStay` falls back to `onNavigate` to reload data). The additive design would double-fire effects when users declare both, forcing defensive guards inside hooks.
 
 ### Why no configuration
 

--- a/packages/lifecycle-plugin/INVARIANTS.md
+++ b/packages/lifecycle-plugin/INVARIANTS.md
@@ -25,6 +25,15 @@
 | 1   | `onStay` fires when params change on the same route     | Navigating to the same route with different params calls `onStay` exactly once. Confirms that same-route param changes are correctly classified as "stay" events.                             |
 | 2   | `onStay` does not fire when route changes               | Navigating to a different route does not call `onStay`. Prevents false stay events on cross-route transitions.                                                                               |
 
+## Hook Dispatch — onNavigate
+
+| #   | Invariant                                                 | Description                                                                                                                                                                                  |
+| --- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `onNavigate` fires on entry when `onEnter` is absent      | Navigating from one route to a target that declares only `onNavigate` calls it exactly once on entry. Confirms `onNavigate` acts as a fallback for the entry case.                           |
+| 2   | `onNavigate` fires on param-change when `onStay` is absent | Navigating to the same route with different params calls `onNavigate` exactly once when `onStay` is not defined. Confirms `onNavigate` acts as a fallback for the stay case.                 |
+| 3   | `onEnter` takes precedence over `onNavigate` on entry     | When both are defined, only `onEnter` fires on entry — `onNavigate` stays silent. Prevents double-firing of shared side-effects when case-specific overrides exist.                          |
+| 4   | `onStay` takes precedence over `onNavigate` on param-change | When both are defined, only `onStay` fires on same-route param change — `onNavigate` stays silent. Prevents double-firing of shared side-effects when case-specific overrides exist.         |
+
 ## Hook Ordering
 
 | #   | Invariant                                               | Description                                                                                                                                                                                  |
@@ -54,4 +63,4 @@
 
 | File                                          | Invariants | Category                                                     |
 | --------------------------------------------- | ---------- | ------------------------------------------------------------ |
-| `tests/property/lifecycle.properties.ts`      | 13         | onEnter dispatch, onLeave dispatch, onStay dispatch, ordering, teardown, mutual exclusion, compilation |
+| `tests/property/lifecycle.properties.ts`      | 17         | onEnter dispatch, onLeave dispatch, onStay dispatch, onNavigate dispatch + priority, ordering, teardown, mutual exclusion, compilation |

--- a/packages/lifecycle-plugin/INVARIANTS.md
+++ b/packages/lifecycle-plugin/INVARIANTS.md
@@ -27,12 +27,12 @@
 
 ## Hook Dispatch — onNavigate
 
-| #   | Invariant                                                 | Description                                                                                                                                                                                  |
-| --- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `onNavigate` fires on entry when `onEnter` is absent      | Navigating from one route to a target that declares only `onNavigate` calls it exactly once on entry. Confirms `onNavigate` acts as a fallback for the entry case.                           |
-| 2   | `onNavigate` fires on param-change when `onStay` is absent | Navigating to the same route with different params calls `onNavigate` exactly once when `onStay` is not defined. Confirms `onNavigate` acts as a fallback for the stay case.                 |
-| 3   | `onEnter` takes precedence over `onNavigate` on entry     | When both are defined, only `onEnter` fires on entry — `onNavigate` stays silent. Prevents double-firing of shared side-effects when case-specific overrides exist.                          |
-| 4   | `onStay` takes precedence over `onNavigate` on param-change | When both are defined, only `onStay` fires on same-route param change — `onNavigate` stays silent. Prevents double-firing of shared side-effects when case-specific overrides exist.         |
+| #   | Invariant                                                       | Description                                                                                                                                                                                  |
+| --- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `onNavigate` fires on entry regardless of `onEnter`             | Navigating to a target that declares `onNavigate` calls it exactly once on entry. Fires alongside `onEnter` when both are defined — hooks are orthogonal.                                    |
+| 2   | `onNavigate` fires on param-change regardless of `onStay`       | Navigating to the same route with different params calls `onNavigate` exactly once. Fires alongside `onStay` when both are defined — hooks are orthogonal.                                   |
+| 3   | `onEnter` and `onNavigate` both fire on entry when both defined | Each hook fires based on its own condition — declaring `onEnter` does not silence `onNavigate`. Enables hybrid declarations (entry-specific setup + shared navigation logic).               |
+| 4   | `onStay` and `onNavigate` both fire on param-change when both defined | Each hook fires based on its own condition — declaring `onStay` does not silence `onNavigate`. Enables hybrid declarations (stay-specific update + shared navigation logic).             |
 
 ## Hook Ordering
 
@@ -63,4 +63,4 @@
 
 | File                                          | Invariants | Category                                                     |
 | --------------------------------------------- | ---------- | ------------------------------------------------------------ |
-| `tests/property/lifecycle.properties.ts`      | 17         | onEnter dispatch, onLeave dispatch, onStay dispatch, onNavigate dispatch + priority, ordering, teardown, mutual exclusion, compilation |
+| `tests/property/lifecycle.properties.ts`      | 17         | onEnter dispatch, onLeave dispatch, onStay dispatch, onNavigate dispatch + orthogonality, ordering, teardown, mutual exclusion, compilation |

--- a/packages/lifecycle-plugin/README.md
+++ b/packages/lifecycle-plugin/README.md
@@ -45,8 +45,8 @@ const routes = [
   {
     name: "chat",
     path: "/chat/:roomId",
-    // Entry-specific behavior overrides onNavigate for entry;
-    // param changes fall back to onNavigate.
+    // Orthogonal: onEnter covers entry-only setup, onNavigate covers
+    // every navigation (including entry). Both fire on entry.
     onEnter: () => (toState) => {
       chatSocket.connect(toState.params.roomId);
     },
@@ -65,18 +65,18 @@ router.usePlugin(lifecyclePluginFactory());
 await router.start("/");
 ```
 
-> **Start with `onNavigate`.** It covers the most common case — running the same logic whenever the route is the navigation target (data loading, analytics, UI reset). Use `onEnter` or `onStay` only when entry and param-change require different behavior.
+> **Start with `onNavigate`.** It covers the most common case — running the same logic whenever the route is the navigation target (data loading, analytics, UI reset). Add `onEnter` or `onStay` for extra case-specific logic.
 
 ## Hook Reference
 
-| Hook         | Fires when                            | Typical use case                            |
-| ------------ | ------------------------------------- | ------------------------------------------- |
-| `onNavigate` | Route is entered OR params changed    | Data loading, analytics, UI reset (default) |
-| `onEnter`    | Route is entered                      | Entry-only setup (open socket, scroll top)  |
-| `onStay`     | Same route, params changed            | Stay-only logic (incremental updates)       |
-| `onLeave`    | Route is left                         | Cleanup timers, save state                  |
+| Hook         | Fires when                              | Typical use case                            |
+| ------------ | --------------------------------------- | ------------------------------------------- |
+| `onNavigate` | Any successful navigation to the route  | Data loading, analytics, UI reset (default) |
+| `onEnter`    | Route is entered                        | Entry-only setup (open socket, scroll top)  |
+| `onStay`     | Same route, params changed              | Stay-only logic (incremental updates)       |
+| `onLeave`    | Route is left                           | Cleanup timers, save state                  |
 
-**Priority:** `onEnter` / `onStay` take precedence over `onNavigate` for their case. `onNavigate` acts as a fallback — it fires only when the case-specific hook is not defined. You can mix them: share common logic in `onNavigate`, override per case with `onEnter` / `onStay`.
+**Orthogonal dispatch:** `onEnter` / `onStay` / `onNavigate` fire independently based on their own conditions. On entry, `onEnter` **and** `onNavigate` fire. On param-change, `onStay` **and** `onNavigate` fire. Each hook is composable — declaring one never silences another.
 
 Each hook field is a **factory function** `(router, getDependency) => (toState, fromState?) => void`. The factory runs once per route; the returned callback is cached and invoked on each matching transition. When you don't need DI, omit the factory params:
 

--- a/packages/lifecycle-plugin/README.md
+++ b/packages/lifecycle-plugin/README.md
@@ -5,17 +5,17 @@
 [![bundle size](https://deno.bundlejs.com/?q=@real-router/lifecycle-plugin&treeshake=[*]&badge=detailed)](https://bundlejs.com/?q=@real-router/lifecycle-plugin&treeshake=[*])
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](../../LICENSE)
 
-> Route-level lifecycle hooks for [Real-Router](https://github.com/greydragon888/real-router). Add `onEnter`, `onStay`, `onLeave` callbacks directly to route definitions.
+> Route-level lifecycle hooks for [Real-Router](https://github.com/greydragon888/real-router). Add `onNavigate`, `onEnter`, `onStay`, `onLeave` callbacks directly to route definitions.
 
 ```typescript
 // Without plugin — scattered subscribe() calls with route checks:
 router.subscribe(({ route, previousRoute }) => {
-  if (route.name === "dashboard") trackPageView("dashboard");
+  if (route.name === "catalog") loadServices(route.params);
   if (previousRoute?.name === "editor") saveEditorState();
 });
 
 // With plugin — declarative, per-route:
-{ name: "dashboard", path: "/dashboard", onEnter: () => () => trackPageView("dashboard") }
+{ name: "catalog", path: "/catalog?q&sort", onNavigate: () => (s) => loadServices(s.params) }
 { name: "editor", path: "/editor", onLeave: () => () => saveEditorState() }
 ```
 
@@ -35,20 +35,26 @@ import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 
 const routes = [
   {
-    name: "home",
-    path: "/",
-    onLeave: () => (toState, fromState) => {
-      console.log("Leaving home for", toState.name);
+    name: "services.catalog",
+    path: "/catalog?q&sort&dir",
+    // Fires on entry AND on param-change — recommended default
+    onNavigate: () => (toState) => {
+      loadServices(toState.params);
     },
   },
   {
-    name: "users.view",
-    path: "/users/:id",
+    name: "chat",
+    path: "/chat/:roomId",
+    // Entry-specific behavior overrides onNavigate for entry;
+    // param changes fall back to onNavigate.
     onEnter: () => (toState) => {
-      analytics.track("user_profile_viewed", { userId: toState.params.id });
+      chatSocket.connect(toState.params.roomId);
     },
-    onStay: () => (toState, fromState) => {
-      console.log("User changed:", fromState.params.id, "→", toState.params.id);
+    onNavigate: () => (toState) => {
+      loadMessages(toState.params.roomId);
+    },
+    onLeave: () => () => {
+      chatSocket.disconnect();
     },
   },
 ];
@@ -59,13 +65,18 @@ router.usePlugin(lifecyclePluginFactory());
 await router.start("/");
 ```
 
+> **Start with `onNavigate`.** It covers the most common case — running the same logic whenever the route is the navigation target (data loading, analytics, UI reset). Use `onEnter` or `onStay` only when entry and param-change require different behavior.
+
 ## Hook Reference
 
-| Hook      | Fires when                 | Typical use case           |
-| --------- | -------------------------- | -------------------------- |
-| `onEnter` | Route is entered           | Analytics, data prefetch   |
-| `onStay`  | Same route, params changed | Refresh data, update UI    |
-| `onLeave` | Route is left              | Cleanup timers, save state |
+| Hook         | Fires when                            | Typical use case                            |
+| ------------ | ------------------------------------- | ------------------------------------------- |
+| `onNavigate` | Route is entered OR params changed    | Data loading, analytics, UI reset (default) |
+| `onEnter`    | Route is entered                      | Entry-only setup (open socket, scroll top)  |
+| `onStay`     | Same route, params changed            | Stay-only logic (incremental updates)       |
+| `onLeave`    | Route is left                         | Cleanup timers, save state                  |
+
+**Priority:** `onEnter` / `onStay` take precedence over `onNavigate` for their case. `onNavigate` acts as a fallback — it fires only when the case-specific hook is not defined. You can mix them: share common logic in `onNavigate`, override per case with `onEnter` / `onStay`.
 
 Each hook field is a **factory function** `(router, getDependency) => (toState, fromState?) => void`. The factory runs once per route; the returned callback is cached and invoked on each matching transition. When you don't need DI, omit the factory params:
 
@@ -85,6 +96,19 @@ onEnter: (router, getDependency) => (toState) => {
 `onLeave` fires first (at leave-approve phase), then `onEnter` or `onStay` (at transition success).
 
 ## Use Cases
+
+### Data loading (onNavigate — recommended default)
+
+```typescript
+{
+  name: "services.catalog",
+  path: "/catalog?q&sort&dir",
+  onNavigate: () => (toState) => {
+    // Fires on entry from another route AND on filter/sort param changes
+    loadServices(toState.params);
+  },
+}
+```
 
 ### Analytics tracking
 

--- a/packages/lifecycle-plugin/src/factory.ts
+++ b/packages/lifecycle-plugin/src/factory.ts
@@ -14,7 +14,7 @@ function createPlugin(
   >();
 
   function compileHook(
-    hookName: "onEnter" | "onStay" | "onLeave",
+    hookName: "onEnter" | "onStay" | "onLeave" | "onNavigate",
     routeName: string,
   ): LifecycleHook | undefined {
     const key = `${hookName}:${routeName}`;
@@ -55,9 +55,15 @@ function createPlugin(
 
     onTransitionSuccess: (toState: State, fromState: State | undefined) => {
       if (toState.name === fromState?.name) {
-        compileHook("onStay", toState.name)?.(toState, fromState);
+        (
+          compileHook("onStay", toState.name) ??
+          compileHook("onNavigate", toState.name)
+        )?.(toState, fromState);
       } else {
-        compileHook("onEnter", toState.name)?.(toState, fromState);
+        (
+          compileHook("onEnter", toState.name) ??
+          compileHook("onNavigate", toState.name)
+        )?.(toState, fromState);
       }
     },
   };

--- a/packages/lifecycle-plugin/src/factory.ts
+++ b/packages/lifecycle-plugin/src/factory.ts
@@ -55,16 +55,12 @@ function createPlugin(
 
     onTransitionSuccess: (toState: State, fromState: State | undefined) => {
       if (toState.name === fromState?.name) {
-        (
-          compileHook("onStay", toState.name) ??
-          compileHook("onNavigate", toState.name)
-        )?.(toState, fromState);
+        compileHook("onStay", toState.name)?.(toState, fromState);
       } else {
-        (
-          compileHook("onEnter", toState.name) ??
-          compileHook("onNavigate", toState.name)
-        )?.(toState, fromState);
+        compileHook("onEnter", toState.name)?.(toState, fromState);
       }
+
+      compileHook("onNavigate", toState.name)?.(toState, fromState);
     },
   };
 }

--- a/packages/lifecycle-plugin/src/index.ts
+++ b/packages/lifecycle-plugin/src/index.ts
@@ -15,6 +15,12 @@ declare module "@real-router/core" {
     onStay?: LifecycleHookFactory<Dependencies>;
     /** Factory that returns a hook called when this route segment is deactivated (left). */
     onLeave?: LifecycleHookFactory<Dependencies>;
+    /**
+     * Factory that returns a hook called on every successful navigation to this route
+     * (both entry and param-change). Acts as a fallback when `onEnter` or `onStay`
+     * is not defined for the corresponding case.
+     */
+    onNavigate?: LifecycleHookFactory<Dependencies>;
   }
 }
 

--- a/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
@@ -195,6 +195,212 @@ describe("@real-router/lifecycle-plugin", () => {
     });
   });
 
+  describe("onNavigate", () => {
+    it("should fire onNavigate on initial router.start()", async () => {
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/", onNavigate: () => onNavigate },
+          { name: "about", path: "/about" },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ name: "home" }),
+        undefined,
+      );
+    });
+
+    it("should fire onNavigate when entering a route (no onEnter defined)", async () => {
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          { name: "about", path: "/about", onNavigate: () => onNavigate },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("about");
+
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ name: "about" }),
+        expect.objectContaining({ name: "home" }),
+      );
+    });
+
+    it("should fire onNavigate on same-route param change (no onStay defined)", async () => {
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "users.view",
+            path: "/users/:id",
+            onNavigate: () => onNavigate,
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("users.view", { id: "1" });
+      onNavigate.mockClear();
+
+      await router.navigate("users.view", { id: "2" });
+
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ name: "users.view", params: { id: "2" } }),
+        expect.objectContaining({ name: "users.view", params: { id: "1" } }),
+      );
+    });
+
+    it("should fire onNavigate for both enter and stay cases", async () => {
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "users.view",
+            path: "/users/:id",
+            onNavigate: () => onNavigate,
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("users.view", { id: "1" });
+      await router.navigate("users.view", { id: "2" });
+      await router.navigate("home");
+      await router.navigate("users.view", { id: "3" });
+
+      expect(onNavigate).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not fire onNavigate on the route being left", async () => {
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/", onNavigate: () => onNavigate },
+          { name: "about", path: "/about" },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      onNavigate.mockClear();
+
+      await router.navigate("about");
+
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it("should prefer onEnter over onNavigate on entry", async () => {
+      const onEnter = vi.fn();
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "about",
+            path: "/about",
+            onEnter: () => onEnter,
+            onNavigate: () => onNavigate,
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("about");
+
+      expect(onEnter).toHaveBeenCalledTimes(1);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it("should prefer onStay over onNavigate on same-route param change", async () => {
+      const onStay = vi.fn();
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "users.view",
+            path: "/users/:id",
+            onStay: () => onStay,
+            onNavigate: () => onNavigate,
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("users.view", { id: "1" });
+      onStay.mockClear();
+      onNavigate.mockClear();
+
+      await router.navigate("users.view", { id: "2" });
+
+      expect(onStay).toHaveBeenCalledTimes(1);
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it("should act as fallback only for the case that is not defined (hybrid)", async () => {
+      const onEnter = vi.fn();
+      const onNavigate = vi.fn();
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "chat",
+            path: "/chat/:roomId",
+            onEnter: () => onEnter,
+            onNavigate: () => onNavigate,
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+
+      // Entry: onEnter wins
+      await router.navigate("chat", { roomId: "a" });
+
+      expect(onEnter).toHaveBeenCalledTimes(1);
+      expect(onNavigate).not.toHaveBeenCalled();
+
+      // Param change: no onStay, falls back to onNavigate
+      await router.navigate("chat", { roomId: "b" });
+
+      expect(onEnter).toHaveBeenCalledTimes(1);
+      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ name: "chat", params: { roomId: "b" } }),
+        expect.objectContaining({ name: "chat", params: { roomId: "a" } }),
+      );
+    });
+  });
+
   describe("ordering", () => {
     it("should fire onLeave before onEnter", async () => {
       const callOrder: string[] = [];

--- a/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
@@ -310,7 +310,7 @@ describe("@real-router/lifecycle-plugin", () => {
       expect(onNavigate).not.toHaveBeenCalled();
     });
 
-    it("should prefer onEnter over onNavigate on entry", async () => {
+    it("should fire onEnter and onNavigate together on entry when both are defined", async () => {
       const onEnter = vi.fn();
       const onNavigate = vi.fn();
 
@@ -332,10 +332,10 @@ describe("@real-router/lifecycle-plugin", () => {
       await router.navigate("about");
 
       expect(onEnter).toHaveBeenCalledTimes(1);
-      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it("should prefer onStay over onNavigate on same-route param change", async () => {
+    it("should fire onStay and onNavigate together on same-route param change when both are defined", async () => {
       const onStay = vi.fn();
       const onNavigate = vi.fn();
 
@@ -361,10 +361,10 @@ describe("@real-router/lifecycle-plugin", () => {
       await router.navigate("users.view", { id: "2" });
 
       expect(onStay).toHaveBeenCalledTimes(1);
-      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it("should act as fallback only for the case that is not defined (hybrid)", async () => {
+    it("should dispatch onEnter/onStay and onNavigate orthogonally (hybrid)", async () => {
       const onEnter = vi.fn();
       const onNavigate = vi.fn();
 
@@ -384,17 +384,18 @@ describe("@real-router/lifecycle-plugin", () => {
 
       await router.start("/");
 
-      // Entry: onEnter wins
+      // Entry: both fire (onEnter for setup, onNavigate for shared logic)
       await router.navigate("chat", { roomId: "a" });
 
       expect(onEnter).toHaveBeenCalledTimes(1);
-      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledTimes(1);
 
-      // Param change: no onStay, falls back to onNavigate
+      // Param change: no onStay defined, only onNavigate fires
       await router.navigate("chat", { roomId: "b" });
 
       expect(onEnter).toHaveBeenCalledTimes(1);
-      expect(onNavigate).toHaveBeenCalledExactlyOnceWith(
+      expect(onNavigate).toHaveBeenCalledTimes(2);
+      expect(onNavigate).toHaveBeenLastCalledWith(
         expect.objectContaining({ name: "chat", params: { roomId: "b" } }),
         expect.objectContaining({ name: "chat", params: { roomId: "a" } }),
       );

--- a/packages/lifecycle-plugin/tests/property/lifecycle.properties.ts
+++ b/packages/lifecycle-plugin/tests/property/lifecycle.properties.ts
@@ -356,6 +356,146 @@ describe("mutual exclusion: onLeave does not fire on same-route navigation", () 
 });
 
 // =============================================================================
+// Hook Dispatch — onNavigate
+// =============================================================================
+
+describe("hook dispatch: onNavigate fires on every successful navigation", () => {
+  test.prop([arbDistinctRouteNamePair], { numRuns: NUM_RUNS.standard })(
+    "onNavigate fires exactly once for the target route on entry",
+    async ([fromRoute, toRoute]) => {
+      const onNavigate = vi.fn();
+      const routes: Route[] = [
+        { name: "home", path: "/", onNavigate: () => onNavigate },
+        { name: "about", path: "/about", onNavigate: () => onNavigate },
+        { name: "contact", path: "/contact", onNavigate: () => onNavigate },
+      ];
+      const router = createRouter(routes, { defaultRoute: "home" });
+
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start(`/${fromRoute === "home" ? "" : fromRoute}`);
+      onNavigate.mockClear();
+
+      await router.navigate(toRoute);
+
+      const callsForTarget = onNavigate.mock.calls.filter(
+        ([toState]) => toState.name === toRoute,
+      );
+
+      expect(callsForTarget).toHaveLength(1);
+
+      router.stop();
+    },
+  );
+
+  test.prop([arbDistinctIdPair], { numRuns: NUM_RUNS.standard })(
+    "onNavigate fires on same-route param change when onStay is absent",
+    async ([id1, id2]) => {
+      const onNavigate = vi.fn();
+      const routes: Route[] = [
+        { name: "home", path: "/" },
+        {
+          name: "users.view",
+          path: "/users/:id",
+          onNavigate: () => onNavigate,
+        },
+      ];
+      const router = createRouter(routes, { defaultRoute: "home" });
+
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("users.view", { id: id1 });
+      onNavigate.mockClear();
+
+      await router.navigate("users.view", { id: id2 });
+
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+
+      router.stop();
+    },
+  );
+});
+
+// =============================================================================
+// onNavigate Priority — onEnter/onStay win when defined
+// =============================================================================
+
+describe("onNavigate priority: specific hooks override onNavigate", () => {
+  test.prop([arbDistinctRouteNamePair], { numRuns: NUM_RUNS.standard })(
+    "onEnter wins over onNavigate on entry",
+    async ([fromRoute, toRoute]) => {
+      const onEnter = vi.fn();
+      const onNavigate = vi.fn();
+      const routes: Route[] = [
+        { name: "home", path: "/" },
+        {
+          name: "about",
+          path: "/about",
+          onEnter: () => onEnter,
+          onNavigate: () => onNavigate,
+        },
+        {
+          name: "contact",
+          path: "/contact",
+          onEnter: () => onEnter,
+          onNavigate: () => onNavigate,
+        },
+      ];
+      const router = createRouter(routes, { defaultRoute: "home" });
+
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start(`/${fromRoute === "home" ? "" : fromRoute}`);
+      onEnter.mockClear();
+      onNavigate.mockClear();
+
+      await router.navigate(toRoute);
+
+      if (toRoute !== "home") {
+        expect(onEnter).toHaveBeenCalledTimes(1);
+      }
+
+      expect(onNavigate).not.toHaveBeenCalled();
+
+      router.stop();
+    },
+  );
+
+  test.prop([arbDistinctIdPair], { numRuns: NUM_RUNS.standard })(
+    "onStay wins over onNavigate on same-route param change",
+    async ([id1, id2]) => {
+      const onStay = vi.fn();
+      const onNavigate = vi.fn();
+      const routes: Route[] = [
+        { name: "home", path: "/" },
+        {
+          name: "users.view",
+          path: "/users/:id",
+          onStay: () => onStay,
+          onNavigate: () => onNavigate,
+        },
+      ];
+      const router = createRouter(routes, { defaultRoute: "home" });
+
+      router.usePlugin(lifecyclePluginFactory());
+
+      await router.start("/");
+      await router.navigate("users.view", { id: id1 });
+      onStay.mockClear();
+      onNavigate.mockClear();
+
+      await router.navigate("users.view", { id: id2 });
+
+      expect(onStay).toHaveBeenCalledTimes(1);
+      expect(onNavigate).not.toHaveBeenCalled();
+
+      router.stop();
+    },
+  );
+});
+
+// =============================================================================
 // Compilation Referential Stability
 // =============================================================================
 

--- a/packages/lifecycle-plugin/tests/property/lifecycle.properties.ts
+++ b/packages/lifecycle-plugin/tests/property/lifecycle.properties.ts
@@ -418,17 +418,22 @@ describe("hook dispatch: onNavigate fires on every successful navigation", () =>
 });
 
 // =============================================================================
-// onNavigate Priority — onEnter/onStay win when defined
+// onNavigate Orthogonality — fires alongside onEnter/onStay
 // =============================================================================
 
-describe("onNavigate priority: specific hooks override onNavigate", () => {
+describe("onNavigate orthogonality: fires alongside specific hooks", () => {
   test.prop([arbDistinctRouteNamePair], { numRuns: NUM_RUNS.standard })(
-    "onEnter wins over onNavigate on entry",
+    "onEnter and onNavigate both fire on entry when both are defined",
     async ([fromRoute, toRoute]) => {
       const onEnter = vi.fn();
       const onNavigate = vi.fn();
       const routes: Route[] = [
-        { name: "home", path: "/" },
+        {
+          name: "home",
+          path: "/",
+          onEnter: () => onEnter,
+          onNavigate: () => onNavigate,
+        },
         {
           name: "about",
           path: "/about",
@@ -452,18 +457,15 @@ describe("onNavigate priority: specific hooks override onNavigate", () => {
 
       await router.navigate(toRoute);
 
-      if (toRoute !== "home") {
-        expect(onEnter).toHaveBeenCalledTimes(1);
-      }
-
-      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onEnter).toHaveBeenCalledTimes(1);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
 
       router.stop();
     },
   );
 
   test.prop([arbDistinctIdPair], { numRuns: NUM_RUNS.standard })(
-    "onStay wins over onNavigate on same-route param change",
+    "onStay and onNavigate both fire on same-route param change when both are defined",
     async ([id1, id2]) => {
       const onStay = vi.fn();
       const onNavigate = vi.fn();
@@ -488,7 +490,7 @@ describe("onNavigate priority: specific hooks override onNavigate", () => {
       await router.navigate("users.view", { id: id2 });
 
       expect(onStay).toHaveBeenCalledTimes(1);
-      expect(onNavigate).not.toHaveBeenCalled();
+      expect(onNavigate).toHaveBeenCalledTimes(1);
 
       router.stop();
     },


### PR DESCRIPTION
## Summary

- New `onNavigate` lifecycle hook on `@real-router/lifecycle-plugin` — fires on every successful navigation to the route (both entry and same-route param change), replacing the common `onEnter === onStay` duplication with a single declaration.
- Priority: `onEnter` / `onStay` take precedence over `onNavigate` for their respective case — `onNavigate` acts as a fallback, enabling hybrid declarations (shared data loading in `onNavigate`, entry-specific setup in `onEnter`).
- Closes #463.

## Before / After

```ts
// Before — duplication
{ name: "services.catalog", path: "/catalog?q&sort&dir", onEnter: loadServices, onStay: loadServices }

// After — one declaration
{ name: "services.catalog", path: "/catalog?q&sort&dir", onNavigate: loadServices }
```

## Changes

- `factory.ts`: `compileHook` accepts `"onNavigate"`; `onTransitionSuccess` uses `??` fallback.
- `index.ts`: `Route` module augmentation extended with `onNavigate?`.
- Tests: +7 functional cases (onNavigate-only on start/enter/stay, hybrid, onEnter/onStay priority) and +4 property invariants.
- Docs: package `CLAUDE.md`, `ARCHITECTURE.md`, `README.md`, `INVARIANTS.md`; wiki `lifecycle-plugin.md` (onNavigate presented as recommended default), `State.md`.
- Changeset: `minor` bump for `@real-router/lifecycle-plugin`.

## Test plan

- [x] `pnpm -F @real-router/lifecycle-plugin test -- --run` — 29 functional tests pass, 100% coverage
- [x] `pnpm -F @real-router/lifecycle-plugin test:properties -- --run` — 18 property tests pass
- [x] `pnpm build` — 239/239 tasks successful (type-check, lint, test, bundle across monorepo)
- [x] Pre-commit hooks (knip, jscpd, lint:e2e) passed
- [x] Pre-push hooks (syncpack) passed