### PR TITLE
feat: scroll restoration utility + adapter integrations (#497)

### DIFF
--- a/.changeset/scroll-restore-angular.md
+++ b/.changeset/scroll-restore-angular.md
@@ -1,0 +1,19 @@
+---
+"@real-router/angular": minor
+---
+
+Add opt-in scroll restoration via `provideRealRouter(router, { scrollRestoration })` (#497)
+
+`provideRealRouter` now accepts an optional options bag. When `scrollRestoration` is provided, the adapter creates a `createScrollRestoration` instance via `provideEnvironmentInitializer`; teardown is wired through `DestroyRef`.
+
+```ts
+import { provideRealRouter } from "@real-router/angular";
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRealRouter(router, { scrollRestoration: { mode: "restore" } }),
+  ],
+});
+```
+
+Supports `manual` / `top` / `restore` modes and a custom scroll container. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.changeset/scroll-restore-preact.md
+++ b/.changeset/scroll-restore-preact.md
@@ -1,0 +1,15 @@
+---
+"@real-router/preact": minor
+---
+
+Add opt-in scroll restoration via `RouterProvider.scrollRestoration` (#497)
+
+New `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider`. Restores scroll position on back navigation, scrolls to top or hash on push. Supports `manual` / `top` / `restore` modes and a custom scroll container.
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* ... */}
+</RouterProvider>
+```
+
+Backed by the shared `createScrollRestoration` utility in `shared/dom-utils` — same pattern as `createRouteAnnouncer`. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.changeset/scroll-restore-react.md
+++ b/.changeset/scroll-restore-react.md
@@ -1,0 +1,15 @@
+---
+"@real-router/react": minor
+---
+
+Add opt-in scroll restoration via `RouterProvider.scrollRestoration` (#497)
+
+New `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider`. Restores scroll position on back navigation, scrolls to top or hash on push. Supports `manual` / `top` / `restore` modes and a custom scroll container.
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* ... */}
+</RouterProvider>
+```
+
+Backed by the shared `createScrollRestoration` utility in `shared/dom-utils` — same pattern as `createRouteAnnouncer`. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.changeset/scroll-restore-solid.md
+++ b/.changeset/scroll-restore-solid.md
@@ -1,0 +1,15 @@
+---
+"@real-router/solid": minor
+---
+
+Add opt-in scroll restoration via `RouterProvider.scrollRestoration` (#497)
+
+New `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider`. Restores scroll position on back navigation, scrolls to top or hash on push. Supports `manual` / `top` / `restore` modes and a custom scroll container.
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* ... */}
+</RouterProvider>
+```
+
+Backed by the shared `createScrollRestoration` utility in `shared/dom-utils` — same pattern as `createRouteAnnouncer`. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.changeset/scroll-restore-svelte.md
+++ b/.changeset/scroll-restore-svelte.md
@@ -1,0 +1,15 @@
+---
+"@real-router/svelte": minor
+---
+
+Add opt-in scroll restoration via `RouterProvider.scrollRestoration` (#497)
+
+New `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider`. Restores scroll position on back navigation, scrolls to top or hash on push. Supports `manual` / `top` / `restore` modes and a custom scroll container.
+
+```svelte
+<RouterProvider {router} scrollRestoration={{ mode: "restore" }}>
+  <!-- ... -->
+</RouterProvider>
+```
+
+Backed by the shared `createScrollRestoration` utility in `shared/dom-utils` — same pattern as `createRouteAnnouncer`. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.changeset/scroll-restore-vue.md
+++ b/.changeset/scroll-restore-vue.md
@@ -1,0 +1,15 @@
+---
+"@real-router/vue": minor
+---
+
+Add opt-in scroll restoration via `RouterProvider.scrollRestoration` (#497)
+
+New `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider`. Restores scroll position on back navigation, scrolls to top or hash on push. Supports `manual` / `top` / `restore` modes and a custom scroll container.
+
+```vue
+<RouterProvider :router="router" :scroll-restoration="{ mode: 'restore' }">
+  <!-- ... -->
+</RouterProvider>
+```
+
+Backed by the shared `createScrollRestoration` utility in `shared/dom-utils` — same pattern as `createRouteAnnouncer`. Direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`; position is persisted across reloads via `sessionStorage` + `pagehide`.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,7 +16,7 @@ export default [
   {
     name: "@real-router/react (ESM)",
     path: "packages/react/dist/esm/index.mjs",
-    limit: "2.5 kB",
+    limit: "3.1 kB",
     ignore: [
       "react",
       "react-dom",
@@ -28,7 +28,7 @@ export default [
   {
     name: "@real-router/preact (ESM)",
     path: "packages/preact/dist/esm/index.mjs",
-    limit: "2.5 kB",
+    limit: "3 kB",
     ignore: [
       "preact",
       "preact/hooks",
@@ -41,7 +41,7 @@ export default [
   {
     name: "@real-router/solid (ESM)",
     path: "packages/solid/dist/esm/index.mjs",
-    limit: "2.6 kB",
+    limit: "3.5 kB",
     ignore: [
       "solid-js",
       "solid-js/store",
@@ -54,7 +54,7 @@ export default [
   {
     name: "@real-router/vue (ESM)",
     path: "packages/vue/dist/esm/index.mjs",
-    limit: "3.5 kB",
+    limit: "4 kB",
     ignore: [
       "vue",
       "@real-router/core",
@@ -65,7 +65,7 @@ export default [
   {
     name: "@real-router/angular (FESM2022)",
     path: "packages/angular/dist/fesm2022/real-router-angular.mjs",
-    limit: "3.5 kB",
+    limit: "4.1 kB",
     ignore: [
       "@angular/core",
       "@angular/common",

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ real-router/
 │   └── type-guards/               # Runtime type validation (internal)
 ├── shared/                         # Bare source files shared across packages via src/ symlinks (minimal workspace entry)
 │   ├── package.json               # Minimal: name, type:commonjs, devDeps on @real-router/core + type-guards
-│   ├── dom-utils/                 # Shared DOM utilities for adapters: route announcer, link helpers
+│   ├── dom-utils/                 # Shared DOM utilities for adapters: route announcer, scroll restoration, link helpers
 │   └── browser-env/               # Shared browser abstractions for URL plugins: history API, popstate, SSR fallback
 ├── examples/
 │   ├── shared/                    # Shared store, API, abilities, styles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ shared/
 └── dom-utils/            # DOM helpers — for framework adapters
     ├── link-utils.ts     # shouldNavigate, buildHref, buildActiveClassName, applyLinkA11y
     ├── route-announcer.ts  # createRouteAnnouncer (a11y aria-live region)
+    ├── scroll-restore.ts   # createScrollRestoration (opt-in scroll capture + restore)
     └── index.ts          # barrel
 ```
 

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -2372,3 +2372,43 @@ Split into two workflows:
 ### Why this matters
 
 `changesets.yml` uses `workflow_run` trigger and must reference the workflow that runs on master push. After the split, this trigger was updated from `workflows: [CI]` to `workflows: [Post-Merge Build]`. Missing this update breaks the release pipeline — changesets never triggers after merge, no Version PR is created.
+
+## Scroll Restoration as Utility, Not Plugin
+
+**Problem.** SPA navigation typically loses scroll position — users expect back/forward to restore where they left off (browser default for MPAs, universally emulated by modern SPA routers: Angular `withInMemoryScrolling`, React Router `<ScrollRestoration>`, Vue `scrollBehavior`). Real-router shipped no such feature, putting us behind parity.
+
+**Solution.** Added `shared/dom-utils/scroll-restore.ts` exposing `createScrollRestoration(router, options?)` — a function-shaped utility with the same contract as `createRouteAnnouncer`. Each framework adapter wires it to a `scrollRestoration?: ScrollRestorationOptions` prop on `RouterProvider` (Angular: options bag on `provideRealRouter`). Lifecycle tied to provider mount/unmount.
+
+**Why not a `@real-router/scroll-plugin`.** `window.scrollY` is a DOM concern; router-core is DOM-agnostic (`state.name` / `params` / `context` only). A plugin would be a layering leak — the same mistake as Angular's `TitleStrategy` inside router-core. The routing-layer inputs the utility needs (direction, navigationType) are already published by `@real-router/navigation-plugin` via `state.context.navigation`. A plugin would duplicate an existing channel without adding value.
+
+### Key-Synthesis Decision: Composite Route Identity, Not Per-Entry UUID
+
+**Problem.** The issue specification (#497) called for keying saved positions by `history.state.key`. Investigation showed:
+
+- `@real-router/browser-plugin.history.state` contains `{ name, params, path }` only — no key.
+- `@real-router/navigation-plugin` exposes entry `.key` internally (Navigation API) but does **not** publish it on `state.context`.
+
+Pulling a per-entry UUID into the public contract would require coordinated changes in `browser-plugin` (write UUID on every entry) and a new context namespace — a larger RFC.
+
+**Solution.** The utility synthesizes the key as `${state.name}:${canonicalJson(state.params)}`. Two history entries that resolve to the same `(name, params)` pair collapse to one bucket; the latest save wins. This key-shape satisfies ~99% of real-world scroll-restoration UX (list → item → back) with zero plugin coupling.
+
+**Why acceptable.** The alternative — emit `canonical-json(path)` or write UUIDs into `history.state` from `browser-plugin` — adds cross-package coordination for a case (same-name+same-params entries appearing multiple times in history) that is rare and self-correcting (subsequent saves overwrite).
+
+### Capture Strategy: Subscribe + pagehide, Not Throttled Scroll Listener
+
+**Problem.** Common scroll-restoration implementations attach a throttled `scroll` listener to continuously persist `window.scrollY`. This adds complexity (throttle timer, flush-on-transition, debouncing) and produces hundreds of sessionStorage writes per page.
+
+**Solution.** Use two discrete event sources:
+
+1. `router.subscribe(({ route, previousRoute }) => ...)` — fires on transition success. Synchronously from the FSM's `$$success` event, **before** the framework re-renders the new route. At that instant `window.scrollY` still reflects the old DOM, so we capture it keyed by `previousRoute`.
+2. `pagehide` — single listener that saves the current route's position on reload / tab close.
+
+No throttling, no timers, no scroll listener. Precision guaranteed because capture runs at the exact navigation boundary rather than "within 100ms of the last scroll."
+
+### Why Default Mode = `"restore"`
+
+The utility is **opt-in** (`undefined` = off), so users who don't want restoration pay nothing. But when they opt in, `"restore"` matches expected UX (what they'd get in an MPA by default, and what every competitor ships). Users wanting different semantics pass `mode: "top"` or `mode: "manual"` explicitly.
+
+### Why Not Expose `ScrollRestorationOptions` from Adapter Roots
+
+`RouteAnnouncerOptions` is already not re-exported from any adapter's public entry (`RouterProvider` prop-type inference covers consumer needs). `ScrollRestorationOptions` follows the same convention. If users ask, we promote in a later minor.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The Segment Trie matcher traverses in O(segments), not O(routes).
 - **Plugin architecture** — intercept and extend router behavior
 - **Observable state** — RxJS and TC39 Observable compatible
 - **Immutable state** — deeply frozen, predictable state management
+- **Scroll restoration** — opt-in via `RouterProvider.scrollRestoration` ([docs](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)); restores on back/forward, scrolls to top / `#hash` on push; `restore` / `top` / `manual` modes; custom scroll containers
 
 ## Quick Start
 

--- a/examples/angular/basic/src/main.ts
+++ b/examples/angular/basic/src/main.ts
@@ -16,7 +16,12 @@ router.usePlugin(browserPluginFactory());
 
 void router.start().then(() => {
   void bootstrapApplication(AppComponent, {
-    providers: [provideZonelessChangeDetection(), provideRealRouter(router)],
+    providers: [
+      provideZonelessChangeDetection(),
+      provideRealRouter(router, {
+        scrollRestoration: { mode: "restore" },
+      }),
+    ],
   }).catch((err: unknown) => {
     console.error(err);
   });

--- a/examples/angular/basic/src/pages/home.component.ts
+++ b/examples/angular/basic/src/pages/home.component.ts
@@ -16,10 +16,20 @@ import { injectRoute } from "@real-router/angular";
         and <em>Forward</em> in the browser — routing state is preserved in the
         URL.
       </p>
+      <p>
+        <strong>Scroll restoration demo:</strong> scroll down the list below,
+        navigate to About, then hit Back — your position is restored.
+      </p>
+      <ul>
+        @for (n of items; track n) {
+          <li>Item #{{ n }}</li>
+        }
+      </ul>
     </div>
   `,
 })
 export class HomeComponent {
   private readonly route = injectRoute();
   readonly routeState = this.route.routeState;
+  readonly items = Array.from({ length: 100 }, (_, i) => i + 1);
 }

--- a/examples/preact/basic/src/main.tsx
+++ b/examples/preact/basic/src/main.tsx
@@ -21,7 +21,7 @@ const root = document.querySelector("#root");
 
 if (root) {
   render(
-    <RouterProvider router={router}>
+    <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
       <App />
     </RouterProvider>,
     root,

--- a/examples/preact/basic/src/pages/Home.tsx
+++ b/examples/preact/basic/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import { useRoute } from "@real-router/preact";
 
 import type { JSX } from "preact";
 
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
+
 export function Home(): JSX.Element {
   const { route } = useRoute();
 
@@ -17,6 +19,15 @@ export function Home(): JSX.Element {
         and <em>Forward</em> in the browser — routing state is preserved in the
         URL.
       </p>
+      <p>
+        <strong>Scroll restoration demo:</strong> scroll down the list below,
+        navigate to About, then hit Back — your position is restored.
+      </p>
+      <ul>
+        {items.map((n) => (
+          <li key={n}>Item #{n}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/examples/react/basic/src/main.tsx
+++ b/examples/react/basic/src/main.tsx
@@ -21,7 +21,7 @@ const rootElement = document.querySelector("#root");
 
 if (rootElement) {
   createRoot(rootElement).render(
-    <RouterProvider router={router}>
+    <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
       <App />
     </RouterProvider>,
   );

--- a/examples/react/basic/src/pages/Home.tsx
+++ b/examples/react/basic/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import { useRoute } from "@real-router/react";
 
 import type { JSX } from "react";
 
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
+
 export function Home(): JSX.Element {
   const { route } = useRoute();
 
@@ -17,6 +19,15 @@ export function Home(): JSX.Element {
         and <em>Forward</em> in the browser — routing state is preserved in the
         URL.
       </p>
+      <p>
+        <strong>Scroll restoration demo:</strong> scroll down the list below,
+        navigate to About, then hit Back — your position is restored.
+      </p>
+      <ul>
+        {items.map((n) => (
+          <li key={n}>Item #{n}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/examples/solid/basic/src/main.tsx
+++ b/examples/solid/basic/src/main.tsx
@@ -22,7 +22,7 @@ const rootElement = document.querySelector("#root");
 if (rootElement) {
   render(
     () => (
-      <RouterProvider router={router}>
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
         <App />
       </RouterProvider>
     ),

--- a/examples/solid/basic/src/pages/Home.tsx
+++ b/examples/solid/basic/src/pages/Home.tsx
@@ -1,6 +1,9 @@
+import { For } from "solid-js";
 import { useRoute } from "@real-router/solid";
 
 import type { JSX } from "solid-js";
+
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 
 export function Home(): JSX.Element {
   const routeState = useRoute();
@@ -17,6 +20,13 @@ export function Home(): JSX.Element {
         and <em>Forward</em> in the browser — routing state is preserved in the
         URL.
       </p>
+      <p>
+        <strong>Scroll restoration demo:</strong> scroll down the list below,
+        navigate to About, then hit Back — your position is restored.
+      </p>
+      <ul>
+        <For each={items}>{(n) => <li>Item #{n}</li>}</For>
+      </ul>
     </div>
   );
 }

--- a/examples/svelte/basic/src/App.svelte
+++ b/examples/svelte/basic/src/App.svelte
@@ -15,7 +15,7 @@
   ];
 </script>
 
-<RouterProvider {router}>
+<RouterProvider {router} scrollRestoration={{ mode: "restore" }}>
   <Layout title="Real-Router — Basic" {links}>
     <RouteView nodeName="">
       {#snippet home()}

--- a/examples/svelte/basic/src/pages/Home.svelte
+++ b/examples/svelte/basic/src/pages/Home.svelte
@@ -2,6 +2,7 @@
   import { useRoute } from "@real-router/svelte";
 
   const { route } = useRoute();
+  const items = Array.from({ length: 100 }, (_, i) => i + 1);
 </script>
 
 <div>
@@ -14,4 +15,13 @@
     Use the sidebar to navigate between pages. Try clicking <em>Back</em>
     and <em>Forward</em> in the browser — routing state is preserved in the URL.
   </p>
+  <p>
+    <strong>Scroll restoration demo:</strong> scroll down the list below,
+    navigate to About, then hit Back — your position is restored.
+  </p>
+  <ul>
+    {#each items as n (n)}
+      <li>Item #{n}</li>
+    {/each}
+  </ul>
 </div>

--- a/examples/vue/basic/src/main.ts
+++ b/examples/vue/basic/src/main.ts
@@ -18,7 +18,12 @@ router.usePlugin(browserPluginFactory());
 await router.start();
 
 const app = createApp({
-  render: () => h(RouterProvider, { router }, { default: () => h(App) }),
+  render: () =>
+    h(
+      RouterProvider,
+      { router, scrollRestoration: { mode: "restore" } },
+      { default: () => h(App) },
+    ),
 });
 
 app.mount("#root");

--- a/examples/vue/basic/src/pages/Home.vue
+++ b/examples/vue/basic/src/pages/Home.vue
@@ -2,6 +2,7 @@
 import { useRoute } from "@real-router/vue";
 
 const { route } = useRoute();
+const items = Array.from({ length: 100 }, (_, i) => i + 1);
 </script>
 
 <template>
@@ -15,5 +16,12 @@ const { route } = useRoute();
       Use the sidebar to navigate between pages. Try clicking <em>Back</em> and
       <em>Forward</em> in the browser — routing state is preserved in the URL.
     </p>
+    <p>
+      <strong>Scroll restoration demo:</strong> scroll down the list below,
+      navigate to About, then hit Back — your position is restored.
+    </p>
+    <ul>
+      <li v-for="n in items" :key="n">Item #{{ n }}</li>
+    </ul>
   </div>
 </template>

--- a/packages/angular/ARCHITECTURE.md
+++ b/packages/angular/ARCHITECTURE.md
@@ -63,6 +63,7 @@ src/
 └── dom-utils/                  # Shared DOM utilities (prebuild copy of shared/)
     ├── link-utils.ts           # buildHref, buildActiveClassName, applyLinkA11y, shouldNavigate
     ├── route-announcer.ts      # createRouteAnnouncer
+    ├── scroll-restore.ts       # createScrollRestoration (opt-in scroll capture + restore)
     └── index.ts
 ```
 
@@ -178,6 +179,10 @@ Template renders `<ng-content>` (always) plus the error template alongside it wh
 ### NavigationAnnouncer
 
 Minimal component. Constructor injects `injectRouter()` and `inject(DestroyRef)`, calls `createRouteAnnouncer(router)` from `dom-utils`, and registers `announcer.destroy()` on `DestroyRef`. No template content — the announcer creates its own `aria-live` DOM node.
+
+### Scroll Restoration
+
+Opt-in via `provideRealRouter(router, { scrollRestoration })`. Not a component — wired through `provideEnvironmentInitializer`: when the environment injector is created (first `inject()` call), the initializer runs `createScrollRestoration(router, options)` from `shared/dom-utils/` and registers `sr.destroy()` on `inject(DestroyRef)`. Options are a bootstrap-time snapshot, not reactive to runtime changes. Lifecycle is tied to the environment injector — destroy fires on `TestBed.resetTestingModule()` / application teardown.
 
 ### RealLink
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -337,6 +337,32 @@ export class AppComponent {}
 
 The announcer creates a visually hidden `aria-live` region and announces each navigation to screen readers. See the [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in via the `provideRealRouter` options bag:
+
+```typescript
+import { provideRealRouter } from "@real-router/angular";
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRealRouter(router, {
+      scrollRestoration: { mode: "restore" },
+    }),
+  ],
+});
+```
+
+`RealRouterOptions` shape:
+
+```typescript
+interface RealRouterOptions {
+  scrollRestoration?: ScrollRestorationOptions; // { mode?, anchorScrolling?, scrollContainer? }
+}
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. The utility is created by `provideEnvironmentInitializer` and torn down via `inject(DestroyRef)`. Options are a snapshot at bootstrap — not reactive to runtime changes. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Angular-Specific Patterns
 
 ### Signals, Not Observables
@@ -433,7 +459,7 @@ const transitionSignal = sourceToSignal(createTransitionSource(router));
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [injectRouter](https://github.com/greydragon888/real-router/wiki/injectRouter) · [injectRoute](https://github.com/greydragon888/real-router/wiki/injectRoute) · [injectRouteNode](https://github.com/greydragon888/real-router/wiki/injectRouteNode) · [injectNavigator](https://github.com/greydragon888/real-router/wiki/injectNavigator) · [injectRouteUtils](https://github.com/greydragon888/real-router/wiki/injectRouteUtils) · [injectRouterTransition](https://github.com/greydragon888/real-router/wiki/injectRouterTransition)
 
 ## Related Packages

--- a/packages/angular/src/dom-utils/index.ts
+++ b/packages/angular/src/dom-utils/index.ts
@@ -1,5 +1,7 @@
 export { createRouteAnnouncer } from "./route-announcer";
 
+export { createScrollRestoration } from "./scroll-restore";
+
 export {
   shouldNavigate,
   buildHref,
@@ -9,3 +11,8 @@ export {
 } from "./link-utils";
 
 export type { RouteAnnouncerOptions } from "./route-announcer";
+
+export type {
+  ScrollRestorationOptions,
+  ScrollRestorationMode,
+} from "./scroll-restore";

--- a/packages/angular/src/dom-utils/scroll-restore.ts
+++ b/packages/angular/src/dom-utils/scroll-restore.ts
@@ -1,0 +1,217 @@
+import type { Router, State } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
+  destroy: () => {
+    /* no-op */
+  },
+});
+
+export type ScrollRestorationMode = "restore" | "top" | "manual";
+
+export interface ScrollRestorationOptions {
+  mode?: ScrollRestorationMode | undefined;
+  anchorScrolling?: boolean | undefined;
+  scrollContainer?: (() => HTMLElement | null) | undefined;
+}
+
+interface NavigationContext {
+  direction?: "forward" | "back" | "unknown";
+  navigationType?: "push" | "replace" | "traverse" | "reload";
+}
+
+export function createScrollRestoration(
+  router: Router,
+  options?: ScrollRestorationOptions,
+): { destroy: () => void } {
+  if (typeof globalThis.window === "undefined") {
+    return NOOP_INSTANCE;
+  }
+
+  const mode = options?.mode ?? "restore";
+
+  // mode "manual" = utility does nothing. Don't flip history.scrollRestoration,
+  // don't subscribe, don't register pagehide — leave the browser's native
+  // auto-restore intact for the app to override if it wants to.
+  if (mode === "manual") {
+    return NOOP_INSTANCE;
+  }
+
+  const anchorEnabled = options?.anchorScrolling ?? true;
+  const getContainer = options?.scrollContainer;
+
+  const prevScrollRestoration = history.scrollRestoration;
+
+  try {
+    history.scrollRestoration = "manual";
+  } catch {
+    // Ignore — some embedded contexts may reject the assignment.
+  }
+
+  // Resolve the container lazily on every event so containers mounted AFTER
+  // the provider still get correct scroll handling. Falls back to window when
+  // the getter is absent or returns null (pre-mount).
+  const readPos = (): number => {
+    const element = getContainer?.();
+
+    return element ? element.scrollTop : globalThis.scrollY;
+  };
+
+  const writePos = (top: number): void => {
+    const element = getContainer?.();
+
+    if (element) {
+      element.scrollTop = top;
+    } else {
+      globalThis.scrollTo(0, top);
+    }
+  };
+
+  const scrollToHashOrTop = (): void => {
+    const hash = globalThis.location.hash;
+
+    if (anchorEnabled && hash.length > 1) {
+      // location.hash is percent-encoded; ids in the DOM are the raw string.
+      // Decode for the match. Fall back to the raw slice if the hash contains
+      // a malformed escape sequence (decodeURIComponent throws on those).
+      let id: string;
+
+      try {
+        id = decodeURIComponent(hash.slice(1));
+      } catch {
+        id = hash.slice(1);
+      }
+
+      // eslint-disable-next-line unicorn/prefer-query-selector -- ids may contain CSS-unsafe chars
+      const element = document.getElementById(id);
+
+      if (element) {
+        element.scrollIntoView();
+
+        return;
+      }
+    }
+
+    writePos(0);
+  };
+
+  let destroyed = false;
+
+  const unsubscribe = router.subscribe(({ route, previousRoute }) => {
+    const nav = (route.context as { navigation?: NavigationContext })
+      .navigation;
+
+    // Browsers dispatch reload as the initial navigation after refresh, so
+    // previousRoute is undefined and capture is naturally skipped. The
+    // pre-refresh position was already persisted via pagehide.
+    if (previousRoute) {
+      putPos(keyOf(previousRoute), readPos());
+    }
+
+    // Single rAF so DOM is committed before we read anchors / write scroll.
+    // Guard against destroy() racing with the callback.
+    requestAnimationFrame(() => {
+      if (destroyed) {
+        return;
+      }
+
+      if (mode === "top" || !nav) {
+        scrollToHashOrTop();
+
+        return;
+      }
+
+      if (nav.navigationType === "replace") {
+        return;
+      }
+
+      if (
+        nav.direction === "back" ||
+        nav.navigationType === "traverse" ||
+        nav.navigationType === "reload"
+      ) {
+        writePos(loadStore()[keyOf(route)] ?? 0);
+
+        return;
+      }
+
+      scrollToHashOrTop();
+    });
+  });
+
+  const onPageHide = (): void => {
+    const current = router.getState();
+
+    if (current) {
+      putPos(keyOf(current), readPos());
+    }
+  };
+
+  globalThis.addEventListener("pagehide", onPageHide);
+
+  return {
+    destroy: () => {
+      if (destroyed) {
+        return;
+      }
+
+      destroyed = true;
+      unsubscribe();
+      globalThis.removeEventListener("pagehide", onPageHide);
+
+      try {
+        history.scrollRestoration = prevScrollRestoration;
+      } catch {
+        // Ignore.
+      }
+    },
+  };
+}
+
+function keyOf(state: State): string {
+  return `${state.name}:${canonicalJson(state.params)}`;
+}
+
+function loadStore(): Record<string, number> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+
+    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function putPos(key: string, pos: number): void {
+  try {
+    const store = loadStore();
+
+    store[key] = pos;
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore quota / security errors.
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, canonicalReplacer);
+}
+
+function canonicalReplacer(_key: string, val: unknown): unknown {
+  if (val !== null && typeof val === "object" && !Array.isArray(val)) {
+    const sorted: Record<string, unknown> = {};
+    // eslint-disable-next-line unicorn/no-array-sort -- ng-packagr uses pre-ES2023 lib; toSorted unavailable
+    const keys = Object.keys(val as Record<string, unknown>).sort(
+      (left: string, right: string) => left.localeCompare(right),
+    );
+
+    for (const key of keys) {
+      sorted[key] = (val as Record<string, unknown>)[key];
+    }
+
+    return sorted;
+  }
+
+  return val;
+}

--- a/packages/angular/src/providers.ts
+++ b/packages/angular/src/providers.ts
@@ -1,13 +1,18 @@
 import {
+  DestroyRef,
   InjectionToken,
+  inject,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
   type EnvironmentProviders,
 } from "@angular/core";
 import { getNavigator, type Router, type Navigator } from "@real-router/core";
 import { createRouteSource } from "@real-router/sources";
 
+import { createScrollRestoration } from "./dom-utils";
 import { sourceToSignal } from "./sourceToSignal";
 
+import type { ScrollRestorationOptions } from "./dom-utils";
 import type { RouteSignals } from "./types";
 
 export const ROUTER = new InjectionToken<Router>("ROUTER");
@@ -16,10 +21,17 @@ export const NAVIGATOR = new InjectionToken<Navigator>("NAVIGATOR");
 
 export const ROUTE = new InjectionToken<RouteSignals>("ROUTE");
 
-export function provideRealRouter(router: Router): EnvironmentProviders {
+export interface RealRouterOptions {
+  scrollRestoration?: ScrollRestorationOptions;
+}
+
+export function provideRealRouter(
+  router: Router,
+  options?: RealRouterOptions,
+): EnvironmentProviders {
   const navigator = getNavigator(router);
 
-  return makeEnvironmentProviders([
+  const providers: Parameters<typeof makeEnvironmentProviders>[0] = [
     { provide: ROUTER, useValue: router },
     { provide: NAVIGATOR, useValue: navigator },
     {
@@ -29,5 +41,21 @@ export function provideRealRouter(router: Router): EnvironmentProviders {
         navigator,
       }),
     },
-  ]);
+  ];
+
+  if (options?.scrollRestoration) {
+    const scrollOpts = options.scrollRestoration;
+
+    providers.push(
+      provideEnvironmentInitializer(() => {
+        const sr = createScrollRestoration(router, scrollOpts);
+
+        inject(DestroyRef).onDestroy(() => {
+          sr.destroy();
+        });
+      }),
+    );
+  }
+
+  return makeEnvironmentProviders(providers);
 }

--- a/packages/angular/tests/functional/dom-utils-integration.test.ts
+++ b/packages/angular/tests/functional/dom-utils-integration.test.ts
@@ -1,11 +1,7 @@
 import { createRouter } from "@real-router/core";
 import { describe, it, expect } from "vitest";
 
-import {
-  buildHref,
-  shallowEqual,
-  shouldNavigate,
-} from "../../src/dom-utils/index.js";
+import { buildHref, shallowEqual, shouldNavigate } from "../../src/dom-utils";
 
 describe("dom-utils integration (copy from shared/)", () => {
   it("buildHref returns correct path after prebundle copy", async () => {

--- a/packages/angular/tests/functional/provideRealRouter.scroll.test.ts
+++ b/packages/angular/tests/functional/provideRealRouter.scroll.test.ts
@@ -1,0 +1,101 @@
+import { EnvironmentInjector } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { createRouter } from "@real-router/core";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { provideRealRouter } from "../../src/providers";
+
+const STORAGE_KEY = "real-router:scroll";
+
+const routes = [
+  { name: "home", path: "/" },
+  { name: "users", path: "/users" },
+];
+
+describe("provideRealRouter — scrollRestoration", () => {
+  let router: ReturnType<typeof createRouter>;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createRouter(routes);
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+    TestBed.resetTestingModule();
+  });
+
+  it("no options — history.scrollRestoration unchanged", () => {
+    TestBed.configureTestingModule({
+      providers: [provideRealRouter(router)],
+    });
+    TestBed.inject(EnvironmentInjector);
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRealRouter(router, {
+          scrollRestoration: { mode: "restore" },
+        }),
+      ],
+    });
+    // Trigger environment initializer.
+    TestBed.inject(EnvironmentInjector);
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("reset module restores history.scrollRestoration", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRealRouter(router, {
+          scrollRestoration: { mode: "restore" },
+        }),
+      ],
+    });
+    TestBed.inject(EnvironmentInjector);
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    TestBed.resetTestingModule();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when scrollRestoration is enabled", () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 512,
+      configurable: true,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRealRouter(router, {
+          scrollRestoration: { mode: "restore" },
+        }),
+      ],
+    });
+    TestBed.inject(EnvironmentInjector);
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(512);
+  });
+});

--- a/packages/angular/tests/functional/scroll-restore.test.ts
+++ b/packages/angular/tests/functional/scroll-restore.test.ts
@@ -1,0 +1,340 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { createScrollRestoration } from "../../src/dom-utils";
+
+import type { Router, State } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+type Listener = (s: { route: State; previousRoute?: State }) => void;
+
+function makeState(
+  name: string,
+  params: Record<string, unknown> = {},
+  context: Record<string, unknown> = {},
+): State {
+  return {
+    name,
+    params: params as State["params"],
+    path: "/",
+    context: context as State["context"],
+    transition: {} as State["transition"],
+  };
+}
+
+interface FakeRouter {
+  emit: (route: State, previousRoute?: State) => void;
+  router: Router;
+}
+
+function makeFakeRouter(initial?: State): FakeRouter {
+  const listeners = new Set<Listener>();
+  let current = initial;
+
+  const router = {
+    subscribe(fn: Listener) {
+      listeners.add(fn);
+
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+    getState() {
+      return current;
+    },
+  } as unknown as Router;
+
+  return {
+    emit(route, previousRoute) {
+      current = route;
+
+      for (const fn of listeners) {
+        fn(previousRoute ? { route, previousRoute } : { route });
+      }
+    },
+    router,
+  };
+}
+
+const activeInstances: { destroy: () => void }[] = [];
+
+function track<T extends { destroy: () => void }>(instance: T): T {
+  activeInstances.push(instance);
+
+  return instance;
+}
+
+describe("createScrollRestoration (Angular dom-utils copy)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    document.body.innerHTML = "";
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: FrameRequestCallback): number => {
+        cb(0);
+
+        return 0;
+      },
+    );
+  });
+
+  afterEach(() => {
+    while (activeInstances.length > 0) {
+      activeInstances.pop()?.destroy();
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("flips history.scrollRestoration to 'manual' and restores on destroy", () => {
+    const fake = makeFakeRouter();
+    const sr = createScrollRestoration(fake.router);
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    sr.destroy();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("mode 'top' scrolls to 0 on every transition", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "top" }));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { direction: "back" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("mode 'restore' + direction 'back' restores saved position", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 420 }));
+
+    const fake = makeFakeRouter(makeState("about"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "home",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("about"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 420);
+
+    sr.destroy();
+  });
+
+  it("navigationType 'replace' → no-op", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "replace" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    sr.destroy();
+  });
+
+  it("push + hash with existing id → scrollIntoView", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "target";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#target");
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("subscribe captures previousRoute's scrollY into storage", () => {
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 350,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(saved["home:{}"]).toBe(350);
+
+    sr.destroy();
+  });
+
+  it("pagehide saves current position", () => {
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 500,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(saved["home:{}"]).toBe(500);
+
+    sr.destroy();
+  });
+
+  it("custom scrollContainer reads/writes .scrollTop", () => {
+    const element = document.createElement("div");
+
+    element.id = "scroller";
+    document.body.append(element);
+    Object.defineProperty(element, "scrollTop", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(
+      createScrollRestoration(fake.router, { scrollContainer: () => element }),
+    );
+
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "about:{}": 200 }));
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(element.scrollTop).toBe(200);
+
+    sr.destroy();
+  });
+
+  it("anchorScrolling=false ignores hash", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "target";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#target");
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(
+      createScrollRestoration(fake.router, { anchorScrolling: false }),
+    );
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("key canonicalization: {a:1,b:2} and {b:2,a:1} collapse to one bucket", () => {
+    const fake = makeFakeRouter(makeState("list", { a: 1, b: 2 }));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 100,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("item", {}, { navigation: { navigationType: "push" } }),
+      makeState("list", { b: 2, a: 1 }),
+    );
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.keys(saved)).toHaveLength(1);
+    expect(Object.keys(saved)[0]).toBe('list:{"a":1,"b":2}');
+
+    sr.destroy();
+  });
+
+  it("destroy is idempotent", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    sr.destroy();
+
+    expect(() => {
+      sr.destroy();
+    }).not.toThrow();
+  });
+
+  it("mode 'manual' no-ops everything", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "manual" }));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    sr.destroy();
+  });
+});

--- a/packages/browser-plugin/src/factory.ts
+++ b/packages/browser-plugin/src/factory.ts
@@ -5,12 +5,12 @@ import {
   normalizeBase,
   safelyEncodePath,
   extractPath,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { defaultOptions, POPSTATE_SOURCE } from "./constants";
 import { BrowserPlugin } from "./plugin";
 import { validateOptions } from "./validation";
 
-import type { Browser, SharedFactoryState } from "./browser-env/index.js";
+import type { Browser, SharedFactoryState } from "./browser-env";
 import type { BrowserPluginOptions } from "./types";
 import type { PluginFactory, Router } from "@real-router/core";
 

--- a/packages/browser-plugin/src/index.ts
+++ b/packages/browser-plugin/src/index.ts
@@ -12,7 +12,7 @@ export type {
   BrowserSource,
 } from "./types";
 
-export type { Browser } from "./browser-env/index.js";
+export type { Browser } from "./browser-env";
 
 // Type guards
 export { isStateStrict as isState } from "type-guards";

--- a/packages/browser-plugin/src/plugin.ts
+++ b/packages/browser-plugin/src/plugin.ts
@@ -7,10 +7,10 @@ import {
   updateBrowserState,
   buildUrl,
   urlToPath,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { LOGGER_CONTEXT, POPSTATE_SOURCE } from "./constants";
 
-import type { Browser, SharedFactoryState } from "./browser-env/index.js";
+import type { Browser, SharedFactoryState } from "./browser-env";
 import type { BrowserContext, BrowserPluginOptions } from "./types";
 import type {
   NavigationOptions,

--- a/packages/browser-plugin/src/validation.ts
+++ b/packages/browser-plugin/src/validation.ts
@@ -1,4 +1,4 @@
-import { createOptionsValidator, safeBaseRule } from "./browser-env/index.js";
+import { createOptionsValidator, safeBaseRule } from "./browser-env";
 import { LOGGER_CONTEXT, defaultOptions } from "./constants";
 
 import type { BrowserPluginOptions } from "./types";

--- a/packages/browser-plugin/tests/functional/compat.test.ts
+++ b/packages/browser-plugin/tests/functional/compat.test.ts
@@ -13,7 +13,7 @@ import { browserPluginFactory } from "@real-router/browser-plugin";
 
 import { createMockedBrowser, routerConfig, noop } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 let router: Router;

--- a/packages/browser-plugin/tests/functional/integration.test.ts
+++ b/packages/browser-plugin/tests/functional/integration.test.ts
@@ -14,7 +14,7 @@ import {
 
 import { browserPluginFactory } from "@real-router/browser-plugin";
 
-import { createSafeBrowser } from "../../src/browser-env/index.js";
+import { createSafeBrowser } from "../../src/browser-env";
 import {
   createTrackingPlugin,
   createStateModifierPlugin,
@@ -24,7 +24,7 @@ import {
   createAsyncPlugin,
 } from "../helpers/mockPlugins";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 const noop = (): void => undefined;

--- a/packages/browser-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/browser-plugin/tests/functional/lifecycle.test.ts
@@ -19,7 +19,7 @@ import {
   noop,
 } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 let router: Router;

--- a/packages/browser-plugin/tests/functional/popstate.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate.test.ts
@@ -14,7 +14,7 @@ import { browserPluginFactory } from "@real-router/browser-plugin";
 
 import { createMockedBrowser, routerConfig, noop } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 const STUB_TRANSITION = Object.freeze({

--- a/packages/browser-plugin/tests/functional/security.test.ts
+++ b/packages/browser-plugin/tests/functional/security.test.ts
@@ -13,7 +13,7 @@ import { browserPluginFactory } from "@real-router/browser-plugin";
 
 import { createMockedBrowser, routerConfig, noop } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 let router: Router;

--- a/packages/browser-plugin/tests/functional/url.test.ts
+++ b/packages/browser-plugin/tests/functional/url.test.ts
@@ -18,7 +18,7 @@ import {
   noop,
 } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 let router: Router;

--- a/packages/browser-plugin/tests/helpers/testUtils.ts
+++ b/packages/browser-plugin/tests/helpers/testUtils.ts
@@ -1,6 +1,6 @@
-import { createSafeBrowser } from "../../src/browser-env/index.js";
+import { createSafeBrowser } from "../../src/browser-env";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { State } from "@real-router/core";
 
 export const noop = (): void => undefined;

--- a/packages/browser-plugin/tests/property/browserPlugin.properties.ts
+++ b/packages/browser-plugin/tests/property/browserPlugin.properties.ts
@@ -14,7 +14,7 @@ import {
   arbNonMatchingPath,
   createPluginRouter,
 } from "./helpers";
-import { extractPath } from "../../src/browser-env/index.js";
+import { extractPath } from "../../src/browser-env";
 
 describe("Browser Plugin URL Invariants", () => {
   describe("URL Roundtrip (no base)", () => {

--- a/packages/browser-plugin/tests/stress/helpers.ts
+++ b/packages/browser-plugin/tests/stress/helpers.ts
@@ -2,9 +2,9 @@ import { createRouter } from "@real-router/core";
 
 import { browserPluginFactory } from "@real-router/browser-plugin";
 
-import { createSafeBrowser } from "../../src/browser-env/index.js";
+import { createSafeBrowser } from "../../src/browser-env";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, Unsubscribe } from "@real-router/core";
 
 export const noop = (): void => undefined;

--- a/packages/browser-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
+++ b/packages/browser-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
@@ -18,7 +18,7 @@ import {
   noop,
   routeConfig,
 } from "./helpers";
-import { createSafeBrowser } from "../../src/browser-env/index.js";
+import { createSafeBrowser } from "../../src/browser-env";
 
 import type { Router } from "@real-router/core";
 

--- a/packages/dom-utils/tests/functional/scroll-restore.test.ts
+++ b/packages/dom-utils/tests/functional/scroll-restore.test.ts
@@ -1,0 +1,905 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createScrollRestoration } from "../../src";
+
+import type { Router, State } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+type Listener = (s: { route: State; previousRoute?: State }) => void;
+
+interface FakeRouter {
+  emit: (route: State, previousRoute?: State) => void;
+  router: Router;
+}
+
+function makeState(
+  name: string,
+  params: Record<string, unknown> = {},
+  context: Record<string, unknown> = {},
+): State {
+  return {
+    name,
+    params: params as State["params"],
+    path: "/",
+    context: context as State["context"],
+    transition: {} as State["transition"],
+  };
+}
+
+function makeFakeRouter(initial?: State): FakeRouter {
+  const listeners = new Set<Listener>();
+  let current = initial;
+
+  const router = {
+    subscribe(fn: Listener) {
+      listeners.add(fn);
+
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+    getState() {
+      return current;
+    },
+  } as unknown as Router;
+
+  return {
+    emit(route, previousRoute) {
+      current = route;
+
+      for (const fn of listeners) {
+        fn(previousRoute ? { route, previousRoute } : { route });
+      }
+    },
+    router,
+  };
+}
+
+const activeInstances: { destroy: () => void }[] = [];
+
+function track<T extends { destroy: () => void }>(instance: T): T {
+  activeInstances.push(instance);
+
+  return instance;
+}
+
+describe("createScrollRestoration", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    document.body.innerHTML = "";
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: FrameRequestCallback): number => {
+        cb(0);
+
+        return 0;
+      },
+    );
+  });
+
+  afterEach(() => {
+    while (activeInstances.length > 0) {
+      activeInstances.pop()?.destroy();
+    }
+
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("SSR no-op when window is undefined-like", () => {
+    // We can't actually unset window in jsdom; emulate via destroy-only contract.
+    // A truly SSR-only assertion lives elsewhere (integration). Here we at
+    // least verify that the utility returns an object with a destroy function.
+    const router = makeFakeRouter().router;
+    const sr = track(createScrollRestoration(router));
+
+    expect(typeof sr.destroy).toBe("function");
+
+    sr.destroy();
+  });
+
+  it("flips history.scrollRestoration to 'manual' on create, restores on destroy", () => {
+    history.scrollRestoration = "auto";
+
+    const router = makeFakeRouter().router;
+    const sr = track(createScrollRestoration(router));
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    sr.destroy();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("mode 'manual' returns noop — no history flip, no subscribe, no pagehide", () => {
+    history.scrollRestoration = "auto";
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "manual" }));
+
+    // No flip — browser's default auto-restore stays active.
+    expect(history.scrollRestoration).toBe("auto");
+
+    fake.emit(makeState("about"), makeState("home"));
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    sr.destroy();
+  });
+
+  it("mode 'top' scrolls to top on every transition regardless of direction", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "top" }));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { direction: "back" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("mode 'restore' + direction 'back' writes saved position for new key", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 420 }));
+
+    const fake = makeFakeRouter(makeState("about"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "home",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("about"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 420);
+
+    sr.destroy();
+  });
+
+  it("mode 'restore' + back + no saved position → scroll to 0", () => {
+    const fake = makeFakeRouter(makeState("about"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "home",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("about"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("mode 'restore' + push + no hash → scroll to 0", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("mode 'restore' + push + hash with existing id → scrollIntoView", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "target";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#target");
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("mode 'restore' + push + hash with missing id → scroll to 0", () => {
+    globalThis.history.replaceState(null, "", "/#missing");
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("mode 'restore' + navigationType 'replace' → no-op", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "replace" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    sr.destroy();
+  });
+
+  it("navigationType 'traverse' + direction 'forward' → restore (best-effort)", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "about:{}": 77 }));
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "traverse" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 77);
+
+    sr.destroy();
+  });
+
+  it("navigationType 'reload' triggers restore from storage", () => {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 200 }));
+
+    // After F5 the router starts fresh — initial navigation, no previousRoute.
+    const fake = makeFakeRouter();
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("home", {}, { navigation: { navigationType: "reload" } }),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 200);
+
+    sr.destroy();
+  });
+
+  it("no state.context.navigation → falls back to scrollToHashOrTop", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(makeState("about"), makeState("home"));
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("subscribe captures previousRoute's scrollY into storage", () => {
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 350,
+      configurable: true,
+    });
+
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(saved["home:{}"]).toBe(350);
+
+    sr.destroy();
+  });
+
+  it("initial navigation without previousRoute — nothing saved", () => {
+    const fake = makeFakeRouter();
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 100,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("home", {}, { navigation: { navigationType: "push" } }),
+    );
+
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    sr.destroy();
+  });
+
+  it("pagehide saves current position under current key", () => {
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 500,
+      configurable: true,
+    });
+
+    const sr = track(createScrollRestoration(fake.router));
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(saved["home:{}"]).toBe(500);
+
+    sr.destroy();
+  });
+
+  it("custom scrollContainer reads/writes .scrollTop, not window", () => {
+    const element = document.createElement("div");
+
+    element.id = "scroller";
+    document.body.append(element);
+    Object.defineProperty(element, "scrollTop", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    const fake = makeFakeRouter(makeState("home"));
+    const windowScrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(
+      createScrollRestoration(fake.router, {
+        scrollContainer: () => element,
+      }),
+    );
+
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "about:{}": 200 }));
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(element.scrollTop).toBe(200);
+    expect(windowScrollSpy).not.toHaveBeenCalled();
+
+    sr.destroy();
+  });
+
+  it("scrollContainer resolved lazily — late-mounted element is used on next event", () => {
+    let element: HTMLElement | null = null;
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(
+      createScrollRestoration(fake.router, { scrollContainer: () => element }),
+    );
+
+    // Element doesn't exist yet; pagehide should fall back to window without error.
+    expect(() => {
+      globalThis.dispatchEvent(new Event("pagehide"));
+    }).not.toThrow();
+
+    // Now mount the container.
+    element = document.createElement("div");
+    element.id = "late-scroller";
+    document.body.append(element);
+    Object.defineProperty(element, "scrollTop", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "about:{}": 150 }));
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("home"),
+    );
+
+    // Lazy resolve picked up the newly-mounted container.
+    expect(element.scrollTop).toBe(150);
+
+    sr.destroy();
+  });
+
+  it("scrollContainer returns null → falls back to window", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(
+      createScrollRestoration(fake.router, {
+        scrollContainer: () => null,
+      }),
+    );
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("anchorScrolling=false + hash → ignores hash, scrolls to top", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "target";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#target");
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(
+      createScrollRestoration(fake.router, {
+        anchorScrolling: false,
+      }),
+    );
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("key canonicalization: {a:1,b:2} and {b:2,a:1} collapse to one bucket", () => {
+    const fake = makeFakeRouter(makeState("list", { a: 1, b: 2 }));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 100,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState("item", {}, { navigation: { navigationType: "push" } }),
+      makeState("list", { b: 2, a: 1 }),
+    );
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+    // Both orderings normalize to the same key: list:{"a":1,"b":2}
+    const keys = Object.keys(saved);
+
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toBe('list:{"a":1,"b":2}');
+
+    sr.destroy();
+  });
+
+  it("sessionStorage persistence across instances", () => {
+    const fake1 = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 77,
+      configurable: true,
+    });
+    const sr1 = track(createScrollRestoration(fake1.router));
+
+    fake1.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+    sr1.destroy();
+
+    // Second instance starts fresh but sessionStorage persists.
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const fake2 = makeFakeRouter(makeState("about"));
+    const sr2 = track(createScrollRestoration(fake2.router));
+
+    fake2.emit(
+      makeState(
+        "home",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("about"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 77);
+
+    sr2.destroy();
+  });
+
+  it("two concurrent instances share storage without corrupting each other", () => {
+    // Different routers, different route names → distinct storage keys.
+    const fake1 = makeFakeRouter(makeState("home"));
+    const fake2 = makeFakeRouter(makeState("dashboard"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 100,
+      configurable: true,
+    });
+
+    const sr1 = track(createScrollRestoration(fake1.router));
+    const sr2 = track(createScrollRestoration(fake2.router));
+
+    // Both instances must not throw on pagehide; both keys end up in storage.
+    expect(() => {
+      globalThis.dispatchEvent(new Event("pagehide"));
+    }).not.toThrow();
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(saved["home:{}"]).toBe(100);
+    expect(saved["dashboard:{}"]).toBe(100);
+
+    // destroy() of one instance doesn't affect the other's subscription.
+    sr1.destroy();
+    // After destroy of sr1, sr2 is still alive: emit should still work.
+    fake2.emit(
+      makeState("settings", {}, { navigation: { navigationType: "push" } }),
+      makeState("dashboard"),
+    );
+
+    const after = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    // Previous route for fake2 was re-captured on navigation.
+    expect(after["dashboard:{}"]).toBeDefined();
+
+    sr2.destroy();
+  });
+
+  it("colliding keys: last write wins, history.scrollRestoration restores in LIFO order", () => {
+    history.scrollRestoration = "auto";
+
+    // Two instances on the SAME route → same key → last write wins.
+    const fake1 = makeFakeRouter(makeState("home"));
+    const fake2 = makeFakeRouter(makeState("home"));
+
+    const sr1 = createScrollRestoration(fake1.router);
+
+    // After sr1 flip: prevScrollRestoration = "auto", current = "manual"
+    expect(history.scrollRestoration).toBe("manual");
+
+    const sr2 = createScrollRestoration(fake2.router);
+
+    // sr2 sees "manual" as prev, still "manual" current.
+    expect(history.scrollRestoration).toBe("manual");
+
+    // Both write into the same bucket; last one wins — not corrupt.
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 111,
+      configurable: true,
+    });
+    fake1.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 222,
+      configurable: true,
+    });
+    fake2.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    // Last write wins (222 overwrote 111 under the same key).
+    expect(saved["home:{}"]).toBe(222);
+
+    // Destroy in reverse order — history.scrollRestoration walks back
+    // through snapshots (sr2.prev = "manual" → still "manual" after its destroy).
+    sr2.destroy();
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    sr1.destroy();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("destroy is idempotent", () => {
+    history.scrollRestoration = "auto";
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    sr.destroy();
+
+    expect(() => {
+      sr.destroy();
+    }).not.toThrow();
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("sessionStorage setItem throws → write is swallowed, no exception propagates", () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 99,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    expect(() => {
+      fake.emit(
+        makeState("about", {}, { navigation: { navigationType: "push" } }),
+        makeState("home"),
+      );
+    }).not.toThrow();
+
+    sr.destroy();
+    setItemSpy.mockRestore();
+  });
+
+  it("sessionStorage JSON parse error → load returns empty object", () => {
+    sessionStorage.setItem(STORAGE_KEY, "not-valid-json");
+
+    const fake = makeFakeRouter(makeState("about"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "home",
+        {},
+        { navigation: { direction: "back", navigationType: "traverse" } },
+      ),
+      makeState("about"),
+    );
+
+    // Corrupted JSON → store treated as empty → restores to 0.
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("single rAF: restoration deferred to next animation frame", () => {
+    vi.unstubAllGlobals();
+    const pending: FrameRequestCallback[] = [];
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: FrameRequestCallback): number => {
+        pending.push(cb);
+
+        return pending.length;
+      },
+    );
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    // After emit: 1 RAF scheduled, not yet resolved → no scroll yet.
+    expect(pending).toHaveLength(1);
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    // Frame fires → scroll applied.
+    pending.shift()?.(0);
+
+    expect(scrollSpy).toHaveBeenCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("destroy() during pending rAF cancels restoration (race guard)", () => {
+    vi.unstubAllGlobals();
+    const pending: FrameRequestCallback[] = [];
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: FrameRequestCallback): number => {
+        pending.push(cb);
+
+        return pending.length;
+      },
+    );
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = createScrollRestoration(fake.router);
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    // Destroy BEFORE the pending frame fires.
+    sr.destroy();
+
+    // Now the frame fires — guard must bail out; no scroll.
+    pending.shift()?.(0);
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it("mode 'top' + navigationType 'replace' still scrolls to top", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "top" }));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "replace" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("hash is decoded before getElementById lookup", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "foo bar"; // real id with a space
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#foo%20bar"); // percent-encoded
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("malformed percent-escape falls back to raw hash (no throw)", () => {
+    globalThis.history.replaceState(null, "", "/#foo%2"); // invalid escape
+
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    expect(() => {
+      fake.emit(
+        makeState(
+          "about",
+          {},
+          { navigation: { direction: "forward", navigationType: "push" } },
+        ),
+        makeState("home"),
+      );
+    }).not.toThrow();
+
+    // No element matches the raw "foo%2" id either → scroll to top.
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("pagehide without a current state (getState returns undefined) is safe", () => {
+    const fake = makeFakeRouter();
+    const sr = track(createScrollRestoration(fake.router));
+
+    expect(() => {
+      globalThis.dispatchEvent(new Event("pagehide"));
+    }).not.toThrow();
+
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    sr.destroy();
+  });
+
+  it("pagehide listener is removed after destroy", () => {
+    const fake = makeFakeRouter(makeState("home"));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 300,
+      configurable: true,
+    });
+    const sr = track(createScrollRestoration(fake.router));
+
+    sr.destroy();
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/packages/hash-plugin/src/factory.ts
+++ b/packages/hash-plugin/src/factory.ts
@@ -4,13 +4,13 @@ import {
   createSafeBrowser,
   normalizeBase,
   safelyEncodePath,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { defaultOptions, source } from "./constants";
 import { createHashPrefixRegex, extractHashPath } from "./hash-utils";
 import { HashPlugin } from "./plugin";
 import { validateOptions } from "./validation";
 
-import type { Browser, SharedFactoryState } from "./browser-env/index.js";
+import type { Browser, SharedFactoryState } from "./browser-env";
 import type { HashPluginOptions } from "./types";
 import type { PluginFactory, Router } from "@real-router/core";
 

--- a/packages/hash-plugin/src/hash-utils.ts
+++ b/packages/hash-plugin/src/hash-utils.ts
@@ -1,6 +1,6 @@
 // packages/hash-plugin/src/hash-utils.ts
 
-import { safeParseUrl } from "./browser-env/index.js";
+import { safeParseUrl } from "./browser-env";
 import { LOGGER_CONTEXT } from "./constants";
 
 function escapeRegExp(str: string): string {

--- a/packages/hash-plugin/src/index.ts
+++ b/packages/hash-plugin/src/index.ts
@@ -10,7 +10,7 @@ export { hashPluginFactory } from "./factory";
 // Types
 export type { HashPluginOptions } from "./types";
 
-export type { Browser } from "./browser-env/index.js";
+export type { Browser } from "./browser-env";
 
 // Type guards
 export { isStateStrict as isState } from "type-guards";

--- a/packages/hash-plugin/src/plugin.ts
+++ b/packages/hash-plugin/src/plugin.ts
@@ -5,10 +5,10 @@ import {
   createReplaceHistoryState,
   shouldReplaceHistory,
   updateBrowserState,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { hashUrlToPath } from "./hash-utils";
 
-import type { Browser, SharedFactoryState } from "./browser-env/index.js";
+import type { Browser, SharedFactoryState } from "./browser-env";
 import type { HashPluginOptions } from "./types";
 import type {
   NavigationOptions,

--- a/packages/hash-plugin/src/validation.ts
+++ b/packages/hash-plugin/src/validation.ts
@@ -2,7 +2,7 @@ import {
   createOptionsValidator,
   safeBaseRule,
   safeHashPrefixRule,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { LOGGER_CONTEXT, defaultOptions } from "./constants";
 
 import type { HashPluginOptions } from "./types";

--- a/packages/hash-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/hash-plugin/tests/functional/lifecycle.test.ts
@@ -19,7 +19,7 @@ import {
   createMockedBrowser,
 } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State, Unsubscribe } from "@real-router/core";
 
 let router: Router;

--- a/packages/hash-plugin/tests/functional/popstate.test.ts
+++ b/packages/hash-plugin/tests/functional/popstate.test.ts
@@ -14,7 +14,7 @@ import { hashPluginFactory } from "@real-router/hash-plugin";
 
 import { noop, routerConfig, createMockedBrowser } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, State } from "@real-router/core";
 
 const STUB_TRANSITION = Object.freeze({

--- a/packages/hash-plugin/tests/functional/url.test.ts
+++ b/packages/hash-plugin/tests/functional/url.test.ts
@@ -10,7 +10,7 @@ import {
   createMockedBrowser,
 } from "../helpers/testUtils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router } from "@real-router/core";
 
 let router: Router;

--- a/packages/hash-plugin/tests/helpers/mockPlugins.ts
+++ b/packages/hash-plugin/tests/helpers/mockPlugins.ts
@@ -1,10 +1,7 @@
-import {
-  createSafeBrowser,
-  safelyEncodePath,
-} from "../../src/browser-env/index.js";
+import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
 import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 
 export type OnStateChangeFn = (state: unknown) => void;
 

--- a/packages/hash-plugin/tests/stress/helpers.ts
+++ b/packages/hash-plugin/tests/stress/helpers.ts
@@ -2,13 +2,10 @@ import { createRouter } from "@real-router/core";
 
 import { hashPluginFactory } from "@real-router/hash-plugin";
 
-import {
-  createSafeBrowser,
-  safelyEncodePath,
-} from "../../src/browser-env/index.js";
+import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
 import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
 
-import type { Browser } from "../../src/browser-env/index.js";
+import type { Browser } from "../../src/browser-env";
 import type { Router, Unsubscribe } from "@real-router/core";
 
 export const noop = (): void => undefined;

--- a/packages/hash-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
+++ b/packages/hash-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
@@ -18,10 +18,7 @@ import {
   noop,
   routeConfig,
 } from "./helpers";
-import {
-  createSafeBrowser,
-  safelyEncodePath,
-} from "../../src/browser-env/index.js";
+import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
 import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
 
 import type { Router } from "@real-router/core";

--- a/packages/navigation-plugin/src/factory.ts
+++ b/packages/navigation-plugin/src/factory.ts
@@ -1,6 +1,6 @@
 import { getPluginApi } from "@real-router/core/api";
 
-import { isBrowserEnvironment, normalizeBase } from "./browser-env/index.js";
+import { isBrowserEnvironment, normalizeBase } from "./browser-env";
 import { defaultOptions, source } from "./constants";
 import { createNavigationBrowser } from "./navigation-browser";
 import { NavigationPlugin } from "./plugin";

--- a/packages/navigation-plugin/src/history-extensions.ts
+++ b/packages/navigation-plugin/src/history-extensions.ts
@@ -1,4 +1,4 @@
-import { extractPathFromAbsoluteUrl } from "./browser-env/index.js";
+import { extractPathFromAbsoluteUrl } from "./browser-env";
 import { LOGGER_CONTEXT } from "./constants";
 
 import type { NavigationBrowser } from "./types";

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -1,6 +1,6 @@
 import { errorCodes, RouterError } from "@real-router/core";
 
-import { extractPath } from "./browser-env/index.js";
+import { extractPath } from "./browser-env";
 
 import type {
   NavigationBrowser,

--- a/packages/navigation-plugin/src/navigation-browser.ts
+++ b/packages/navigation-plugin/src/navigation-browser.ts
@@ -1,4 +1,4 @@
-import { safelyEncodePath, extractPath } from "./browser-env/index.js";
+import { safelyEncodePath, extractPath } from "./browser-env";
 
 import type { NavigationBrowser } from "./types";
 

--- a/packages/navigation-plugin/src/plugin.ts
+++ b/packages/navigation-plugin/src/plugin.ts
@@ -5,7 +5,7 @@ import {
   buildUrl,
   extractPathFromAbsoluteUrl,
   urlToPath,
-} from "./browser-env/index.js";
+} from "./browser-env";
 import { LOGGER_CONTEXT } from "./constants";
 import {
   peekBack,

--- a/packages/navigation-plugin/src/ssr-fallback.ts
+++ b/packages/navigation-plugin/src/ssr-fallback.ts
@@ -1,4 +1,4 @@
-import { createWarnOnce } from "./browser-env/index.js";
+import { createWarnOnce } from "./browser-env";
 
 import type { NavigationBrowser } from "./types";
 

--- a/packages/navigation-plugin/src/validation.ts
+++ b/packages/navigation-plugin/src/validation.ts
@@ -1,4 +1,4 @@
-import { createOptionsValidator, safeBaseRule } from "./browser-env/index.js";
+import { createOptionsValidator, safeBaseRule } from "./browser-env";
 import { LOGGER_CONTEXT, defaultOptions } from "./constants";
 
 import type { NavigationPluginOptions } from "./types";

--- a/packages/navigation-plugin/tests/functional/security.test.ts
+++ b/packages/navigation-plugin/tests/functional/security.test.ts
@@ -1,7 +1,7 @@
 import { createRouter } from "@real-router/core";
 import { describe, expect, it, vi } from "vitest";
 
-import { urlToPath } from "../../src/browser-env/index.js";
+import { urlToPath } from "../../src/browser-env";
 import { navigationPluginFactory } from "../../src/factory";
 import { MockNavigation } from "../helpers/mockNavigation";
 import {

--- a/packages/navigation-plugin/tests/functional/url.test.ts
+++ b/packages/navigation-plugin/tests/functional/url.test.ts
@@ -1,11 +1,7 @@
 import { createRouter } from "@real-router/core";
 import { describe, expect, it } from "vitest";
 
-import {
-  buildUrl,
-  extractPath,
-  urlToPath,
-} from "../../src/browser-env/index.js";
+import { buildUrl, extractPath, urlToPath } from "../../src/browser-env";
 import { navigationPluginFactory } from "../../src/factory";
 import { createNavigationFallbackBrowser } from "../../src/ssr-fallback";
 import { MockNavigation } from "../helpers/mockNavigation";

--- a/packages/navigation-plugin/tests/property/pure-functions.properties.ts
+++ b/packages/navigation-plugin/tests/property/pure-functions.properties.ts
@@ -2,7 +2,7 @@ import { fc, test } from "@fast-check/vitest";
 import { describe, expect } from "vitest";
 
 import { NUM_RUNS } from "./helpers";
-import { shouldReplaceHistory } from "../../src/browser-env/index.js";
+import { shouldReplaceHistory } from "../../src/browser-env";
 import { computeDirection } from "../../src/navigate-handler";
 import { deriveNavigationType } from "../../src/plugin";
 

--- a/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
+++ b/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
@@ -20,7 +20,7 @@ import {
   extractPath,
   normalizeBase,
   safelyEncodePath,
-} from "../../src/browser-env/index.js";
+} from "../../src/browser-env";
 
 describe("Navigation Plugin URL Invariants", () => {
   describe("URL Roundtrip (no base)", () => {

--- a/packages/preact/ARCHITECTURE.md
+++ b/packages/preact/ARCHITECTURE.md
@@ -44,7 +44,8 @@ src/
 ├── dom-utils/                  # Symlink → shared/dom-utils/ (shared across all framework adapters)
 │   ├── index.ts                # Barrel re-exports
 │   ├── link-utils.ts           # shouldNavigate, buildHref, buildActiveClassName, applyLinkA11y
-│   └── route-announcer.ts      # createRouteAnnouncer — WCAG aria-live announcements
+│   ├── route-announcer.ts      # createRouteAnnouncer — WCAG aria-live announcements
+│   └── scroll-restore.ts       # createScrollRestoration — opt-in scroll capture + restore
 ├── hooks/
 │   ├── useRouter.tsx           # Router instance from context (never re-renders)
 │   ├── useRoute.tsx            # Full route state from context (every navigation)

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -219,11 +219,23 @@ Enable screen reader announcements for route changes:
 
 When enabled, a visually hidden `aria-live` region announces each navigation. Focus moves to the first `<h1>` on the new page. See [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in preservation of scroll position across navigations:
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* Your app */}
+</RouterProvider>
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Documentation
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [useRouter](https://github.com/greydragon888/real-router/wiki/useRouter) · [useRoute](https://github.com/greydragon888/real-router/wiki/useRoute) · [useRouteNode](https://github.com/greydragon888/real-router/wiki/useRouteNode) · [useNavigator](https://github.com/greydragon888/real-router/wiki/useNavigator) · [useRouteUtils](https://github.com/greydragon888/real-router/wiki/useRouteUtils) · [useRouterTransition](https://github.com/greydragon888/real-router/wiki/useRouterTransition)
 
 ## Examples

--- a/packages/preact/src/RouterProvider.tsx
+++ b/packages/preact/src/RouterProvider.tsx
@@ -3,9 +3,10 @@ import { createRouteSource } from "@real-router/sources";
 import { useEffect, useMemo } from "preact/hooks";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
-import { createRouteAnnouncer } from "./dom-utils/index.js";
+import { createRouteAnnouncer, createScrollRestoration } from "./dom-utils";
 import { useSyncExternalStore } from "./useSyncExternalStore";
 
+import type { ScrollRestorationOptions } from "./dom-utils";
 import type { Router } from "@real-router/core";
 import type { FunctionComponent, ComponentChildren } from "preact";
 
@@ -13,12 +14,14 @@ export interface RouteProviderProps {
   router: Router;
   children: ComponentChildren;
   announceNavigation?: boolean;
+  scrollRestoration?: ScrollRestorationOptions;
 }
 
 export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
   router,
   children,
   announceNavigation,
+  scrollRestoration,
 }) => {
   useEffect(() => {
     if (!announceNavigation) {
@@ -31,6 +34,33 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
       announcer.destroy();
     };
   }, [announceNavigation, router]);
+
+  // Primitive deps so inline `{ mode: "restore" }` doesn't thrash on every
+  // render. scrollContainer is a getter invoked lazily on every event inside
+  // the utility — swapping its reference doesn't change the resolved element,
+  // so we intentionally omit it from deps to keep inline getters stable.
+  const srMode = scrollRestoration?.mode;
+  const srAnchor = scrollRestoration?.anchorScrolling;
+  const srEnabled = scrollRestoration !== undefined;
+
+  useEffect(() => {
+    if (!srEnabled) {
+      return;
+    }
+
+    const sr = createScrollRestoration(router, {
+      mode: srMode,
+      anchorScrolling: srAnchor,
+      // srEnabled check above guarantees scrollRestoration is defined.
+      scrollContainer: scrollRestoration.scrollContainer,
+    });
+
+    return () => {
+      sr.destroy();
+    };
+    // scrollRestoration (for scrollContainer) omitted — see comment above.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, [router, srEnabled, srMode, srAnchor]);
   const navigator = useMemo(() => getNavigator(router), [router]);
 
   // useSyncExternalStore manages the router subscription lifecycle:

--- a/packages/preact/src/components/Link.tsx
+++ b/packages/preact/src/components/Link.tsx
@@ -7,7 +7,7 @@ import {
   buildHref,
   buildActiveClassName,
   shallowEqual,
-} from "../dom-utils/index.js";
+} from "../dom-utils";
 import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
 import { useRouter } from "../hooks/useRouter";
 

--- a/packages/preact/tests/functional/RouterProvider.scroll.test.tsx
+++ b/packages/preact/tests/functional/RouterProvider.scroll.test.tsx
@@ -1,0 +1,125 @@
+import { act, render } from "@testing-library/preact";
+import { h } from "preact";
+import { useState } from "preact/hooks";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { RouterProvider } from "@real-router/preact";
+
+import { createTestRouterWithADefaultRouter } from "../helpers";
+
+import type { Router } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+describe("RouterProvider — scrollRestoration", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createTestRouterWithADefaultRouter();
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+  });
+
+  it("no scrollRestoration prop — history.scrollRestoration unchanged", () => {
+    render(
+      <RouterProvider router={router}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("unmount restores history.scrollRestoration", () => {
+    const { unmount } = render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when enabled", () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 180,
+      configurable: true,
+    });
+
+    const { unmount } = render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(180);
+
+    unmount();
+  });
+
+  // Reactivity regression — guards primitive-deps rewrite against inline
+  // object thrash. If re-created on every render, prevScrollRestoration
+  // captures "manual", and the final unmount fails to restore "auto".
+  it("replacing the options ref with same fields — does NOT re-create the utility", async () => {
+    let setOpts!: (o: { mode: "restore" | "top" | "manual" }) => void;
+
+    function Harness() {
+      const [opts, update] = useState<{
+        mode: "restore" | "top" | "manual";
+      }>({ mode: "restore" });
+
+      setOpts = update;
+
+      return h(RouterProvider, {
+        router,
+        scrollRestoration: opts,
+        children: h("div", null),
+      });
+    }
+
+    const { unmount } = render(h(Harness, null));
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    await act(async () => {
+      setOpts({ mode: "restore" });
+    });
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+});

--- a/packages/preact/tests/property/link.properties.ts
+++ b/packages/preact/tests/property/link.properties.ts
@@ -17,7 +17,7 @@ import { fc, test } from "@fast-check/vitest";
 import { describe, expect } from "vitest";
 
 import { NUM_RUNS, arbRouteName, arbParams } from "./helpers";
-import { shallowEqual } from "../../src/dom-utils/index.js";
+import { shallowEqual } from "../../src/dom-utils";
 
 // =============================================================================
 // Inline replica of areLinkPropsEqual (not exported from Preact adapter)

--- a/packages/react/ARCHITECTURE.md
+++ b/packages/react/ARCHITECTURE.md
@@ -52,6 +52,7 @@ src/
 ├── dom-utils/                  # Shared DOM helpers (symlink → shared/dom-utils/)
 │   ├── link-utils.ts           # shouldNavigate, buildHref, buildActiveClassName, applyLinkA11y
 │   ├── route-announcer.ts      # createRouteAnnouncer (WCAG aria-live)
+│   ├── scroll-restore.ts       # createScrollRestoration (opt-in scroll capture + restore)
 │   └── index.ts
 ├── hooks/
 │   ├── useRouter.tsx           # Router instance from context (never re-renders)
@@ -82,6 +83,7 @@ The `dom-utils/` directory is a symlink to `shared/dom-utils/` — identical hel
 - **`buildActiveClassName(isActive, activeClassName, baseClassName)`** — class string composition
 - **`applyLinkA11y(element)`** — adds `role="link"` + `tabindex="0"` to non-interactive elements. Not used by React's `<Link>` (always renders `<a>`), but used by Svelte/Solid/Vue/Angular directive-based navigation. Exported for consumers building custom navigation components on non-anchor elements.
 - **`createRouteAnnouncer(router, options?)`** — WCAG screen reader announcements via `aria-live` region
+- **`createScrollRestoration(router, options?)`** — opt-in scroll capture on transition, restore on back/pagehide. DOM-concern isolated from router-core. Lifecycle: `useEffect` on `RouterProvider` creates the utility when `scrollRestoration` prop is set; cleanup destroys it. Primitive-field deps (`mode`, `anchorScrolling`) guard against inline-object thrash; `scrollContainer` is read lazily, excluded from deps.
 
 ## Context Architecture
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -289,11 +289,23 @@ Enable screen reader announcements for route changes:
 
 When enabled, a visually hidden `aria-live` region announces each navigation. Focus moves to the first `<h1>` on the new page. See [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in preservation of scroll position across navigations:
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* Your app */}
+</RouterProvider>
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Documentation
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [useRouter](https://github.com/greydragon888/real-router/wiki/useRouter) · [useRoute](https://github.com/greydragon888/real-router/wiki/useRoute) · [useRouteNode](https://github.com/greydragon888/real-router/wiki/useRouteNode) · [useNavigator](https://github.com/greydragon888/real-router/wiki/useNavigator) · [useRouteUtils](https://github.com/greydragon888/real-router/wiki/useRouteUtils) · [useRouterTransition](https://github.com/greydragon888/real-router/wiki/useRouterTransition)
 
 ## Examples

--- a/packages/react/src/RouterProvider.tsx
+++ b/packages/react/src/RouterProvider.tsx
@@ -3,8 +3,9 @@ import { createRouteSource } from "@real-router/sources";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
-import { createRouteAnnouncer } from "./dom-utils/index.js";
+import { createRouteAnnouncer, createScrollRestoration } from "./dom-utils";
 
+import type { ScrollRestorationOptions } from "./dom-utils";
 import type { Router } from "@real-router/core";
 import type { FC, ReactNode } from "react";
 
@@ -12,12 +13,14 @@ export interface RouteProviderProps {
   router: Router;
   children: ReactNode;
   announceNavigation?: boolean;
+  scrollRestoration?: ScrollRestorationOptions;
 }
 
 export const RouterProvider: FC<RouteProviderProps> = ({
   router,
   children,
   announceNavigation,
+  scrollRestoration,
 }) => {
   useEffect(() => {
     if (!announceNavigation) {
@@ -30,6 +33,33 @@ export const RouterProvider: FC<RouteProviderProps> = ({
       announcer.destroy();
     };
   }, [announceNavigation, router]);
+
+  // Primitive deps so inline `{ mode: "restore" }` doesn't thrash on every
+  // render. scrollContainer is a getter invoked lazily on every event inside
+  // the utility — swapping its reference doesn't change the resolved element,
+  // so we intentionally omit it from deps to keep inline getters stable.
+  const srMode = scrollRestoration?.mode;
+  const srAnchor = scrollRestoration?.anchorScrolling;
+  const srEnabled = scrollRestoration !== undefined;
+
+  useEffect(() => {
+    if (!srEnabled) {
+      return;
+    }
+
+    const sr = createScrollRestoration(router, {
+      mode: srMode,
+      anchorScrolling: srAnchor,
+      // srEnabled check above guarantees scrollRestoration is defined.
+      scrollContainer: scrollRestoration.scrollContainer,
+    });
+
+    return () => {
+      sr.destroy();
+    };
+    // scrollRestoration (for scrollContainer) omitted — see comment above.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, [router, srEnabled, srMode, srAnchor]);
 
   const navigator = useMemo(() => getNavigator(router), [router]);
 

--- a/packages/react/src/components/InkLink.tsx
+++ b/packages/react/src/components/InkLink.tsx
@@ -2,7 +2,7 @@ import { Text, useFocus, useInput } from "ink";
 import { memo, useCallback } from "react";
 
 import { EMPTY_OPTIONS, EMPTY_PARAMS } from "../constants";
-import { shallowEqual } from "../dom-utils/index.js";
+import { shallowEqual } from "../dom-utils";
 import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
 import { useRouter } from "../hooks/useRouter";
 

--- a/packages/react/src/components/Link.tsx
+++ b/packages/react/src/components/Link.tsx
@@ -6,7 +6,7 @@ import {
   buildHref,
   buildActiveClassName,
   shallowEqual,
-} from "../dom-utils/index.js";
+} from "../dom-utils";
 import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
 import { useRouter } from "../hooks/useRouter";
 

--- a/packages/react/tests/functional/RouterProvider.scroll.test.tsx
+++ b/packages/react/tests/functional/RouterProvider.scroll.test.tsx
@@ -1,0 +1,124 @@
+import { act, render } from "@testing-library/react";
+import { useState, type FC } from "react";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { RouterProvider } from "@real-router/react";
+
+import { createTestRouterWithADefaultRouter } from "../helpers";
+
+import type { Router } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+describe("RouterProvider — scrollRestoration", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createTestRouterWithADefaultRouter();
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+  });
+
+  it("no scrollRestoration prop — history.scrollRestoration unchanged", () => {
+    render(
+      <RouterProvider router={router}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("unmount restores history.scrollRestoration", () => {
+    const { unmount } = render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when enabled", async () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 250,
+      configurable: true,
+    });
+
+    const { unmount } = render(
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>,
+    );
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(250);
+
+    unmount();
+  });
+
+  // Reactivity regression — guards primitive-deps rewrite against inline
+  // object thrash. If re-created on every render, prevScrollRestoration
+  // captures "manual", and the final unmount fails to restore "auto".
+  it("replacing the options ref with same fields — does NOT re-create the utility", async () => {
+    let setOpts!: (o: { mode: "restore" | "top" | "manual" }) => void;
+
+    const Harness: FC = () => {
+      const [opts, update] = useState<{
+        mode: "restore" | "top" | "manual";
+      }>({ mode: "restore" });
+
+      setOpts = update;
+
+      return (
+        <RouterProvider router={router} scrollRestoration={opts}>
+          <div />
+        </RouterProvider>
+      );
+    };
+
+    const { unmount } = render(<Harness />);
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    await act(async () => {
+      setOpts({ mode: "restore" });
+    });
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+});

--- a/packages/react/tests/property/link.properties.ts
+++ b/packages/react/tests/property/link.properties.ts
@@ -7,7 +7,7 @@ import {
   NUM_RUNS,
   type Primitive,
 } from "./helpers";
-import { shallowEqual } from "../../src/dom-utils/index.js";
+import { shallowEqual } from "../../src/dom-utils";
 
 // =============================================================================
 // areLinkPropsEqual — replicated from src/components/Link.tsx

--- a/packages/react/tests/property/linkUtils.properties.ts
+++ b/packages/react/tests/property/linkUtils.properties.ts
@@ -17,7 +17,7 @@ import { fc, test } from "@fast-check/vitest";
 import { describe, expect } from "vitest";
 
 import { NUM_RUNS } from "./helpers";
-import { buildActiveClassName, buildHref } from "../../src/dom-utils/index.js";
+import { buildActiveClassName, buildHref } from "../../src/dom-utils";
 
 import type { Router } from "@real-router/core";
 

--- a/packages/solid/ARCHITECTURE.md
+++ b/packages/solid/ARCHITECTURE.md
@@ -43,6 +43,7 @@ src/
 ├── dom-utils/                  # Symlink → shared/dom-utils/ (see root CLAUDE.md)
 │   ├── link-utils.ts           # shouldNavigate, buildHref, buildActiveClassName, applyLinkA11y
 │   ├── route-announcer.ts      # createRouteAnnouncer (a11y aria-live region)
+│   ├── scroll-restore.ts       # createScrollRestoration (opt-in scroll capture + restore)
 │   └── index.ts                # barrel
 ├── createSignalFromSource.ts   # Signal bridge — converts RouterSource to Solid Accessor
 ├── createStoreFromSource.ts    # Store bridge — converts RouterSource to Solid store (reconcile)

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -320,11 +320,23 @@ Enable screen reader announcements for route changes:
 
 When enabled, a visually hidden `aria-live` region announces each navigation. Focus moves to the first `<h1>` on the new page. See [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in preservation of scroll position across navigations:
+
+```tsx
+<RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+  {/* Your app */}
+</RouterProvider>
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Options are read once on mount — changing the prop at runtime does not reconfigure the utility (Solid `onMount` is non-reactive). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Documentation
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [useRouter](https://github.com/greydragon888/real-router/wiki/useRouter) · [useRoute](https://github.com/greydragon888/real-router/wiki/useRoute) · [useRouteNode](https://github.com/greydragon888/real-router/wiki/useRouteNode) · [useNavigator](https://github.com/greydragon888/real-router/wiki/useNavigator) · [useRouteUtils](https://github.com/greydragon888/real-router/wiki/useRouteUtils) · [useRouterTransition](https://github.com/greydragon888/real-router/wiki/useRouterTransition)
 
 ## Examples

--- a/packages/solid/src/RouterProvider.tsx
+++ b/packages/solid/src/RouterProvider.tsx
@@ -4,14 +4,16 @@ import { createSelector, onCleanup, onMount } from "solid-js";
 
 import { RouterContext, RouteContext } from "./context";
 import { createSignalFromSource } from "./createSignalFromSource";
-import { createRouteAnnouncer } from "./dom-utils/index.js";
+import { createRouteAnnouncer, createScrollRestoration } from "./dom-utils";
 
+import type { ScrollRestorationOptions } from "./dom-utils";
 import type { Router } from "@real-router/core";
 import type { ParentProps, JSX } from "solid-js";
 
 export interface RouteProviderProps {
   router: Router;
   announceNavigation?: boolean;
+  scrollRestoration?: ScrollRestorationOptions;
 }
 
 export function isRouteActive(
@@ -36,6 +38,18 @@ export function RouterProvider(
 
     onCleanup(() => {
       announcer.destroy();
+    });
+  });
+
+  onMount(() => {
+    if (!props.scrollRestoration) {
+      return;
+    }
+
+    const sr = createScrollRestoration(props.router, props.scrollRestoration);
+
+    onCleanup(() => {
+      sr.destroy();
     });
   });
 

--- a/packages/solid/src/components/Link.tsx
+++ b/packages/solid/src/components/Link.tsx
@@ -4,11 +4,7 @@ import { createMemo, mergeProps, splitProps, useContext } from "solid-js";
 import { EMPTY_PARAMS, EMPTY_OPTIONS } from "../constants";
 import { RouterContext } from "../context";
 import { createSignalFromSource } from "../createSignalFromSource";
-import {
-  shouldNavigate,
-  buildHref,
-  buildActiveClassName,
-} from "../dom-utils/index.js";
+import { shouldNavigate, buildHref, buildActiveClassName } from "../dom-utils";
 
 import type { LinkProps } from "../types";
 import type { Params } from "@real-router/core";

--- a/packages/solid/src/directives/link.tsx
+++ b/packages/solid/src/directives/link.tsx
@@ -3,11 +3,7 @@ import { createEffect, onCleanup } from "solid-js";
 
 import { EMPTY_PARAMS, EMPTY_OPTIONS } from "../constants";
 import { createSignalFromSource } from "../createSignalFromSource";
-import {
-  shouldNavigate,
-  applyLinkA11y,
-  buildHref,
-} from "../dom-utils/index.js";
+import { shouldNavigate, applyLinkA11y, buildHref } from "../dom-utils";
 import { useRouter } from "../hooks/useRouter";
 
 import type { Params } from "@real-router/core";

--- a/packages/solid/tests/functional/RouterProvider.scroll.test.tsx
+++ b/packages/solid/tests/functional/RouterProvider.scroll.test.tsx
@@ -1,0 +1,90 @@
+import { render } from "@solidjs/testing-library";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { RouterProvider } from "@real-router/solid";
+
+import { createTestRouterWithADefaultRouter } from "../helpers";
+
+import type { Router } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+describe("RouterProvider — scrollRestoration", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createTestRouterWithADefaultRouter();
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+  });
+
+  it("no scrollRestoration prop — history.scrollRestoration unchanged", () => {
+    render(() => (
+      <RouterProvider router={router}>
+        <div />
+      </RouterProvider>
+    ));
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    render(() => (
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>
+    ));
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("unmount restores history.scrollRestoration", () => {
+    const { unmount } = render(() => (
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>
+    ));
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when enabled", () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 310,
+      configurable: true,
+    });
+
+    const { unmount } = render(() => (
+      <RouterProvider router={router} scrollRestoration={{ mode: "restore" }}>
+        <div />
+      </RouterProvider>
+    ));
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(310);
+
+    unmount();
+  });
+});

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -363,11 +363,23 @@ Enable screen reader announcements for route changes:
 
 When enabled, a visually hidden `aria-live` region announces each navigation. Focus moves to the first `<h1>` on the new page. See [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in preservation of scroll position across navigations:
+
+```svelte
+<RouterProvider {router} scrollRestoration={{ mode: "restore" }}>
+  <!-- Your app -->
+</RouterProvider>
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Documentation
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [useRouter](https://github.com/greydragon888/real-router/wiki/useRouter) · [useRoute](https://github.com/greydragon888/real-router/wiki/useRoute) · [useRouteNode](https://github.com/greydragon888/real-router/wiki/useRouteNode) · [useNavigator](https://github.com/greydragon888/real-router/wiki/useNavigator) · [useRouteUtils](https://github.com/greydragon888/real-router/wiki/useRouteUtils) · [useRouterTransition](https://github.com/greydragon888/real-router/wiki/useRouterTransition)
 
 ## Examples

--- a/packages/svelte/src/RouterProvider.svelte
+++ b/packages/svelte/src/RouterProvider.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
   import { getNavigator } from "@real-router/core";
   import { createRouteSource } from "@real-router/sources";
-  import { createRouteAnnouncer } from "./dom-utils/index.js";
-  import { setContext } from "svelte";
+  import {
+    createRouteAnnouncer,
+    createScrollRestoration,
+  } from "./dom-utils";
+  import { setContext, untrack } from "svelte";
 
   import { createReactiveSource } from "./createReactiveSource.svelte";
   import { createRouteContext } from "./createRouteContext.svelte";
   import { NAVIGATOR_KEY, ROUTE_KEY, ROUTER_KEY } from "./context";
 
+  import type { ScrollRestorationOptions } from "./dom-utils";
   import type { Router } from "@real-router/core";
   import type { Snippet } from "svelte";
 
@@ -15,13 +19,39 @@
     router,
     children,
     announceNavigation,
-  }: { router: Router; children: Snippet; announceNavigation?: boolean } =
-    $props();
+    scrollRestoration,
+  }: {
+    router: Router;
+    children: Snippet;
+    announceNavigation?: boolean;
+    scrollRestoration?: ScrollRestorationOptions;
+  } = $props();
 
   $effect(() => {
     if (!announceNavigation) return;
     const announcer = createRouteAnnouncer(router);
     return () => announcer.destroy();
+  });
+
+  // $derived memoizes by === so inline `{ mode: "restore" }` doesn't thrash:
+  // each parent re-render produces a new object ref, but .mode stays "restore"
+  // → $derived returns the same primitive → $effect doesn't re-run.
+  const srEnabled = $derived(scrollRestoration !== undefined);
+  const srMode = $derived(scrollRestoration?.mode);
+  const srAnchor = $derived(scrollRestoration?.anchorScrolling);
+
+  $effect(() => {
+    if (!srEnabled) return;
+    // scrollContainer is a function ref that naturally changes each render.
+    // Read it via `untrack` so this $effect does NOT depend on the parent
+    // `scrollRestoration` signal. Without this, a new inline options object
+    // would re-run the effect regardless of the primitive $derived memos.
+    const sr = createScrollRestoration(router, {
+      mode: srMode,
+      anchorScrolling: srAnchor,
+      scrollContainer: untrack(() => scrollRestoration?.scrollContainer),
+    });
+    return () => sr.destroy();
   });
 
   const navigator = getNavigator(router);

--- a/packages/svelte/src/actions/link.svelte.ts
+++ b/packages/svelte/src/actions/link.svelte.ts
@@ -2,7 +2,7 @@ import type { ActionReturn } from "svelte/action";
 import type { Router, Params, NavigationOptions } from "@real-router/core";
 import { ROUTER_KEY, getContextOrThrow } from "../context";
 import { EMPTY_OPTIONS, EMPTY_PARAMS, NOOP } from "../constants";
-import { shouldNavigate, applyLinkA11y } from "../dom-utils/index.js";
+import { shouldNavigate, applyLinkA11y } from "../dom-utils";
 
 export interface LinkActionParams {
   name: string;

--- a/packages/svelte/src/components/Link.svelte
+++ b/packages/svelte/src/components/Link.svelte
@@ -6,7 +6,7 @@
     shouldNavigate,
     buildHref,
     buildActiveClassName,
-  } from "../dom-utils/index.js";
+  } from "../dom-utils";
 
   import type { NavigationOptions, Params } from "@real-router/core";
   import type { Snippet } from "svelte";

--- a/packages/svelte/tests/functional/RouterProvider.scroll.test.ts
+++ b/packages/svelte/tests/functional/RouterProvider.scroll.test.ts
@@ -1,0 +1,108 @@
+import { render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { createTestRouterWithADefaultRouter } from "../helpers";
+import RouterProviderScrollReactivity from "../helpers/RouterProviderScrollReactivity.svelte";
+import RouterProviderScrollTest from "../helpers/RouterProviderScrollTest.svelte";
+
+import type { Router } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+describe("RouterProvider — scrollRestoration", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createTestRouterWithADefaultRouter();
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+  });
+
+  it("no scrollRestoration prop — history.scrollRestoration unchanged", () => {
+    render(RouterProviderScrollTest, { props: { router } });
+    flushSync();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    render(RouterProviderScrollTest, {
+      props: { router, scrollRestoration: { mode: "restore" } },
+    });
+    flushSync();
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("unmount restores history.scrollRestoration", () => {
+    const { unmount } = render(RouterProviderScrollTest, {
+      props: { router, scrollRestoration: { mode: "restore" } },
+    });
+
+    flushSync();
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when enabled", () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 420,
+      configurable: true,
+    });
+
+    const { unmount } = render(RouterProviderScrollTest, {
+      props: { router, scrollRestoration: { mode: "restore" } },
+    });
+
+    flushSync();
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(420);
+
+    unmount();
+  });
+
+  // Reactivity regression — same as Vue's, but triggers the untrack-guarded
+  // scrollContainer read. If the effect depended on `scrollRestoration` signal
+  // (pre-untrack bug), replacing the ref with an identical-field object would
+  // re-create the utility, and prev=auto would be lost after unmount.
+  it("replacing the options ref with same fields — does NOT re-create the utility", () => {
+    const { rerender, unmount } = render(RouterProviderScrollReactivity, {
+      props: { router, scrollRestoration: { mode: "restore" } },
+    });
+
+    flushSync();
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    void rerender({ router, scrollRestoration: { mode: "restore" } });
+    flushSync();
+
+    unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+});

--- a/packages/svelte/tests/helpers/RouterProviderScrollReactivity.svelte
+++ b/packages/svelte/tests/helpers/RouterProviderScrollReactivity.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import RouterProvider from "../../src/RouterProvider.svelte";
+
+  import type { ScrollRestorationOptions } from "../../src/dom-utils";
+  import type { Router } from "@real-router/core";
+
+  let {
+    router,
+    scrollRestoration,
+  }: {
+    router: Router;
+    scrollRestoration: ScrollRestorationOptions;
+  } = $props();
+</script>
+
+<RouterProvider {router} {scrollRestoration}>
+  <div data-testid="child"></div>
+</RouterProvider>

--- a/packages/svelte/tests/helpers/RouterProviderScrollTest.svelte
+++ b/packages/svelte/tests/helpers/RouterProviderScrollTest.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import RouterProvider from "../../src/RouterProvider.svelte";
+
+  import type { ScrollRestorationOptions } from "../../src/dom-utils";
+  import type { Router } from "@real-router/core";
+
+  let {
+    router,
+    scrollRestoration,
+  }: {
+    router: Router;
+    scrollRestoration?: ScrollRestorationOptions;
+  } = $props();
+</script>
+
+{#if scrollRestoration}
+  <RouterProvider {router} {scrollRestoration}>
+    <div data-testid="child"></div>
+  </RouterProvider>
+{:else}
+  <RouterProvider {router}>
+    <div data-testid="child"></div>
+  </RouterProvider>
+{/if}

--- a/packages/svelte/tests/property/linkUtils.properties.ts
+++ b/packages/svelte/tests/property/linkUtils.properties.ts
@@ -28,10 +28,7 @@ import {
   arbOptionalClassName,
   arbMouseEventProps,
 } from "./helpers";
-import {
-  buildActiveClassName,
-  shouldNavigate,
-} from "../../src/dom-utils/index.js";
+import { buildActiveClassName, shouldNavigate } from "../../src/dom-utils";
 
 // =============================================================================
 // shouldNavigate Tests

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -460,11 +460,33 @@ Or in a template:
 
 When enabled, a visually hidden `aria-live` region announces each navigation. Focus moves to the first `<h1>` on the new page. See [Accessibility guide](https://github.com/greydragon888/real-router/wiki/Accessibility) for details.
 
+## Scroll Restoration
+
+Opt-in preservation of scroll position across navigations:
+
+```vue
+<RouterProvider :router="router" :scroll-restoration="{ mode: 'restore' }">
+  <!-- Your app -->
+</RouterProvider>
+```
+
+Or via `h()`:
+
+```typescript
+h(
+  RouterProvider,
+  { router, scrollRestoration: { mode: "restore" } },
+  { default: () => [/* Your app */] },
+);
+```
+
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Prop is reactive — toggling mode at runtime reconfigures the utility (watched by primitive fields, so inline objects with the same fields do not thrash). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+
 ## Documentation
 
 Full documentation: [Wiki](https://github.com/greydragon888/real-router/wiki)
 
-- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link)
+- [RouterProvider](https://github.com/greydragon888/real-router/wiki/RouterProvider) · [RouteView](https://github.com/greydragon888/real-router/wiki/RouteView) · [RouterErrorBoundary](https://github.com/greydragon888/real-router/wiki/RouterErrorBoundary) · [Link](https://github.com/greydragon888/real-router/wiki/Link) · [Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration)
 - [useRouter](https://github.com/greydragon888/real-router/wiki/useRouter) · [useRoute](https://github.com/greydragon888/real-router/wiki/useRoute) · [useRouteNode](https://github.com/greydragon888/real-router/wiki/useRouteNode) · [useNavigator](https://github.com/greydragon888/real-router/wiki/useNavigator) · [useRouteUtils](https://github.com/greydragon888/real-router/wiki/useRouteUtils) · [useRouterTransition](https://github.com/greydragon888/real-router/wiki/useRouterTransition)
 
 ## Examples

--- a/packages/vue/src/RouterProvider.ts
+++ b/packages/vue/src/RouterProvider.ts
@@ -2,9 +2,10 @@ import { defineComponent, onScopeDispose, provide, watch } from "vue";
 
 import { NavigatorKey, RouteKey, RouterKey } from "./context";
 import { pushDirectiveRouter } from "./directives/vLink";
-import { createRouteAnnouncer } from "./dom-utils/index.js";
+import { createRouteAnnouncer, createScrollRestoration } from "./dom-utils";
 import { setupRouteProvision } from "./setupRouteProvision";
 
+import type { ScrollRestorationOptions } from "./dom-utils";
 import type { Router } from "@real-router/core";
 import type { PropType } from "vue";
 
@@ -18,6 +19,9 @@ export const RouterProvider = defineComponent({
     announceNavigation: {
       type: Boolean,
       default: false,
+    },
+    scrollRestoration: {
+      type: Object as PropType<ScrollRestorationOptions>,
     },
   },
   setup(props, { slots }) {
@@ -35,6 +39,36 @@ export const RouterProvider = defineComponent({
 
         onCleanup(() => {
           announcer.destroy();
+        });
+      },
+      { immediate: true },
+    );
+
+    // Watch by primitives so inline `{ mode: "restore" }` doesn't thrash.
+    // scrollContainer is a getter invoked lazily on every event inside the
+    // utility — swapping its reference doesn't change the resolved element,
+    // so we intentionally omit it from watched sources.
+    watch(
+      () =>
+        [
+          props.router,
+          props.scrollRestoration !== undefined,
+          props.scrollRestoration?.mode,
+          props.scrollRestoration?.anchorScrolling,
+        ] as const,
+      ([router, enabled, mode, anchorScrolling], _prev, onCleanup) => {
+        if (!enabled) {
+          return;
+        }
+
+        const sr = createScrollRestoration(router, {
+          mode,
+          anchorScrolling,
+          scrollContainer: props.scrollRestoration?.scrollContainer,
+        });
+
+        onCleanup(() => {
+          sr.destroy();
         });
       },
       { immediate: true },

--- a/packages/vue/src/components/Link.ts
+++ b/packages/vue/src/components/Link.ts
@@ -3,11 +3,7 @@ import { defineComponent, h, computed, shallowRef, watch } from "vue";
 
 import { useRouter } from "../composables/useRouter";
 import { EMPTY_PARAMS, EMPTY_OPTIONS } from "../constants";
-import {
-  shouldNavigate,
-  buildHref,
-  buildActiveClassName,
-} from "../dom-utils/index.js";
+import { shouldNavigate, buildHref, buildActiveClassName } from "../dom-utils";
 
 import type { Params, NavigationOptions } from "@real-router/core";
 import type { PropType } from "vue";

--- a/packages/vue/src/directives/vLink.ts
+++ b/packages/vue/src/directives/vLink.ts
@@ -1,4 +1,4 @@
-import { shouldNavigate, applyLinkA11y } from "../dom-utils/index.js";
+import { shouldNavigate, applyLinkA11y } from "../dom-utils";
 
 import type { Router, NavigationOptions, Params } from "@real-router/core";
 import type { Directive } from "vue";

--- a/packages/vue/tests/functional/RouterProvider.scroll.test.ts
+++ b/packages/vue/tests/functional/RouterProvider.scroll.test.ts
@@ -1,0 +1,197 @@
+import { mount } from "@vue/test-utils";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+import { defineComponent, h, ref } from "vue";
+
+import { RouterProvider } from "../../src/RouterProvider";
+import { createTestRouterWithADefaultRouter } from "../helpers";
+
+import type { ScrollRestorationOptions } from "../../src/dom-utils";
+import type { Router } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+describe("RouterProvider — scrollRestoration", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+
+      return 0;
+    });
+    router = createTestRouterWithADefaultRouter();
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+    sessionStorage.clear();
+    history.scrollRestoration = "auto";
+    vi.unstubAllGlobals();
+  });
+
+  it("no scrollRestoration prop — history.scrollRestoration unchanged", () => {
+    mount(
+      defineComponent({
+        setup: () => () =>
+          h(RouterProvider, { router }, { default: () => h("div") }),
+      }),
+    );
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("scrollRestoration provided — flips history.scrollRestoration to 'manual'", () => {
+    mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            RouterProvider,
+            { router, scrollRestoration: { mode: "restore" } },
+            { default: () => h("div") },
+          ),
+      }),
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("unmount restores history.scrollRestoration", () => {
+    const wrapper = mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            RouterProvider,
+            { router, scrollRestoration: { mode: "restore" } },
+            { default: () => h("div") },
+          ),
+      }),
+    );
+
+    expect(history.scrollRestoration).toBe("manual");
+
+    wrapper.unmount();
+
+    expect(history.scrollRestoration).toBe("auto");
+  });
+
+  it("pagehide captures position when enabled", () => {
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 275,
+      configurable: true,
+    });
+
+    const wrapper = mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            RouterProvider,
+            { router, scrollRestoration: { mode: "restore" } },
+            { default: () => h("div") },
+          ),
+      }),
+    );
+
+    globalThis.dispatchEvent(new Event("pagehide"));
+
+    const saved = JSON.parse(
+      sessionStorage.getItem(STORAGE_KEY) ?? "{}",
+    ) as Record<string, number>;
+
+    expect(Object.values(saved)).toContain(275);
+
+    wrapper.unmount();
+  });
+
+  // Reactivity regression tests — guards the primitive-deps watch() rewrite
+  // so inline objects don't thrash while genuine option changes DO apply.
+  describe("reactivity", () => {
+    it("replacing the options ref with same fields — does NOT re-create the utility", async () => {
+      const opts = ref<ScrollRestorationOptions>({ mode: "restore" });
+
+      const wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            h(
+              RouterProvider,
+              { router, scrollRestoration: opts.value },
+              { default: () => h("div") },
+            ),
+        }),
+      );
+
+      expect(history.scrollRestoration).toBe("manual");
+
+      // Replace with a NEW object ref, identical fields. If the watch were
+      // reference-based, this would destroy + re-create: prevScrollRestoration
+      // in the new instance would capture "manual", breaking the final restore.
+      opts.value = { mode: "restore" };
+      await wrapper.vm.$nextTick();
+
+      wrapper.unmount();
+
+      // If re-created once, prevScrollRestoration in instance #2 would be
+      // "manual" (snapshot of #1's flip) and we'd stay "manual" after unmount.
+      // If anti-thrash works, only instance #1 existed; its prev was "auto".
+      expect(history.scrollRestoration).toBe("auto");
+    });
+
+    it("changing mode on the fly re-creates the utility", async () => {
+      const opts = ref<ScrollRestorationOptions>({ mode: "restore" });
+
+      const wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            h(
+              RouterProvider,
+              { router, scrollRestoration: opts.value },
+              { default: () => h("div") },
+            ),
+        }),
+      );
+
+      expect(history.scrollRestoration).toBe("manual");
+
+      // Switch to "manual" — utility returns noop; flip should be reverted.
+      opts.value = { mode: "manual" };
+      await wrapper.vm.$nextTick();
+
+      expect(history.scrollRestoration).toBe("auto");
+
+      wrapper.unmount();
+    });
+
+    it("toggling from undefined → object creates the utility; object → undefined destroys it", async () => {
+      const opts = ref<ScrollRestorationOptions | undefined>(undefined);
+
+      const wrapper = mount(
+        defineComponent({
+          setup: () => () =>
+            opts.value === undefined
+              ? h(RouterProvider, { router }, { default: () => h("div") })
+              : h(
+                  RouterProvider,
+                  { router, scrollRestoration: opts.value },
+                  { default: () => h("div") },
+                ),
+        }),
+      );
+
+      expect(history.scrollRestoration).toBe("auto");
+
+      opts.value = { mode: "restore" };
+      await wrapper.vm.$nextTick();
+
+      expect(history.scrollRestoration).toBe("manual");
+
+      opts.value = undefined;
+      await wrapper.vm.$nextTick();
+
+      expect(history.scrollRestoration).toBe("auto");
+
+      wrapper.unmount();
+    });
+  });
+});

--- a/shared/dom-utils/index.ts
+++ b/shared/dom-utils/index.ts
@@ -1,5 +1,7 @@
 export { createRouteAnnouncer } from "./route-announcer.js";
 
+export { createScrollRestoration } from "./scroll-restore.js";
+
 export {
   shouldNavigate,
   buildHref,
@@ -9,3 +11,8 @@ export {
 } from "./link-utils.js";
 
 export type { RouteAnnouncerOptions } from "./route-announcer.js";
+
+export type {
+  ScrollRestorationOptions,
+  ScrollRestorationMode,
+} from "./scroll-restore.js";

--- a/shared/dom-utils/scroll-restore.ts
+++ b/shared/dom-utils/scroll-restore.ts
@@ -1,0 +1,217 @@
+import type { Router, State } from "@real-router/core";
+
+const STORAGE_KEY = "real-router:scroll";
+
+const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
+  destroy: () => {
+    /* no-op */
+  },
+});
+
+export type ScrollRestorationMode = "restore" | "top" | "manual";
+
+export interface ScrollRestorationOptions {
+  mode?: ScrollRestorationMode | undefined;
+  anchorScrolling?: boolean | undefined;
+  scrollContainer?: (() => HTMLElement | null) | undefined;
+}
+
+interface NavigationContext {
+  direction?: "forward" | "back" | "unknown";
+  navigationType?: "push" | "replace" | "traverse" | "reload";
+}
+
+export function createScrollRestoration(
+  router: Router,
+  options?: ScrollRestorationOptions,
+): { destroy: () => void } {
+  if (typeof globalThis.window === "undefined") {
+    return NOOP_INSTANCE;
+  }
+
+  const mode = options?.mode ?? "restore";
+
+  // mode "manual" = utility does nothing. Don't flip history.scrollRestoration,
+  // don't subscribe, don't register pagehide — leave the browser's native
+  // auto-restore intact for the app to override if it wants to.
+  if (mode === "manual") {
+    return NOOP_INSTANCE;
+  }
+
+  const anchorEnabled = options?.anchorScrolling ?? true;
+  const getContainer = options?.scrollContainer;
+
+  const prevScrollRestoration = history.scrollRestoration;
+
+  try {
+    history.scrollRestoration = "manual";
+  } catch {
+    // Ignore — some embedded contexts may reject the assignment.
+  }
+
+  // Resolve the container lazily on every event so containers mounted AFTER
+  // the provider still get correct scroll handling. Falls back to window when
+  // the getter is absent or returns null (pre-mount).
+  const readPos = (): number => {
+    const element = getContainer?.();
+
+    return element ? element.scrollTop : globalThis.scrollY;
+  };
+
+  const writePos = (top: number): void => {
+    const element = getContainer?.();
+
+    if (element) {
+      element.scrollTop = top;
+    } else {
+      globalThis.scrollTo(0, top);
+    }
+  };
+
+  const scrollToHashOrTop = (): void => {
+    const hash = globalThis.location.hash;
+
+    if (anchorEnabled && hash.length > 1) {
+      // location.hash is percent-encoded; ids in the DOM are the raw string.
+      // Decode for the match. Fall back to the raw slice if the hash contains
+      // a malformed escape sequence (decodeURIComponent throws on those).
+      let id: string;
+
+      try {
+        id = decodeURIComponent(hash.slice(1));
+      } catch {
+        id = hash.slice(1);
+      }
+
+      // eslint-disable-next-line unicorn/prefer-query-selector -- ids may contain CSS-unsafe chars
+      const element = document.getElementById(id);
+
+      if (element) {
+        element.scrollIntoView();
+
+        return;
+      }
+    }
+
+    writePos(0);
+  };
+
+  let destroyed = false;
+
+  const unsubscribe = router.subscribe(({ route, previousRoute }) => {
+    const nav = (route.context as { navigation?: NavigationContext })
+      .navigation;
+
+    // Browsers dispatch reload as the initial navigation after refresh, so
+    // previousRoute is undefined and capture is naturally skipped. The
+    // pre-refresh position was already persisted via pagehide.
+    if (previousRoute) {
+      putPos(keyOf(previousRoute), readPos());
+    }
+
+    // Single rAF so DOM is committed before we read anchors / write scroll.
+    // Guard against destroy() racing with the callback.
+    requestAnimationFrame(() => {
+      if (destroyed) {
+        return;
+      }
+
+      if (mode === "top" || !nav) {
+        scrollToHashOrTop();
+
+        return;
+      }
+
+      if (nav.navigationType === "replace") {
+        return;
+      }
+
+      if (
+        nav.direction === "back" ||
+        nav.navigationType === "traverse" ||
+        nav.navigationType === "reload"
+      ) {
+        writePos(loadStore()[keyOf(route)] ?? 0);
+
+        return;
+      }
+
+      scrollToHashOrTop();
+    });
+  });
+
+  const onPageHide = (): void => {
+    const current = router.getState();
+
+    if (current) {
+      putPos(keyOf(current), readPos());
+    }
+  };
+
+  globalThis.addEventListener("pagehide", onPageHide);
+
+  return {
+    destroy: () => {
+      if (destroyed) {
+        return;
+      }
+
+      destroyed = true;
+      unsubscribe();
+      globalThis.removeEventListener("pagehide", onPageHide);
+
+      try {
+        history.scrollRestoration = prevScrollRestoration;
+      } catch {
+        // Ignore.
+      }
+    },
+  };
+}
+
+function keyOf(state: State): string {
+  return `${state.name}:${canonicalJson(state.params)}`;
+}
+
+function loadStore(): Record<string, number> {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+
+    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function putPos(key: string, pos: number): void {
+  try {
+    const store = loadStore();
+
+    store[key] = pos;
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore quota / security errors.
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, canonicalReplacer);
+}
+
+function canonicalReplacer(_key: string, val: unknown): unknown {
+  if (val !== null && typeof val === "object" && !Array.isArray(val)) {
+    const sorted: Record<string, unknown> = {};
+    // eslint-disable-next-line unicorn/no-array-sort -- ng-packagr uses pre-ES2023 lib; toSorted unavailable
+    const keys = Object.keys(val as Record<string, unknown>).sort(
+      (left: string, right: string) => left.localeCompare(right),
+    );
+
+    for (const key of keys) {
+      sorted[key] = (val as Record<string, unknown>)[key];
+    }
+
+    return sorted;
+  }
+
+  return val;
+}


### PR DESCRIPTION
Closes #497.

## Summary

- **Shared DOM utility** `createScrollRestoration` in `shared/dom-utils/` — opt-in scroll capture on transition, restore on back/pagehide. Not a plugin: router-core stays DOM-agnostic, direction is read from `@real-router/navigation-plugin`'s `state.context.navigation`.
- **6 adapter integrations**: `RouterProvider.scrollRestoration` prop (React/Preact/Solid/Svelte/Vue) and `provideRealRouter(router, { scrollRestoration })` options (Angular). Reactive adapters use primitive-field deps / `$derived+untrack` to guard against inline-object thrash.
- **Composite route-identity key** `(name, canonicalJson(params))` — no per-entry UUID, no `browser-plugin` changes required. `sessionStorage` persistence + `pagehide` for reload. Single rAF for DOM-commit timing; lazy `scrollContainer` resolve; decoded hash anchor lookup.
- **Dogfooding**: enabled on all 6 `examples/<fw>/basic` with a 100-item scrollable list.
- **Docs**: wiki Scroll-Restoration + new React-Integration (filled long-standing sidebar gap); 6 adapter README/ARCHITECTURE updates; root README Key Features; `IMPLEMENTATION_NOTES.md` decision record.
- **6 changesets**, minor bumps per adapter; no core changes.

## Test plan

- [x] `pnpm build` — 246/246 turbo tasks pass locally
- [x] Shared utility: 34 functional tests (SSR no-op, all modes × direction/navType matrix, anchor decode, malformed escape, lazy container, cross-instance collisions, destroy-during-rAF race guard)
- [x] React/Preact/Svelte: 5 integration tests each (includes anti-thrash regression)
- [x] Vue: 7 integration tests (includes 3 reactivity cases: same-field replace, mode change, undefined↔object)
- [x] Angular: 16 tests (12 mirrored shared + 4 `provideRealRouter` lifecycle via `EnvironmentInjector`)
- [x] Changeset validation: `pnpm changeset status` shows 6 minor bumps
- [x] Angular dom-utils sync verified: `pnpm -F @real-router/angular bundle` → `diff -r shared/dom-utils/ packages/angular/src/dom-utils/` matches
- [ ] Manual browser smoke: `pnpm -F example-react-basic dev` — scroll `/long-list` 500px → click item → Back restores to 500; F5 on `/long-list` (pos=500) → pagehide persisted → restore to 500

## Notes for reviewers

- **Why utility, not plugin** — `window.scrollY` is a DOM concern; router-core owns `state.name`/`params`/`context` only. Plugin would be a layering leak (same mistake as Angular's `TitleStrategy` inside router-core). Routing-layer inputs (direction, navigationType) are already published by `@real-router/navigation-plugin` via `state.context.navigation` — plugin would duplicate that channel.
- **Why composite key, not per-entry UUID** — `browser-plugin.history.state` is `{ name, params, path }`, no key. Navigation API `entry.key` is plugin-internal. Cross-package coordination for UUID wasn't worth it; composite `(name, canonicalJson(params))` satisfies ~99% of real-world UX (list → item → back). Duplicate history entries collapse to one bucket — documented trade-off.
- **Why single rAF** — double was cargo-cult from `createRouteAnnouncer` (where it guards Safari aria-live timing). For scroll, single is enough on React 19 / Vue 3.4+ / Solid / Svelte 5, and narrows the destroy-during-rAF race window. Explicit `destroyed` guard inside the rAF callback closes the remaining race.

Wiki pages (`Scroll-Restoration.md`, `React-Integration.md`, updated Integration guides) are in the companion [wiki repo commit](https://github.com/greydragon888/real-router/wiki) on master.