### PR TITLE
fix(memory-plugin): lifecycle race with in-flight #go (#505)

### DIFF
--- a/.changeset/memory-plugin-505-lifecycle-race-fix.md
+++ b/.changeset/memory-plugin-505-lifecycle-race-fix.md
@@ -1,0 +1,65 @@
+---
+"@real-router/memory-plugin": patch
+---
+
+Fix lifecycle race between `stop()`/`teardown()` and in-flight `#go()` (#505)
+
+Before this fix, calling `router.stop()` or `unsubscribe()` while a
+`back()` / `forward()` / `go(delta)` navigation was still in flight
+could leave plugin state desynchronised.
+
+**Root cause.** `#go(delta)` updates `#index` optimistically (synchronously)
+and reverts it in the reject-handler of the navigation promise. The
+revert is guarded by the `#goGeneration` counter, so a second `#go` that
+bumps the generation protects its own optimistic update from a stale
+settler. But `onStop` and `teardown` did **not** bump the counter, so a
+settler whose generation was captured before the lifecycle change still
+observed a match and wrote into already-cleared state:
+
+```
+router.back();    // #go: #index = 1 (optimistic), navigate("a") in flight
+router.stop();    // #clear(): #entries = [], #index = -1
+
+// navigate() rejects after stop
+// reject-handler sees #goGeneration === generation → runs revert
+// → this.#index = previousIndex (= 2)
+// Result: #index = 2, #entries.length = 0 — desynced
+```
+
+A separate flow-on bug: `#clear()` did not reset `#navigatingFromHistory`
+or `#pendingDirection`, so the flag remained `true` after a stop/start
+cycle and the next `onTransitionSuccess` took the history-restore branch,
+silently skipping the `push` of a new entry.
+
+**Fix.** Two coordinated changes in `src/plugin.ts`:
+
+1. **`onStop` and `teardown` bump `#goGeneration`** — in-flight settlers
+   see a mismatch and skip both the revert and the `#navigatingFromHistory
+   = false` reset. Mirrors the existing generation-guard pattern used
+   between consecutive `#go` calls.
+2. **`#clear()` resets transient `#go` state** — `#navigatingFromHistory =
+   false` and `#pendingDirection = "navigate"` so the next lifecycle
+   starts clean regardless of whether a settler ran.
+
+Together these cover both `stop()`/`start()` cycles (HMR, test harnesses)
+and `unsubscribe()` called mid-navigation. Variant (2) from the issue
+(dispose-check in settlers) is **not** needed — generation bump covers
+both lifecycle paths, where variant (2) would only catch `teardown`.
+
+**Regression tests.** Three new functional tests in
+`tests/functional/plugin.test.ts` under
+`describe("lifecycle race with in-flight #go (#505)")`:
+
+- `stop() mid-flight leaves history empty and next navigation records
+  entry` — exercises both invariants: post-stop geometry is zeroed, and
+  the re-start + navigate sequence actually pushes. Fails without either
+  half of the fix.
+- `unsubscribe() mid-flight does not desync #index against cleared
+  entries` — same race for the `teardown` path.
+- `stop() → start() cycle leaves #navigatingFromHistory false even with
+  no in-flight #go` — sanity check that `#clear()`'s new resets do not
+  regress the normal lifecycle.
+
+Existing stress S3 (`teardown-mid-nav.stress.ts`) continues to pass.
+
+No public API changes.

--- a/packages/memory-plugin/src/plugin.ts
+++ b/packages/memory-plugin/src/plugin.ts
@@ -88,6 +88,10 @@ export class MemoryPlugin {
       },
 
       onStop: () => {
+        // Bump generation so any in-flight #go settler observes a mismatch
+        // and skips its revert / flag reset — writing into cleared state
+        // would otherwise leave #index pointing into an empty #entries (#505).
+        this.#goGeneration++;
         this.#clear();
       },
 
@@ -98,6 +102,9 @@ export class MemoryPlugin {
         }
 
         this.#disposed = true;
+        // Same generation bump as onStop — pre-teardown in-flight #go settlers
+        // must not write into a released plugin (#505).
+        this.#goGeneration++;
         this.#removeExtensions();
         this.#claim.release();
         this.#clear();
@@ -163,5 +170,14 @@ export class MemoryPlugin {
   #clear(): void {
     this.#entries.length = 0;
     this.#index = -1;
+    // Reset transient #go state as well: if #clear runs while a #go is in
+    // flight, the reject-handler skips (generation mismatch) and would
+    // otherwise leave #navigatingFromHistory stuck at true — the next
+    // onTransitionSuccess after restart would take the history-restore
+    // branch and silently skip pushing a new entry. Both fields are
+    // "current #go intent", not persistent history, so resetting them on
+    // clear is always correct (#505).
+    this.#navigatingFromHistory = false;
+    this.#pendingDirection = "navigate";
   }
 }

--- a/packages/memory-plugin/tests/functional/plugin.test.ts
+++ b/packages/memory-plugin/tests/functional/plugin.test.ts
@@ -699,4 +699,117 @@ describe("Memory plugin", () => {
       });
     });
   });
+
+  describe("lifecycle race with in-flight #go (#505)", () => {
+    // Regression tests for https://github.com/greydragon888/real-router/issues/505
+    //
+    // Before the fix: stop() / teardown() called while #go is in flight would
+    // let the superseded reject-handler write #index = previousIndex into
+    // already-cleared state, and leave #navigatingFromHistory stuck at true
+    // so the next push after restart silently skipped recording an entry.
+    //
+    // The fix bumps #goGeneration in onStop and teardown (so settlers skip
+    // via generation mismatch) and resets #navigatingFromHistory /
+    // #pendingDirection inside #clear (so the next lifecycle starts clean).
+
+    it("stop() mid-flight leaves history empty and next navigation records entry", async () => {
+      router.usePlugin(memoryPluginFactory());
+      await router.start("/");
+      await router.navigate("users");
+      await router.navigate("user", { id: "42" });
+
+      // History: [home, users, user/42], index = 2.
+
+      // Stall the in-flight navigate so its settler cannot run before
+      // router.stop() clears the plugin. A rejected navigate fires after
+      // stop() — the reject-handler must then observe a generation mismatch
+      // and skip its revert.
+      const navigateSpy = vi.spyOn(router, "navigate").mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(new Error("stalled rejection"));
+            }, 50);
+          }),
+      );
+
+      router.back(); // kicks off #go(-1): optimistic #index = 1
+
+      router.stop(); // #clear + generation bump — settler must no-op
+
+      // Wait out the mocked rejection so the settler has a chance to run.
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Post-stop invariants: history empty, geometry reports cleared.
+      expect(router.canGoBack()).toBe(false);
+      expect(router.canGoForward()).toBe(false);
+
+      navigateSpy.mockRestore();
+
+      // Restart: the next navigation must actually record a new entry.
+      // Without the #navigatingFromHistory reset in #clear(), the flag
+      // would be stuck at true and onTransitionSuccess would skip the push,
+      // leaving history empty forever.
+      await router.start("/");
+      await router.navigate("users");
+
+      expect(router.canGoBack()).toBe(true);
+      expect(router.canGoForward()).toBe(false);
+      expect(router.getState()?.name).toBe("users");
+      expect(router.getState()?.context.memory?.historyIndex).toBe(1);
+    });
+
+    it("unsubscribe() mid-flight does not desync #index against cleared entries", async () => {
+      const unsubscribe = router.usePlugin(memoryPluginFactory());
+
+      await router.start("/");
+      await router.navigate("users");
+      await router.navigate("user", { id: "42" });
+
+      const navigateSpy = vi.spyOn(router, "navigate").mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(new Error("stalled rejection"));
+            }, 50);
+          }),
+      );
+
+      router.back(); // in-flight #go
+
+      unsubscribe(); // teardown: removes extensions, bumps generation
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // After teardown the router no longer exposes the memory extensions;
+      // accessing them should throw (extendRouter unsubscribe removes them).
+      expect(() => router.canGoBack()).toThrow();
+      expect(() => router.canGoForward()).toThrow();
+
+      navigateSpy.mockRestore();
+    });
+
+    it("stop() → start() cycle leaves #navigatingFromHistory false even with no in-flight #go", async () => {
+      // Sanity check: the #clear() reset must not introduce regressions for
+      // the normal stop/start cycle with no race. Before the fix, #clear()
+      // only touched #entries + #index; after the fix it also resets the
+      // #go flags. Normal code paths must still behave identically.
+
+      router.usePlugin(memoryPluginFactory());
+      await router.start("/");
+      await router.navigate("users");
+      router.stop();
+
+      await router.start("/");
+      await router.navigate("settings");
+
+      expect(router.getState()?.name).toBe("settings");
+      expect(router.canGoBack()).toBe(true);
+      expect(router.canGoForward()).toBe(false);
+      expect(router.getState()?.context.memory).toStrictEqual({
+        direction: "navigate",
+        historyIndex: 1,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #505.

Fixes a race where `router.stop()` or `unsubscribe()` called while a `back()` / `forward()` / `go(delta)` navigation is still in flight desynchronises the plugin's `#index` from `#entries`, and leaks `#navigatingFromHistory` across the lifecycle boundary.

### Root cause

`#go(delta)` updates `#index` optimistically and reverts it in the reject-handler of the navigation promise, guarded by the `#goGeneration` counter. But `onStop` and `teardown` did **not** bump the counter, so a settler whose generation was captured before the lifecycle change still observed a match and wrote into already-cleared state:

```ts
router.back();    // #go: #index = 1 (optimistic), navigate("a") in flight
router.stop();    // #clear(): #entries = [], #index = -1

// navigate() rejects after stop
// reject-handler sees #goGeneration === generation → runs revert
// → this.#index = previousIndex (= 2)
// Result: #index = 2, #entries.length = 0 — desynced
```

Additionally, `#clear()` did not reset `#navigatingFromHistory` / `#pendingDirection`. After a `stop/start` cycle the flag stayed `true` and the next `onTransitionSuccess` took the history-restore branch, silently skipping the `push` of a new entry — history stayed empty forever.

### Fix

Two coordinated changes in `src/plugin.ts`:

1. **`onStop` and `teardown` bump `#goGeneration`** — in-flight settlers see a mismatch and skip both the revert and the flag reset. Mirrors the existing generation-guard pattern used between consecutive `#go` calls.
2. **`#clear()` resets transient `#go` state** — `#navigatingFromHistory = false` and `#pendingDirection = "navigate"` so the next lifecycle starts clean regardless of whether a settler ran.

Variant (2) from the issue (dispose-check in settlers) is **not** needed — generation bump covers both lifecycle paths uniformly, where variant (2) would only catch `teardown`.

### Regression tests

Three new functional tests in `tests/functional/plugin.test.ts` under `describe("lifecycle race with in-flight #go (#505)")`:

- `stop() mid-flight leaves history empty and next navigation records entry` — exercises both invariants: post-stop geometry is zeroed, and the re-start + navigate sequence actually pushes. **Fails without either half of the fix.**
- `unsubscribe() mid-flight does not desync #index against cleared entries` — same race for the `teardown` path.
- `stop() → start() cycle leaves #navigatingFromHistory false even with no in-flight #go` — sanity check that `#clear()`'s new resets do not regress the normal lifecycle.

Existing stress `S3` (`teardown-mid-nav.stress.ts`) continues to pass.

No public API changes.

## Test plan

- [x] `pnpm -F @real-router/memory-plugin type-check` — clean
- [x] `pnpm -F @real-router/memory-plugin lint` — clean
- [x] `pnpm -F @real-router/memory-plugin test` — 43 passed (40 existing + 3 new)
- [x] `pnpm vitest run --config vitest.config.properties.mts` — 21 passed
- [x] `pnpm vitest run --config vitest.config.stress.mts` — 25 passed
- [x] `pnpm build` — 251/251 tasks successful across the monorepo
- [ ] CI green