### PR TITLE
feat: unify strict-mode behavior — remove silent defaultRoute fallback (#483)

### DIFF
--- a/.changeset/browser-plugin-strict-mode-break.md
+++ b/.changeset/browser-plugin-strict-mode-break.md
@@ -1,0 +1,29 @@
+---
+"@real-router/browser-plugin": minor
+---
+
+**BREAKING:** popstate to unmatched URL in strict mode no longer silently redirects to `defaultRoute` (#483)
+
+When `allowNotFound: false` and a popstate event targets a URL that matches no registered route, the plugin used to silently call `router.navigateToDefault({ reload: true, replace: true })`. This hid the error from logs, analytics, and the `onTransitionError` plugin hook, and overloaded `defaultRoute` with two unrelated meanings (explicit target + implicit auto-fallback).
+
+**New behaviour:**
+
+- `$$error` event is emitted with `ROUTE_NOT_FOUND` — reaches `Plugin.onTransitionError` hooks and `router.addEventListener("$$error", ...)` listeners.
+- Browser URL is rolled back to the last-known router state (URL↔state consistency preserved).
+- Router state is unchanged.
+
+The `defaultRoute` option now has a single purpose: it is only consulted by an **explicit** `router.navigateToDefault()` call.
+
+**Incidental fix:** the same catch now rolls back URL on any `RouterError` (including guard-rejected navigations). Previously, a `canDeactivate: false` on popstate left the browser URL on the new location while router state stayed on the old — an inconsistent observable state that is now resolved.
+
+**Migration** — if you relied on the silent fallback:
+
+```ts
+router.usePlugin(() => ({
+  onTransitionError(_toState, _fromState, err) {
+    if (err.code === "ROUTE_NOT_FOUND") {
+      void router.navigateToDefault({ replace: true });
+    }
+  },
+}));
+```

--- a/.changeset/hash-plugin-strict-mode-break.md
+++ b/.changeset/hash-plugin-strict-mode-break.md
@@ -1,0 +1,27 @@
+---
+"@real-router/hash-plugin": minor
+---
+
+**BREAKING:** popstate to unmatched hash in strict mode no longer silently redirects to `defaultRoute` (#483)
+
+Same change as `@real-router/browser-plugin` — hash-plugin reuses the shared `popstate-handler` from `browser-env`, so the fix propagates automatically.
+
+When `allowNotFound: false` and a popstate targets a hash that matches no registered route, the plugin used to silently call `router.navigateToDefault({ reload: true, replace: true })`. This is removed.
+
+**New behaviour:**
+
+- `$$error` event with `ROUTE_NOT_FOUND` — observable via `onTransitionError` hook.
+- Browser URL is rolled back to the last-known router state.
+- Router state is unchanged.
+
+**Migration** — same as browser-plugin:
+
+```ts
+router.usePlugin(() => ({
+  onTransitionError(_toState, _fromState, err) {
+    if (err.code === "ROUTE_NOT_FOUND") {
+      void router.navigateToDefault({ replace: true });
+    }
+  },
+}));
+```

--- a/.changeset/navigation-plugin-strict-mode-break.md
+++ b/.changeset/navigation-plugin-strict-mode-break.md
@@ -1,0 +1,27 @@
+---
+"@real-router/navigation-plugin": minor
+---
+
+**BREAKING:** navigate event on unmatched URL in strict mode no longer silently redirects to `defaultRoute` (#483)
+
+When `allowNotFound: false` and a navigate event targets a URL that matches no registered route, the plugin used to silently call `router.navigateToDefault()` inside `event.intercept`. This hid the error from logs, analytics, and the `onTransitionError` plugin hook.
+
+**New behaviour:**
+
+- `$$error` event is emitted with `ROUTE_NOT_FOUND` — reaches `Plugin.onTransitionError` hooks and `router.addEventListener("$$error", ...)` listeners.
+- `event.intercept()` handler rejects, so the Navigation API automatically rolls back the URL (no manual `browser.navigate()` call needed).
+- Router state is unchanged.
+
+The `defaultRoute` option now has a single purpose: it is only consulted by an **explicit** `router.navigateToDefault()` call.
+
+**Migration** — if you relied on the silent fallback:
+
+```ts
+router.usePlugin(() => ({
+  onTransitionError(_toState, _fromState, err) {
+    if (err.code === "ROUTE_NOT_FOUND") {
+      void router.navigateToDefault({ replace: true });
+    }
+  },
+}));
+```

--- a/.changeset/strict-mode-unified-behavior-feature.md
+++ b/.changeset/strict-mode-unified-behavior-feature.md
@@ -1,0 +1,9 @@
+---
+"@real-router/core": minor
+---
+
+Add `PluginApi.emitTransitionError(error)` (#483)
+
+Plugins can now emit `$$error` events without going through the navigation pipeline. Delegates to `eventBus.sendFailSafe` internally with the current router state as `fromState` and `toState: undefined`. Safe to call at any FSM state.
+
+Used by `@real-router/browser-plugin`, `@real-router/navigation-plugin`, and `@real-router/hash-plugin` to surface strict-mode errors (`ROUTE_NOT_FOUND` on unmatched URL) through the standard `onTransitionError` hook instead of silently falling back to `navigateToDefault()`.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -2270,6 +2270,56 @@ Added `decodeURIComponent()` to both key and value extraction in `defaultParseQu
 
 `defaultParseQueryString` is a fallback for standalone `path-matcher` usage. Standard configuration uses `search-params` package (injected via DI in `route-tree/createMatcher.ts`) which handles encoding correctly.
 
+## Unified Strict-Mode Behavior on Unmatched URLs (#483)
+
+### Problem
+
+`allowNotFound: false` had inconsistent semantics depending on the entry point:
+
+| Entry point                    | Behaviour on unmatched URL + strict mode                            |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `router.start(path)`           | throws `ROUTE_NOT_FOUND`                                            |
+| `browser-plugin` popstate      | silent `router.navigateToDefault({ reload, replace })`              |
+| `navigation-plugin` navigate   | silent `router.navigateToDefault()` in `event.intercept`            |
+| `hash-plugin` popstate         | silent fallback (shared `browser-env/popstate-handler`)             |
+
+The same configuration, the same unmatched URL → three different outcomes depending on how the URL arrived. `defaultRoute` was overloaded: explicit target for `navigateToDefault()` **and** implicit auto-fallback on popstate. The silent fallback hid errors from logs, analytics, and the `onTransitionError` hook.
+
+### Solution
+
+Unified contract: `allowNotFound: false` means "unknown route is an error, reported, everywhere". `start()` already implemented it — the three plugins now match.
+
+1. Added `PluginApi.emitTransitionError(error)` — a standard point-of-entry for plugins to emit `$$error` without synthesising a navigation. Delegates to `ctx.emitTransitionError` on `RouterInternals`, which calls `eventBus.sendFailSafe(undefined, state.get(), error)` (safe at any FSM state — direct emit when not READY).
+2. `shared/browser-env/popstate-handler.ts`: strict-mode else-branch emits `ROUTE_NOT_FOUND` via `api.emitTransitionError` and calls `rollbackUrlToCurrentState()` (replaces URL with the current router state's path) — no more silent `navigateToDefault`.
+3. `navigation-plugin/navigate-handler.ts`: strict-mode branch emits the same error and throws inside an `async` `event.intercept()` handler — Navigation API auto-rolls back the URL via intercept rejection.
+4. `hash-plugin`: inherits the fix via `browser-env` symlink.
+
+### Incidental fix bundled in
+
+The popstate-handler catch was extended: `RouterError` from `deps.router.navigate()` (e.g., `CANNOT_DEACTIVATE` from a blocking guard) now also rolls the URL back. Previously, guard-rejected popstate left the browser URL on the new location while state stayed on the old — an inconsistent observable state.
+
+Teardown-safe: the rollback is wrapped in try/catch because `router.buildUrl` may have been removed by plugin teardown while a popstate event was still queued.
+
+### Userland migration
+
+Users who relied on the silent fallback subscribe explicitly:
+
+```ts
+router.usePlugin(() => ({
+  onTransitionError(_toState, _fromState, err) {
+    if (err.code === "ROUTE_NOT_FOUND") {
+      void router.navigateToDefault({ replace: true });
+    }
+  },
+}));
+```
+
+### Why this matters
+
+- Closes #471 case 3 from the opposite direction — `{ allowNotFound: false, defaultRoute: "" }` is no longer a dead-end configuration.
+- Single purpose for `defaultRoute`: only the explicit `router.navigateToDefault()` target.
+- All error surfaces go through one channel (`onTransitionError`) — uniform observability for logs, analytics, and recovery UIs.
+
 ## CI/CD: Split CI into PR-only and Post-Merge Workflows
 
 ### Problem

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -333,10 +333,11 @@ User clicks back or forward
         ├── route found?
         │     YES: await router.navigate(route.name, route.params, transitionOptions)
         │     NO + allowNotFound: router.navigateToNotFound(browser.getLocation())
-        │     NO + !allowNotFound: await router.navigateToDefault({ ...transitionOptions, reload: true, replace: true })
+        │     NO + !allowNotFound: api.emitTransitionError(ROUTE_NOT_FOUND) + rollbackUrlToCurrentState()
+        │                          (no silent navigateToDefault — see #483)
         │
         ├── catch (error):
-        │     error instanceof RouterError? → ignore (CANNOT_DEACTIVATE, etc.)
+        │     error instanceof RouterError? → rollbackUrlToCurrentState() (URL↔state resync)
         │     otherwise: recoverFromCriticalError(error)
         │               └── browser.replaceState(currentState, buildUrl(...))
         │

--- a/packages/browser-plugin/tests/functional/popstate.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate.test.ts
@@ -87,7 +87,7 @@ describe("Browser Plugin — Popstate", () => {
       expect(navigateSpy).toHaveBeenCalled();
     });
 
-    it("navigates to default when allowNotFound is false and no route matches", async () => {
+    it("emits $$error and rolls back URL when allowNotFound is false and no route matches (#483)", async () => {
       router.stop();
 
       const restrictedRouter = createRouter(routerConfig, {
@@ -99,12 +99,34 @@ describe("Browser Plugin — Popstate", () => {
       restrictedRouter.usePlugin(browserPluginFactory({}, mockedBrowser));
       await restrictedRouter.start();
 
-      globalThis.history.replaceState({}, "", "/nonexistent-path");
-      const navigateSpy = vi.spyOn(restrictedRouter, "navigateToDefault");
+      const previousState = restrictedRouter.getState()!;
+      const errorHook = vi.fn();
 
+      restrictedRouter.usePlugin(() => ({ onTransitionError: errorHook }));
+
+      const defaultSpy = vi.spyOn(restrictedRouter, "navigateToDefault");
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.history.replaceState({}, "", "/nonexistent-path");
       globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
 
-      expect(navigateSpy).toHaveBeenCalled();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // No silent fallback
+      expect(defaultSpy).not.toHaveBeenCalled();
+
+      // Error surfaces via onTransitionError
+      expect(errorHook).toHaveBeenCalledTimes(1);
+      expect(errorHook.mock.calls[0][2]).toMatchObject({
+        code: "ROUTE_NOT_FOUND",
+      });
+
+      // State unchanged, URL re-synced to previous state
+      expect(restrictedRouter.getState()).toStrictEqual(previousState);
+      expect(replaceSpy).toHaveBeenCalledWith(
+        previousState,
+        expect.stringContaining(previousState.path),
+      );
 
       restrictedRouter.stop();
     });

--- a/packages/browser-plugin/tests/stress/popstate-storm.stress.ts
+++ b/packages/browser-plugin/tests/stress/popstate-storm.stress.ts
@@ -188,7 +188,7 @@ describe("B1 — Popstate Storm", () => {
     expect(router.getState()).toStrictEqual(stateBefore);
   });
 
-  it("1.6 — 50 null-state events, allowNotFound=false: navigateToDefault called, replaceState used", async () => {
+  it("1.6 — 50 null-state events, allowNotFound=false: no silent fallback, errors surface, URL rolls back (#483)", async () => {
     globalThis.history.replaceState({}, "", "/");
 
     const result = createStressRouter({ allowNotFound: false });
@@ -200,9 +200,14 @@ describe("B1 — Popstate Storm", () => {
 
     await router.start();
 
+    const initialState = router.getState()!;
+    const errorHook = vi.fn();
+
+    router.usePlugin(() => ({ onTransitionError: errorHook }));
+
     globalThis.history.replaceState({}, "", "/nonexistent");
 
-    const navigateSpy = vi.spyOn(router, "navigateToDefault");
+    const navigateDefaultSpy = vi.spyOn(router, "navigateToDefault");
     const replaceStateSpy = vi.spyOn(browser, "replaceState");
 
     for (let i = 0; i < 50; i++) {
@@ -211,8 +216,14 @@ describe("B1 — Popstate Storm", () => {
 
     await waitForTransitions(200);
 
-    expect(navigateSpy).toHaveBeenCalled();
+    // No silent fallback
+    expect(navigateDefaultSpy).not.toHaveBeenCalled();
+
+    // Every popstate produced a ROUTE_NOT_FOUND error + URL rollback
+    expect(errorHook).toHaveBeenCalled();
     expect(replaceStateSpy).toHaveBeenCalled();
-    expect(router.getState()?.name).toBe("home");
+
+    // Router state is pinned to what it was before the storm — no drift
+    expect(router.getState()).toStrictEqual(initialState);
   });
 });

--- a/packages/core-types/src/api.ts
+++ b/packages/core-types/src/api.ts
@@ -133,6 +133,20 @@ export interface PluginApi {
 
   extendRouter: (extensions: Record<string, unknown>) => Unsubscribe;
 
+  /**
+   * Emits a `$$error` event without going through the navigation pipeline.
+   *
+   * Used by plugins that detect an error outside a running transition (e.g.,
+   * an unmatched URL on popstate in strict mode). The event reaches any
+   * `onTransitionError` plugin hook and any `$$error` listener so developers
+   * can observe errors raised by the plugin layer.
+   *
+   * The current router state is used as `fromState`; `toState` is `undefined`
+   * because no transition was attempted. Safe to call at any FSM state —
+   * delegates to `sendFailSafe` internally (direct emit when not READY).
+   */
+  emitTransitionError: (error: Error) => void;
+
   claimContextNamespace: {
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- StateContext is an empty interface extended via module augmentation, so `keyof StateContext & string` is `never` at baseline and resolves to the augmented keys when plugins extend it
     <K extends keyof StateContext & string>(

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -123,7 +123,7 @@ import {
 | `getRoutesApi(router)`       | Dynamic route CRUD    | `add`, `remove`, `update`, `replace`, `has`, `get`                           |
 | `getDependenciesApi(router)` | Dependency injection  | `get`, `set`, `setAll`, `remove`, `has`                                      |
 | `getLifecycleApi(router)`    | Guard registration    | `addActivateGuard`, `addDeactivateGuard`, `remove*`                          |
-| `getPluginApi(router)`       | Plugin infrastructure | `makeState`, `matchPath`, `addInterceptor`, `extendRouter`, `getRouteConfig` |
+| `getPluginApi(router)`       | Plugin infrastructure | `makeState`, `matchPath`, `addInterceptor`, `extendRouter`, `emitTransitionError`, `getRouteConfig` |
 | `cloneRouter(router, deps?)` | SSR cloning           | Shares route definitions, independent state                                  |
 
 ## Utilities

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -215,6 +215,9 @@ export class Router<
           ),
         interceptorsMap,
       ) as unknown as RouterInternals["buildPath"],
+      emitTransitionError: (error) => {
+        this.#eventBus.sendFailSafe(undefined, this.#state.get(), error);
+      },
       start: createInterceptable(
         "start",
         (path: string) => {

--- a/packages/core/src/api/getPluginApi.ts
+++ b/packages/core/src/api/getPluginApi.ts
@@ -169,6 +169,10 @@ export function getPluginApi<
         }
       };
     },
+    emitTransitionError: (error) => {
+      throwIfDisposed(ctx.isDisposed);
+      ctx.emitTransitionError(error);
+    },
     claimContextNamespace: ((namespace: string) => {
       throwIfDisposed(ctx.isDisposed);
 

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -51,6 +51,8 @@ export interface RouterInternals<
 
   readonly buildPath: (route: string, params?: Params) => string;
 
+  readonly emitTransitionError: (error: Error) => void;
+
   readonly start: (path: string) => Promise<State>;
 
   /* eslint-disable @typescript-eslint/no-explicit-any -- heterogeneous map: stores different InterceptorFn<M> types under different keys */

--- a/packages/core/tests/functional/api/getPluginApi/emitTransitionError.test.ts
+++ b/packages/core/tests/functional/api/getPluginApi/emitTransitionError.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { errorCodes, RouterError } from "@real-router/core";
+import { getPluginApi } from "@real-router/core/api";
+
+import { createTestRouter } from "../../../helpers";
+
+import type { Router } from "@real-router/core";
+import type { PluginApi } from "@real-router/core/api";
+
+let router: Router;
+let api: PluginApi;
+
+describe("getPluginApi().emitTransitionError()", () => {
+  beforeEach(() => {
+    router = createTestRouter();
+    api = getPluginApi(router);
+  });
+
+  afterEach(() => {
+    if (router.isActive()) {
+      router.stop();
+    }
+  });
+
+  it("delivers the error to $$error event listeners", async () => {
+    const listener = vi.fn();
+
+    await router.start("/home");
+    api.addEventListener("$$error", listener);
+
+    const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, { path: "/oops" });
+
+    api.emitTransitionError(err);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(undefined, router.getState(), err);
+  });
+
+  it("delivers the error to Plugin.onTransitionError hook", async () => {
+    const onTransitionError = vi.fn();
+
+    router.usePlugin(() => ({
+      onTransitionError,
+    }));
+    await router.start("/home");
+
+    const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, { path: "/oops" });
+
+    api.emitTransitionError(err);
+
+    expect(onTransitionError).toHaveBeenCalledTimes(1);
+    expect(onTransitionError).toHaveBeenCalledWith(
+      undefined,
+      router.getState(),
+      err,
+    );
+  });
+
+  it("uses the current router state as fromState", async () => {
+    const listener = vi.fn();
+
+    api.addEventListener("$$error", listener);
+
+    await router.start("/home");
+    await router.navigate("users");
+
+    const currentState = router.getState();
+    const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, { path: "/x" });
+
+    api.emitTransitionError(err);
+
+    expect(listener).toHaveBeenCalledWith(undefined, currentState, err);
+  });
+
+  it("works before router.start() — fromState is undefined", () => {
+    const listener = vi.fn();
+
+    api.addEventListener("$$error", listener);
+
+    const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, { path: "/y" });
+
+    api.emitTransitionError(err);
+
+    expect(listener).toHaveBeenCalledWith(undefined, undefined, err);
+  });
+
+  it("throws ROUTER_DISPOSED when called on a disposed router", () => {
+    router.dispose();
+
+    const err = new Error("boom");
+
+    expect(() => {
+      api.emitTransitionError(err);
+    }).toThrow(RouterError);
+  });
+
+  it("does not corrupt router state or FSM — subsequent navigation still works", async () => {
+    await router.start("/home");
+
+    api.emitTransitionError(new Error("boom"));
+
+    const state = await router.navigate("users");
+
+    expect(state.name).toBe("users");
+    expect(router.isActive()).toBe(true);
+  });
+});

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -340,10 +340,11 @@ User clicks back or forward
         ├── route found?
         │     YES: await router.navigate(route.name, route.params, transitionOptions)
         │     NO + allowNotFound: router.navigateToNotFound(browser.getLocation())
-        │     NO + !allowNotFound: await router.navigateToDefault({ ...transitionOptions, reload: true, replace: true })
+        │     NO + !allowNotFound: api.emitTransitionError(ROUTE_NOT_FOUND) + rollbackUrlToCurrentState()
+        │                          (no silent navigateToDefault — see #483)
         │
         ├── catch (error):
-        │     error instanceof RouterError? → ignore (CANNOT_DEACTIVATE, etc.)
+        │     error instanceof RouterError? → rollbackUrlToCurrentState() (URL↔state resync)
         │     otherwise: recoverFromCriticalError(error)
         │               └── browser.replaceState(currentState, buildUrl(...))
         │

--- a/packages/hash-plugin/tests/functional/popstate.test.ts
+++ b/packages/hash-plugin/tests/functional/popstate.test.ts
@@ -98,7 +98,7 @@ describe("Hash Plugin — Popstate & Error Recovery", async () => {
       expect(navigateSpy).toHaveBeenCalledWith("/nonexistent");
     });
 
-    it("navigates to default when allowNotFound is false and hash does not match any route", async () => {
+    it("emits $$error and rolls back URL when allowNotFound is false and hash does not match (#483)", async () => {
       router.stop();
 
       const restrictedRouter = createRouter(routerConfig, {
@@ -110,12 +110,26 @@ describe("Hash Plugin — Popstate & Error Recovery", async () => {
       restrictedRouter.usePlugin(hashPluginFactory({}, mockedBrowser));
       await restrictedRouter.start();
 
-      globalThis.history.replaceState({}, "", "/#/nonexistent");
-      const navigateSpy = vi.spyOn(restrictedRouter, "navigateToDefault");
+      const previousState = restrictedRouter.getState()!;
+      const errorHook = vi.fn();
 
+      restrictedRouter.usePlugin(() => ({ onTransitionError: errorHook }));
+
+      const defaultSpy = vi.spyOn(restrictedRouter, "navigateToDefault");
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.history.replaceState({}, "", "/#/nonexistent");
       globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
 
-      expect(navigateSpy).toHaveBeenCalledTimes(1);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(defaultSpy).not.toHaveBeenCalled();
+      expect(errorHook).toHaveBeenCalledTimes(1);
+      expect(errorHook.mock.calls[0][2]).toMatchObject({
+        code: "ROUTE_NOT_FOUND",
+      });
+      expect(restrictedRouter.getState()).toStrictEqual(previousState);
+      expect(replaceSpy).toHaveBeenCalled();
 
       restrictedRouter.stop();
     });

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -410,10 +410,11 @@ User clicks back/forward/link, or navigation.navigate() fires
         │
         └── !matchedState && !allowNotFound?
               event.intercept({ handler: async () => {
-                await router.navigateToDefault()
-                catch RouterError → ignore
-                catch other → recoverFromNavigateError()
+                const err = new RouterError(ROUTE_NOT_FOUND, { path })
+                api.emitTransitionError(err)
+                throw err  // Navigation API auto-rolls back URL on reject
               }})
+              (no silent navigateToDefault — see #483)
 ```
 
 ### No Race Condition

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -1,4 +1,4 @@
-import { RouterError } from "@real-router/core";
+import { errorCodes, RouterError } from "@real-router/core";
 
 import { extractPath } from "./browser-env/index.js";
 
@@ -105,8 +105,18 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
         },
       });
     } else {
+      // Strict mode — unmatched URL is an error. Emit $$error and reject the
+      // intercept so the Navigation API auto-rolls back the URL. No silent
+      // fallback to defaultRoute.
       event.intercept({
-        handler: () => withRecovery(() => router.navigateToDefault()),
+        // eslint-disable-next-line @typescript-eslint/require-await -- Navigation API requires async handler; synchronous throw is the rollback signal
+        handler: async () => {
+          const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, { path });
+
+          api.emitTransitionError(err);
+
+          throw err;
+        },
       });
     }
   };

--- a/packages/navigation-plugin/tests/functional/navigate.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigate.test.ts
@@ -1,4 +1,4 @@
-import { createRouter, RouterError, UNKNOWN_ROUTE } from "@real-router/core";
+import { createRouter, UNKNOWN_ROUTE } from "@real-router/core";
 import { getLifecycleApi } from "@real-router/core/api";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
@@ -61,7 +61,7 @@ describe("Navigation Plugin — Navigate", () => {
       expect(router.getState()?.name).toBe(UNKNOWN_ROUTE);
     });
 
-    it("handles navigate to unknown URL without allowNotFound (navigateToDefault)", async () => {
+    it("emits $$error and rejects intercept on unknown URL when allowNotFound is false (#483)", async () => {
       router.stop();
       unsubscribe?.();
       unsubscribe = undefined;
@@ -74,6 +74,11 @@ describe("Navigation Plugin — Navigate", () => {
       restrictedRouter.usePlugin(navigationPluginFactory({}, browser));
       await restrictedRouter.start();
 
+      const previousState = restrictedRouter.getState()!;
+      const errorHook = vi.fn();
+
+      restrictedRouter.usePlugin(() => ({ onTransitionError: errorHook }));
+
       const navigateDefaultSpy = vi.spyOn(
         restrictedRouter,
         "navigateToDefault",
@@ -83,9 +88,20 @@ describe("Navigation Plugin — Navigate", () => {
         "http://localhost/nonexistent-path",
       );
 
-      await finished;
+      await finished.catch(() => undefined);
 
-      expect(navigateDefaultSpy).toHaveBeenCalled();
+      // No silent fallback
+      expect(navigateDefaultSpy).not.toHaveBeenCalled();
+
+      // Error surfaces via onTransitionError
+      expect(errorHook).toHaveBeenCalledTimes(1);
+      expect(errorHook.mock.calls[0][2]).toMatchObject({
+        code: "ROUTE_NOT_FOUND",
+      });
+
+      // Router state unchanged — Navigation API auto-rolls back the URL
+      // via intercept rejection
+      expect(restrictedRouter.getState()).toStrictEqual(previousState);
 
       restrictedRouter.stop();
     });
@@ -400,41 +416,8 @@ describe("Error Recovery", () => {
     consoleSpy.mockRestore();
   });
 
-  it("recovers URL on non-RouterError in navigateToDefault handler", async () => {
-    router.stop();
-
-    const restrictedRouter = createRouter(routerConfig, {
-      defaultRoute: "home",
-      allowNotFound: false,
-    });
-
-    unsub = restrictedRouter.usePlugin(navigationPluginFactory({}, browser));
-    await restrictedRouter.start();
-
-    vi.spyOn(restrictedRouter, "navigateToDefault").mockRejectedValue(
-      new TypeError("navigateToDefault crash"),
-    );
-
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const browserNavigateSpy = vi.spyOn(browser, "navigate");
-
-    const { finished } = mockNav.navigate("http://localhost/nonexistent");
-
-    await finished;
-
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "[navigation-plugin] Critical error in navigate handler",
-      expect.any(TypeError),
-    );
-
-    expect(browserNavigateSpy).toHaveBeenCalledWith(
-      "/",
-      expect.objectContaining({ history: "replace" }),
-    );
-
-    consoleSpy.mockRestore();
-    restrictedRouter.stop();
-  });
+  // Obsolete after #483: strict-mode path no longer invokes navigateToDefault,
+  // so there is no "navigateToDefault crash" code path to recover from.
 
   it("does NOT recover on RouterError (expected behavior)", async () => {
     unsub = router.usePlugin(
@@ -458,7 +441,7 @@ describe("Error Recovery", () => {
     consoleSpy.mockRestore();
   });
 
-  it("does NOT recover on RouterError from navigateToDefault", async () => {
+  it("strict-mode throws ROUTE_NOT_FOUND silently (no critical recovery) — Navigation API auto-rolls back URL (#483)", async () => {
     router.stop();
 
     const restrictedRouter = createRouter(routerConfig, {
@@ -469,20 +452,22 @@ describe("Error Recovery", () => {
     unsub = restrictedRouter.usePlugin(navigationPluginFactory({}, browser));
     await restrictedRouter.start();
 
-    vi.spyOn(restrictedRouter, "navigateToDefault").mockImplementation(() => {
-      throw new RouterError("TRANSITION_ERR");
-    });
-
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const browserNavigateSpy = vi.spyOn(browser, "navigate");
 
     const { finished } = mockNav.navigate("http://localhost/nonexistent");
 
-    await finished;
+    await finished.catch(() => undefined);
 
+    // RouterError does not trigger the critical-recovery console.error path
     expect(consoleSpy).not.toHaveBeenCalledWith(
       "[navigation-plugin] Critical error in navigate handler",
       expect.anything(),
     );
+
+    // Plugin does not call browser.navigate for recovery — Navigation API
+    // rolls back URL automatically on intercept rejection
+    expect(browserNavigateSpy).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
     restrictedRouter.stop();

--- a/packages/navigation-plugin/tests/stress/navigate-event-storm.stress.ts
+++ b/packages/navigation-plugin/tests/stress/navigate-event-storm.stress.ts
@@ -179,7 +179,7 @@ describe("N1 — Navigate Event Storm", () => {
     expect(router.getState()).toStrictEqual(stateBefore);
   });
 
-  it("1.6 — 50 navigate events, allowNotFound=false: navigateToDefault called", async () => {
+  it("1.6 — 50 navigate events, allowNotFound=false: no silent fallback, errors surface, state pinned (#483)", async () => {
     const result = createStressRouter({ allowNotFound: false });
 
     router = result.router;
@@ -189,15 +189,28 @@ describe("N1 — Navigate Event Storm", () => {
 
     await router.start();
 
-    const navigateSpy = vi.spyOn(router, "navigateToDefault");
+    const initialState = router.getState()!;
+    const errorHook = vi.fn();
+
+    router.usePlugin(() => ({ onTransitionError: errorHook }));
+
+    const navigateDefaultSpy = vi.spyOn(router, "navigateToDefault");
 
     for (let i = 0; i < 50; i++) {
-      mockNav.navigate("http://localhost/nonexistent");
+      mockNav
+        .navigate("http://localhost/nonexistent")
+        .finished.catch(() => undefined);
     }
 
     await waitForTransitions(200);
 
-    expect(navigateSpy).toHaveBeenCalled();
-    expect(router.getState()?.name).toBe("home");
+    // No silent fallback
+    expect(navigateDefaultSpy).not.toHaveBeenCalled();
+
+    // Every navigate event produced a ROUTE_NOT_FOUND error hook invocation
+    expect(errorHook).toHaveBeenCalled();
+
+    // Router state pinned to initial — Navigation API rolled back each URL
+    expect(router.getState()).toStrictEqual(initialState);
   });
 });

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -1,4 +1,4 @@
-import { RouterError } from "@real-router/core";
+import { errorCodes, RouterError } from "@real-router/core";
 
 import { getRouteFromEvent } from "./popstate-utils.js";
 
@@ -38,6 +38,19 @@ export function createPopstateHandler(
     }
   }
 
+  function rollbackUrlToCurrentState(): void {
+    const currentState = deps.router.getState();
+
+    /* v8 ignore next -- @preserve: router always has state after start(); defensive guard for edge cases */
+    if (!currentState) {
+      return;
+    }
+
+    const url = deps.buildUrl(currentState.name, currentState.params);
+
+    deps.browser.replaceState(currentState, url);
+  }
+
   function recoverFromCriticalError(error: unknown): void {
     console.error(
       `[${deps.loggerContext}] Critical error in onPopState`,
@@ -45,14 +58,7 @@ export function createPopstateHandler(
     );
 
     try {
-      const currentState = deps.router.getState();
-
-      /* v8 ignore next -- @preserve: router always has state after start(); defensive guard for edge cases */
-      if (currentState) {
-        const url = deps.buildUrl(currentState.name, currentState.params);
-
-        deps.browser.replaceState(currentState, url);
-      }
+      rollbackUrlToCurrentState();
     } catch (recoveryError) {
       console.error(
         `[${deps.loggerContext}] Failed to recover from critical error`,
@@ -85,14 +91,26 @@ export function createPopstateHandler(
       } else if (deps.allowNotFound) {
         deps.router.navigateToNotFound(deps.browser.getLocation());
       } else {
-        await deps.router.navigateToDefault({
-          ...deps.transitionOptions,
-          reload: true,
-          replace: true,
+        // Strict mode — unmatched URL is an error. Emit $$error and sync URL
+        // back to the current router state (no silent fallback to defaultRoute).
+        const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, {
+          path: deps.browser.getLocation(),
         });
+
+        deps.api.emitTransitionError(err);
+        rollbackUrlToCurrentState();
       }
     } catch (error) {
-      if (!(error instanceof RouterError)) {
+      if (error instanceof RouterError) {
+        // navigate() already emitted $$error — just sync URL with router state.
+        // Swallow rollback errors: teardown races may remove router.buildUrl
+        // while a popstate event is still queued.
+        try {
+          rollbackUrlToCurrentState();
+        } catch {
+          // noop — nothing safe to do here
+        }
+      } else {
         recoverFromCriticalError(error);
       }
     } finally {


### PR DESCRIPTION
## Summary

Unifies `allowNotFound: false` behaviour across all URL entry points. Closes #483 and removes case 3 of #471 from the list of open issues by eliminating the underlying cause.

Prior to this PR, the same configuration (`{ allowNotFound: false, defaultRoute: "home" }`) and the same unmatched URL produced three different outcomes depending on the entry point — `start()` threw, the browser plugins silently redirected to `defaultRoute`. The silent fallback hid errors from logs, analytics, and the `onTransitionError` plugin hook, and overloaded `defaultRoute` with two unrelated meanings (explicit target + implicit auto-fallback).

### New contract (unified)

`allowNotFound: false` means \"unknown route is an error, reported, everywhere\":

| Entry point                        | Behaviour on unmatched URL + strict                                                          |
| ---------------------------------- | -------------------------------------------------------------------------------------------- |
| `router.start(path)`               | rejects Promise with `ROUTE_NOT_FOUND` (unchanged — already correct)                         |
| `browser-plugin` popstate          | emits `$$error` via `PluginApi.emitTransitionError`; browser URL rolled back via `replaceState` |
| `navigation-plugin` navigate event | emits `$$error`; `event.intercept()` rejects so Navigation API auto-rolls back the URL      |
| `hash-plugin` popstate             | same as browser-plugin (shares `browser-env/popstate-handler`)                              |

`defaultRoute` now has a single purpose: it is only consulted by an explicit `router.navigateToDefault()` call.

### Changes

**Core** (minor):
- New `PluginApi.emitTransitionError(error: Error)` — delegates to `eventBus.sendFailSafe(undefined, state.get(), error)`, safe at any FSM state. Plugins emit `$$error` without synthesising a navigation.

**Plugins** (minor, BREAKING):
- `shared/browser-env/popstate-handler.ts` — strict-mode else-branch emits `ROUTE_NOT_FOUND` + rolls URL back; new `rollbackUrlToCurrentState()` helper, kept teardown-safe via try/catch
- `packages/navigation-plugin/src/navigate-handler.ts` — strict-mode branch uses async handler that emits + throws (Navigation API auto-rolls back)
- `hash-plugin` — inherits via `browser-env` symlink

**Incidental fix bundled in**: popstate catch now rolls URL back on any `RouterError` — previously, guard-rejected popstate (`CANNOT_DEACTIVATE`) left the URL on the new location while router state stayed on the old.

### Migration

```ts
// Before: popstate to unknown URL silently redirected to defaultRoute
// After: subscribe to onTransitionError and call navigateToDefault() explicitly
router.usePlugin(() => ({
  onTransitionError(_toState, _fromState, err) {
    if (err.code === \"ROUTE_NOT_FOUND\") {
      void router.navigateToDefault({ replace: true });
    }
  },
}));
```

See [migration-guide#strict-mode](https://github.com/greydragon888/real-router/wiki/migration-guide#strict-mode-allownotfound-false-no-longer-silently-redirects) and [RouterOptions#allowNotFound](https://github.com/greydragon888/real-router/wiki/RouterOptions#allowNotFound) for the full userland contract.

## Version bumps

- `@real-router/core` — minor (new `PluginApi.emitTransitionError`)
- `@real-router/browser-plugin` — minor (BREAKING: silent fallback removed)
- `@real-router/navigation-plugin` — minor (BREAKING)
- `@real-router/hash-plugin` — minor (BREAKING)

## Related

- Closes #483
- Removes case 3 of #471 (dead-end `{ allowNotFound: false, defaultRoute: \"\" }` — `defaultRoute` is no longer consulted for implicit fallback, so the dead-end no longer exists)
- Builds on #471 work (validation-plugin, PR #484)

## Test plan

- [ ] `pnpm build` green — 239/239 tasks
- [ ] Core functional tests: `emitTransitionError` delivery via `$$error` listener + `Plugin.onTransitionError` hook; fromState = current router state; disposed-router throws; no FSM corruption
- [ ] browser-plugin / hash-plugin popstate: strict-mode storms surface `onTransitionError` for every event, URL rolls back, state pinned to initial
- [ ] navigation-plugin navigate: strict-mode emits `onTransitionError`, no manual `browser.navigate` recovery, Navigation API auto-rolls back
- [ ] Regression: matched path still navigates; `allowNotFound: true` still produces UNKNOWN_ROUTE; explicit `router.navigateToDefault()` works unchanged
- [ ] CANNOT_DEACTIVATE popstate (bundled fix): URL rolls back to previous state
- [ ] Teardown-safe rollback: stress test `teardown-mid-nav` no longer triggers unhandled rejection after plugin teardown