### PR TITLE
feat: cross-field validation and trailingSlash preserve fix (#471)

### DIFF
--- a/.changeset/callback-ignores-level-without-callback-feature.md
+++ b/.changeset/callback-ignores-level-without-callback-feature.md
@@ -1,0 +1,9 @@
+---
+"@real-router/validation-plugin": minor
+---
+
+Log error when `logger.callbackIgnoresLevel` is set without `logger.callback` (#471)
+
+`callbackIgnoresLevel` only has meaning when a `callback` is provided; setting it alone was a silent no-op. `validateOptions` now emits `logger.error` in that case — the option is non-load-bearing, so throwing would be overreach, but a silent ignore left users debugging phantom log-filter behavior.
+
+The check fires whenever `validateOptions` runs (router construction via retrospective pass, direct calls via `RouterValidator.options.validateOptions`).

--- a/.changeset/default-route-validation-feature.md
+++ b/.changeset/default-route-validation-feature.md
@@ -1,0 +1,12 @@
+---
+"@real-router/validation-plugin": minor
+---
+
+Validate `defaultRoute` resolves to an existing route (#471)
+
+`validationPlugin` now verifies that `options.defaultRoute` points to a route that actually exists in the route tree:
+
+- **Static string `defaultRoute`** — checked at `router.usePlugin(validationPlugin())` time. A non-existent name throws immediately with `[validation-plugin] defaultRoute resolved to non-existent route: "<name>"`.
+- **`DefaultRouteCallback`** — checked at runtime inside `resolveDefault()` on every `navigateToDefault()` / `start()` invocation. A callback that returns a non-existent route name surfaces as `Promise.reject` from `navigateToDefault()` with the same error message instead of the previous opaque `ROUTE_NOT_FOUND`.
+
+Callbacks are **not** probed at registration time — their return value depends on dependencies that may not be registered yet. The runtime check guarantees that a bad return value is diagnosed on first navigation with a pointer to the callback as the source, rather than the generic `ROUTE_NOT_FOUND` at an unrelated call site.

--- a/.changeset/navigate-to-default-promise-contract-fix.md
+++ b/.changeset/navigate-to-default-promise-contract-fix.md
@@ -1,0 +1,11 @@
+---
+"@real-router/core": minor
+---
+
+Honor `Promise<State>` contract for `navigateToDefault()` synchronous errors (#471)
+
+`navigateToDefault()` is declared to return `Promise<State>`, but synchronous exceptions thrown by `deps.resolveDefault()` (e.g., a `DefaultRouteCallback` that throws, or a validator that rejects a callback's return value) escaped the Promise chain and surfaced as uncaught sync exceptions on the call site.
+
+The body of `navigateToDefault()` now wraps `resolveDefault()` in a try/catch and converts synchronous throws into `Promise.reject`, so callers can uniformly handle errors via `.catch()` / `await`.
+
+Internal hook for `@real-router/validation-plugin`: new `RouterValidator.options.validateResolvedDefaultRoute(routeName, store)`, invoked from `resolveDefault()` when `options.defaultRoute` is a callback.

--- a/.changeset/preserve-trailing-slash-on-rewrite-fix.md
+++ b/.changeset/preserve-trailing-slash-on-rewrite-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/core": patch
+---
+
+Honor `trailingSlash: "preserve"` when `rewritePathOnMatch` is active (#471)
+
+Previously `trailingSlash: "preserve"` was silently overridden by `rewritePathOnMatch: true` (the default): the matcher built the canonical path with the trailing slash stripped, ignoring whether the source URL had one. Since both options are default-on, every user hitting a URL like `/users/` ended up with `state.path === "/users"` even though `"preserve"` promised the opposite.
+
+`matchPath()` now re-attaches a trailing slash to the rewritten path when the source had one and `trailingSlash: "preserve"` is set. Rewrite semantics (forwardTo, encoders, defaultParams merging) are unchanged — only trailing-slash handling is respected per the option's documented meaning.

--- a/.changeset/warn-listeners-cross-field-feature.md
+++ b/.changeset/warn-listeners-cross-field-feature.md
@@ -1,0 +1,9 @@
+---
+"@real-router/validation-plugin": minor
+---
+
+Reject `warnListeners > maxListeners` cross-field combination (#471)
+
+`validateLimits` now throws `RangeError` when `limits.warnListeners` exceeds `limits.maxListeners` (and `maxListeners > 0`). Previously both bounds were checked only in isolation, so `{ warnListeners: 5000, maxListeners: 100 }` passed validation yet the warning channel was dead code — the hard cap would always fire first.
+
+The check fires both on router construction (when validation-plugin is installed) and through any direct `validateOptions` / `validateLimits` call. `maxListeners: 0` (unlimited) disables the cross-check, matching the existing "0 means unlimited" convention.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -167,40 +167,8 @@ export default [
 
   // ── Standalone (zero deps) ────────────────────────────────────────
   {
-    name: "@real-router/fsm (ESM)",
-    path: "packages/fsm/dist/esm/index.mjs",
-    limit: "0.5 kB",
-  },
-  {
     name: "@real-router/logger (ESM)",
     path: "packages/logger/dist/esm/index.mjs",
     limit: "0.5 kB",
-  },
-
-  // ── Internal (bundled into consumers) ─────────────────────────────
-  {
-    name: "route-tree (ESM)",
-    path: "packages/route-tree/dist/esm/index.mjs",
-    limit: "6.5 kB",
-  },
-  {
-    name: "path-matcher (ESM)",
-    path: "packages/path-matcher/dist/esm/index.mjs",
-    limit: "3.5 kB",
-  },
-  {
-    name: "search-params (ESM)",
-    path: "packages/search-params/dist/esm/index.mjs",
-    limit: "2 kB",
-  },
-  {
-    name: "type-guards (ESM)",
-    path: "packages/type-guards/dist/esm/index.mjs",
-    limit: "1 kB",
-  },
-  {
-    name: "event-emitter (ESM)",
-    path: "packages/event-emitter/dist/esm/index.mjs",
-    limit: "1 kB",
   },
 ];

--- a/packages/core-types/src/router.ts
+++ b/packages/core-types/src/router.ts
@@ -85,7 +85,8 @@ export interface Options {
    * - "strict": Route must match exactly
    * - "never": Always remove trailing slash
    * - "always": Always add trailing slash
-   * - "preserve": Keep as provided
+   * - "preserve": Keep the source path's trailing-slash choice, even when
+   *   `rewritePathOnMatch: true` rewrites the rest of the path.
    *
    * @default "preserve"
    */
@@ -125,9 +126,13 @@ export interface Options {
   allowNotFound: boolean;
 
   /**
-   * Rewrite path on successful match.
+   * Rewrite `state.path` on successful match to the canonical path built
+   * from the matched route's pattern. Applies `forwardTo` aliases, encoders,
+   * `defaultParams`, and `trailingSlash` normalization (`"never"` / `"always"`).
+   * When `trailingSlash: "preserve"`, the source path's trailing-slash choice
+   * is kept on the rewritten path.
    *
-   * @default false
+   * @default true
    */
   rewritePathOnMatch: boolean;
 

--- a/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
@@ -268,7 +268,14 @@ export class NavigationNamespace {
       );
     }
 
-    const { route, params } = deps.resolveDefault();
+    let route: string;
+    let params: Params;
+
+    try {
+      ({ route, params } = deps.resolveDefault());
+    } catch (error) {
+      return Promise.reject(error as Error);
+    }
 
     if (!route) {
       return Promise.reject(

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -1,7 +1,11 @@
 // packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
 
 import { DEFAULT_ROUTE_NAME } from "./constants";
-import { paramsMatch, paramsMatchExcluding } from "./helpers";
+import {
+  matchSourceTrailingSlash,
+  paramsMatch,
+  paramsMatchExcluding,
+} from "./helpers";
 import {
   createRoutesStore,
   rebuildTreeInPlace,
@@ -266,6 +270,10 @@ export class RoutesNamespace<
         trailingSlash: ts === "never" || ts === "always" ? ts : undefined,
         queryParamsMode: opts.queryParamsMode,
       });
+
+      if (ts === "preserve") {
+        builtPath = matchSourceTrailingSlash(path, builtPath);
+      }
     }
 
     return this.#deps.makeState<P>(routeName, routeParams, builtPath, meta);

--- a/packages/core/src/namespaces/RoutesNamespace/helpers.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/helpers.ts
@@ -124,3 +124,39 @@ export function clearConfigEntries<T>(
     }
   }
 }
+
+/**
+ * Used by matchPath() when trailingSlash is "preserve": the matcher's
+ * buildPath() with an unset trailingSlash mode strips trailing slashes,
+ * but "preserve" means the source path's trailing-slash choice wins.
+ * If the source had a trailing slash, re-attach it to the rewritten path.
+ * The reverse case (rewritten has trailing, source does not) is not
+ * reachable with the current matcher — it never adds a trailing slash
+ * with undefined mode.
+ */
+export function matchSourceTrailingSlash(
+  sourcePath: string,
+  rewrittenPath: string,
+): string {
+  const queryIndex = rewrittenPath.search(/[?#]/);
+  const pathPart =
+    queryIndex === -1 ? rewrittenPath : rewrittenPath.slice(0, queryIndex);
+
+  if (pathPart === "/" || pathPart.endsWith("/")) {
+    return rewrittenPath;
+  }
+
+  const sourceQueryIndex = sourcePath.search(/[?#]/);
+  const sourcePathPart =
+    sourceQueryIndex === -1
+      ? sourcePath
+      : sourcePath.slice(0, sourceQueryIndex);
+
+  if (!(sourcePathPart.length > 1 && sourcePathPart.endsWith("/"))) {
+    return rewrittenPath;
+  }
+
+  const querySuffix = queryIndex === -1 ? "" : rewrittenPath.slice(queryIndex);
+
+  return `${pathPart}/${querySuffix}`;
+}

--- a/packages/core/src/types/RouterValidator.ts
+++ b/packages/core/src/types/RouterValidator.ts
@@ -56,6 +56,7 @@ export interface RouterValidator {
     validateLimitValue: (name: string, value: unknown) => void;
     validateLimits: (limits: unknown) => void;
     validateOptions: (options: unknown, methodName: string) => void;
+    validateResolvedDefaultRoute: (routeName: unknown, store: unknown) => void;
   };
 
   /**

--- a/packages/core/src/wiring/RouterWiringBuilder.ts
+++ b/packages/core/src/wiring/RouterWiringBuilder.ts
@@ -156,20 +156,28 @@ export class RouterWiringBuilder<
       },
       resolveDefault: () => {
         const options = this.options.get();
+        const ctx = getInternals(this.router);
 
-        return {
-          route: resolveOption(
-            options.defaultRoute,
-            (name: string) =>
-              this.dependenciesStore.dependencies[name as keyof Dependencies],
-          ),
-          params: resolveOption(
-            options.defaultParams,
-            /* v8 ignore next -- @preserve: unreachable unless defaultParams is a callback that calls getDependency */
-            (name: string) =>
-              this.dependenciesStore.dependencies[name as keyof Dependencies],
-          ),
-        };
+        const route = resolveOption(
+          options.defaultRoute,
+          (name: string) =>
+            this.dependenciesStore.dependencies[name as keyof Dependencies],
+        );
+        const params = resolveOption(
+          options.defaultParams,
+          /* v8 ignore next -- @preserve: unreachable unless defaultParams is a callback that calls getDependency */
+          (name: string) =>
+            this.dependenciesStore.dependencies[name as keyof Dependencies],
+        );
+
+        if (typeof options.defaultRoute === "function") {
+          ctx.validator?.options.validateResolvedDefaultRoute(
+            route,
+            ctx.routeGetStore(),
+          );
+        }
+
+        return { route, params };
       },
       startTransition: (toState, fromState) => {
         this.eventBus.sendNavigate(toState, fromState);

--- a/packages/core/tests/functional/navigation/navigateToDefault.test.ts
+++ b/packages/core/tests/functional/navigation/navigateToDefault.test.ts
@@ -895,4 +895,20 @@ describe("navigateToDefault", () => {
       });
     });
   });
+
+  describe("when defaultRoute callback throws", () => {
+    it("should surface the thrown error as Promise rejection", async () => {
+      router.stop();
+      router = createTestRouter({
+        defaultRoute: () => {
+          throw new Error("callback exploded");
+        },
+      });
+      await router.start("/home");
+
+      await expect(router.navigateToDefault()).rejects.toThrow(
+        "callback exploded",
+      );
+    });
+  });
 });

--- a/packages/core/tests/functional/routes/matchPath.test.ts
+++ b/packages/core/tests/functional/routes/matchPath.test.ts
@@ -203,6 +203,83 @@ describe("core/routes/routePath/matchPath", () => {
       expect(withoutSlash?.name).toBe("page");
     });
 
+    describe("trailingSlash: preserve + rewritePathOnMatch: true (#471 case 2)", () => {
+      it("preserves trailing slash from source path when rewrite would strip it", () => {
+        const customRouter = createTestRouter({
+          trailingSlash: "preserve",
+          rewritePathOnMatch: true,
+        });
+
+        getRoutesApi(customRouter).add({ name: "page", path: "/page" });
+
+        const state = getPluginApi(customRouter).matchPath("/page/");
+
+        expect(state?.name).toBe("page");
+        expect(state?.path).toBe("/page/");
+      });
+
+      it("preserves absence of trailing slash when source has none", () => {
+        const customRouter = createTestRouter({
+          trailingSlash: "preserve",
+          rewritePathOnMatch: true,
+        });
+
+        getRoutesApi(customRouter).add({ name: "page", path: "/page" });
+
+        const state = getPluginApi(customRouter).matchPath("/page");
+
+        expect(state?.path).toBe("/page");
+      });
+
+      it("preserves trailing slash even when rewrite changes route (forwardTo)", () => {
+        const customRouter = createTestRouter({
+          trailingSlash: "preserve",
+          rewritePathOnMatch: true,
+        });
+
+        getRoutesApi(customRouter).add([
+          { name: "target", path: "/target" },
+          { name: "source", path: "/source", forwardTo: "target" },
+        ]);
+
+        const state = getPluginApi(customRouter).matchPath("/source/");
+
+        expect(state?.name).toBe("target");
+        expect(state?.path).toBe("/target/");
+      });
+
+      it("keeps rewritten query string intact when adjusting trailing slash", () => {
+        const customRouter = createTestRouter({
+          trailingSlash: "preserve",
+          rewritePathOnMatch: true,
+        });
+
+        getRoutesApi(customRouter).add({
+          name: "search",
+          path: "/search?q",
+          defaultParams: { sort: "date" },
+        });
+
+        const state = getPluginApi(customRouter).matchPath("/search/?q=test");
+
+        expect(state?.path).toMatch(/^\/search\/\?/);
+        expect(state?.path).toContain("q=test");
+      });
+
+      it("is a no-op for root path /", () => {
+        const customRouter = createTestRouter({
+          trailingSlash: "preserve",
+          rewritePathOnMatch: true,
+        });
+
+        getRoutesApi(customRouter).add({ name: "root", path: "/" });
+
+        const state = getPluginApi(customRouter).matchPath("/");
+
+        expect(state?.path).toBe("/");
+      });
+    });
+
     it("should match both with and without trailing slash when trailingSlash is never", () => {
       // Note: "never" affects path building (buildPath), not matching
       // During matching, trailing slashes are normalized

--- a/packages/validation-plugin/ARCHITECTURE.md
+++ b/packages/validation-plugin/ARCHITECTURE.md
@@ -51,7 +51,12 @@ router.usePlugin(validationPlugin())
     │       ├── retroV.validateRoutePropertiesStore(store)
     │       ├── retroV.validateForwardToTargetsStore(store)
     │       ├── retroV.validateDependenciesStructure(deps)
-    │       └── retroV.validateLimitsConsistency(options, store, deps)
+    │       ├── retroV.validateLimitsConsistency(options, store, deps)
+    │       ├── validator.options.validateOptions(options)
+    │       │       └── cross-field: warnListeners ≤ maxListeners, callbackIgnoresLevel requires callback
+    │       └── retroV.validateResolvedDefaultRoute(options.defaultRoute, store)  ← string defaultRoute only
+    │               (callback defaultRoute is validated at runtime via ctx.validator?.options.validateResolvedDefaultRoute,
+    │                called from core's resolveDefault() on each navigateToDefault() / start() fallback)
     │
     │   On error: ctx.validator = null  ← rollback, then re-throw
     │
@@ -164,11 +169,11 @@ Examples:
 
 **Error type mapping:**
 
-| Error type       | When to use                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| `TypeError`      | Wrong argument type or shape                                  |
-| `ReferenceError` | Resource not found (route, dependency)                        |
-| `RangeError`     | Numeric limit exceeded (`maxPlugins`, `maxLifecycleHandlers`) |
+| Error type       | When to use                                                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `TypeError`      | Wrong argument type or shape                                                                                         |
+| `ReferenceError` | Resource not found (route, dependency)                                                                               |
+| `RangeError`     | Numeric limit exceeded (`maxPlugins`, `maxLifecycleHandlers`), cross-field limit violation (`warnListeners > maxListeners`) |
 
 Retrospective validation errors use `[validation-plugin]` prefix instead of `[router.METHOD]`, because no specific public method was called — the plugin is checking accumulated state at registration time:
 

--- a/packages/validation-plugin/README.md
+++ b/packages/validation-plugin/README.md
@@ -41,6 +41,7 @@ Without this plugin, core has structural guards (constructor, plugin registratio
 - Decoder/encoder async detection (sync required for `matchPath`/`buildPath`)
 - Dependency store structure validation
 - Limits consistency checks
+- Cross-field `Options` diagnostics: `warnListeners > maxListeners`, `callbackIgnoresLevel` without `callback`, `defaultRoute` pointing to a missing route (static at registration, callbacks at first use)
 
 The plugin also runs a **retrospective pass** at registration time, validating routes and dependencies that were added before `usePlugin()` was called.
 
@@ -95,17 +96,17 @@ If the retrospective pass fails, the plugin rolls back cleanly. The router is le
 
 ## What Gets Validated
 
-| Namespace     | Validated operations                                                                                                                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Routes        | `buildPath`, `matchPath`, `isActiveRoute`, `shouldUpdateNode`, `addRoute`, `removeRoute`, `updateRoute`, `forwardTo` targets and cycles                 |
-| Options       | `limits` object shape, individual limit values                                                                                                          |
-| Dependencies  | `setDependency` args, dependency name format, full store structure                                                                                      |
-| Plugins       | Plugin count vs `maxPlugins` limit, `addInterceptor` args (method enum + function type)                                                                 |
-| Lifecycle     | Guard/hook handler type, count vs `maxLifecycleHandlers`                                                                                                |
-| Navigation    | `navigate` args, `navigateToDefault` args, `NavigationOptions` shape, `params` validation (navigate, buildPath, canNavigateTo), `start` path validation |
-| State         | `makeState` args, `areStatesEqual` args                                                                                                                 |
-| Event bus     | Event name format, listener args                                                                                                                        |
-| Retrospective | Existing route tree integrity, `forwardTo` consistency, decoder/encoder types, dependency store structure, limits consistency                           |
+| Namespace     | Validated operations                                                                                                                                                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Routes        | `buildPath`, `matchPath`, `isActiveRoute`, `shouldUpdateNode`, `addRoute`, `removeRoute`, `updateRoute`, `forwardTo` targets and cycles                                                      |
+| Options       | `limits` object shape, individual limit values; cross-field `warnListeners ≤ maxListeners`; `logger.callbackIgnoresLevel` requires `logger.callback`; `defaultRoute` callback return value   |
+| Dependencies  | `setDependency` args, dependency name format, full store structure                                                                                                                           |
+| Plugins       | Plugin count vs `maxPlugins` limit, `addInterceptor` args (method enum + function type)                                                                                                      |
+| Lifecycle     | Guard/hook handler type, count vs `maxLifecycleHandlers`                                                                                                                                     |
+| Navigation    | `navigate` args, `navigateToDefault` args, `NavigationOptions` shape, `params` validation (navigate, buildPath, canNavigateTo), `start` path validation                                      |
+| State         | `makeState` args, `areStatesEqual` args                                                                                                                                                      |
+| Event bus     | Event name format, listener args                                                                                                                                                             |
+| Retrospective | Existing route tree integrity, `forwardTo` consistency, decoder/encoder types, dependency store structure, limits consistency, static `defaultRoute` resolves to a registered route         |
 
 ## Error Messages
 

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -57,6 +57,7 @@ import {
   validateForwardToTargetsStore,
   validateDependenciesStructure,
   validateLimitsConsistency,
+  validateResolvedDefaultRoute,
 } from "./validators/retrospective";
 import {
   validateBuildPathArgs,
@@ -186,6 +187,7 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
         validateLimits(limits, "validate");
       },
       validateOptions,
+      validateResolvedDefaultRoute,
     },
     dependencies: {
       validateDependencyName,
@@ -315,6 +317,10 @@ export function validationPlugin(): PluginFactory {
         options as unknown,
         "constructor (retrospective)",
       );
+
+      if (typeof options.defaultRoute === "string") {
+        validateResolvedDefaultRoute(options.defaultRoute, store);
+      }
     } catch (error) {
       ctx.validator = null;
 

--- a/packages/validation-plugin/src/validators/options.ts
+++ b/packages/validation-plugin/src/validators/options.ts
@@ -98,6 +98,19 @@ export function validateLimits(
 
     validateLimitValue(key as keyof LimitsConfig, value, methodName);
   }
+
+  const { warnListeners, maxListeners } = limits as Partial<LimitsConfig>;
+
+  if (
+    typeof warnListeners === "number" &&
+    typeof maxListeners === "number" &&
+    maxListeners > 0 &&
+    warnListeners > maxListeners
+  ) {
+    throw new RangeError(
+      `[router.${methodName}] "limits.warnListeners" (${warnListeners}) must not exceed "limits.maxListeners" (${maxListeners}) — the warning channel would be unreachable`,
+    );
+  }
 }
 
 function validateStringEnum(

--- a/packages/validation-plugin/src/validators/options.ts
+++ b/packages/validation-plugin/src/validators/options.ts
@@ -1,5 +1,6 @@
 // packages/validation-plugin/src/validators/options.ts
 
+import { logger } from "@real-router/logger";
 import { isObjKey } from "type-guards";
 
 const VALID_OPTION_VALUES = {
@@ -252,6 +253,16 @@ function validateLoggerOption(loggerOpt: unknown, methodName: string): void {
   ) {
     throw new TypeError(
       `[router.${methodName}] Invalid "logger.callbackIgnoresLevel": expected boolean`,
+    );
+  }
+
+  if (
+    loggerOptions.callbackIgnoresLevel === true &&
+    loggerOptions.callback === undefined
+  ) {
+    logger.error(
+      `router.${methodName}`,
+      `"logger.callbackIgnoresLevel: true" has no effect without "logger.callback" — the option is ignored`,
     );
   }
 }

--- a/packages/validation-plugin/src/validators/retrospective.ts
+++ b/packages/validation-plugin/src/validators/retrospective.ts
@@ -538,3 +538,36 @@ export function validateLimitsConsistency(
   checkRouteCountLimit(store, configuredLimits);
   checkDepCountLimit(deps, configuredLimits);
 }
+
+// =============================================================================
+// 7. validateResolvedDefaultRoute
+// =============================================================================
+
+/**
+ * Validates that a resolved defaultRoute name points to a route that exists
+ * in the tree. Called at two places:
+ *
+ *   1. At plugin registration (retrospective) — with the static string value
+ *      of options.defaultRoute, if any.
+ *   2. At runtime inside resolveDefault() — with the return value of a
+ *      DefaultRouteCallback, on every navigateToDefault() / start() fallback.
+ *
+ * No-op for empty string (means "no default configured" — handled upstream by
+ * NavigationNamespace.navigateToDefault).
+ */
+export function validateResolvedDefaultRoute(
+  routeName: unknown,
+  store: unknown,
+): void {
+  if (typeof routeName !== "string" || !routeName) {
+    return;
+  }
+
+  const routesStore = assertRoutesStore(store, "validateResolvedDefaultRoute");
+
+  if (!routeExistsInTree(routesStore.tree, routeName)) {
+    throw new Error(
+      `[validation-plugin] defaultRoute resolved to non-existent route: "${routeName}"`,
+    );
+  }
+}

--- a/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
@@ -209,4 +209,25 @@ describe("retrospective validation — triggered at usePlugin() time", () => {
       expect(callCount).toBe(0);
     });
   });
+
+  describe("limits cross-field (#471 case 1)", () => {
+    it("warnListeners exceeding maxListeners throws RangeError at usePlugin", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        limits: { warnListeners: 5000, maxListeners: 100 },
+      });
+
+      expect(() => router.usePlugin(validationPlugin())).toThrow(RangeError);
+      expect(() => router.usePlugin(validationPlugin())).toThrow(
+        /warning channel would be unreachable/,
+      );
+    });
+
+    it("warnListeners <= maxListeners passes", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        limits: { warnListeners: 50, maxListeners: 100 },
+      });
+
+      expect(() => router.usePlugin(validationPlugin())).not.toThrow();
+    });
+  });
 });

--- a/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
@@ -125,4 +125,88 @@ describe("retrospective validation — triggered at usePlugin() time", () => {
 
     r.stop();
   });
+
+  describe("defaultRoute validation (#471 case 5)", () => {
+    it("static defaultRoute pointing to missing route throws at usePlugin", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: "missing",
+      });
+
+      expect(() => router.usePlugin(validationPlugin())).toThrow(
+        /defaultRoute resolved to non-existent route: "missing"/,
+      );
+    });
+
+    it("static defaultRoute pointing to existing route passes", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: "home",
+      });
+
+      expect(() => router.usePlugin(validationPlugin())).not.toThrow();
+    });
+
+    it("empty static defaultRoute passes (means not configured)", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: "",
+      });
+
+      expect(() => router.usePlugin(validationPlugin())).not.toThrow();
+    });
+
+    it("callback defaultRoute returning missing route surfaces on navigateToDefault", async () => {
+      router = createRouter(
+        [
+          { name: "home", path: "/home" },
+          { name: "about", path: "/about" },
+        ],
+        {
+          defaultRoute: () => "ghost",
+        },
+      );
+
+      router.usePlugin(validationPlugin());
+
+      await router.start("/home");
+
+      await expect(router.navigateToDefault()).rejects.toThrow(
+        /defaultRoute resolved to non-existent route: "ghost"/,
+      );
+    });
+
+    it("callback defaultRoute returning existing route works", async () => {
+      router = createRouter(
+        [
+          { name: "home", path: "/home" },
+          { name: "about", path: "/about" },
+        ],
+        {
+          defaultRoute: () => "about",
+        },
+      );
+
+      router.usePlugin(validationPlugin());
+
+      await router.start("/home");
+
+      const state = await router.navigateToDefault();
+
+      expect(state.name).toBe("about");
+    });
+
+    it("callback defaultRoute is not probed at usePlugin time", () => {
+      let callCount = 0;
+
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: () => {
+          callCount++;
+
+          return "home";
+        },
+      });
+
+      router.usePlugin(validationPlugin());
+
+      expect(callCount).toBe(0);
+    });
+  });
 });

--- a/packages/validation-plugin/tests/functional/retrospective/retrospective.test.ts
+++ b/packages/validation-plugin/tests/functional/retrospective/retrospective.test.ts
@@ -7,6 +7,7 @@ import {
   validateForwardToTargetsStore,
   validateDependenciesStructure,
   validateLimitsConsistency,
+  validateResolvedDefaultRoute,
 } from "../../../src/validators/retrospective";
 
 function makeTree(routes: { name: string; children?: typeof routes }[] = []) {
@@ -771,5 +772,102 @@ describe("validateLimitsConsistency", () => {
         makeDeps(),
       );
     }).not.toThrow();
+  });
+});
+
+describe("validateResolvedDefaultRoute", () => {
+  it("is a no-op when routeName is not a string", () => {
+    const store = makeStore({ treeRoutes: [{ name: "home" }] });
+
+    expect(() => {
+      validateResolvedDefaultRoute(undefined, store);
+    }).not.toThrow();
+    expect(() => {
+      validateResolvedDefaultRoute(null, store);
+    }).not.toThrow();
+    expect(() => {
+      validateResolvedDefaultRoute(42, store);
+    }).not.toThrow();
+    expect(() => {
+      validateResolvedDefaultRoute({}, store);
+    }).not.toThrow();
+  });
+
+  it("is a no-op when routeName is empty string", () => {
+    const store = makeStore({ treeRoutes: [{ name: "home" }] });
+
+    expect(() => {
+      validateResolvedDefaultRoute("", store);
+    }).not.toThrow();
+  });
+
+  it("passes when route exists in tree", () => {
+    const store = makeStore({
+      treeRoutes: [{ name: "home" }, { name: "about" }],
+    });
+
+    expect(() => {
+      validateResolvedDefaultRoute("home", store);
+    }).not.toThrow();
+  });
+
+  it("passes for nested route that exists in tree", () => {
+    const store = {
+      definitions: [],
+      config: {
+        forwardMap: {},
+        forwardFnMap: {},
+        decoders: {},
+        encoders: {},
+        defaultParams: {},
+      },
+      tree: {
+        children: new Map([
+          [
+            "admin",
+            {
+              children: new Map([
+                [
+                  "dashboard",
+                  {
+                    children: new Map(),
+                    paramMeta: { urlParams: [], spatParams: [] },
+                  },
+                ],
+              ]),
+              paramMeta: { urlParams: [], spatParams: [] },
+            },
+          ],
+        ]),
+        paramMeta: { urlParams: [], spatParams: [] },
+      },
+      matcher: { getSegmentsByName: () => null },
+    };
+
+    expect(() => {
+      validateResolvedDefaultRoute("admin.dashboard", store);
+    }).not.toThrow();
+  });
+
+  it("throws when route does not exist in tree", () => {
+    const store = makeStore({ treeRoutes: [{ name: "home" }] });
+
+    expect(() => {
+      validateResolvedDefaultRoute("missing", store);
+    }).toThrow(/defaultRoute resolved to non-existent route: "missing"/);
+  });
+
+  it("throws when nested route's parent is missing", () => {
+    const store = makeStore({ treeRoutes: [{ name: "home" }] });
+
+    expect(() => {
+      validateResolvedDefaultRoute("admin.dashboard", store);
+    }).toThrow(/non-existent route: "admin.dashboard"/);
+  });
+
+  it("throws TypeError when store is invalid", () => {
+    expect(() => {
+      validateResolvedDefaultRoute("home", null);
+    }).toThrow(TypeError);
   });
 });

--- a/packages/validation-plugin/tests/functional/validators.test.ts
+++ b/packages/validation-plugin/tests/functional/validators.test.ts
@@ -999,6 +999,53 @@ describe("Phase 2 options validators", () => {
         validateOptions({ logger: { callback: () => {} } }, "test");
       }).not.toThrow();
     });
+
+    describe("callbackIgnoresLevel without callback (#471 case 4)", () => {
+      let errorSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        errorSpy.mockRestore();
+      });
+
+      it("logs error when callbackIgnoresLevel is true and callback missing", () => {
+        validateOptions({ logger: { callbackIgnoresLevel: true } }, "test");
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          "router.test",
+          expect.stringContaining("has no effect without"),
+        );
+      });
+
+      it("does not log error when callbackIgnoresLevel is false", () => {
+        validateOptions({ logger: { callbackIgnoresLevel: false } }, "test");
+
+        expect(errorSpy).not.toHaveBeenCalled();
+      });
+
+      it("does not log error when callback is provided alongside callbackIgnoresLevel", () => {
+        validateOptions(
+          {
+            logger: {
+              callbackIgnoresLevel: true,
+              callback: () => {},
+            },
+          },
+          "test",
+        );
+
+        expect(errorSpy).not.toHaveBeenCalled();
+      });
+
+      it("does not log error when callbackIgnoresLevel is undefined", () => {
+        validateOptions({ logger: { level: "all" } }, "test");
+
+        expect(errorSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 });
 

--- a/packages/validation-plugin/tests/functional/validators.test.ts
+++ b/packages/validation-plugin/tests/functional/validators.test.ts
@@ -155,6 +155,47 @@ describe("options validators", () => {
         );
       }).not.toThrow();
     });
+
+    describe("warnListeners vs maxListeners cross-field (#471 case 1)", () => {
+      it("throws RangeError when warnListeners exceeds maxListeners", () => {
+        expect(() => {
+          validateLimits({ warnListeners: 5000, maxListeners: 100 }, "test");
+        }).toThrow(RangeError);
+        expect(() => {
+          validateLimits({ warnListeners: 5000, maxListeners: 100 }, "test");
+        }).toThrow(/warning channel would be unreachable/);
+      });
+
+      it("accepts warnListeners equal to maxListeners", () => {
+        expect(() => {
+          validateLimits({ warnListeners: 100, maxListeners: 100 }, "test");
+        }).not.toThrow();
+      });
+
+      it("accepts warnListeners below maxListeners", () => {
+        expect(() => {
+          validateLimits({ warnListeners: 50, maxListeners: 100 }, "test");
+        }).not.toThrow();
+      });
+
+      it("skips cross-check when maxListeners is 0 (unlimited)", () => {
+        expect(() => {
+          validateLimits({ warnListeners: 5000, maxListeners: 0 }, "test");
+        }).not.toThrow();
+      });
+
+      it("skips cross-check when only warnListeners provided", () => {
+        expect(() => {
+          validateLimits({ warnListeners: 5000 }, "test");
+        }).not.toThrow();
+      });
+
+      it("skips cross-check when only maxListeners provided", () => {
+        expect(() => {
+          validateLimits({ maxListeners: 100 }, "test");
+        }).not.toThrow();
+      });
+    });
   });
 });
 

--- a/packages/validation-plugin/tests/property/helpers.ts
+++ b/packages/validation-plugin/tests/property/helpers.ts
@@ -106,6 +106,13 @@ const validLoggerArbitrary = fc
       }
     }
 
+    // Cross-field invariant (#471 case 4): callbackIgnoresLevel: true has no
+    // effect without callback. Drop the flag in that case so the generated
+    // options don't trigger the validator's noisy logger.error on every run.
+    if (result.callbackIgnoresLevel === true && result.callback === undefined) {
+      delete result.callbackIgnoresLevel;
+    }
+
     return result;
   });
 

--- a/packages/validation-plugin/tests/property/helpers.ts
+++ b/packages/validation-plugin/tests/property/helpers.ts
@@ -139,6 +139,18 @@ const validLimitsArbitrary = fc
       }
     }
 
+    // Cross-field invariant (#471 case 1): warnListeners must not exceed
+    // maxListeners when both are provided and maxListeners > 0.
+    // Clamp warn to max to keep generated options semantically valid.
+    if (
+      typeof result.warnListeners === "number" &&
+      typeof result.maxListeners === "number" &&
+      result.maxListeners > 0 &&
+      result.warnListeners > result.maxListeners
+    ) {
+      result.warnListeners = result.maxListeners;
+    }
+
     return result;
   });
 

--- a/packages/validation-plugin/tests/property/validateOptions.properties.ts
+++ b/packages/validation-plugin/tests/property/validateOptions.properties.ts
@@ -118,4 +118,37 @@ describe("validateOptions — property-based", () => {
       expect(threw1).toBe(threw2);
     },
   );
+
+  test.prop(
+    [
+      fc.integer({ min: 1, max: 100_000 }).chain((max) =>
+        fc.record({
+          maxListeners: fc.constant(max),
+          warnListeners: fc.integer({ min: max + 1, max: max + 100_000 }),
+        }),
+      ),
+    ],
+    { numRuns: 2000 },
+  )(
+    "warnListeners > maxListeners always throws RangeError (#471 case 1)",
+    ({ maxListeners, warnListeners }) => {
+      // fast-check's .chain upper bound can exceed LIMIT_BOUNDS.warnListeners
+      // (100_000); clamp so we only exercise the cross-field path, not the
+      // per-field bounds path.
+      const clampedWarn = Math.min(warnListeners, 100_000);
+
+      // Skip if clamping collapsed the inequality (max=100_000, warn=100_001
+      // → clampedWarn=100_000 == max). Cross-field check uses strict `>`.
+      if (clampedWarn <= maxListeners) {
+        return;
+      }
+
+      expect(() => {
+        validateOptions(
+          { limits: { maxListeners, warnListeners: clampedWarn } },
+          "test",
+        );
+      }).toThrow(RangeError);
+    },
+  );
 });

--- a/packages/vue/tests/functional/useRoute.test.ts
+++ b/packages/vue/tests/functional/useRoute.test.ts
@@ -2,8 +2,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 import { defineComponent, h, watchSyncEffect } from "vue";
 
-import { useRoute } from "../../src";
-import { RouterProvider } from "../../src";
+import { useRoute, RouterProvider } from "../../src";
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
 import type { RouteContext } from "../../src/types";


### PR DESCRIPTION
## Summary

Closes cases 1, 2, 4, 5 of #471 (cross-field `Options` validation) and fixes a latent Promise-contract bug in `navigateToDefault()`. Case 3 is deferred to #483 as a separate feature (`start()` fallback to `defaultRoute`).

- **Case 1 (8daf6683):** `validateLimits` now throws `RangeError` when `warnListeners > maxListeners` (and `maxListeners > 0`). Previously the warn channel was dead code.
- **Case 2 (519f8e7d):** `matchPath()` honours `trailingSlash: "preserve"` when `rewritePathOnMatch: true` — the source path's trailing-slash choice wins. Both options are default-on, so the previous silent override affected every router with default config.
- **Case 4 (9b9f533a):** `validateLoggerOption` logs `logger.error` when `callbackIgnoresLevel: true` is set without `callback` (non-throwing — the option would be ignored, but the misconfiguration is now visible).
- **Case 5 (ed8be1a6):** Static `defaultRoute` checked against the route tree at `usePlugin()` time; `DefaultRouteCallback` result checked at runtime via a new `RouterValidator.options.validateResolvedDefaultRoute` hook called from core's `resolveDefault()`. `navigateToDefault()` body wrapped in try/catch so sync throws from `resolveDefault()` honour the declared `Promise<State>` return contract.
- **Docs (a9e0b785):** core-types JSDoc, wiki `RouterOptions` / `validation-plugin` / `navigateToDefault` / `matchPath`, validation-plugin README/ARCHITECTURE synced; pre-existing `rewritePathOnMatch @default false` doc bug fixed (actual default is `true`).

## Version Bumps

- `@real-router/core` — minor (new `RouterValidator` hook; behavioural fix on `matchPath()` for default config; Promise-contract fix on `navigateToDefault`)
- `@real-router/validation-plugin` — minor × 3 features (cross-field limits, callback default route, callbackIgnoresLevel)

## Related Issues

- Closes cases 1, 2, 4, 5 of #471
- Case 3 of #471 tracked separately in #483 (`start()` fallback to `defaultRoute` when `allowNotFound: false`)

## Test plan

- [ ] `pnpm build` green (239/239 tasks)
- [ ] `@real-router/core` functional tests pass (2153/2153)
- [ ] `@real-router/validation-plugin` functional + property tests pass (563 + 86)
- [ ] Verify validation-plugin catches a bad-config router at `usePlugin()` time (`{ limits: { warnListeners: 5000, maxListeners: 100 } }` throws `RangeError`; `{ defaultRoute: "missing" }` throws plain Error with `[validation-plugin]` prefix)
- [ ] Verify `matchPath("/users/")` with default options returns `state.path === "/users/"` — the `"preserve"` semantic restored
- [ ] Verify `navigateToDefault()` with a throwing callback returns a rejected Promise (not an escaped sync throw)
- [ ] Confirm release notes cover `rewritePathOnMatch` doc correction for users who relied on the wrong default