### PR TITLE
feat: generic type parameter for useRoute across all adapters (#464)

### DIFF
--- a/.changeset/useroute-generic-angular.md
+++ b/.changeset/useroute-generic-angular.md
@@ -1,0 +1,14 @@
+---
+"@real-router/angular": minor
+---
+
+Add generic type parameter to `injectRoute<P>()` / `RouteSignals<P>` (#464)
+
+`injectRoute<P>()` now accepts an optional generic so `routeState().route?.params` is typed without `as` casts. `RouteSignals<P>` is likewise generic, defaulting to `Params`. Runtime is unchanged — the cast happens once inside the function.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const route = injectRoute<SearchParams>();
+const q = route.routeState().route?.params.q; // typed as string
+```

--- a/.changeset/useroute-generic-preact.md
+++ b/.changeset/useroute-generic-preact.md
@@ -1,0 +1,15 @@
+---
+"@real-router/preact": minor
+---
+
+Add generic type parameter to `useRoute<P>()` / `RouteContext<P>` (#464)
+
+`useRoute<P>()` now accepts an optional generic so `route.params` is typed without `as` casts at the call site. The generic is erased at compile time — no runtime change. `RouteContext<P>` is likewise generic, defaulting to `Params`.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const { route } = useRoute<SearchParams>();
+
+route?.params.q; // typed as string — no cast needed
+```

--- a/.changeset/useroute-generic-react.md
+++ b/.changeset/useroute-generic-react.md
@@ -1,0 +1,16 @@
+---
+"@real-router/react": minor
+---
+
+Add generic type parameter to `useRoute<P>()` / `RouteContext<P>` (#464)
+
+`useRoute<P>()` now accepts an optional generic so `route.params` is typed without `as` casts at the call site. The generic is erased at compile time — no runtime change. `RouteContext<P>` is likewise generic, defaulting to `Params`.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const { route } = useRoute<SearchParams>();
+
+route?.params.q;    // typed as string — no cast needed
+route?.params.sort; // typed as string
+```

--- a/.changeset/useroute-generic-solid.md
+++ b/.changeset/useroute-generic-solid.md
@@ -1,0 +1,14 @@
+---
+"@real-router/solid": minor
+---
+
+Add generic type parameter to `useRoute<P>()` (#464)
+
+`useRoute<P>()` now accepts an optional generic so `route.params` is typed without `as` casts at the call site. Returns `Accessor<RouteState<P>>`. The generic is erased at compile time — no runtime change.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const routeState = useRoute<SearchParams>();
+const q = routeState().route?.params.q; // typed as string
+```

--- a/.changeset/useroute-generic-sources.md
+++ b/.changeset/useroute-generic-sources.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": minor
+---
+
+Add optional generic parameter to `RouteSnapshot<P>` / `RouteNodeSnapshot<P>` (#464)
+
+Both snapshot types now accept an optional generic for typed `route.params`, defaulting to `Params` for full backward compatibility. Enables adapter-level propagation in `injectRoute<P>()` and similar hooks without a framework-specific snapshot shape.

--- a/.changeset/useroute-generic-svelte.md
+++ b/.changeset/useroute-generic-svelte.md
@@ -1,0 +1,14 @@
+---
+"@real-router/svelte": minor
+---
+
+Add generic type parameter to `useRoute<P>()` / `RouteContext<P>` (#464)
+
+`useRoute<P>()` now accepts an optional generic so `route.current?.params` is typed without `as` casts. `RouteContext<P>` is likewise generic, defaulting to `Params`. Runtime is unchanged — the cast happens once inside the composable.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const { route } = useRoute<SearchParams>();
+const q = route.current?.params.q; // typed as string
+```

--- a/.changeset/useroute-generic-vue.md
+++ b/.changeset/useroute-generic-vue.md
@@ -1,0 +1,14 @@
+---
+"@real-router/vue": minor
+---
+
+Add generic type parameter to `useRoute<P>()` / `RouteContext<P>` (#464)
+
+`useRoute<P>()` now accepts an optional generic so `route.value?.params` is typed without `as` casts. `RouteContext<P>` is likewise generic, defaulting to `Params`. Runtime is unchanged — the cast happens once inside the composable.
+
+```typescript
+type SearchParams = { q: string; sort: string } & Params;
+
+const { route } = useRoute<SearchParams>();
+const q = route.value?.params.q; // typed as string
+```

--- a/packages/angular/src/functions/injectRoute.ts
+++ b/packages/angular/src/functions/injectRoute.ts
@@ -2,7 +2,8 @@ import { injectOrThrow } from "./injectOrThrow";
 import { ROUTE } from "../providers";
 
 import type { RouteSignals } from "../types";
+import type { Params } from "@real-router/core";
 
-export function injectRoute(): RouteSignals {
-  return injectOrThrow(ROUTE, "injectRoute");
+export function injectRoute<P extends Params = Params>(): RouteSignals<P> {
+  return injectOrThrow(ROUTE, "injectRoute") as RouteSignals<P>;
 }

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -1,8 +1,8 @@
 import type { Signal } from "@angular/core";
-import type { Navigator } from "@real-router/core";
+import type { Navigator, Params } from "@real-router/core";
 import type { RouteSnapshot } from "@real-router/sources";
 
-export interface RouteSignals {
-  readonly routeState: Signal<RouteSnapshot>;
+export interface RouteSignals<P extends Params = Params> {
+  readonly routeState: Signal<RouteSnapshot<P>>;
   readonly navigator: Navigator;
 }

--- a/packages/angular/tests/functional/inject-functions.test.ts
+++ b/packages/angular/tests/functional/inject-functions.test.ts
@@ -12,6 +12,8 @@ import { injectRouterTransition } from "../../src/functions/injectRouterTransiti
 import { injectRouteUtils } from "../../src/functions/injectRouteUtils";
 import { provideRealRouter } from "../../src/providers";
 
+import type { Params } from "@real-router/core";
+
 const routes = [
   { name: "home", path: "/" },
   {
@@ -111,6 +113,21 @@ describe("inject functions", () => {
           injectRoute();
         });
       }).toThrow("injectRoute must be used within a provideRealRouter context");
+    });
+
+    it("propagates generic params type without runtime change", () => {
+      type TypedParams = { id: string; tab: string } & Params;
+
+      const injector = TestBed.inject(Injector);
+
+      runInInjectionContext(injector, () => {
+        const route = injectRoute<TypedParams>();
+        const params: TypedParams | undefined =
+          route.routeState().route?.params;
+
+        expect(route.routeState().route?.name).toBe("home");
+        expect(params).toBeDefined();
+      });
     });
   });
 

--- a/packages/preact/src/hooks/useRoute.tsx
+++ b/packages/preact/src/hooks/useRoute.tsx
@@ -3,13 +3,14 @@ import { useContext } from "preact/hooks";
 import { RouteContext } from "../context";
 
 import type { RouteContext as RouteContextType } from "../types";
+import type { Params } from "@real-router/core";
 
-export const useRoute = (): RouteContextType => {
+export const useRoute = <P extends Params = Params>(): RouteContextType<P> => {
   const routeContext = useContext(RouteContext);
 
   if (!routeContext) {
     throw new Error("useRoute must be used within a RouteProvider");
   }
 
-  return routeContext;
+  return routeContext as RouteContextType<P>;
 };

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -11,9 +11,9 @@ export interface RouteState<P extends Params = Params> {
   previousRoute?: State | undefined;
 }
 
-export type RouteContext = {
+export type RouteContext<P extends Params = Params> = {
   navigator: Navigator;
-} & RouteState;
+} & RouteState<P>;
 
 export interface LinkProps<P extends Params = Params> extends Omit<
   JSX.HTMLAttributes<HTMLAnchorElement>,

--- a/packages/preact/tests/functional/useRoute.test.tsx
+++ b/packages/preact/tests/functional/useRoute.test.tsx
@@ -5,7 +5,7 @@ import { RouterProvider, useRoute } from "@real-router/preact";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
-import type { Router } from "@real-router/core";
+import type { Params, Router } from "@real-router/core";
 import type { ComponentChildren } from "preact";
 
 const wrapper =
@@ -73,5 +73,20 @@ describe("useRoute hook", () => {
 
   it("should throw error if router instance was not passed to provider", () => {
     expect(() => renderHook(() => useRoute())).toThrow();
+  });
+
+  it("should propagate generic params type without runtime change", async () => {
+    type TypedParams = { id: string; tab: string } & Params;
+
+    await router.navigate("test");
+
+    const { result } = renderHook(() => useRoute<TypedParams>(), {
+      wrapper: wrapper(router),
+    });
+
+    const params: TypedParams | undefined = result.current.route?.params;
+
+    expect(result.current.route?.name).toStrictEqual("test");
+    expect(params).toBeDefined();
   });
 });

--- a/packages/react/src/hooks/useRoute.tsx
+++ b/packages/react/src/hooks/useRoute.tsx
@@ -5,13 +5,14 @@ import { useContext } from "react";
 import { RouteContext } from "../context";
 
 import type { RouteContext as RouteContextType } from "../types";
+import type { Params } from "@real-router/core";
 
-export const useRoute = (): RouteContextType => {
+export const useRoute = <P extends Params = Params>(): RouteContextType<P> => {
   const routeContext = useContext(RouteContext);
 
   if (!routeContext) {
     throw new Error("useRoute must be used within a RouteProvider");
   }
 
-  return routeContext;
+  return routeContext as RouteContextType<P>;
 };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -11,9 +11,9 @@ export interface RouteState<P extends Params = Params> {
   previousRoute?: State | undefined;
 }
 
-export type RouteContext = {
+export type RouteContext<P extends Params = Params> = {
   navigator: Navigator;
-} & RouteState;
+} & RouteState<P>;
 
 export interface LinkProps<
   P extends Params = Params,

--- a/packages/react/tests/functional/useRoute.test.tsx
+++ b/packages/react/tests/functional/useRoute.test.tsx
@@ -5,7 +5,7 @@ import { RouterProvider, useRoute } from "@real-router/react";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
-import type { Router } from "@real-router/core";
+import type { Params, Router } from "@real-router/core";
 import type { ReactNode } from "react";
 
 const wrapper =
@@ -88,5 +88,20 @@ describe("useRoute hook", () => {
     expect(() => renderHook(() => useRoute())).toThrow(
       "useRoute must be used within a RouteProvider",
     );
+  });
+
+  it("should propagate generic params type without runtime change", async () => {
+    type TypedParams = { id: string; tab: string } & Params;
+
+    await router.navigate("test");
+
+    const { result } = renderHook(() => useRoute<TypedParams>(), {
+      wrapper: wrapper(router),
+    });
+
+    const params: TypedParams | undefined = result.current.route?.params;
+
+    expect(result.current.route?.name).toStrictEqual("test");
+    expect(params).toBeDefined();
   });
 });

--- a/packages/solid/src/hooks/useRoute.tsx
+++ b/packages/solid/src/hooks/useRoute.tsx
@@ -3,14 +3,17 @@ import { useContext } from "solid-js";
 import { RouteContext } from "../context";
 
 import type { RouteState } from "../types";
+import type { Params } from "@real-router/core";
 import type { Accessor } from "solid-js";
 
-export const useRoute = (): Accessor<RouteState> => {
+export const useRoute = <P extends Params = Params>(): Accessor<
+  RouteState<P>
+> => {
   const routeSignal = useContext(RouteContext);
 
   if (!routeSignal) {
     throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeSignal;
+  return routeSignal as Accessor<RouteState<P>>;
 };

--- a/packages/solid/tests/functional/useRoute.test.tsx
+++ b/packages/solid/tests/functional/useRoute.test.tsx
@@ -6,7 +6,7 @@ import { RouterProvider, useRoute } from "@real-router/solid";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
-import type { Router } from "@real-router/core";
+import type { Params, Router } from "@real-router/core";
 import type { JSX } from "solid-js";
 
 const wrapper = (router: Router) => (props: { children: JSX.Element }) => (
@@ -98,5 +98,20 @@ describe("useRoute hook", () => {
     await router.navigate("about");
 
     expect(effectRunCount).toBe(3);
+  });
+
+  it("should propagate generic params type without runtime change", async () => {
+    type TypedParams = { id: string; tab: string } & Params;
+
+    await router.navigate("test").catch(() => {});
+
+    const { result } = renderHook(() => useRoute<TypedParams>(), {
+      wrapper: wrapper(router),
+    });
+
+    const params: TypedParams | undefined = result().route?.params;
+
+    expect(result().route?.name).toStrictEqual("test");
+    expect(params).toBeDefined();
   });
 });

--- a/packages/sources/src/types.ts
+++ b/packages/sources/src/types.ts
@@ -1,12 +1,12 @@
-import type { RouterError, State } from "@real-router/core";
+import type { Params, RouterError, State } from "@real-router/core";
 
-export interface RouteSnapshot {
-  route: State | undefined;
+export interface RouteSnapshot<P extends Params = Params> {
+  route: State<P> | undefined;
   previousRoute: State | undefined;
 }
 
-export interface RouteNodeSnapshot {
-  route: State | undefined;
+export interface RouteNodeSnapshot<P extends Params = Params> {
+  route: State<P> | undefined;
   previousRoute: State | undefined;
 }
 

--- a/packages/svelte/src/composables/useRoute.svelte.ts
+++ b/packages/svelte/src/composables/useRoute.svelte.ts
@@ -1,6 +1,7 @@
 import { ROUTE_KEY, getContextOrThrow } from "../context";
 
 import type { RouteContext } from "../types";
+import type { Params } from "@real-router/core";
 
-export const useRoute = (): RouteContext =>
-  getContextOrThrow<RouteContext>(ROUTE_KEY, "useRoute");
+export const useRoute = <P extends Params = Params>(): RouteContext<P> =>
+  getContextOrThrow<RouteContext>(ROUTE_KEY, "useRoute") as RouteContext<P>;

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -5,9 +5,9 @@ import type {
   State,
 } from "@real-router/core";
 
-export interface RouteContext {
+export interface RouteContext<P extends Params = Params> {
   readonly navigator: Navigator;
-  readonly route: { readonly current: State | undefined };
+  readonly route: { readonly current: State<P> | undefined };
   readonly previousRoute: { readonly current: State | undefined };
 }
 

--- a/packages/svelte/tests/functional/useRoute.test.ts
+++ b/packages/svelte/tests/functional/useRoute.test.ts
@@ -9,8 +9,8 @@ import {
 } from "../helpers";
 import RouteCapture from "../helpers/RouteCapture.svelte";
 
-import type { RouteContext } from "../../src/types";
-import type { Router } from "@real-router/core";
+import type { RouteContext } from "../../src";
+import type { Params, Router } from "@real-router/core";
 
 describe("useRoute composable", () => {
   let router: Router;
@@ -183,5 +183,25 @@ describe("useRoute composable", () => {
         props: { onCapture: () => {} },
       }),
     ).toThrow();
+  });
+
+  it("should propagate generic params type without runtime change", async () => {
+    type TypedParams = { id: string; tab: string } & Params;
+
+    await router.navigate("test");
+    flushSync();
+
+    let typed: RouteContext<TypedParams> | undefined;
+
+    renderWithRouter(router, RouteCapture, {
+      onCapture: (r: RouteContext) => {
+        typed = r as RouteContext<TypedParams>;
+      },
+    });
+
+    const params: TypedParams | undefined = typed!.route.current?.params;
+
+    expect(typed!.route.current?.name).toStrictEqual("test");
+    expect(params).toBeDefined();
   });
 });

--- a/packages/vue/src/composables/useRoute.ts
+++ b/packages/vue/src/composables/useRoute.ts
@@ -3,13 +3,14 @@ import { inject } from "vue";
 import { RouteKey } from "../context";
 
 import type { RouteContext } from "../types";
+import type { Params } from "@real-router/core";
 
-export const useRoute = (): RouteContext => {
+export const useRoute = <P extends Params = Params>(): RouteContext<P> => {
   const routeContext = inject(RouteKey);
 
   if (!routeContext) {
     throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeContext;
+  return routeContext as RouteContext<P>;
 };

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -12,9 +12,9 @@ import type { Ref } from "vue";
  * (`useRoute` mirrors via `shallowRef`, `useRouteNode` derives via `computed`),
  * but consumers only need `.value` read access — typed as `Readonly<Ref<…>>`.
  */
-export interface RouteContext {
+export interface RouteContext<P extends Params = Params> {
   navigator: Navigator;
-  route: Readonly<Ref<State | undefined>>;
+  route: Readonly<Ref<State<P> | undefined>>;
   previousRoute: Readonly<Ref<State | undefined>>;
 }
 

--- a/packages/vue/tests/functional/useRoute.test.ts
+++ b/packages/vue/tests/functional/useRoute.test.ts
@@ -2,12 +2,12 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 import { defineComponent, h, watchSyncEffect } from "vue";
 
-import { useRoute } from "../../src/composables/useRoute";
-import { RouterProvider } from "../../src/RouterProvider";
+import { useRoute } from "../../src";
+import { RouterProvider } from "../../src";
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
 import type { RouteContext } from "../../src/types";
-import type { Router } from "@real-router/core";
+import type { Params, Router } from "@real-router/core";
 
 function mountWithRouter(router: Router, composable: () => RouteContext) {
   let result: RouteContext;
@@ -137,5 +137,30 @@ describe("useRoute composable", () => {
     await flushPromises();
 
     expect(effectCount).toBe(countAfterNavigation + 1);
+  });
+
+  it("should propagate generic params type without runtime change", () => {
+    type TypedParams = { id: string; tab: string } & Params;
+
+    let typedParams: TypedParams | undefined;
+
+    const App = defineComponent({
+      setup() {
+        const { route } = useRoute<TypedParams>();
+
+        typedParams = route.value?.params;
+
+        return () => h("div");
+      },
+    });
+
+    mount(
+      defineComponent({
+        setup: () => () =>
+          h(RouterProvider, { router }, { default: () => h(App) }),
+      }),
+    );
+
+    expect(typedParams).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- `useRoute<P>()` / `injectRoute<P>()` now accepts an optional generic so `route.params` is typed without `as` casts at the call site. The generic is erased at compile time — no runtime change; the cast moves from user code into the hook body, in one place.
- Covers every adapter: React, Preact, Solid, Vue, Svelte (opt-in despite rune-based), Angular. Sources package propagates through `RouteSnapshot<P>` / `RouteNodeSnapshot<P>` (default `Params` — backward compatible).
- Closes #464.

## API

```ts
type SearchParams = { q: string; sort: string } & Params;

// React / Preact
const { route } = useRoute<SearchParams>();
route?.params.q;    // string — no cast

// Solid
const state = useRoute<SearchParams>();
state().route?.params.q;

// Vue
const { route } = useRoute<SearchParams>();
route.value?.params.q;

// Svelte
const { route } = useRoute<SearchParams>();
route.current?.params.q;

// Angular
const r = injectRoute<SearchParams>();
r.routeState().route?.params.q;
```

## Test plan

- [x] `pnpm build` green (239/239 tasks)
- [x] Regression test "propagate generic params type without runtime change" added to every adapter's `useRoute` functional suite
- [x] Type-check passes for all 31 packages
- [x] Pre-commit hooks (tests + knip + jscpd + lint:e2e) passed
- [x] Adapter CLAUDE.md files updated with "Typed route params via generic" section
- [x] Wiki `useRoute.md` updated with signature, per-adapter usage table, and typed example
- [x] Changesets: 7 files (one per affected public package), all `minor` per pre-1.0 policy