### PR TITLE
fix(vue): per-Match keepAlive template shorthand + cache dist/ across e2e job (#499)

### DIFF
--- a/.changeset/vue-keepalive-template-shorthand-fix.md
+++ b/.changeset/vue-keepalive-template-shorthand-fix.md
@@ -1,0 +1,18 @@
+---
+"@real-router/vue": patch
+---
+
+Fix per-Match `keepAlive` when used as template boolean shorthand
+
+Template usage like `<RouteView.Match segment="dashboard" keepAlive>` was not
+preserving state across navigation. Vue compiles boolean-shorthand attributes
+to an empty string and only promotes them to `true` when the receiving prop is
+declared with `type: Boolean`. `Match` is a render-null marker — its props are
+inspected directly on the VNode without going through the cast pipeline, so
+the raw `""` reached `RouteView` and failed the strict `=== true` check,
+causing the component to fall through to the non-keepAlive render path.
+
+`detectPerMatchKA` and `renderWithPerMatchKA` now accept the three values Vue's
+own runtime treats as `true` for Boolean props: `true`, `""`, and the
+hyphenated attribute name. Programmatic `h(RouteView.Match, { keepAlive: true })`
+continues to work unchanged.

--- a/.changeset/vue-keepalive-template-shorthand-fix.md
+++ b/.changeset/vue-keepalive-template-shorthand-fix.md
@@ -2,7 +2,7 @@
 "@real-router/vue": patch
 ---
 
-Fix per-Match `keepAlive` when used as template boolean shorthand
+Fix per-Match `keepAlive` when used as template boolean shorthand (#500)
 
 Template usage like `<RouteView.Match segment="dashboard" keepAlive>` was not
 preserving state across navigation. Vue compiles boolean-shorthand attributes

--- a/packages/vue/src/components/RouteView/RouteView.ts
+++ b/packages/vue/src/components/RouteView/RouteView.ts
@@ -92,6 +92,17 @@ function renderWithRootKA(
   return wrapWithSuspense(keepAliveContent, fallback);
 }
 
+// Vue compiles boolean-shorthand template attributes (`<Match keepAlive>`) to
+// an empty string instead of `true`, and converts them to `true` only when the
+// receiving component's prop is declared with `type: Boolean`. `Match` is a
+// marker component (`render: null`) — its props are inspected on the VNode
+// without ever going through Vue's prop-casting pipeline, so the raw `""` (or
+// the hyphenated attribute name) reaches us here. Accept the same trio Vue's
+// runtime does.
+function isKeepAliveEnabled(value: unknown): boolean {
+  return value === true || value === "" || value === "keep-alive";
+}
+
 function renderWithPerMatchKA(
   activeChild: VNode,
   wrapperCache: Map<string, Component>,
@@ -99,12 +110,12 @@ function renderWithPerMatchKA(
 ): VNode | null {
   const matchProps = activeChild.props as {
     segment?: string;
-    keepAlive?: boolean;
+    keepAlive?: unknown;
   } | null;
 
-  if (matchProps?.keepAlive === true && activeChild.type === Match) {
+  if (isKeepAliveEnabled(matchProps?.keepAlive) && activeChild.type === Match) {
     /* v8 ignore start */
-    const segment = matchProps.segment ?? "__not-found__";
+    const segment = matchProps?.segment ?? "__not-found__";
     /* v8 ignore stop */
     const WrapperComponent = getOrCreateWrapper(wrapperCache, segment);
     const slotContent = getSlotContent(activeChild) ?? [];
@@ -166,7 +177,9 @@ const RouteViewComponent = defineComponent({
       lastHasPerMatchKA = elements.some(
         (element) =>
           element.type === Match &&
-          (element.props as { keepAlive?: boolean } | null)?.keepAlive === true,
+          isKeepAliveEnabled(
+            (element.props as { keepAlive?: unknown } | null)?.keepAlive,
+          ),
       );
 
       return lastHasPerMatchKA;

--- a/packages/vue/tests/integration/RouteView.test.ts
+++ b/packages/vue/tests/integration/RouteView.test.ts
@@ -539,6 +539,82 @@ describe("RouteView - Integration Tests", () => {
       expect(wrapper.find("[data-testid='count']").text()).toBe("1");
     });
 
+    it("per-Match keepAlive: accepts template-compiled boolean shorthand (empty string)", async () => {
+      // Vue compiles `<Match keepAlive>` to `{ keepAlive: "" }` and only
+      // promotes it to `true` when the prop is declared `type: Boolean` on the
+      // receiving component. Match is a render: null marker — its props never
+      // go through the cast pipeline, so the raw `""` reaches RouteView.
+      await router.start("/users/list");
+
+      const Counter = defineComponent({
+        setup() {
+          const count = ref(0);
+
+          return () =>
+            h("div", [
+              h("span", { "data-testid": "count" }, String(count.value)),
+              h(
+                "button",
+                {
+                  "data-testid": "increment",
+                  onClick: () => {
+                    count.value++;
+                  },
+                },
+                "+",
+              ),
+            ]);
+        },
+      });
+
+      const wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            h(
+              RouterProvider,
+              { router },
+              {
+                default: () =>
+                  h(
+                    RouteView,
+                    { nodeName: "" },
+                    {
+                      default: () => [
+                        h(
+                          RouteView.Match,
+
+                          { segment: "users", keepAlive: "" as any },
+                          { default: () => h(Counter) },
+                        ),
+                        h(
+                          RouteView.Match,
+                          { segment: "about" },
+                          {
+                            default: () =>
+                              h("div", { "data-testid": "about" }, "About"),
+                          },
+                        ),
+                      ],
+                    },
+                  ),
+              },
+            ),
+        }),
+      );
+
+      await wrapper.find("[data-testid='increment']").trigger("click");
+      await flushPromises();
+
+      expect(wrapper.find("[data-testid='count']").text()).toBe("1");
+
+      await router.navigate("about");
+      await flushPromises();
+      await router.navigate("users.list");
+      await flushPromises();
+
+      expect(wrapper.find("[data-testid='count']").text()).toBe("1");
+    });
+
     it("per-Match keepAlive: calls onActivated/onDeactivated lifecycle hooks", async () => {
       await router.start("/users/list");
 

--- a/turbo.json
+++ b/turbo.json
@@ -35,12 +35,20 @@
     },
     "build": {
       "dependsOn": ["bundle", "test", "test:properties", "test:stress"],
-      "inputs": [],
-      "outputs": [],
+      "inputs": [
+        "src/**/*.{ts,tsx,vue,svelte,html,css}",
+        "index.html",
+        "vite.config.*",
+        "angular.json",
+        "tsconfig.json",
+        "tsconfig.app.json",
+        "package.json"
+      ],
+      "outputs": ["dist/**"],
       "cache": true
     },
     "test:e2e": {
-      "dependsOn": ["^bundle"],
+      "dependsOn": ["^bundle", "build"],
       "outputs": [],
       "inputs": [
         "src/**/*.{ts,tsx,vue,svelte}",


### PR DESCRIPTION
## Summary

- Fix `examples.yml` failing 6 consecutive runs — e2e job started `vite preview` without a built `dist/` because `turbo`'s `build` task cached no outputs and `test:e2e` didn't depend on own build.
- Fix per-Match `keepAlive` in `@real-router/vue` when used as template boolean shorthand (`<RouteView.Match keepAlive>`) — Vue compiles that to `{ keepAlive: "" }` and the strict `=== true` check in `RouteView` fell through to the non-keepAlive branch, fully unmounting the component instead of caching it.
- Added integration test exercising the template-compiled `{ keepAlive: "" }` path.

Closes #499.

## Test plan

- [x] `pnpm build` — 246/246 tasks, 0 failures
- [x] `pnpm --filter @real-router/vue test` — 216 passed (215 → 216, +1 new)
- [x] `pnpm turbo run test:e2e --filter=vue-keep-alive-example` — 3/3 passed
- [x] Removed `examples/vue/keep-alive/dist` and re-ran `turbo run build` — restored from Remote Cache (FULL TURBO, 74 ms)
- [ ] Trigger `examples.yml` workflow after merge to confirm the e2e job passes end-to-end