### PR TITLE
fix(navigation-plugin): cross-document reload loop (#518)

### DIFF
--- a/.changeset/navigation-plugin-518-cross-document-loop-fix.md
+++ b/.changeset/navigation-plugin-518-cross-document-loop-fix.md
@@ -1,0 +1,28 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix cross-document reload loop under router-syncing navigation events (#518)
+
+When the plugin's `onTransitionSuccess` hook called `browser.navigate()` to sync
+the URL after a successful transition, the dispatched `navigate` event was
+short-circuited by the handler via a bare `return` while `isSyncingFromRouter`
+was `true`. Per the Navigation API spec, a same-origin `canIntercept` event
+with **no** `event.intercept()` call falls back to a cross-document navigation
+(full page reload). In headless Chromium (Playwright + `vite preview`) this
+triggered an infinite loop: every reload re-ran the app bootstrap, which
+re-entered the same `browser.navigate → navigate event → bare return → reload`
+cycle hundreds of times per second. `page.goto()` could never reach the `load`
+event, breaking Playwright e2e for every example that relied on the plugin
+(e.g. `examples/tauri/react-navigation`).
+
+The handler now calls `event.intercept({ handler: async () => {} })` on the
+syncing branch — cancelling the cross-document fallback without running any
+router logic (state is already committed). Non-syncing events keep their
+previous behaviour.
+
+The bug was invisible to the existing test suite because `MockNavigation` did
+not model the cross-document fallback — an un-intercepted event was silently
+committed rather than producing the observable reload. `MockNavigation` now
+has an opt-in `enableStrictIntercept()` mode that mirrors Chromium's behaviour,
+and the fix is covered by four new regression tests under `#518`.

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -54,7 +54,21 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
   const { allowNotFound } = api.getOptions();
 
   return function handleNavigateEvent(event: NavigateEvent): void {
-    if (!event.canIntercept || isSyncingFromRouter() || !router.isActive()) {
+    if (!event.canIntercept || !router.isActive()) {
+      return;
+    }
+
+    if (isSyncingFromRouter()) {
+      // Plugin-originated navigate event after its own successful transition
+      // (onTransitionSuccess calls browser.navigate to sync URL). We must still
+      // intercept — a bare `return` leaves the event un-intercepted, and
+      // Chromium falls back to a cross-document navigation (full page reload).
+      // The noop handler cancels the fallback without running router logic;
+      // state is already committed.
+      event.intercept({
+        handler: async () => {},
+      });
+
       return;
     }
 

--- a/packages/navigation-plugin/tests/functional/navigate.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigate.test.ts
@@ -206,6 +206,47 @@ describe("Navigation Plugin — Navigate", () => {
     });
   });
 
+  describe("Cross-document fallback prevention — #518", () => {
+    // Verifies that plugin-initiated navigations (from onTransitionSuccess) never
+    // leave a navigate event un-intercepted. An un-intercepted canIntercept
+    // event triggers Chromium's cross-document fallback (full page reload) —
+    // the root cause of the #518 infinite loop under vite preview + Playwright.
+    beforeEach(async () => {
+      mockNav.enableStrictIntercept();
+      unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
+      await router.start();
+    });
+
+    it("router.start() does not trigger cross-document reload", () => {
+      expect(mockNav.crossDocumentReloadCount).toBe(0);
+    });
+
+    it("router.navigate() does not trigger cross-document reload", async () => {
+      await router.navigate("users.list");
+
+      expect(mockNav.crossDocumentReloadCount).toBe(0);
+      expect(router.getState()?.name).toBe("users.list");
+    });
+
+    it("multiple consecutive router.navigate() calls stay loop-free", async () => {
+      await router.navigate("users.list");
+      await router.navigate("home");
+      await router.navigate("users.view", { id: "42" });
+
+      expect(mockNav.crossDocumentReloadCount).toBe(0);
+      expect(router.getState()?.name).toBe("users.view");
+    });
+
+    it("browser-initiated navigate event does not trigger cross-document reload", async () => {
+      const { finished } = mockNav.navigate("http://localhost/users/list");
+
+      await finished;
+
+      expect(mockNav.crossDocumentReloadCount).toBe(0);
+      expect(router.getState()?.name).toBe("users.list");
+    });
+  });
+
   describe("Navigate Event Properties", () => {
     beforeEach(async () => {
       unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
@@ -343,7 +384,13 @@ describe("createNavigateHandler — direct", () => {
     expect(setCapturedMeta).not.toHaveBeenCalled();
   });
 
-  it("skips event when isSyncingFromRouter() returns true", () => {
+  it("intercepts with noop handler when isSyncingFromRouter() returns true — #518", () => {
+    // Regression test for #518: when the plugin itself triggers a navigate
+    // event (via browser.navigate in onTransitionSuccess), the handler MUST
+    // still call event.intercept(). Per Navigation API spec, a bare `return`
+    // leaves a same-origin canIntercept event un-intercepted, and Chromium
+    // falls back to a cross-document (full-reload) navigation — which
+    // re-runs the bootstrap and triggers an infinite loop.
     const setCapturedMeta = vi.fn();
     const handler = createNavigateHandler(
       makeHandlerDeps({
@@ -351,11 +398,23 @@ describe("createNavigateHandler — direct", () => {
         setCapturedMeta,
       }),
     );
-    const event = makeEvent();
+    const interceptSpy = vi.fn();
+    const event = makeEvent({
+      intercept: interceptSpy,
+    } as unknown as Partial<NavigateEvent>);
 
     handler(event);
 
-    expect(event.intercept).not.toHaveBeenCalled();
+    // Must intercept to cancel the cross-document fallback.
+    expect(interceptSpy).toHaveBeenCalledTimes(1);
+
+    // But the handler must be a noop — router state is already committed.
+    const interceptCall = interceptSpy.mock.calls[0][0] as {
+      handler: () => Promise<unknown>;
+    };
+
+    expect(typeof interceptCall.handler).toBe("function");
+    // Must NOT capture meta — the plugin-initiated navigation already has it.
     expect(setCapturedMeta).not.toHaveBeenCalled();
   });
 });

--- a/packages/navigation-plugin/tests/helpers/mockNavigation.ts
+++ b/packages/navigation-plugin/tests/helpers/mockNavigation.ts
@@ -483,6 +483,23 @@ export class MockNavigation implements Navigation {
       return { committed: committedPromise, finished: finishedPromise };
     }
 
+    if (params.canIntercept && this._strictIntercept) {
+      // Emulate Chromium behaviour: a `navigate` event on a same-origin,
+      // canIntercept URL that NO listener intercepts falls back to a
+      // cross-document navigation (full page reload). In a real browser that
+      // tears down the document and re-runs the bootstrap script, which is
+      // exactly the infinite-loop symptom of #518. Tests that need to catch
+      // that regression should opt in via `strictIntercept: true` — see
+      // `enableStrictIntercept()`.
+      this._crossDocumentReloads += 1;
+      this._ongoingAbortController = null;
+
+      throw new DOMException(
+        "Navigate event was not intercepted — Chromium would perform a cross-document reload",
+        "InvalidStateError",
+      );
+    }
+
     const entry = applyNavigation();
 
     this._ongoingAbortController = null;
@@ -491,5 +508,23 @@ export class MockNavigation implements Navigation {
       committed: Promise.resolve(entry),
       finished: Promise.resolve(entry),
     };
+  }
+
+  private _strictIntercept = false;
+  private _crossDocumentReloads = 0;
+
+  /**
+   * Opt in to strict cross-document fallback emulation. When enabled, any
+   * `navigate` event with `canIntercept: true` that is NOT intercepted by
+   * any listener causes the mock to throw `InvalidStateError` from the
+   * `navigate()` call site, mirroring Chromium's cross-document reload
+   * behaviour (the primary symptom of #518).
+   */
+  enableStrictIntercept(): void {
+    this._strictIntercept = true;
+  }
+
+  get crossDocumentReloadCount(): number {
+    return this._crossDocumentReloads;
   }
 }


### PR DESCRIPTION
## Summary

- `navigate-handler.ts` now calls `event.intercept({ handler: async () => {} })` on the `isSyncingFromRouter` branch instead of a bare `return` — cancelling Chromium's cross-document fallback that previously caused an infinite reload loop under `vite preview` + Playwright. Root-cause analysis is in [#518](https://github.com/greydragon888/real-router/issues/518).
- `MockNavigation` gains opt-in `enableStrictIntercept()` that emulates Chromium's cross-document fallback. Four new regression tests under "Cross-document fallback prevention — #518" use it to pin the fix; the pre-existing `skips event when isSyncingFromRouter() returns true` test, which was encoding the buggy behaviour as correct, is rewritten to assert the corrected contract.
- Changeset: `@real-router/navigation-plugin` — patch.

## Test plan

- [ ] `pnpm -F @real-router/navigation-plugin test -- --run` — 187/187 tests pass (8 files).
- [ ] Revert `src/navigate-handler.ts` locally and re-run the test suite — 5 tests fail (1 handler-direct + 4 strict-intercept regression), confirming the new tests catch the bug.
- [ ] `pnpm -F @real-router/navigation-plugin lint` — 0 warnings, 0 errors.
- [ ] `pnpm -F @real-router/navigation-plugin type-check` — clean.
- [ ] `pnpm -F @real-router/navigation-plugin bundle` — produces ESM + CJS bundles.
- [ ] End-to-end: `cd examples/tauri/react-navigation && pnpm exec vite build && pnpm exec playwright test` — 7/8 pass (was 0/8). The remaining failure is tracked separately in [#519](https://github.com/greydragon888/real-router/issues/519) (unrelated rendering regression exposed once `page.goto()` stopped timing out).

Closes #518.