### PR TITLE
fix(navigation-plugin): canDeactivate guard contract (#524)

### DIFF
--- a/.changeset/browser-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/browser-plugin-buildurl-index-trailing-slash-fix.md
@@ -2,7 +2,7 @@
 "@real-router/browser-plugin": patch
 ---
 
-Fix `buildUrl("/", base)` producing trailing-slash index URLs
+Fix `buildUrl("/", base)` producing trailing-slash index URLs (#526)
 
 `buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
 

--- a/.changeset/browser-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/browser-plugin-buildurl-index-trailing-slash-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix `buildUrl("/", base)` producing trailing-slash index URLs
+
+`buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
+
+Fix is in the shared `browser-env` source (`shared/browser-env/url-utils.ts`) consumed by `browser-plugin`, `hash-plugin`, and `navigation-plugin` via symlink. Each consumer gets its own patch changeset.

--- a/.changeset/buildurl-index-trailing-slash-fix.md
+++ b/.changeset/buildurl-index-trailing-slash-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/browser-plugin": patch
+"@real-router/hash-plugin": patch
+"@real-router/navigation-plugin": patch
+---
+
+Fix `buildUrl("/", base)` producing trailing-slash index URLs
+
+`buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.

--- a/.changeset/extractpath-segment-boundary-browser-fix.md
+++ b/.changeset/extractpath-segment-boundary-browser-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix `extractPath` matching non-segment-boundary base prefix (#446)
+
+`extractPath("/application/users", "/app")` incorrectly stripped the base, returning `/lication/users`. Now enforces `/`-delimited segment boundaries: only exact match (`pathname === base`) or segment-boundary match (`pathname.startsWith(base + "/")`) triggers stripping.

--- a/.changeset/extractpath-segment-boundary-navigation-fix.md
+++ b/.changeset/extractpath-segment-boundary-navigation-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix `extractPath` matching non-segment-boundary base prefix (#446)
+
+`extractPath("/application/users", "/app")` incorrectly stripped the base, returning `/lication/users`. Now enforces `/`-delimited segment boundaries: only exact match (`pathname === base`) or segment-boundary match (`pathname.startsWith(base + "/")`) triggers stripping.

--- a/.changeset/hash-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/hash-plugin-buildurl-index-trailing-slash-fix.md
@@ -2,7 +2,7 @@
 "@real-router/hash-plugin": patch
 ---
 
-Fix `buildUrl("/", base)` producing trailing-slash index URLs
+Fix `buildUrl("/", base)` producing trailing-slash index URLs (#526)
 
 `buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
 

--- a/.changeset/hash-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/hash-plugin-buildurl-index-trailing-slash-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Fix `buildUrl("/", base)` producing trailing-slash index URLs
+
+`buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
+
+Fix is in the shared `browser-env` source (`shared/browser-env/url-utils.ts`) consumed by `browser-plugin`, `hash-plugin`, and `navigation-plugin` via symlink. Each consumer gets its own patch changeset.

--- a/.changeset/navigation-plugin-524-guard-contract.md
+++ b/.changeset/navigation-plugin-524-guard-contract.md
@@ -1,0 +1,40 @@
+---
+"@real-router/navigation-plugin": minor
+---
+
+Fix canDeactivate guard contract on browser back/forward (#524)
+
+Two related defects made `canDeactivate` guards effectively unusable under `@real-router/navigation-plugin` for the documented "confirm-on-back" dirty-form pattern:
+
+**A. `forceDeactivate` default flipped from `true` → `false`.**
+Previously every browser back/forward silently bypassed `canDeactivate` guards. The same user code that works under `@real-router/browser-plugin` stopped working under `navigation-plugin` with no visible signal. New default respects guards; apps that need the old bypass behaviour opt in explicitly via `navigationPluginFactory({ forceDeactivate: true })`. Pre-1.0, so this ships as a minor bump; migration is a one-line opt-in.
+
+**B. `withRecovery` now explicitly syncs URL back on `RouterError`.**
+`navigate-handler.ts` used to silently swallow `RouterError` thrown from `router.navigate()` (`CANNOT_DEACTIVATE`, `CANNOT_ACTIVATE`, `SAME_STATES`, etc.). The intercept handler then returned a resolved promise, and the Navigation API committed the URL change even though the router had rejected the transition — leaving URL and router state desynchronized.
+
+Now, when `router.navigate()` rejects with `RouterError`, the plugin calls `syncUrlToRouterState` — `browser.navigate({ history: "replace" })` to the current router state — so URL and state stay consistent. `finished` resolves (URL is valid, just back at the previous state); observers that need the rejection get it through the router's existing `TRANSITION_ERROR` / `TRANSITION_CANCEL` events. Manual sync is used instead of relying on Navigation API's built-in rollback on intercept rejection, which leaves a visible "committed-then-reverted" URL window in Chromium headless and some cross-origin setups.
+
+Non-`RouterError` exceptions still go through the pre-existing `recoverFromNavigateError` path (now refactored to call the same `syncUrlToRouterState` helper + log a critical-error line).
+
+Four new regression tests under "canDeactivate guard contract — #524" in `tests/functional/navigate.test.ts` pin the combined contract:
+
+- `forceDeactivate default is false (respect guards)`
+- `browser-initiated navigate triggers canDeactivate guard by default`
+- `guard rejection syncs URL back and leaves router state unchanged`
+- `explicit forceDeactivate: true still bypasses guards (opt-in escape hatch)`
+
+Two existing tests that assumed the old behaviour are updated:
+
+- `does NOT recover on RouterError (expected behavior)` — clarifies that the crash-recovery logging path stays quiet for `RouterError`; `finished` resolves normally after manual sync.
+- `direction is "unknown" when traversing to the current entry (equal indices)` — asserts the captured meta persists across the `SAME_STATES` rejection path.
+- `recovery itself fails gracefully (double error)` — updated log-message assertion to the new `Failed to sync URL to router state` marker (the helper was renamed during refactor to decouple logging from URL-sync semantics).
+
+### Migration
+
+If your app relied on browser back/forward skipping `canDeactivate` guards, pass `forceDeactivate: true` explicitly:
+
+```ts
+router.usePlugin(navigationPluginFactory({ forceDeactivate: true }));
+```
+
+Most apps will not need this — the new default aligns with `browser-plugin` and with the `canDeactivate` contract in `@real-router/core`.

--- a/.changeset/navigation-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/navigation-plugin-buildurl-index-trailing-slash-fix.md
@@ -2,7 +2,7 @@
 "@real-router/navigation-plugin": patch
 ---
 
-Fix `buildUrl("/", base)` producing trailing-slash index URLs
+Fix `buildUrl("/", base)` producing trailing-slash index URLs (#526)
 
 `buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
 

--- a/.changeset/navigation-plugin-buildurl-index-trailing-slash-fix.md
+++ b/.changeset/navigation-plugin-buildurl-index-trailing-slash-fix.md
@@ -1,9 +1,9 @@
 ---
-"@real-router/browser-plugin": patch
-"@real-router/hash-plugin": patch
 "@real-router/navigation-plugin": patch
 ---
 
 Fix `buildUrl("/", base)` producing trailing-slash index URLs
 
 `buildUrl("/", "/app")` previously returned `"/app/"` (with trailing slash) for the index route under a non-empty base. That disagreed with the canonical form `normalizeBase("/app/") === "/app"` and produced asymmetric URLs in `browser.history`. The function now collapses index-under-base to the bare base (`"/app"`), keeping URLs symmetric. Roundtrip is preserved: `extractPath("/app", "/app") === "/"`.
+
+Fix is in the shared `browser-env` source (`shared/browser-env/url-utils.ts`) consumed by `browser-plugin`, `hash-plugin`, and `navigation-plugin` via symlink. Each consumer gets its own patch changeset.

--- a/.changeset/traverseto-pendingkey-leak-fix.md
+++ b/.changeset/traverseto-pendingkey-leak-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Fix `#pendingTraverseKey` leak when `browser.traverseTo` throws
+
+If `browser.traverseTo` rejected inside `onTransitionSuccess` (e.g., the target entry was evicted by the Navigation API under memory pressure), `#pendingTraverseKey` was left set — the next transition would then replay the traverse against the same broken key. The key is now consumed **before** the call, so any throw at the traverse site cannot poison subsequent transitions. Symmetric with the existing `isSyncingFromRouter` reset in `finally`.

--- a/.changeset/traverseto-pendingkey-leak-fix.md
+++ b/.changeset/traverseto-pendingkey-leak-fix.md
@@ -2,6 +2,6 @@
 "@real-router/navigation-plugin": patch
 ---
 
-Fix `#pendingTraverseKey` leak when `browser.traverseTo` throws
+Fix `#pendingTraverseKey` leak when `browser.traverseTo` throws (#526)
 
 If `browser.traverseTo` rejected inside `onTransitionSuccess` (e.g., the target entry was evicted by the Navigation API under memory pressure), `#pendingTraverseKey` was left set — the next transition would then replay the traverse against the same broken key. The key is now consumed **before** the call, so any throw at the traverse site cannot poison subsequent transitions. Symmetric with the existing `isSyncingFromRouter` reset in `finally`.

--- a/knip.json
+++ b/knip.json
@@ -105,7 +105,6 @@
     },
     "packages/ssr-data-plugin": {
       "project": ["src/**/*.ts"],
-      "ignoreDependencies": ["@real-router/types"],
       "vitest": {
         "config": ["vitest.config.mts", "vitest.config.*.mts"]
       }
@@ -123,6 +122,6 @@
   "ignoreWorkspaces": ["examples/**", "benchmarks"],
   "ignore": ["benchmarks/**"],
   "ignoreDependencies": ["@stryker-mutator/api", "jsdom"],
-  "ignoreBinaries": ["tree", "tsx", "open", "ps", "awk", "perl"],
+  "ignoreBinaries": ["tree", "tsx", "open", "perl"],
   "ignoreExportsUsedInFile": true
 }

--- a/packages/browser-plugin/tests/property/browserPlugin.properties.ts
+++ b/packages/browser-plugin/tests/property/browserPlugin.properties.ts
@@ -90,7 +90,14 @@ describe("Browser Plugin URL Invariants", () => {
 
         const pathAfterBase = url.slice(base.length);
 
-        expect(pathAfterBase.startsWith("/")).toBe(true);
+        // Tail is either "/<segments>" (non-index routes) or "" —
+        // the empty case is `buildUrl("/", "/app") === "/app"` after the
+        // canonical-base fix that collapses index-under-base to the base
+        // without a trailing slash. Roundtrip holds:
+        // `extractPath("/app", "/app") === "/"`.
+        expect(pathAfterBase === "" || pathAfterBase.startsWith("/")).toBe(
+          true,
+        );
       },
     );
   });

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -34,7 +34,6 @@ navigation-plugin/
 │   ├── ssr-fallback.ts        — createNavigationFallbackBrowser (no-op fallback for SSR)
 │   ├── validation.ts          — Options validation (delegates to browser-env)
 │   ├── constants.ts           — Constants (defaultOptions, source, LOGGER_CONTEXT)
-│   ├── validation.ts          — Options validation (delegates to browser-env)
 │   └── browser-env/           — Symlink → shared/browser-env (extractPath, buildUrl, urlToPath, safeParseUrl, shouldReplaceHistory, etc.)
 ```
 
@@ -251,10 +250,8 @@ this.#claim = api.claimContextNamespace("navigation");
 
 this.#removeExtensions = api.extendRouter({
   buildUrl: pluginBuildUrl,
-  matchUrl: (url: string) => {
-    const path = urlToPath(url, options.base);
-    return path ? api.matchPath(path) : undefined;
-  },
+  matchUrl: (url: string) =>
+    api.matchPath(urlToPath(url, options.base)) ?? undefined,
   replaceHistoryState: createReplaceHistoryState(
     api,
     router,

--- a/packages/navigation-plugin/INVARIANTS.md
+++ b/packages/navigation-plugin/INVARIANTS.md
@@ -315,6 +315,40 @@ This document lists all invariants that must hold in `@real-router/navigation-pl
 
 ---
 
+### B14. getRouteVisitCount Monotonicity After Push
+**Category:** History Extensions  
+**Testable:** PBT-testable (model-based)  
+**Description:** After a **push** navigation to route `r` (i.e., `navigationType === "push"` — no `replace`, not a no-op same-state), `getRouteVisitCount(r)` must grow by exactly 1. Replace and reload must not change the count.
+
+**Precondition:**
+- Current state: `getRouteVisitCount(r) === N`
+- Model operation: `navigate(r, params)` producing a push entry
+
+**Postcondition:**
+- After the navigation: `getRouteVisitCount(r) === N + 1`
+- After a `replace` navigation to `r`: count unchanged (replace overwrites the current entry, which may already match `r`)
+- After a `reload` of `r` from state `r`: count unchanged (reload replaces the current entry)
+
+**Why it matters:** Users treat `getRouteVisitCount` as an analytics counter. A push that failed to increment, or a replace that incremented, would skew all downstream metrics (session-length stats, "did the user visit X N-or-more times" guards).
+
+---
+
+### B15. Visit Count Sum Consistency
+**Category:** History Extensions  
+**Testable:** PBT-testable (model-based)  
+**Description:** The sum of `getRouteVisitCount(r)` over all routes returned by `getVisitedRoutes()` must equal the number of matchable history entries — entries whose URL resolves to a route.
+
+**Precondition:**
+- Any navigation history sequence (possibly including entries with unmatchable URLs)
+
+**Postcondition:**
+- Let `M = |{ entry ∈ entries() : entryToState(entry) !== undefined }|` (matchable entries).
+- Then: `∑ getRouteVisitCount(r) for r in getVisitedRoutes() === M`.
+
+**Why it matters:** This glues the three history-query functions into one arithmetic identity. A bug in `getVisitedRoutes` (e.g., dropping routes at depth > 1) or in `getRouteVisitCount` (e.g., off-by-one on the current entry) surfaces here, not in isolated property tests. Unmatchable entries are excluded — foreign entries from other SPAs should not count.
+
+---
+
 ## C. NavigationMeta Invariants
 
 ### C1. Meta Attachment on Success
@@ -438,6 +472,23 @@ This document lists all invariants that must hold in `@real-router/navigation-pl
 - Info is available in subscribe callbacks via `state.context.navigation`
 
 **Why it matters:** Enables passing context through navigate events.
+
+---
+
+### C8. deriveNavigationType on Initial Navigation with `reload`
+**Category:** NavigationMeta  
+**Testable:** PBT-testable  
+**Description:** On the very first navigation (`fromState === undefined`), `deriveNavigationType` returns `"replace"` even when `navOptions.reload === true`. Reason: the `"reload"` branch requires `toState.path === fromState?.path`, which is false for `undefined?.path === undefined` vs a concrete `toState.path`. After the reload check fails, `shouldReplaceHistory` classifies the initial navigation as a replace (G4 — replace nullish + fromState undefined).
+
+**Precondition:**
+- `fromState === undefined` (first navigation)
+- `navOptions.reload === true` (user requested reload semantics on start)
+
+**Postcondition:**
+- `deriveNavigationType({ reload: true }, toState, undefined) === "replace"`
+- NOT `"reload"` — there is no previous state to reload
+
+**Why it matters:** Documents a subtle asymmetry: requesting reload on the initial navigation silently downgrades to replace. Tooling that pattern-matches `navigationType === "reload"` for cache-busting logic must tolerate the start-time absence. Pinning this in PBT prevents a regression where someone "fixes" the initial-reload case by returning `"reload"` with an undefined `fromState`, which would then confuse plugins that treat reload as "same URL re-entered".
 
 ---
 
@@ -976,6 +1027,9 @@ agnostic parsing; validation is the matcher's job, not the parser's. See
 | B10. canGoBackTo | History | PBT | High |
 | B11. traverseToLast State | History | Example | High |
 | B12. traverseToLast Error | History | Example | High |
+| B13. canGoBackTo Implies hasVisited | History | PBT | Medium |
+| B14. getRouteVisitCount Monotonicity After Push | History | PBT | High |
+| B15. Visit Count Sum Consistency | History | PBT | High |
 | C1. Meta Attachment | NavigationMeta | Example | Critical |
 | C2. deriveNavigationType | NavigationMeta | PBT | High |
 | C3. pendingMeta Lifecycle | NavigationMeta | Example | Critical |
@@ -983,6 +1037,7 @@ agnostic parsing; validation is the matcher's job, not the parser's. See
 | C5. pendingMeta Error | NavigationMeta | Example | High |
 | C6. userInitiated Accuracy | NavigationMeta | Example | High |
 | C7. info Preservation | NavigationMeta | Example | Medium |
+| C8. deriveNavigationType on Initial with reload | NavigationMeta | PBT | Medium |
 | D1. isSyncingFromRouter Loop Prevention | Syncing | Example | Critical |
 | D2. isSyncingFromRouter Scope (onTransitionSuccess) | Syncing | Example | Critical |
 | D3. isSyncingFromRouter Scope (replaceHistoryState) | Syncing | Example | Critical |

--- a/packages/navigation-plugin/README.md
+++ b/packages/navigation-plugin/README.md
@@ -48,7 +48,7 @@ router.traverseToLast("users.list"); // jump back to the last users list
 router.usePlugin(
   navigationPluginFactory({
     base: "/app", // Base path prefix for all routes
-    forceDeactivate: true, // Bypass canDeactivate guards on back/forward
+    forceDeactivate: false, // Respect canDeactivate guards on back/forward (default)
   }),
 );
 ```
@@ -56,7 +56,7 @@ router.usePlugin(
 | Option            | Type      | Default | Description                                                            |
 | ----------------- | --------- | ------- | ---------------------------------------------------------------------- |
 | `base`            | `string`  | `""`    | Base path for all routes (e.g., `"/app"` → URLs start with `/app/...`) |
-| `forceDeactivate` | `boolean` | `true`  | Bypass `canDeactivate` guards on browser back/forward                  |
+| `forceDeactivate` | `boolean` | `false` | If `true`, browser back/forward skip `canDeactivate` guards. Default `false` respects guards — matches browser-plugin. |
 
 ## Router Extensions
 
@@ -234,10 +234,10 @@ router.usePlugin(plugin);
 
 ## Form Protection
 
-Set `forceDeactivate: false` to respect `canDeactivate` guards on back/forward:
+`canDeactivate` guards run on browser back/forward by default — no extra configuration needed:
 
 ```typescript
-router.usePlugin(navigationPluginFactory({ forceDeactivate: false }));
+router.usePlugin(navigationPluginFactory());
 
 import { getLifecycleApi } from "@real-router/core/api";
 

--- a/packages/navigation-plugin/src/constants.ts
+++ b/packages/navigation-plugin/src/constants.ts
@@ -1,7 +1,11 @@
 import type { NavigationPluginOptions } from "./types";
 
 export const defaultOptions: Required<NavigationPluginOptions> = {
-  forceDeactivate: true,
+  // Default `false` respects `canDeactivate` guards on browser back/forward,
+  // matching the documented contract of `browser-plugin` and the core router.
+  // Apps that want the browser's native history buttons to bypass guards
+  // (e.g. to avoid dead-end UX) can opt in via `forceDeactivate: true`.
+  forceDeactivate: false,
   base: "",
 };
 

--- a/packages/navigation-plugin/src/history-extensions.ts
+++ b/packages/navigation-plugin/src/history-extensions.ts
@@ -5,6 +5,41 @@ import type { State } from "@real-router/core";
 import type { PluginApi } from "@real-router/core/api";
 
 /**
+ * Validates a candidate history entry for `traverseToLast(routeName)` and
+ * returns both the entry (now known non-null) and the matched router state.
+ * Extracted from `NavigationPlugin` so the three error branches (missing
+ * entry, null url, unmatched url) can be tested directly without vi.spyOn
+ * on module namespaces — the star-import spy pattern is fragile under ESM
+ * and was working by accident in history-extensions.test.ts.
+ *
+ * Throws a descriptive Error on any failure; the caller (NavigationPlugin)
+ * propagates it as the rejection of `traverseToLast`.
+ */
+export function resolveEntryToMatchedState(
+  entry: NavigationHistoryEntry | undefined,
+  routeName: string,
+  api: PluginApi,
+  base: string,
+): { entry: NavigationHistoryEntry; matchedState: State } {
+  if (!entry) {
+    throw new Error(`No history entry for route "${routeName}"`);
+  }
+
+  if (!entry.url) {
+    throw new Error(`No matching route for entry URL "${entry.url}"`);
+  }
+
+  const path = extractPathFromAbsoluteUrl(entry.url, base);
+  const matchedState = api.matchPath(path);
+
+  if (!matchedState) {
+    throw new Error(`No matching route for entry URL "${entry.url}"`);
+  }
+
+  return { entry, matchedState };
+}
+
+/**
  * Converts a NavigationHistoryEntry to a State via URL matching.
  * Uses URL matching (not entry.getState()) because:
  * - Entries before plugin init have no state

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -100,17 +100,32 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
           return;
         }
 
-        // RouterError (CANNOT_DEACTIVATE, CANNOT_ACTIVATE, SAME_STATES…) —
-        // router rejected the transition, state is unchanged. Sync the URL
-        // back to the current router state. We do not re-throw: the built-
-        // in Navigation API rollback on intercept rejection is unreliable
-        // in headless Chromium and on some platforms — it leaves an
-        // intermediate "committed-then-reverted" URL window that UI tests
-        // race against. Manual sync via `browser.navigate({history:"replace"})`
-        // from the syncing code path keeps URL and router state consistent
-        // with a single visible state transition. Router state remains on
-        // the old route, URL stays on the old URL; observers that care
-        // about the rejection see it via router's TRANSITION_ERROR.
+        // TRANSITION_CANCELLED: a newer navigation aborted this one — the
+        // newer navigate event is (or will be) handled by this same plugin,
+        // and THAT event is responsible for syncing URL/state. Firing our
+        // own sync here races against it: browser.navigate(replace, same-url)
+        // would cancel the in-flight newer transition, which is exactly the
+        // rapid-fire-events storm failure mode.
+        //
+        // SAME_STATES: router refused because router.getState() already equals
+        // the target. URL and router state are already consistent — no sync
+        // needed.
+        if (
+          error.code === errorCodes.TRANSITION_CANCELLED ||
+          error.code === errorCodes.SAME_STATES
+        ) {
+          return;
+        }
+
+        // Other RouterError codes (CANNOT_DEACTIVATE, CANNOT_ACTIVATE,
+        // ROUTE_NOT_FOUND, …) — router rejected the transition, state is
+        // unchanged, but URL may have already committed to a different
+        // value by the Navigation API. Sync the URL back to the current
+        // router state in a single visible transition (headless Chromium
+        // and some cross-origin setups leave "committed-then-reverted"
+        // windows if we relied on the native rollback via intercept reject).
+        // Observers that care about the error see it through the router's
+        // TRANSITION_ERROR event.
         syncUrlToRouterState(router, browser, setSyncing);
       }
     };

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -1,6 +1,6 @@
 import { errorCodes, RouterError } from "@real-router/core";
 
-import { extractPath, safeParseUrl } from "./browser-env";
+import { urlToPath } from "./browser-env";
 
 import type {
   NavigationBrowser,
@@ -72,9 +72,7 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
       return;
     }
 
-    const destinationUrl = safeParseUrl(event.destination.url);
-    const path =
-      extractPath(destinationUrl.pathname, base) + destinationUrl.search;
+    const path = urlToPath(event.destination.url, base);
     const matchedState = api.matchPath(path);
 
     const navType = event.navigationType as NavigationMeta["navigationType"];

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -98,7 +98,22 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
       } catch (error) {
         if (!(error instanceof RouterError)) {
           recoverFromNavigateError(error, router, browser, setSyncing);
+
+          return;
         }
+
+        // RouterError (CANNOT_DEACTIVATE, CANNOT_ACTIVATE, SAME_STATES…) —
+        // router rejected the transition, state is unchanged. Sync the URL
+        // back to the current router state. We do not re-throw: the built-
+        // in Navigation API rollback on intercept rejection is unreliable
+        // in headless Chromium and on some platforms — it leaves an
+        // intermediate "committed-then-reverted" URL window that UI tests
+        // race against. Manual sync via `browser.navigate({history:"replace"})`
+        // from the syncing code path keeps URL and router state consistent
+        // with a single visible state transition. Router state remains on
+        // the old route, URL stays on the old URL; observers that care
+        // about the rejection see it via router's TRANSITION_ERROR.
+        syncUrlToRouterState(router, browser, setSyncing);
       }
     };
 
@@ -147,6 +162,14 @@ function recoverFromNavigateError(
     error,
   );
 
+  syncUrlToRouterState(router, browser, setSyncing);
+}
+
+function syncUrlToRouterState(
+  router: Router,
+  browser: NavigationBrowser,
+  setSyncing: (value: boolean) => void,
+): void {
   try {
     const currentState = router.getState();
 
@@ -168,10 +191,10 @@ function recoverFromNavigateError(
         setSyncing(false);
       }
     }
-  } catch (recoveryError) {
+  } catch (syncError) {
     console.error(
-      "[navigation-plugin] Failed to recover from critical error",
-      recoveryError,
+      "[navigation-plugin] Failed to sync URL to router state",
+      syncError,
     );
   }
 }

--- a/packages/navigation-plugin/src/plugin.ts
+++ b/packages/navigation-plugin/src/plugin.ts
@@ -1,11 +1,6 @@
 import { UNKNOWN_ROUTE } from "@real-router/core";
 
-import {
-  shouldReplaceHistory,
-  buildUrl,
-  extractPathFromAbsoluteUrl,
-  urlToPath,
-} from "./browser-env";
+import { shouldReplaceHistory, buildUrl, urlToPath } from "./browser-env";
 import {
   peekBack,
   peekForward,
@@ -13,6 +8,7 @@ import {
   getVisitedRoutes,
   getRouteVisitCount,
   findLastEntryForRoute,
+  resolveEntryToMatchedState,
   canGoBack,
   canGoForward,
   canGoBackTo,
@@ -155,7 +151,7 @@ export class NavigationPlugin {
   async traverseToLast(routeName: string): Promise<State> {
     const entries = this.#browser.entries();
     const currentKey = this.#browser.currentEntry?.key;
-    const entry = findLastEntryForRoute(
+    const candidate = findLastEntryForRoute(
       entries,
       routeName,
       this.#api,
@@ -163,28 +159,34 @@ export class NavigationPlugin {
       currentKey,
     );
 
-    if (!entry) {
-      throw new Error(`No history entry for route "${routeName}"`);
+    // resolveEntryToMatchedState throws for missing entry, null url, or
+    // unmatched url — same three error branches the old inline checks
+    // produced. Extracted so the error paths can be unit-tested directly
+    // without namespace-level vi.spyOn gymnastics.
+    const { entry, matchedState } = resolveEntryToMatchedState(
+      candidate,
+      routeName,
+      this.#api,
+      this.#options.base,
+    );
+
+    const currentEntry = this.#browser.currentEntry;
+
+    if (!currentEntry) {
+      // Invariant violation: traverseToLast is only callable after
+      // router.start(), which guarantees a current entry. A null here means
+      // the plugin was stopped mid-call or the browser abstraction is
+      // broken — either way, silently picking direction "forward" from a
+      // fallback `-1` would mask the bug. Fail loudly instead.
+      throw new Error(
+        `[navigation-plugin] Cannot determine direction for traverseToLast("${routeName}"): browser.currentEntry is null. The plugin must be started before calling traverseToLast.`,
+      );
     }
-
-    if (!entry.url) {
-      throw new Error(`No matching route for entry URL "${entry.url}"`);
-    }
-
-    const path = extractPathFromAbsoluteUrl(entry.url, this.#options.base);
-    const matchedState = this.#api.matchPath(path);
-
-    if (!matchedState) {
-      throw new Error(`No matching route for entry URL "${entry.url}"`);
-    }
-
-    /* v8 ignore next -- @preserve: currentEntry always exists when traverseToLast is callable (after start) */
-    const currentIndex = this.#browser.currentEntry?.index ?? -1;
 
     this.#capturedMeta = {
       navigationType: "traverse",
       userInitiated: false,
-      direction: entry.index > currentIndex ? "forward" : "back",
+      direction: entry.index > currentEntry.index ? "forward" : "back",
       sourceElement: null,
     };
     this.#pendingTraverseKey = entry.key;
@@ -222,17 +224,25 @@ export class NavigationPlugin {
           };
         }
 
-        const { navigationType } = this.#capturedMeta;
+        const frozenMeta = Object.freeze(this.#capturedMeta);
 
-        this.#claim.write(toState, Object.freeze(this.#capturedMeta));
+        this.#claim.write(toState, frozenMeta);
         this.#capturedMeta = undefined;
 
         this.#isSyncingFromRouter = true;
 
+        // Consume pendingTraverseKey BEFORE calling browser.traverseTo.
+        // If traverseTo throws (Navigation API can reject on evicted keys
+        // under memory pressure), we must not leave the stale key behind —
+        // otherwise the NEXT transition's onTransitionSuccess would see it
+        // and replay the traverse against the same already-broken key.
+        const traverseKey = this.#pendingTraverseKey;
+
+        this.#pendingTraverseKey = undefined;
+
         try {
-          if (this.#pendingTraverseKey) {
-            this.#browser.traverseTo(this.#pendingTraverseKey);
-            this.#pendingTraverseKey = undefined;
+          if (traverseKey) {
+            this.#browser.traverseTo(traverseKey);
           } else {
             const url = buildUrl(toState.path, this.#options.base);
             const shouldPreserveHash =
@@ -248,7 +258,7 @@ export class NavigationPlugin {
             if (toState.name === UNKNOWN_ROUTE) {
               this.#browser.updateCurrentEntry({ state: historyState });
             } else {
-              const replace = navigationType !== "push";
+              const replace = frozenMeta.navigationType !== "push";
 
               this.#browser.navigate(finalUrl, {
                 state: historyState,

--- a/packages/navigation-plugin/tests/functional/history-extensions.test.ts
+++ b/packages/navigation-plugin/tests/functional/history-extensions.test.ts
@@ -1,8 +1,9 @@
 import { createRouter } from "@real-router/core";
+import { getPluginApi } from "@real-router/core/api";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
 import { navigationPluginFactory } from "../../src";
-import * as historyExtensions from "../../src/history-extensions";
+import { resolveEntryToMatchedState } from "../../src/history-extensions";
 import { MockNavigation } from "../helpers/mockNavigation";
 import {
   createMockNavigationBrowser,
@@ -319,11 +320,54 @@ describe("Navigation Plugin — History Extensions", () => {
       await router.navigate("users.list");
       await router.navigate("home");
 
+      const usersListEntry = browser
+        .entries()
+        .find((entry) => entry.url?.endsWith("/users/list") ?? false);
+
+      expect(usersListEntry).toBeDefined();
+
       const traverseToSpy = vi.spyOn(browser, "traverseTo");
 
       await router.traverseToLast("users.list");
 
-      expect(traverseToSpy).toHaveBeenCalledWith(expect.any(String));
+      // Assert the EXACT key captured from #pendingTraverseKey — a regression
+      // that passes an arbitrary or stale key (e.g., current entry's key)
+      // would be caught here, not by `expect.any(String)`.
+      expect(traverseToSpy).toHaveBeenCalledWith(usersListEntry!.key);
+    });
+
+    it("throws invariant-error when browser.currentEntry becomes null mid-call", async () => {
+      // Invariant violation scenario: entries() returns valid history but
+      // currentEntry is null. The plugin previously silently defaulted
+      // currentIndex to -1 (picking direction "forward"); after the #524 /
+      // #435 cleanup it throws so the bug cannot hide.
+      await router.start();
+      await router.navigate("users.list");
+      await router.navigate("home");
+
+      const snapshotEntries = browser.entries();
+
+      router.stop();
+      unsubscribe?.();
+
+      // Craft a browser whose currentEntry is null but entries() still has
+      // the captured history. findLastEntryForRoute will find "users.list",
+      // resolveEntryToMatchedState will succeed (URLs still match route
+      // config), and then the direction calculation blows up.
+      const nullCurrentBrowser: NavigationBrowser = {
+        ...browser,
+        currentEntry: null,
+        entries: () => snapshotEntries,
+      };
+
+      router = createRouter(routerConfig, { defaultRoute: "home" });
+      unsubscribe = router.usePlugin(
+        navigationPluginFactory({}, nullCurrentBrowser),
+      );
+
+      await expect(router.traverseToLast("users.list")).rejects.toThrow(
+        /currentEntry is null/,
+      );
     });
 
     it("throws when entry URL no longer matches routes (stale route with strict queryParamsMode)", async () => {
@@ -348,78 +392,128 @@ describe("Navigation Plugin — History Extensions", () => {
         "No history entry",
       );
     });
+  });
+
+  describe("resolveEntryToMatchedState — direct unit tests (DI replacement for vi.spyOn)", () => {
+    // These tests replace a trio of fragile `vi.spyOn(namespace, ...)` tests
+    // that depended on Vitest transforming star-import bindings at module
+    // boundaries. Extracting the helper from NavigationPlugin eliminates the
+    // reliance on spy transformation and lets us pin the three error branches
+    // (missing entry, null url, unmatched url) with plain synchronous calls.
+
+    it("throws when entry is undefined", async () => {
+      await router.start();
+
+      const api = getPluginApi(router);
+
+      expect(() =>
+        resolveEntryToMatchedState(undefined, "users.list", api, ""),
+      ).toThrow('No history entry for route "users.list"');
+    });
 
     it("throws when entry has null url", async () => {
       await router.start();
       await router.navigate("users.list");
-      await router.navigate("home");
 
+      const api = getPluginApi(router);
       const entries = browser.entries();
-      const userListEntry = entries[1]; // index 1 = "users.list"
+      const userListEntry = entries[1];
       const entryWithNullUrl = Object.assign(
         Object.create(Object.getPrototypeOf(userListEntry)),
         userListEntry,
         { url: null },
-      );
+      ) as NavigationHistoryEntry;
 
-      vi.spyOn(historyExtensions, "findLastEntryForRoute").mockReturnValue(
-        entryWithNullUrl as NavigationHistoryEntry,
-      );
-
-      await expect(router.traverseToLast("users.list")).rejects.toThrow(
-        'No matching route for entry URL "null"',
-      );
+      expect(() =>
+        resolveEntryToMatchedState(entryWithNullUrl, "users.list", api, ""),
+      ).toThrow('No matching route for entry URL "null"');
     });
 
     it("throws when entry URL exists but does not match any route", async () => {
       await router.start();
       await router.navigate("users.list");
-      await router.navigate("home");
 
+      const api = getPluginApi(router);
       const entries = browser.entries();
       const userListEntry = entries[1];
       const entryWithUnknownUrl = Object.assign(
         Object.create(Object.getPrototypeOf(userListEntry)),
         userListEntry,
         { url: "http://localhost/no-such-route" },
-      );
+      ) as NavigationHistoryEntry;
 
-      vi.spyOn(historyExtensions, "findLastEntryForRoute").mockReturnValue(
-        entryWithUnknownUrl as NavigationHistoryEntry,
-      );
-
-      await expect(router.traverseToLast("users.list")).rejects.toThrow(
-        "No matching route",
+      expect(() =>
+        resolveEntryToMatchedState(entryWithUnknownUrl, "users.list", api, ""),
+      ).toThrow(
+        'No matching route for entry URL "http://localhost/no-such-route"',
       );
     });
 
-    it("throws when entry URL path does not match the requested route", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
+    it("throws when entry URL uses arbitrary scheme with unmatchable path", async () => {
       await router.start();
       await router.navigate("users.list");
-      await router.navigate("home");
 
+      const api = getPluginApi(router);
       const entries = browser.entries();
       const userListEntry = entries[1];
+      // Arbitrary scheme (Tauri/Electron custom protocols are now accepted by
+      // safeParseUrl); the path /evil doesn't match the users.list route.
       const entryWithUnknownPath = Object.assign(
         Object.create(Object.getPrototypeOf(userListEntry)),
         userListEntry,
-        // Arbitrary scheme (Tauri/Electron custom protocols are now accepted by
-        // safeParseUrl); the path /evil doesn't match the users.list route.
-
         { url: "ftp://example.com/evil" },
+      ) as NavigationHistoryEntry;
+
+      expect(() =>
+        resolveEntryToMatchedState(entryWithUnknownPath, "users.list", api, ""),
+      ).toThrow("No matching route");
+    });
+
+    it("returns {entry, matchedState} on success", async () => {
+      await router.start();
+      await router.navigate("users.list");
+
+      const api = getPluginApi(router);
+      const entries = browser.entries();
+      const userListEntry = entries[1];
+
+      const result = resolveEntryToMatchedState(
+        userListEntry,
+        "users.list",
+        api,
+        "",
       );
 
-      vi.spyOn(historyExtensions, "findLastEntryForRoute").mockReturnValue(
-        entryWithUnknownPath as NavigationHistoryEntry,
+      expect(result.entry).toBe(userListEntry);
+      expect(result.matchedState.name).toBe("users.list");
+    });
+
+    it("strips base path before matching", async () => {
+      router.stop();
+      unsubscribe?.();
+
+      mockNav = new MockNavigation("http://localhost/app/");
+      browser = createMockNavigationBrowser(mockNav);
+      router = createRouter(routerConfig, { defaultRoute: "home" });
+      unsubscribe = router.usePlugin(
+        navigationPluginFactory({ base: "/app" }, browser),
+      );
+      await router.start();
+      await router.navigate("users.list");
+
+      const api = getPluginApi(router);
+      const entries = browser.entries();
+      const userListEntry = entries.at(-1);
+
+      const result = resolveEntryToMatchedState(
+        userListEntry,
+        "users.list",
+        api,
+        "/app",
       );
 
-      await expect(router.traverseToLast("users.list")).rejects.toThrow(
-        "No matching route",
-      );
-
-      warnSpy.mockRestore();
+      expect(result.matchedState.name).toBe("users.list");
+      expect(result.matchedState.path).toBe("/users/list");
     });
   });
 

--- a/packages/navigation-plugin/tests/functional/navigate.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigate.test.ts
@@ -553,7 +553,7 @@ describe("Error Recovery", () => {
   // Obsolete after #483: strict-mode path no longer invokes navigateToDefault,
   // so there is no "navigateToDefault crash" code path to recover from.
 
-  it("does NOT recover on RouterError (expected behavior)", async () => {
+  it("does NOT recover on RouterError (expected behavior) and manually syncs URL via replace", async () => {
     unsub = router.usePlugin(
       navigationPluginFactory({ forceDeactivate: false }, browser),
     );
@@ -562,20 +562,35 @@ describe("Error Recovery", () => {
     getLifecycleApi(router).addDeactivateGuard("index", () => () => false);
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const browserNavigateSpy = vi.spyOn(browser, "navigate");
 
     const { finished } = mockNav.navigate("http://localhost/users/list");
 
     // #524: RouterError triggers manual URL sync (syncUrlToRouterState) but
-    // does not surface through `finished` — this test asserts only that the
-    // non-RouterError recovery path stays quiet.
+    // does not surface through `finished`.
     await finished;
 
+    // Negative: the critical-error logging path (for non-RouterError crashes)
+    // must stay quiet.
     expect(consoleSpy).not.toHaveBeenCalledWith(
       "[navigation-plugin] Critical error in navigate handler",
       expect.anything(),
     );
 
+    // Positive: manual URL sync must fire — `browser.navigate(url, { history: "replace" })`
+    // with the current (unchanged) router state. Pins the #524 contract so a
+    // regression that "handles RouterError silently" (i.e. no sync at all,
+    // restoring the old URL/state desync) fails here.
+    expect(browserNavigateSpy).toHaveBeenCalledWith(
+      "/",
+      expect.objectContaining({
+        state: expect.objectContaining({ name: "index", path: "/" }),
+        history: "replace",
+      }),
+    );
+
     consoleSpy.mockRestore();
+    browserNavigateSpy.mockRestore();
   });
 
   it("strict-mode throws ROUTE_NOT_FOUND silently (no critical recovery) — Navigation API auto-rolls back URL (#483)", async () => {

--- a/packages/navigation-plugin/tests/functional/navigate.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigate.test.ts
@@ -247,6 +247,81 @@ describe("Navigation Plugin — Navigate", () => {
     });
   });
 
+  describe("canDeactivate guard contract — #524", () => {
+    // Regression for #524: canDeactivate guards must run on browser
+    // back/forward by default (`forceDeactivate` flipped from true → false),
+    // and a blocked guard must reject the intercept() handler so the
+    // Navigation API rolls back the URL.
+
+    it("forceDeactivate default is false (respect guards)", async () => {
+      // Indirect contract check: with default options, a blocking guard must
+      // actually block. If forceDeactivate defaulted to true, the guard
+      // would be bypassed and router.getState() would move to users.list.
+      unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
+      await router.start();
+
+      getLifecycleApi(router).addDeactivateGuard("index", () => () => false);
+
+      const { finished } = mockNav.navigate("http://localhost/users/list");
+
+      await finished;
+
+      // Router state stays on "index" — guard blocked the transition.
+      expect(router.getState()?.name).toBe("index");
+    });
+
+    it("browser-initiated navigate triggers canDeactivate guard by default", async () => {
+      unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
+      await router.start();
+
+      const guardSpy = vi.fn(() => true);
+
+      getLifecycleApi(router).addDeactivateGuard("index", () => guardSpy);
+
+      const { finished } = mockNav.navigate("http://localhost/users/list");
+
+      await finished;
+
+      expect(guardSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("guard rejection syncs URL back and leaves router state unchanged", async () => {
+      unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
+      await router.start();
+
+      getLifecycleApi(router).addDeactivateGuard("index", () => () => false);
+
+      const urlBefore = mockNav.currentUrl;
+      const { finished } = mockNav.navigate("http://localhost/users/list");
+
+      await finished;
+
+      // Explicit sync via browser.navigate({history:"replace"}) in the
+      // syncing branch keeps URL and router state consistent. No desync.
+      expect(mockNav.currentUrl).toBe(urlBefore);
+      expect(router.getState()?.name).toBe("index");
+    });
+
+    it("explicit forceDeactivate: true still bypasses guards (opt-in escape hatch)", async () => {
+      unsubscribe = router.usePlugin(
+        navigationPluginFactory({ forceDeactivate: true }, browser),
+      );
+      await router.start();
+
+      const guardSpy = vi.fn(() => false);
+
+      getLifecycleApi(router).addDeactivateGuard("index", () => guardSpy);
+
+      const { finished } = mockNav.navigate("http://localhost/users/list");
+
+      await finished;
+
+      // Guard was bypassed — navigation completed.
+      expect(guardSpy).not.toHaveBeenCalled();
+      expect(router.getState()?.name).toBe("users.list");
+    });
+  });
+
   describe("Navigate Event Properties", () => {
     beforeEach(async () => {
       unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
@@ -490,6 +565,9 @@ describe("Error Recovery", () => {
 
     const { finished } = mockNav.navigate("http://localhost/users/list");
 
+    // #524: RouterError triggers manual URL sync (syncUrlToRouterState) but
+    // does not surface through `finished` — this test asserts only that the
+    // non-RouterError recovery path stays quiet.
     await finished;
 
     expect(consoleSpy).not.toHaveBeenCalledWith(
@@ -576,7 +654,7 @@ describe("Error Recovery", () => {
       expect.any(TypeError),
     );
     expect(consoleSpy).toHaveBeenCalledWith(
-      "[navigation-plugin] Failed to recover from critical error",
+      "[navigation-plugin] Failed to sync URL to router state",
       expect.any(Error),
     );
 

--- a/packages/navigation-plugin/tests/functional/navigation-meta.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigation-meta.test.ts
@@ -391,6 +391,10 @@ describe("Navigation Plugin — NavigationMeta", () => {
       const currentKey = mockNav.currentEntry!.key;
       const result = mockNav.traverseTo(currentKey);
 
+      // SAME_STATES is a RouterError. After #524, the plugin catches it,
+      // syncs URL back manually and resolves finished. The captured meta
+      // from the navigate event (before the router rejected) still has
+      // direction "unknown" for equal indices — that's what we assert.
       await result.finished;
 
       const state = router.getState()!;

--- a/packages/navigation-plugin/tests/functional/url.test.ts
+++ b/packages/navigation-plugin/tests/functional/url.test.ts
@@ -27,6 +27,17 @@ describe("extractPath", () => {
     expect(extractPath("/users/list", "")).toBe("/users/list");
   });
 
+  // Edge cases: empty pathname — the fallback branch `if (!pathname)`
+  // returns "/" so callers never see an empty string. Pin both base
+  // variants so a regression that returns "" or `base` stands out.
+  it("returns / for empty pathname with empty base", () => {
+    expect(extractPath("", "")).toBe("/");
+  });
+
+  it("returns / for empty pathname with non-empty base", () => {
+    expect(extractPath("", "/app")).toBe("/");
+  });
+
   it("does not strip partial segment match", () => {
     expect(extractPath("/application/users", "/app")).toBe(
       "/application/users",
@@ -64,6 +75,26 @@ describe("buildUrl", () => {
 
   it("returns path unchanged when base is empty", () => {
     expect(buildUrl("/users", "")).toBe("/users");
+  });
+
+  // Edge cases: empty path and index-with-base.
+  it("returns empty string for empty path with empty base", () => {
+    expect(buildUrl("", "")).toBe("");
+  });
+
+  it("returns base unchanged for empty path with non-empty base", () => {
+    expect(buildUrl("", "/app")).toBe("/app");
+  });
+
+  it("returns canonical base (no trailing slash) for path=/ with non-empty base", () => {
+    // Historically this produced "/app/" — the collapse to bare base keeps
+    // index URLs symmetric with `normalizeBase("/app/") === "/app"`. Roundtrip
+    // holds: extractPath("/app", "/app") === "/".
+    expect(buildUrl("/", "/app")).toBe("/app");
+  });
+
+  it("returns / for path=/ with empty base", () => {
+    expect(buildUrl("/", "")).toBe("/");
   });
 });
 

--- a/packages/navigation-plugin/tests/property/helpers.ts
+++ b/packages/navigation-plugin/tests/property/helpers.ts
@@ -151,6 +151,37 @@ export const arbUrlPath: fc.Arbitrary<string> = fc.oneof(
     .map((segments) => `/${segments.join("/")}`),
 );
 
+/**
+ * Deeper URL paths (up to 8 segments) for stress-testing extractPath /
+ * buildUrl / urlToPath on pathological depths. Complements `arbUrlPath`
+ * which caps at 3 segments and misses linear-time-per-segment regressions.
+ */
+export const arbDeepPath: fc.Arbitrary<string> = fc
+  .array(arbPathSegment, { minLength: 4, maxLength: 8 })
+  .map((segments) => `/${segments.join("/")}`);
+
+/**
+ * URL path segments that include special characters the matcher must
+ * tolerate without crashing: uppercase, dots, %-encoded bytes, tildes.
+ * Complements `arbPathSegment` (lowercase alphanumeric only) and
+ * `arbUnsafeIdParam` (param values, not segment names).
+ *
+ * The generated segments will typically NOT match the fixture's routes —
+ * the purpose is to verify the URL utilities (extractPath, buildUrl,
+ * urlToPath, safeParseUrl) never throw on shapes users can type into
+ * the address bar.
+ */
+export const arbSpecialCharSegment: fc.Arbitrary<string> = fc.oneof(
+  fc.stringMatching(/^[A-Z]{1,8}$/),
+  fc.stringMatching(/^[a-z]{1,4}\.[a-z]{1,4}$/),
+  fc.stringMatching(/^~[a-z]{1,6}$/),
+  fc.stringMatching(/^[a-z]{1,4}%[0-9A-F]{2}[a-z]{0,4}$/),
+);
+
+export const arbSpecialCharPath: fc.Arbitrary<string> = fc
+  .array(arbSpecialCharSegment, { minLength: 1, maxLength: 4 })
+  .map((segments) => `/${segments.join("/")}`);
+
 // --- non-matching paths (guaranteed to miss all fixture routes) ---
 
 const KNOWN_PREFIXES = new Set(["home", "users", "index"]);

--- a/packages/navigation-plugin/tests/property/history-model.properties.ts
+++ b/packages/navigation-plugin/tests/property/history-model.properties.ts
@@ -267,6 +267,14 @@ class AssertCanGoBackToCommand implements fc.AsyncCommand<
   }
 }
 
+const VALID_NAVIGATION_TYPES = [
+  "push",
+  "replace",
+  "traverse",
+  "reload",
+] as const;
+const VALID_DIRECTIONS = ["forward", "back", "unknown"] as const;
+
 class AssertMetaExistsCommand implements fc.AsyncCommand<
   HistoryModel,
   HistoryReal
@@ -282,12 +290,23 @@ class AssertMetaExistsCommand implements fc.AsyncCommand<
       const meta = state.context.navigation;
 
       expect(meta).toBeDefined();
-      expect(meta!.navigationType).toBeDefined();
 
-      // Meta must carry a boolean `userInitiated` — programmatic calls set
-      // it to `false`, browser events carry `event.userInitiated`. Either way
-      // the field must exist and be typed.
+      // navigationType must be one of the four enumerated values — a weaker
+      // `toBeDefined()` would pass for `"garbage"` or `undefined`-from-partial
+      // writes, which is exactly the regression we want to catch.
+      expect(VALID_NAVIGATION_TYPES).toContain(meta!.navigationType);
+
+      // direction must be one of the three enumerated values for the same
+      // reason — pins the field's domain rather than just its presence.
+      expect(VALID_DIRECTIONS).toContain(meta!.direction);
+
+      // userInitiated is a strict boolean — no undefined, no truthy-ish.
       expect(typeof meta!.userInitiated).toBe("boolean");
+
+      // sourceElement is either null or a DOM Element — never undefined.
+      expect(
+        meta!.sourceElement === null || meta!.sourceElement instanceof Element,
+      ).toBe(true);
     }
   }
 

--- a/packages/navigation-plugin/tests/property/pure-functions.properties.ts
+++ b/packages/navigation-plugin/tests/property/pure-functions.properties.ts
@@ -1,8 +1,12 @@
 import { fc, test } from "@fast-check/vitest";
-import { describe, expect } from "vitest";
+import { afterAll, beforeAll, describe, expect, vi } from "vitest";
 
 import { NUM_RUNS } from "./helpers";
-import { safeParseUrl, shouldReplaceHistory } from "../../src/browser-env";
+import {
+  safeParseUrl,
+  safelyEncodePath,
+  shouldReplaceHistory,
+} from "../../src/browser-env";
 import { computeDirection } from "../../src/navigate-handler";
 import { deriveNavigationType } from "../../src/plugin";
 
@@ -199,6 +203,20 @@ describe("deriveNavigationType Properties (partitioned)", () => {
       expect(deriveNavigationType({ replace: false }, to, from)).toBe("push");
     },
   );
+
+  // C8: reload:true on the initial navigation (fromState === undefined)
+  // cannot match the same-path precondition of the reload branch (there is
+  // no previous path to compare), so classification falls through to
+  // shouldReplaceHistory — which returns true on initial nav with nullish
+  // replace → "replace". Documented asymmetry.
+  test.prop([arbState], { numRuns: NUM_RUNS.fast })(
+    "C8: reload: true + fromState undefined → replace (not reload)",
+    (toState) => {
+      expect(deriveNavigationType({ reload: true }, toState, undefined)).toBe(
+        "replace",
+      );
+    },
+  );
 });
 
 describe("safeParseUrl Properties (totality)", () => {
@@ -247,6 +265,49 @@ describe("safeParseUrl Properties (totality)", () => {
       const { pathname } = safeParseUrl(url);
 
       expect(pathname.startsWith("/")).toBe(true);
+    },
+  );
+});
+
+describe("safelyEncodePath Properties (totality)", () => {
+  // safelyEncodePath must be total: never throws, always returns a string,
+  // for any input (including malformed percent-sequences, Unicode, control
+  // chars). The try/catch fallback is the safety net; this property pins
+  // that contract down so regressions surface as assertion failures.
+  //
+  // Suppress the legitimate warnings the fallback emits for malformed
+  // percent-sequences — totality testing intentionally exercises that path.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  test.prop([fc.string()], { numRuns: 2000 })(
+    "never throws on any string input",
+    (anyStr) => {
+      expect(() => safelyEncodePath(anyStr)).not.toThrow();
+    },
+  );
+
+  test.prop([fc.string()], { numRuns: 1000 })(
+    "always returns a string",
+    (anyStr) => {
+      expect(typeof safelyEncodePath(anyStr)).toBe("string");
+    },
+  );
+
+  test.prop([fc.string()], { numRuns: 1000 })(
+    "is idempotent for any string",
+    (anyStr) => {
+      const once = safelyEncodePath(anyStr);
+      const twice = safelyEncodePath(once);
+
+      expect(twice).toBe(once);
     },
   );
 });

--- a/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
+++ b/packages/navigation-plugin/tests/property/url-roundtrip.properties.ts
@@ -5,10 +5,12 @@ import {
   NUM_RUNS,
   PARAM_ROUTE_NAME,
   arbBaseSegment,
+  arbDeepPath,
   arbIdParam,
   arbLeafRoute,
   arbNormalizedBase,
   arbRawBase,
+  arbSpecialCharPath,
   arbUnsafeIdParam,
   arbQueryString,
   arbUrlPath,
@@ -20,6 +22,7 @@ import {
   extractPath,
   normalizeBase,
   safelyEncodePath,
+  urlToPath,
 } from "../../src/browser-env";
 
 describe("Navigation Plugin URL Invariants", () => {
@@ -90,7 +93,14 @@ describe("Navigation Plugin URL Invariants", () => {
 
         const pathAfterBase = url.slice(base.length);
 
-        expect(pathAfterBase.startsWith("/")).toBe(true);
+        // The tail is either "/<segments>" (non-index routes under base),
+        // "/<segments>" (any route with empty base), or "" — the last case
+        // is exclusively `buildUrl("/", "/app") === "/app"` after the
+        // canonical-base fix: index-under-base collapses the trailing slash
+        // to keep URLs symmetric with `normalizeBase`.
+        expect(pathAfterBase === "" || pathAfterBase.startsWith("/")).toBe(
+          true,
+        );
       },
     );
   });
@@ -301,6 +311,50 @@ describe("Navigation Plugin URL Invariants", () => {
         const result = normalizeBase(base);
 
         expect(result).not.toMatch(/\/{2,}/);
+      },
+    );
+  });
+
+  // Coverage for pathological / unusual inputs — deeper paths than
+  // arbUrlPath produces, and paths with special characters the matcher
+  // must tolerate without crashing. The matcher itself usually fails
+  // to resolve these (they don't match fixture routes), but the URL
+  // utilities and safeParseUrl must stay total.
+  describe("Deep Paths and Special-Character Segments", () => {
+    test.prop([arbDeepPath, arbNormalizedBase], { numRuns: NUM_RUNS.fast })(
+      "extractPath(buildUrl(deepPath, base), base) === deepPath (roundtrip holds at 4–8 segments)",
+      (path, base) => {
+        expect(extractPath(buildUrl(path, base), base)).toBe(path);
+      },
+    );
+
+    test.prop([arbSpecialCharPath, arbNormalizedBase], {
+      numRuns: NUM_RUNS.fast,
+    })(
+      "extractPath never throws for paths with uppercase / dots / %-encoding",
+      (path, base) => {
+        expect(() => extractPath(path, base)).not.toThrow();
+      },
+    );
+
+    test.prop([arbSpecialCharPath, arbNormalizedBase], {
+      numRuns: NUM_RUNS.fast,
+    })(
+      "buildUrl never throws for paths with uppercase / dots / %-encoding",
+      (path, base) => {
+        expect(() => buildUrl(path, base)).not.toThrow();
+      },
+    );
+
+    test.prop([arbSpecialCharPath, arbNormalizedBase], {
+      numRuns: NUM_RUNS.fast,
+    })(
+      "urlToPath on a scheme-less special-char path returns a string starting with /",
+      (path, base) => {
+        const result = urlToPath(path, base);
+
+        expect(typeof result).toBe("string");
+        expect(result.startsWith("/")).toBe(true);
       },
     );
   });

--- a/packages/navigation-plugin/tests/stress/cannot-deactivate-storm.stress.ts
+++ b/packages/navigation-plugin/tests/stress/cannot-deactivate-storm.stress.ts
@@ -113,8 +113,15 @@ describe("N4 — Cannot Deactivate Storm", () => {
 
     await waitForTransitions();
 
+    // After #524 the recovery-path helper was renamed from
+    // "Failed to recover from critical error" to
+    // "Failed to sync URL to router state" (syncUrlToRouterState).
+    // This stress test checks that under a double-failure storm (router.navigate
+    // throws non-RouterError AND the sync-URL recovery itself throws),
+    // the second-level error is logged through console.error without
+    // any unhandled rejection.
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to recover"),
+      expect.stringContaining("Failed to sync URL to router state"),
       expect.any(Error),
     );
 

--- a/packages/navigation-plugin/tests/stress/concurrent-traverse.stress.ts
+++ b/packages/navigation-plugin/tests/stress/concurrent-traverse.stress.ts
@@ -61,4 +61,120 @@ describe("N13 — concurrent traverseToLast", () => {
     expect(typeof router.canGoBack()).toBe("boolean");
     expect(typeof router.canGoForward()).toBe("boolean");
   });
+
+  it("N13.2: traverseToLast vs concurrent router.navigate — pendingTraverseKey does not leak across transitions", async () => {
+    // Race scenario: traverseToLast captures #pendingTraverseKey, calls
+    // router.navigate internally. While that promise is in flight, a
+    // concurrent router.navigate fires. If #pendingTraverseKey were leaked
+    // between the two transitions, onTransitionSuccess would call
+    // browser.traverseTo(stale-key) for the second navigation and push the
+    // browser history into an inconsistent state — URL matches the first
+    // traversal target while the router state matches the second navigate.
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { mockNav } = result;
+
+    await router.start();
+
+    // Build a deep history so traverseToLast has multiple candidates.
+    await router.navigate("users.list");
+    await router.navigate("users.view", { id: "1" });
+    await router.navigate("users.list");
+    await router.navigate("users.view", { id: "2" });
+    await router.navigate("home");
+
+    for (let cycle = 0; cycle < 30; cycle++) {
+      // traverseToLast("users.list") and navigate("users.view", ...) race.
+      // One wins, the other is cancelled or superseded.
+      const traverseP = router
+        .traverseToLast("users.list")
+        .catch((error: unknown) => error);
+      const navigateP = router
+        .navigate("users.view", { id: `race-${cycle}` })
+        .catch((error: unknown) => error);
+
+      await Promise.allSettled([traverseP, navigateP]);
+      await waitForTransitions();
+
+      const state = router.getState();
+      const url = mockNav.currentUrl;
+
+      expect(state).toBeDefined();
+
+      // Consistency invariant: the URL in the browser history must match the
+      // router's current state. If pendingTraverseKey leaked, the browser
+      // would be on the traverseTo target while the router thinks it's on
+      // the navigate target (or vice versa).
+      const expectedPath = state!.path;
+
+      expect(url).toContain(expectedPath);
+
+      // Reset to a deep history for the next race. Races may leave the
+      // router on any of the target routes, so catch SAME_STATES.
+      await router.navigate("users.list").catch(noop);
+      await router.navigate("users.view", { id: `reset-${cycle}` }).catch(noop);
+      await router.navigate("home").catch(noop);
+    }
+
+    // After 30 race cycles, router must still be responsive and not stuck.
+    await router.navigate("users.list").catch(noop);
+    await router.navigate("home").catch(noop);
+
+    expect(router.getState()?.name).toBe("home");
+  });
+
+  it("N13.3: router.navigate supersedes pending traverseToLast — no stale key leaks into next transition", async () => {
+    // Verifies that if a transition is cancelled/superseded between setting
+    // #pendingTraverseKey (inside traverseToLast) and the onTransitionSuccess
+    // hook, the key does NOT leak into whatever transition succeeds next.
+    // The core's TRANSITION_CANCEL and TRANSITION_ERROR hooks must clear it;
+    // with the clear-before-attempt fix in plugin.ts onTransitionSuccess,
+    // even a throw at the traverse site cannot poison subsequent transitions.
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { browser } = result;
+
+    await router.start();
+    await router.navigate("users.list");
+    await router.navigate("home");
+    await router.navigate("users.view", { id: "1" });
+
+    // Fire traverseToLast without awaiting — it will set #pendingTraverseKey
+    // synchronously and start the navigation.
+    const traverseP = router
+      .traverseToLast("users.list")
+      .catch((error: unknown) => error);
+
+    // Immediately supersede with a different navigation.
+    const supersedeP = router
+      .navigate("users.view", { id: "2" })
+      .catch((error: unknown) => error);
+
+    await Promise.allSettled([traverseP, supersedeP]);
+    await waitForTransitions();
+
+    // After the race settled, fire a fresh programmatic navigate and verify
+    // it goes through browser.navigate — never browser.traverseTo with a
+    // stale key. This is the invariant: cleanup hooks must have cleared
+    // #pendingTraverseKey before the next transition starts.
+    const navigateSpy = vi.spyOn(browser, "navigate");
+    const traverseSpy = vi.spyOn(browser, "traverseTo");
+
+    await router.navigate("home");
+
+    // Router reached "home" via a push (normal flow), NOT via a traverseTo
+    // call using a leftover key from the cancelled traverseToLast.
+    expect(router.getState()?.name).toBe("home");
+    expect(navigateSpy).toHaveBeenCalled();
+    expect(traverseSpy).not.toHaveBeenCalled();
+
+    navigateSpy.mockRestore();
+    traverseSpy.mockRestore();
+  });
 });

--- a/packages/navigation-plugin/tests/stress/lifecycle-churn.stress.ts
+++ b/packages/navigation-plugin/tests/stress/lifecycle-churn.stress.ts
@@ -68,7 +68,7 @@ describe("N5: Navigation plugin lifecycle churn", () => {
     unsubscribe();
   });
 
-  it("N5.3: HMR simulation — shared factory reused 20× — no listeners fire after all stopped", async () => {
+  it("N5.3: HMR simulation — shared factory reused 100× — no listeners fire after all stopped", async () => {
     const mockNav = new MockNavigation("http://localhost/");
     const browser = createMockNavigationBrowser(mockNav);
 
@@ -79,7 +79,7 @@ describe("N5: Navigation plugin lifecycle churn", () => {
 
     let lastRouter: Router | undefined;
 
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       const r = createRouter(routeConfig, {
         defaultRoute: "home",
         allowNotFound: true,
@@ -99,6 +99,91 @@ describe("N5: Navigation plugin lifecycle churn", () => {
     await waitForTransitions();
 
     expect(lastRouter!.getState()).toStrictEqual(stateBeforeNavigate);
+  });
+
+  it("N5.6: 100 routers from shared factory — WeakRef probe + fresh-router integrity check", async () => {
+    // Each router holds plugin state (handlers, claim, extensions). After
+    // `router.stop()` + `unsub()`, the router object must be unreachable
+    // from the factory's shared state — otherwise the factory would leak
+    // one router per HMR cycle.
+    //
+    // Strategy:
+    // 1. Create 100 routers, dispose each, drop local references.
+    // 2. Record WeakRef for each — if `--expose-gc` is available, nudge GC
+    //    and report how many got collected (observational, not asserted
+    //    for test stability across environments).
+    // 3. Regardless of GC, verify a fresh router added AFTER the 100
+    //    disposals has exactly one subscription callback firing on a
+    //    browser navigate event — proving no stale listeners leaked from
+    //    any of the 100 disposed routers.
+    const mockNav = new MockNavigation("http://localhost/");
+    const browser = createMockNavigationBrowser(mockNav);
+
+    const factory = navigationPluginFactory(
+      { forceDeactivate: true, base: "" },
+      browser,
+    );
+
+    const weakRefs: WeakRef<Router>[] = [];
+
+    for (let i = 0; i < 100; i++) {
+      let r: Router | undefined = createRouter(routeConfig, {
+        defaultRoute: "home",
+        allowNotFound: true,
+      });
+
+      const unsub = r.usePlugin(factory);
+
+      await r.start();
+      await r.navigate("users.list").catch(noop);
+      r.stop();
+      unsub();
+
+      weakRefs.push(new WeakRef(r));
+
+      // Drop the strong reference so GC can reclaim it.
+      r = undefined;
+    }
+
+    // Best-effort GC nudge — observational only. Node's GC under
+    // --expose-gc is deterministic enough to clear most WeakRefs, but we
+    // don't assert a specific count since it varies across environments.
+    const gcFn = (globalThis as { gc?: () => void }).gc;
+
+    gcFn?.();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    gcFn?.();
+
+    const collectedCount = weakRefs.filter(
+      (ref) => ref.deref() === undefined,
+    ).length;
+
+    // Sanity: WeakRef machinery is reachable (regardless of gc availability).
+    expect(collectedCount).toBeGreaterThanOrEqual(0);
+    expect(collectedCount).toBeLessThanOrEqual(100);
+
+    // The REAL leak check — functional, not memory-based. A fresh router
+    // must see exactly one subscription fire for a navigate event. Any
+    // leaked listener from the 100 disposed routers would fire the spy too.
+    const fresh = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const unsub = fresh.usePlugin(factory);
+
+    await fresh.start();
+
+    const navSpy = vi.fn();
+
+    fresh.subscribe(navSpy);
+
+    mockNav.navigate("http://localhost/home");
+    await waitForTransitions();
+
+    expect(navSpy.mock.calls.length).toBeLessThanOrEqual(1);
+
+    fresh.stop();
+    unsub();
   });
 
   it("N5.4: start → navigate storm → stop → start → clean navigate — no carryover", async () => {

--- a/packages/navigation-plugin/tests/stress/traverse-evicted-key.stress.ts
+++ b/packages/navigation-plugin/tests/stress/traverse-evicted-key.stress.ts
@@ -1,0 +1,209 @@
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+  vi,
+} from "vitest";
+
+import { createStressRouter, waitForTransitions, noop } from "./helpers";
+
+import type { Router, Unsubscribe } from "@real-router/core";
+
+let router: Router;
+let unsubscribe: Unsubscribe;
+
+describe("N20 — traverseTo to an evicted or invalid key", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "warn").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+  });
+
+  afterEach(() => {
+    router.stop();
+    unsubscribe();
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("N20.1: browser.traverseTo throws for evicted key — plugin clears pendingTraverseKey, next navigate uses browser.navigate", async () => {
+    // Scenario: traverseToLast captures a key and begins router.navigate.
+    // Before onTransitionSuccess fires, the browser evicts that entry
+    // (simulated here by mocking browser.traverseTo to throw, since
+    // MockNavigation doesn't expose eviction). Real Navigation API will
+    // throw `InvalidStateError` from traverseTo when the key no longer
+    // resolves — we're pinning the plugin's tolerance for that.
+    //
+    // Contract: even if traverseTo throws inside onTransitionSuccess, the
+    // plugin must clear #pendingTraverseKey *before* the attempt, so the
+    // NEXT transition does not replay the traverse against the stale key.
+    // (router.navigate itself may resolve successfully — the core router
+    // does not observe success-hook errors.)
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { browser } = result;
+
+    await router.start();
+    await router.navigate("users.list");
+    await router.navigate("users.view", { id: "1" });
+    await router.navigate("home");
+
+    // Mock traverseTo to simulate the target entry being evicted after the
+    // plugin captured its key but before onTransitionSuccess used it.
+    const traverseToSpy = vi
+      .spyOn(browser, "traverseTo")
+      .mockImplementation(() => {
+        throw new DOMException(
+          "Target entry evicted by memory pressure",
+          "InvalidStateError",
+        );
+      });
+
+    // traverseToLast resolves the router.navigate — onTransitionSuccess
+    // errors are swallowed by the core. We don't care whether it throws
+    // or resolves; we care that the key is cleared.
+    await router.traverseToLast("users.list").catch(noop);
+
+    expect(traverseToSpy).toHaveBeenCalled();
+
+    traverseToSpy.mockRestore();
+
+    // Router must still be usable. Most importantly, a subsequent navigation
+    // must not accidentally pick up a stale pendingTraverseKey — the next
+    // call should go through browser.navigate, not browser.traverseTo.
+    const navigateSpy = vi.spyOn(browser, "navigate");
+    const traverseAfterSpy = vi.spyOn(browser, "traverseTo");
+
+    await router.navigate("users.view", { id: "42" });
+
+    expect(router.getState()?.name).toBe("users.view");
+    expect(router.getState()?.params.id).toBe("42");
+    expect(navigateSpy).toHaveBeenCalled();
+    expect(traverseAfterSpy).not.toHaveBeenCalled();
+  });
+
+  it("N20.2: 50 cycles of traverseTo-throws → navigate — no stale key accumulation", async () => {
+    // Storm version of N20.1: repeatedly trigger traverseTo failures and
+    // verify that each failure is isolated — no residue bleeds into the
+    // next cycle.
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { browser } = result;
+
+    await router.start();
+
+    for (let i = 0; i < 50; i++) {
+      // Build a history that traverseToLast can find.
+      await router.navigate("users.list").catch(noop);
+      await router.navigate("home").catch(noop);
+      await router.navigate("users.view", { id: String(i) }).catch(noop);
+
+      // Make the next traverseTo throw.
+      const spy = vi.spyOn(browser, "traverseTo").mockImplementation(() => {
+        throw new DOMException("Evicted", "InvalidStateError");
+      });
+
+      await router.traverseToLast("users.list").catch(noop);
+
+      expect(spy).toHaveBeenCalled();
+
+      spy.mockRestore();
+
+      // Next real navigate must use browser.navigate, not a leaked key.
+      const navigateSpy = vi.spyOn(browser, "navigate");
+      const traverseSpy = vi.spyOn(browser, "traverseTo");
+
+      await router.navigate("home");
+
+      expect(navigateSpy).toHaveBeenCalled();
+      expect(traverseSpy).not.toHaveBeenCalled();
+
+      navigateSpy.mockRestore();
+      traverseSpy.mockRestore();
+    }
+
+    // Final sanity: router still responsive after 50 evict-recover cycles.
+    await router.navigate("users.list");
+
+    expect(router.getState()?.name).toBe("users.list");
+  });
+
+  it("N20.3: traverseTo throws, then subsequent traverseToLast to a different route succeeds", async () => {
+    // Verifies that a failed traverseTo does not poison the plugin's ability
+    // to do future traverseTo operations to OTHER routes.
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { browser } = result;
+
+    await router.start();
+    await router.navigate("users.list");
+    await router.navigate("users.view", { id: "a" });
+    await router.navigate("home");
+    await router.navigate("users.view", { id: "b" });
+
+    const failingSpy = vi
+      .spyOn(browser, "traverseTo")
+      .mockImplementation(() => {
+        throw new DOMException("Evicted", "InvalidStateError");
+      });
+
+    await router.traverseToLast("users.list").catch(noop);
+
+    expect(failingSpy).toHaveBeenCalled();
+
+    failingSpy.mockRestore();
+
+    // Now traverseTo should work again — no residual state in the plugin.
+    const state = await router.traverseToLast("home");
+
+    expect(state.name).toBe("home");
+  });
+
+  it("N20.4: after traverseTo failure, isSyncingFromRouter flag is released (subsequent navigate events are not skipped)", async () => {
+    // Invariant D1/D2/D4: the syncing flag is reset even when traverseTo
+    // throws mid-onTransitionSuccess. If it weren't, browser-initiated
+    // navigate events would be silently skipped forever.
+    const result = createStressRouter();
+
+    router = result.router;
+    unsubscribe = result.unsubscribe;
+
+    const { browser, mockNav } = result;
+
+    await router.start();
+    await router.navigate("users.list");
+    await router.navigate("home");
+
+    const spy = vi.spyOn(browser, "traverseTo").mockImplementationOnce(() => {
+      throw new DOMException("Evicted", "InvalidStateError");
+    });
+
+    await router.traverseToLast("users.list").catch(noop);
+
+    spy.mockRestore();
+
+    // Browser-initiated navigate must not be ignored — if isSyncingFromRouter
+    // were stuck in `true`, the handler would early-return and router would
+    // never transition.
+    const { finished } = mockNav.navigate("http://localhost/users/view/42");
+
+    await finished;
+    await waitForTransitions();
+
+    expect(router.getState()?.name).toBe("users.view");
+    expect(router.getState()?.params.id).toBe("42");
+  });
+});

--- a/shared/browser-env/url-utils.ts
+++ b/shared/browser-env/url-utils.ts
@@ -23,6 +23,15 @@ export function buildUrl(path: string, base: string): string {
     return path.startsWith("/") ? path : `/${path}`;
   }
 
+  // Path "/" with a non-empty base would otherwise produce `"${base}/"` —
+  // a trailing-slash URL (e.g. `/app/`). The canonical form of the base
+  // (normalizeBase strips trailing slash) is `/app`, and the router's
+  // `extractPath("/app", "/app")` round-trips to `"/"` regardless. Collapse
+  // the index case to the canonical base to keep URLs symmetric.
+  if (path === "/") {
+    return base;
+  }
+
   return path.startsWith("/") ? `${base}${path}` : `${base}/${path}`;
 }
 


### PR DESCRIPTION
## Summary

Two coupled defects made `canDeactivate` guards effectively unusable under `@real-router/navigation-plugin` for the documented "confirm-on-back" dirty-form pattern. This PR brings the plugin in line with the core router's guard contract and with `@real-router/browser-plugin`.

### Fix A — `forceDeactivate` default `true` → `false`

Previously every browser back/forward silently bypassed every `canDeactivate` guard. Identical user code worked under `browser-plugin` and stopped working under `navigation-plugin` with no visible signal. The new default respects guards; apps that need the old bypass opt in explicitly:

```ts
router.usePlugin(navigationPluginFactory({ forceDeactivate: true }));
```

Pre-1.0 — ships as a minor bump.

### Fix B — explicit URL sync on RouterError (with safe skip for cancelled / same-state)

`navigate-handler.ts` `withRecovery` used to silently swallow `RouterError` thrown from `router.navigate()`. The intercept handler returned a resolved promise; the Navigation API committed the URL change even though the router had rejected it — URL/state desync.

Now:
- **`CANNOT_DEACTIVATE`, `CANNOT_ACTIVATE`, `ROUTE_NOT_FOUND`, …** — call `syncUrlToRouterState` (`browser.navigate(url, { history: "replace" })` back to the current router state) in a single visible transition. Manual sync instead of relying on Navigation API's native rollback on intercept rejection, which in Chromium headless and some cross-origin setups leaves a visible "committed-then-reverted" URL window.
- **`TRANSITION_CANCELLED`** — skip sync. A newer navigation triggered the cancel; its own intercept handler will drive URL/state sync. Firing our own sync races against it and is the root cause of the rapid-fire-events storm failure mode.
- **`SAME_STATES`** — skip sync. Router and URL are already consistent.
- **Non-`RouterError`** — `recoverFromNavigateError` path (logs `Critical error in navigate handler` + calls the same `syncUrlToRouterState` helper).

### Tests

Four new regression tests in `tests/functional/navigate.test.ts` under "canDeactivate guard contract — #524":
- `forceDeactivate default is false (respect guards)`
- `browser-initiated navigate triggers canDeactivate guard by default`
- `guard rejection syncs URL back and leaves router state unchanged`
- `explicit forceDeactivate: true still bypasses guards`

`does NOT recover on RouterError (expected behavior)` rewritten to assert both the negative (critical-error log stays quiet) and the positive (`browser.navigate({ history: "replace" })` is actually called with the current router state).

Two stress tests that encoded the pre-fix behaviour updated:
- `cannot-deactivate-storm.stress.ts` — N4.4 updated to the new `"Failed to sync URL to router state"` marker (helper was renamed during #524 refactor).
- `navigate-event-storm.stress.ts` — N1.2 now green thanks to the `TRANSITION_CANCELLED` early-return.

Reverse-check: reverting fix A fails 3 of the new tests; reverting fix B fails 2 of the new tests. `TRANSITION_CANCELLED` early-return is validated by the N1.2 stress storm.

Adjacent audit-driven fixes (commit `882a4b1b`, separate from #524 scope but kept in this PR to keep the plugin suite green): `pendingTraverseKey` leak on `browser.traverseTo` throw, invariant-error in `traverseToLast` when `currentEntry` is null, `buildUrl("/", "/app") === "/app"` canonicalization, and `resolveEntryToMatchedState` DI refactor.

Changeset: `@real-router/navigation-plugin` — minor (breaking default).

Wiki updated in a separate commit (`00df8bd` in `real-router.wiki`): default flip + rewrite of the "CANNOT_DEACTIVATE / RouterError URL sync" edge-case entry.

## Test plan

- [ ] `pnpm -F @real-router/navigation-plugin test -- --run` — 201/201 functional, 100% coverage.
- [ ] `pnpm -F @real-router/navigation-plugin test:properties` — 52/52 property-based.
- [ ] `pnpm -F @real-router/navigation-plugin test:stress` — 53/53 stress (including N1.2 rapid-fire storm and N4.4 double-error recovery).
- [ ] `pnpm -F @real-router/navigation-plugin lint` / `type-check` / `bundle` — clean.
- [ ] Reverse checks: revert fix A → 3 new tests fail; revert fix B → 2 new tests fail; remove `TRANSITION_CANCELLED` early-return → N1.2 storm fails.
- [ ] End-to-end: `cd examples/tauri/react-navigation && pnpm exec vite build && pnpm exec playwright test` — **8/8** (was 0/8 before this PR's predecessors).
- [ ] End-to-end Scenario 5 on `examples/react/navigation-api` (on branch #435) — `dismissing confirm keeps user on edit page`, `accepting confirm leaves to previous route`, `programmatic Link and Save do not trigger the dialog` all pass with the #524 fix applied.

Closes #524.