### PR TITLE
refactor(hash-plugin): extract buildHashLocation helper (#506)

### DIFF
--- a/.changeset/hash-plugin-buildhashlocation-refactor.md
+++ b/.changeset/hash-plugin-buildhashlocation-refactor.md
@@ -1,0 +1,40 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Deduplicate `getLocation` callback into `buildHashLocation` helper (#506)
+
+Extracted the hash-path-plus-query construction logic shared by the
+production factory and two test helpers into a single pure function in
+`hash-utils.ts`:
+
+```ts
+export function buildHashLocation(
+  hash: string,
+  search: string,
+  prefixRegex: RegExp | null,
+): string {
+  const hashPath = safelyEncodePath(extractHashPath(hash, prefixRegex));
+  return hashPath.includes("?") ? hashPath : hashPath + search;
+}
+```
+
+Previously the same two-line sequence (strip prefix → encode → append
+outer `search` unless hash already carries a `?`) was copied verbatim in
+three places, with no structural guard against divergence:
+
+- `packages/hash-plugin/src/factory.ts` — production `createSafeBrowser`
+  callback.
+- `packages/hash-plugin/tests/helpers/mockPlugins.ts` — functional-test
+  mock browser.
+- `packages/hash-plugin/tests/stress/helpers.ts` — stress-test router
+  factory.
+
+The "no double `?`" regression fixed in `url.test.ts` — "well-formed
+path (no double '?')" was a direct consequence of the duplication: a
+patch landed in production but the mocks fell behind until the test was
+added. Consolidating into one helper prevents the class of regression.
+
+Internal refactor only — no public API changes. `buildHashLocation` is
+not exported from the package; it lives in `src/hash-utils.ts` alongside
+the other hash-URL primitives.

--- a/.changeset/hash-plugin-buildhashlocation-refactor.md
+++ b/.changeset/hash-plugin-buildhashlocation-refactor.md
@@ -38,3 +38,12 @@ added. Consolidating into one helper prevents the class of regression.
 Internal refactor only — no public API changes. `buildHashLocation` is
 not exported from the package; it lives in `src/hash-utils.ts` alongside
 the other hash-URL primitives.
+
+Direct unit tests added in `tests/functional/hash-utils.test.ts` — 13
+cases covering the "no double `?`" contract, the hashPrefix strip, URL
+encoding of non-ASCII paths, malformed percent-sequence passthrough, and
+composition agreement with `extractHashPath` / `hashUrlToPath`. The
+regression previously surfaced only through an end-to-end router test
+(`url.test.ts` — "well-formed path (no double '?')"); unit coverage now
+pins the helper directly so future edits to `buildHashLocation` fail at
+the helper level before they corrupt the router flow.

--- a/packages/hash-plugin/src/factory.ts
+++ b/packages/hash-plugin/src/factory.ts
@@ -1,12 +1,8 @@
 import { getPluginApi } from "@real-router/core/api";
 
-import {
-  createSafeBrowser,
-  normalizeBase,
-  safelyEncodePath,
-} from "./browser-env";
+import { createSafeBrowser, normalizeBase } from "./browser-env";
 import { defaultOptions, source } from "./constants";
-import { createHashPrefixRegex, extractHashPath } from "./hash-utils";
+import { buildHashLocation, createHashPrefixRegex } from "./hash-utils";
 import { HashPlugin } from "./plugin";
 import { validateOptions } from "./validation";
 
@@ -38,15 +34,15 @@ export function hashPluginFactory(
   const prefixRegex = createHashPrefixRegex(options.hashPrefix);
   const resolvedBrowser =
     browser ??
-    createSafeBrowser(() => {
-      const hashPath = safelyEncodePath(
-        extractHashPath(globalThis.location.hash, prefixRegex),
-      );
-
-      return hashPath.includes("?")
-        ? hashPath
-        : hashPath + globalThis.location.search;
-    }, "hash-plugin");
+    createSafeBrowser(
+      () =>
+        buildHashLocation(
+          globalThis.location.hash,
+          globalThis.location.search,
+          prefixRegex,
+        ),
+      "hash-plugin",
+    );
 
   const transitionOptions = {
     forceDeactivate: options.forceDeactivate,

--- a/packages/hash-plugin/src/hash-utils.ts
+++ b/packages/hash-plugin/src/hash-utils.ts
@@ -1,6 +1,6 @@
 // packages/hash-plugin/src/hash-utils.ts
 
-import { safeParseUrl } from "./browser-env";
+import { safelyEncodePath, safeParseUrl } from "./browser-env";
 
 function escapeRegExp(str: string): string {
   return str.replaceAll(/[$()*+.?[\\\]^{|}-]/g, String.raw`\$&`);
@@ -39,4 +39,27 @@ export function hashUrlToPath(url: string, prefixRegex: RegExp | null): string {
   const hashPath = extractHashPath(parsedUrl.hash, prefixRegex);
 
   return hashPath.includes("?") ? hashPath : hashPath + parsedUrl.search;
+}
+
+/**
+ * Build the router-side location string from a hash + query pair.
+ *
+ * Encodes the hash path via `safelyEncodePath` after stripping the
+ * configured prefix, then appends the outer `search` only when the hash
+ * path itself does not already carry a `?` — otherwise the outer search
+ * would be duplicated (see `url.test.ts` — "well-formed path (no double '?')").
+ *
+ * Used by the `createSafeBrowser` `getLocation` callback both in the
+ * production factory and in functional/stress test helpers. Extracting
+ * here keeps the production path and test mocks aligned; a regression in
+ * this logic previously slipped between the two.
+ */
+export function buildHashLocation(
+  hash: string,
+  search: string,
+  prefixRegex: RegExp | null,
+): string {
+  const hashPath = safelyEncodePath(extractHashPath(hash, prefixRegex));
+
+  return hashPath.includes("?") ? hashPath : hashPath + search;
 }

--- a/packages/hash-plugin/tests/functional/hash-utils.test.ts
+++ b/packages/hash-plugin/tests/functional/hash-utils.test.ts
@@ -1,0 +1,131 @@
+// Direct unit tests for hash-utils.ts — the pure primitives consumed by
+// factory.ts and the test helpers (createMockedBrowser, createStressRouter).
+//
+// These tests guard the *helper itself*; integration-level coverage in
+// url.test.ts proves the helper is wired correctly into the factory path.
+// Both layers are needed: dropping the unit tests would leave regressions
+// in `buildHashLocation` visible only through tangled router flows.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  buildHashLocation,
+  createHashPrefixRegex,
+  extractHashPath,
+  hashUrlToPath,
+} from "../../src/hash-utils";
+
+describe("hash-utils — buildHashLocation (#506)", () => {
+  describe("core cases", () => {
+    it("returns '/' for an empty hash, ignoring search", () => {
+      expect(buildHashLocation("", "", null)).toBe("/");
+      expect(buildHashLocation("", "?page=1", null)).toBe("/?page=1");
+    });
+
+    it("returns '/' for a bare '#', ignoring search", () => {
+      expect(buildHashLocation("#", "", null)).toBe("/");
+      expect(buildHashLocation("#", "?page=1", null)).toBe("/?page=1");
+    });
+
+    it("strips leading '#' and appends outer search for plain hash paths", () => {
+      expect(buildHashLocation("#/users", "?page=1", null)).toBe(
+        "/users?page=1",
+      );
+      expect(buildHashLocation("#/users/42", "", null)).toBe("/users/42");
+    });
+
+    it("strips the configured hashPrefix before encoding", () => {
+      const prefixRegex = createHashPrefixRegex("!");
+
+      expect(buildHashLocation("#!/users", "", prefixRegex)).toBe("/users");
+      expect(buildHashLocation("#!/users", "?sort=asc", prefixRegex)).toBe(
+        "/users?sort=asc",
+      );
+    });
+  });
+
+  describe("no-double-'?' contract", () => {
+    // The regression that motivated extracting this helper: when the hash
+    // itself already carries a query (e.g. `#/users?sort=asc`), the outer
+    // `location.search` must NOT be appended — otherwise the resulting
+    // path contains two `?` separators and query parsing breaks.
+
+    it("does not append outer search when hash path already carries '?'", () => {
+      expect(buildHashLocation("#/users?sort=asc", "?page=1", null)).toBe(
+        "/users?sort=asc",
+      );
+    });
+
+    it("does not append empty outer search when hash has a query either", () => {
+      expect(buildHashLocation("#/users?sort=asc", "", null)).toBe(
+        "/users?sort=asc",
+      );
+    });
+
+    it("appends outer search when hash path has no '?'", () => {
+      expect(buildHashLocation("#/users", "?sort=asc", null)).toBe(
+        "/users?sort=asc",
+      );
+    });
+
+    it("holds the contract with a hashPrefix", () => {
+      const prefixRegex = createHashPrefixRegex("!");
+
+      // Prefix stripped, inner ? wins, outer search discarded.
+      expect(
+        buildHashLocation("#!/users?sort=asc", "?page=1", prefixRegex),
+      ).toBe("/users?sort=asc");
+      // No inner ? → outer search appended.
+      expect(buildHashLocation("#!/users", "?page=1", prefixRegex)).toBe(
+        "/users?page=1",
+      );
+    });
+  });
+
+  describe("URL encoding", () => {
+    it("percent-encodes non-ASCII characters in the hash path", () => {
+      // Unicode in the path must survive safelyEncodePath.
+      expect(buildHashLocation("#/пользователи", "", null)).toBe(
+        "/%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D0%B8",
+      );
+    });
+
+    it("passes already-percent-encoded sequences through unchanged", () => {
+      expect(buildHashLocation("#/users%20list", "", null)).toBe(
+        "/users%20list",
+      );
+    });
+
+    it("leaves malformed percent sequences in place (safelyEncodePath catch)", () => {
+      // safelyEncodePath swallows URIError and returns the input unchanged.
+      expect(buildHashLocation("#/%E0%A4%A", "", null)).toBe("/%E0%A4%A");
+    });
+  });
+
+  describe("composition with extractHashPath / hashUrlToPath", () => {
+    // Smoke-check that `buildHashLocation` stays a thin composition layer
+    // over `extractHashPath` + `safelyEncodePath` + outer-search merge.
+    // If someone inlines a different path-extraction into the helper, these
+    // agreements break.
+
+    it("agrees with extractHashPath for the path portion when outer search is empty", () => {
+      const hash = "#/items/42";
+      const prefixRegex = null;
+      const direct = extractHashPath(hash, prefixRegex);
+
+      expect(buildHashLocation(hash, "", prefixRegex)).toBe(direct);
+    });
+
+    it("matches hashUrlToPath for absolute URLs with the same hash + search", () => {
+      // hashUrlToPath(url) parses url.hash + url.search separately; our
+      // helper receives them as positional arguments. Both should yield
+      // identical strings given the same components.
+      const url = "https://example.com/?page=1#/users?sort=asc";
+      const prefixRegex = null;
+
+      expect(hashUrlToPath(url, prefixRegex)).toBe(
+        buildHashLocation("#/users?sort=asc", "?page=1", prefixRegex),
+      );
+    });
+  });
+});

--- a/packages/hash-plugin/tests/helpers/mockPlugins.ts
+++ b/packages/hash-plugin/tests/helpers/mockPlugins.ts
@@ -1,5 +1,5 @@
-import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
-import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
+import { createSafeBrowser } from "../../src/browser-env";
+import { buildHashLocation, createHashPrefixRegex } from "../../src/hash-utils";
 
 import type { Browser } from "../../src/browser-env";
 
@@ -10,15 +10,15 @@ export function createMockedBrowser(
   hashPrefix = "",
 ): Browser {
   const prefixRegex = createHashPrefixRegex(hashPrefix);
-  const safeBrowser = createSafeBrowser(() => {
-    const hashPath = safelyEncodePath(
-      extractHashPath(globalThis.location.hash, prefixRegex),
-    );
-
-    return hashPath.includes("?")
-      ? hashPath
-      : hashPath + globalThis.location.search;
-  }, "hash-plugin");
+  const safeBrowser = createSafeBrowser(
+    () =>
+      buildHashLocation(
+        globalThis.location.hash,
+        globalThis.location.search,
+        prefixRegex,
+      ),
+    "hash-plugin",
+  );
 
   return {
     ...safeBrowser,

--- a/packages/hash-plugin/tests/stress/helpers.ts
+++ b/packages/hash-plugin/tests/stress/helpers.ts
@@ -2,8 +2,8 @@ import { createRouter } from "@real-router/core";
 
 import { hashPluginFactory } from "@real-router/hash-plugin";
 
-import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
-import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
+import { createSafeBrowser } from "../../src/browser-env";
+import { buildHashLocation, createHashPrefixRegex } from "../../src/hash-utils";
 
 import type { Browser } from "../../src/browser-env";
 import type { Router, Unsubscribe } from "@real-router/core";
@@ -40,15 +40,15 @@ export function createStressRouter(options?: {
   const hashPrefix = options?.hashPrefix ?? "";
   const prefixRegex = createHashPrefixRegex(hashPrefix);
 
-  const safeBrowser = createSafeBrowser(() => {
-    const hashPath = safelyEncodePath(
-      extractHashPath(globalThis.location.hash, prefixRegex),
-    );
-
-    return hashPath.includes("?")
-      ? hashPath
-      : hashPath + globalThis.location.search;
-  }, "hash-plugin");
+  const safeBrowser = createSafeBrowser(
+    () =>
+      buildHashLocation(
+        globalThis.location.hash,
+        globalThis.location.search,
+        prefixRegex,
+      ),
+    "hash-plugin",
+  );
 
   const browser: Browser = {
     ...safeBrowser,


### PR DESCRIPTION
## Summary

Closes #506.

Deduplicates the three-step `getLocation` callback logic (strip hash prefix → encode → append outer search only when hash has no `?`) that was copy-pasted across production and two test helpers. Extracts a pure `buildHashLocation(hash, search, prefixRegex)` function in `src/hash-utils.ts` and points all three call sites at it:

- `packages/hash-plugin/src/factory.ts` — production `createSafeBrowser` callback.
- `packages/hash-plugin/tests/helpers/mockPlugins.ts` — functional-test mock browser.
- `packages/hash-plugin/tests/stress/helpers.ts` — stress-test router factory.

### Why it matters

The duplication was not hypothetical risk — it actually bit us. The "no double `?`" regression (`url.test.ts` — "well-formed path (no double '?')") landed in `factory.ts` but the test mocks fell behind silently until a dedicated test forced synchronisation. Consolidating into one helper makes the class of regression structurally impossible: any future edit touches a single function, not three copies.

### Why direct unit tests were added

Before this PR the helper logic was only exercised transitively through the end-to-end router flow — a regression inside the helper itself would surface as a confusing router-level failure, not as a pinpointed helper failure. `tests/functional/hash-utils.test.ts` now pins `buildHashLocation` with 13 direct cases covering:

- core behaviour (empty hash, bare `#`, plain path, `hashPrefix: "!"`)
- the **no-double-`?`** contract (the regression that motivated the extraction)
- URL encoding (non-ASCII, pre-encoded, malformed percent sequences)
- composition agreements with `extractHashPath` / `hashUrlToPath`

Internal refactor — no public API changes. `buildHashLocation` is not exported from the package.

## Test plan

- [x] `pnpm -F @real-router/hash-plugin type-check` — clean
- [x] `pnpm -F @real-router/hash-plugin lint` — clean
- [x] `pnpm -F @real-router/hash-plugin test` — 84 passed (71 existing + 13 new)
- [x] `pnpm vitest run --config vitest.config.stress.mts` (hash-plugin) — 27 passed
- [x] `pnpm build` — 251/251 tasks successful across the monorepo
- [ ] CI (Dependency Review + Pipeline + SonarCloud + Codecov) green