### PR TITLE
ci: propagate type-check invalidation through ^type-check (#478)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Test with coverage
         run: >-
           pnpm turbo run test test:properties test:stress
+          --summarize
           --filter='...[${{ needs.check.outputs.turbo_base || 'origin/master' }}]'
           --filter='!./examples/**'
           --filter='!./benchmarks'
@@ -127,9 +128,21 @@ jobs:
       - name: Bundle
         run: >-
           pnpm turbo run bundle
+          --summarize
           --filter='...[${{ needs.check.outputs.turbo_base || 'origin/master' }}]'
           --filter='!./examples/**'
           --filter='!./benchmarks'
+
+      # Phase 2 of #478: upload turbo run summaries to diff inputs.hashes
+      # between two CI runs on the same SHA → identify unstable input.
+      # Temporary; remove once the unstable hash source is fixed.
+      - name: Upload turbo summaries
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: turbo-summaries-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .turbo/runs/
+          retention-days: 7
 
       - name: Check dependency consistency
         run: pnpm lint:deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Test with coverage
         run: >-
           pnpm turbo run test test:properties test:stress
-          --summarize
           --filter='...[${{ needs.check.outputs.turbo_base || 'origin/master' }}]'
           --filter='!./examples/**'
           --filter='!./benchmarks'
@@ -128,21 +127,9 @@ jobs:
       - name: Bundle
         run: >-
           pnpm turbo run bundle
-          --summarize
           --filter='...[${{ needs.check.outputs.turbo_base || 'origin/master' }}]'
           --filter='!./examples/**'
           --filter='!./benchmarks'
-
-      # Phase 2 of #478: upload turbo run summaries to diff inputs.hashes
-      # between two CI runs on the same SHA → identify unstable input.
-      # Temporary; remove once the unstable hash source is fixed.
-      - name: Upload turbo summaries
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: turbo-summaries-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .turbo/runs/
-          retention-days: 7
 
       - name: Check dependency consistency
         run: pnpm lint:deps

--- a/turbo.json
+++ b/turbo.json
@@ -105,7 +105,7 @@
       "cache": true
     },
     "type-check": {
-      "dependsOn": [],
+      "dependsOn": ["^type-check"],
       "outputs": [],
       "inputs": [
         "**/*.{ts,tsx,vue,svelte}",


### PR DESCRIPTION
## Summary
- Phase 1 of #478: fix turbo cache correctness for `type-check`.
- Change `type-check.dependsOn: []` → `["^type-check"]` so invalidation of an upstream package's `:type-check` cascades to downstream consumers.

## Why
Before this change, downstream packages' `:type-check` stayed cached even when an upstream package's `src/*.ts` changed. With the `@real-router/internal-source` export condition (#431), `tsc` resolves `@real-router/*` imports directly to upstream src — so downstream type-check **does** depend on upstream sources, but turbo wasn't tracking that edge.

**Risk before:** a breaking type change in `core` / `core-types` was not caught at the `type-check` stage; only later by `bundle` (tsdown's own tsc) or `lint:types` (on dist).

## Verification
Reproduced with a real change to `packages/core-types/src/api.ts`:
- Before fix: 31/31 `type-check` HIT (incorrect — downstream cache stale).
- After fix: 26 MISS (`@real-router/types` + 25 transitive consumers), 6 HIT (`fsm`, `logger`, `event-emitter`, `path-matcher`, `route-tree`, `search-params` — packages with no dep on types) — correct.

`pnpm build` passes (239/239).

## Trade-off
- **Cost:** more `type-check` cache miss on core/types-changing PRs (up to ~25 extra task executions).
- **Benefit:** cache correctness restored — type errors caught at the earliest stage instead of leaking into `bundle` / `lint:types`.

## Scope
Only `turbo.json` changes. No package code is affected, so no changeset is needed.

Phase 2 (diagnose unstable `test:properties` / `test:stress` hash) and Phase 3 (analyze `^bundle` chokepoint for `lint`) tracked in #478.

## Test plan
- [x] `pnpm build` — 239/239 successful
- [x] FULL TURBO on second run (31/31 cached)
- [x] Editing `core-types/src/api.ts` invalidates 25 downstream `:type-check` tasks
- [ ] CI green on this PR