### PR TITLE
feat: useRoute throws when route is undefined (#535)

### DIFF
--- a/.changeset/useroute-throws-on-undefined-angular.md
+++ b/.changeset/useroute-throws-on-undefined-angular.md
@@ -1,0 +1,7 @@
+---
+"@real-router/angular": minor
+---
+
+Narrow `injectRoute()` signal return so `routeState().route` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`injectRoute()` now throws `"injectRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when called before `router.start()` resolves. The `routeState` signal narrows to `Signal<{ route: State<P>; previousRoute?: State }>` — templates use `routeState().route.name` directly. `injectRouteNode(name)` is unchanged.

--- a/.changeset/useroute-throws-on-undefined-preact.md
+++ b/.changeset/useroute-throws-on-undefined-preact.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preact": minor
+---
+
+Narrow `useRoute()` return type so `route` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`useRoute()` now throws `"useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when invoked before `router.start()` resolves (or after stop/dispose). The return type narrows so consumers can read `route.params.id` directly without `route?.` defenses. `useRouteNode(name)` is unchanged.

--- a/.changeset/useroute-throws-on-undefined-react.md
+++ b/.changeset/useroute-throws-on-undefined-react.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": minor
+---
+
+Narrow `useRoute()` return type so `route` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`useRoute()` previously returned `{ route: State | undefined }`, forcing every consumer to write `route?.x` or `if (!route) return null` — defensive code for a case that is unreachable once `await router.start()` has resolved. The hook now throws `"useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when invoked before start (or after stop/dispose), and the return type narrows so consumers can read `route.params.id` directly. `useRouteNode(name)` is unchanged — `route === undefined` there is a legitimate "node inactive" business state.

--- a/.changeset/useroute-throws-on-undefined-solid.md
+++ b/.changeset/useroute-throws-on-undefined-solid.md
@@ -1,0 +1,7 @@
+---
+"@real-router/solid": minor
+---
+
+Narrow `useRoute()` accessor return so `route` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`useRoute()` now throws `"useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when invoked before `router.start()` resolves. The accessor return type narrows so `state().route.name` is direct — no `?.`, no `<Show when={state().route}>` wrapper. `useRouteNode(name)` and `useRouteStore()` are unchanged — node-scoped nullability is intentional.

--- a/.changeset/useroute-throws-on-undefined-svelte.md
+++ b/.changeset/useroute-throws-on-undefined-svelte.md
@@ -1,0 +1,7 @@
+---
+"@real-router/svelte": minor
+---
+
+Narrow `useRoute()` getter return so `route.current` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`useRoute()` now throws `"useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when invoked before `router.start()` resolves. The getter type narrows so `route.current.name` is direct — no `?.`, no `{#if route.current}` wrapper. `useRouteNode(name)` is unchanged.

--- a/.changeset/useroute-throws-on-undefined-vue.md
+++ b/.changeset/useroute-throws-on-undefined-vue.md
@@ -1,0 +1,7 @@
+---
+"@real-router/vue": minor
+---
+
+Narrow `useRoute()` ref return so `route.value` is non-nullable; throw a clear error when the router has no active state (#535)
+
+`useRoute()` now throws `"useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?"` when invoked before `router.start()` resolves. `route` is typed as `Readonly<Ref<State<P>>>` (non-nullable inner value) so `route.value.params.id` is direct in scripts, `{{ route.params.id }}` in templates. `useRouteNode(name)` is unchanged.

--- a/examples/desktop/electron/react-hash/src/pages/UserDetail.tsx
+++ b/examples/desktop/electron/react-hash/src/pages/UserDetail.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "?";
+  const id = route.params.id ?? "?";
 
   return (
     <section>

--- a/examples/desktop/electron/react-hash/src/pages/UserEdit.tsx
+++ b/examples/desktop/electron/react-hash/src/pages/UserEdit.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   return (
     <section>

--- a/examples/desktop/electron/react-navigation/src/pages/UserDetail.tsx
+++ b/examples/desktop/electron/react-navigation/src/pages/UserDetail.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "?";
+  const id = route.params.id ?? "?";
 
   return (
     <section>

--- a/examples/desktop/electron/react-navigation/src/pages/UserEdit.tsx
+++ b/examples/desktop/electron/react-navigation/src/pages/UserEdit.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   return (
     <section>

--- a/examples/desktop/electron/react/src/pages/UserDetail.tsx
+++ b/examples/desktop/electron/react/src/pages/UserDetail.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "?";
+  const id = route.params.id ?? "?";
 
   return (
     <section>

--- a/examples/desktop/electron/react/src/pages/UserEdit.tsx
+++ b/examples/desktop/electron/react/src/pages/UserEdit.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   return (
     <section>

--- a/examples/desktop/tauri/react-navigation/src/pages/UserDetail.tsx
+++ b/examples/desktop/tauri/react-navigation/src/pages/UserDetail.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "?";
+  const id = route.params.id ?? "?";
 
   return (
     <section>

--- a/examples/desktop/tauri/react-navigation/src/pages/UserEdit.tsx
+++ b/examples/desktop/tauri/react-navigation/src/pages/UserEdit.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   return (
     <section>

--- a/examples/desktop/tauri/react/src/pages/UserDetail.tsx
+++ b/examples/desktop/tauri/react/src/pages/UserDetail.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "?";
+  const id = route.params.id ?? "?";
 
   return (
     <section>

--- a/examples/desktop/tauri/react/src/pages/UserEdit.tsx
+++ b/examples/desktop/tauri/react/src/pages/UserEdit.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function UserEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   return (
     <section>

--- a/examples/web/angular/animation-examples/motion-animations/src/pages/product-detail.component.ts
+++ b/examples/web/angular/animation-examples/motion-animations/src/pages/product-detail.component.ts
@@ -46,6 +46,6 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 export class ProductDetailComponent {
   private readonly state = injectRoute<{ id: string }>();
 
-  readonly id = computed(() => this.state.routeState().route?.params["id"] ?? "1");
+  readonly id = computed(() => this.state.routeState().route.params["id"] ?? "1");
   readonly product = computed(() => COVERS[this.id()]);
 }

--- a/examples/web/angular/animation-examples/motion-animations/src/pages/products-list.component.ts
+++ b/examples/web/angular/animation-examples/motion-animations/src/pages/products-list.component.ts
@@ -80,7 +80,7 @@ export class ProductsListComponent {
   private readonly state = injectRoute<{ sort?: SortDirection }>();
 
   readonly sort = computed<SortDirection>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     return params?.["sort"] === "desc" ? "desc" : "asc";
   });
 

--- a/examples/web/angular/animation-examples/motion-animations/src/pages/query-demo.component.ts
+++ b/examples/web/angular/animation-examples/motion-animations/src/pages/query-demo.component.ts
@@ -57,7 +57,7 @@ export class QueryDemoComponent {
   readonly filters = FILTERS;
 
   readonly filter = computed<Filter>(
-    () => (this.state.routeState().route?.params["filter"] as Filter | undefined) ?? "all",
+    () => (this.state.routeState().route.params["filter"] as Filter | undefined) ?? "all",
   );
 
   readonly visible = computed(() => {

--- a/examples/web/angular/animation-examples/page-animations/src/pages/product-detail.component.ts
+++ b/examples/web/angular/animation-examples/page-animations/src/pages/product-detail.component.ts
@@ -45,7 +45,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 export class ProductDetailComponent {
   private readonly state = injectRoute<{ id: string }>();
 
-  readonly id = computed(() => this.state.routeState().route?.params["id"] ?? "1");
+  readonly id = computed(() => this.state.routeState().route.params["id"] ?? "1");
   readonly product = computed(() => COVERS[this.id()]);
 
   constructor() {

--- a/examples/web/angular/animation-examples/page-animations/src/pages/products-list.component.ts
+++ b/examples/web/angular/animation-examples/page-animations/src/pages/products-list.component.ts
@@ -88,7 +88,7 @@ export class ProductsListComponent {
   readonly list = viewChild<ElementRef<HTMLUListElement>>("list");
 
   readonly sort = computed<SortDirection>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     return params?.["sort"] === "desc" ? "desc" : "asc";
   });
 

--- a/examples/web/angular/animation-examples/page-animations/src/pages/query-demo.component.ts
+++ b/examples/web/angular/animation-examples/page-animations/src/pages/query-demo.component.ts
@@ -73,7 +73,7 @@ export class QueryDemoComponent {
   readonly list = viewChild<ElementRef<HTMLUListElement>>("list");
 
   readonly filter = computed<Filter>(
-    () => (this.state.routeState().route?.params["filter"] as Filter | undefined) ?? "all",
+    () => (this.state.routeState().route.params["filter"] as Filter | undefined) ?? "all",
   );
 
   readonly visible = computed(() => {

--- a/examples/web/angular/animation-examples/route-animations/src/pages/product-detail.component.ts
+++ b/examples/web/angular/animation-examples/route-animations/src/pages/product-detail.component.ts
@@ -64,6 +64,6 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 export class ProductDetailComponent {
   private readonly state = injectRoute<{ id: string }>();
 
-  readonly id = computed(() => this.state.routeState().route?.params["id"] ?? "1");
+  readonly id = computed(() => this.state.routeState().route.params["id"] ?? "1");
   readonly product = computed(() => COVERS[this.id()]);
 }

--- a/examples/web/angular/animation-examples/route-animations/src/pages/products-list.component.ts
+++ b/examples/web/angular/animation-examples/route-animations/src/pages/products-list.component.ts
@@ -83,7 +83,7 @@ export class ProductsListComponent {
   private readonly state = injectRoute<{ sort?: SortDirection }>();
 
   readonly sort = computed<SortDirection>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     return params?.["sort"] === "desc" ? "desc" : "asc";
   });
 

--- a/examples/web/angular/animation-examples/route-animations/src/pages/query-demo.component.ts
+++ b/examples/web/angular/animation-examples/route-animations/src/pages/query-demo.component.ts
@@ -60,7 +60,7 @@ export class QueryDemoComponent {
   readonly filters = FILTERS;
 
   readonly filter = computed<Filter>(
-    () => (this.state.routeState().route?.params["filter"] as Filter | undefined) ?? "all",
+    () => (this.state.routeState().route.params["filter"] as Filter | undefined) ?? "all",
   );
 
   readonly visible = computed(() => {

--- a/examples/web/angular/animation-examples/view-transitions/src/pages/product-detail.component.ts
+++ b/examples/web/angular/animation-examples/view-transitions/src/pages/product-detail.component.ts
@@ -47,7 +47,7 @@ export class ProductDetailComponent {
   private readonly state = injectRoute<{ id: string }>();
 
   readonly id = computed(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     return typeof params?.id === "string" ? params.id : "1";
   });
 

--- a/examples/web/angular/animation-examples/view-transitions/src/pages/products-list.component.ts
+++ b/examples/web/angular/animation-examples/view-transitions/src/pages/products-list.component.ts
@@ -73,7 +73,7 @@ export class ProductsListComponent {
   private readonly state = injectRoute<{ sort?: SortDirection }>();
 
   readonly sort = computed<SortDirection>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     return params?.sort === "desc" ? "desc" : "asc";
   });
 

--- a/examples/web/angular/animation-examples/view-transitions/src/pages/query-demo.component.ts
+++ b/examples/web/angular/animation-examples/view-transitions/src/pages/query-demo.component.ts
@@ -71,7 +71,7 @@ export class QueryDemoComponent {
   readonly filters = FILTERS;
 
   readonly filter = computed<Filter>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     const raw = params?.filter;
     return raw && FILTERS.includes(raw) ? raw : "all";
   });

--- a/examples/web/angular/basic/src/pages/home.component.ts
+++ b/examples/web/angular/basic/src/pages/home.component.ts
@@ -9,7 +9,7 @@ import { injectRoute } from "@real-router/angular";
       <p>Welcome to the Real-Router basic example.</p>
       <p>
         Current route:
-        <strong>{{ routeState().route?.name ?? "—" }}</strong>
+        <strong>{{ routeState().route.name }}</strong>
       </p>
       <p>
         Use the sidebar to navigate between pages. Try clicking <em>Back</em>

--- a/examples/web/angular/combined/src/pages/dashboard.component.ts
+++ b/examples/web/angular/combined/src/pages/dashboard.component.ts
@@ -40,7 +40,7 @@ export class DashboardComponent {
   readonly user = signal<User | null>(store.get("user") as User | null);
 
   readonly lang = computed<string>(() => {
-    const params = this.state.routeState().route?.params;
+    const params = this.state.routeState().route.params;
     const value = params?.["lang"];
     return typeof value === "string" ? value : "en";
   });

--- a/examples/web/angular/combined/src/pages/users-layout.component.ts
+++ b/examples/web/angular/combined/src/pages/users-layout.component.ts
@@ -119,7 +119,6 @@ export class UsersLayoutComponent {
 
   readonly crumbs = computed(() => {
     const current = this.route.routeState().route;
-    if (!current) return null;
     const chain = this.utils.getChain(current.name) ?? [current.name];
     const names = ["home", ...chain];
     return names.map((name, i) => ({

--- a/examples/web/angular/dynamic-routes/src/app.component.ts
+++ b/examples/web/angular/dynamic-routes/src/app.component.ts
@@ -137,7 +137,7 @@ export class AppComponent {
 
   async toggleAnalytics(): Promise<void> {
     if (this.analyticsEnabled()) {
-      if (this.route.routeState().route?.name.startsWith("analytics")) {
+      if (this.route.routeState().route.name.startsWith("analytics")) {
         await this.navigator.navigate("home");
       }
       this.routesApi.remove("analytics");
@@ -150,7 +150,7 @@ export class AppComponent {
 
   async toggleAdmin(): Promise<void> {
     if (this.adminEnabled()) {
-      if (this.route.routeState().route?.name.startsWith("admin")) {
+      if (this.route.routeState().route.name.startsWith("admin")) {
         await this.navigator.navigate("home");
       }
       this.routesApi.remove("admin");

--- a/examples/web/angular/hash-routing/src/pages/home.component.ts
+++ b/examples/web/angular/hash-routing/src/pages/home.component.ts
@@ -17,7 +17,7 @@ import { injectRoute } from "@real-router/angular";
       </p>
       <p>
         Current route:
-        <strong>{{ routeState().route?.name ?? "—" }}</strong>
+        <strong>{{ routeState().route.name }}</strong>
       </p>
       <p>
         Current URL hash:

--- a/examples/web/angular/nested-routes/src/pages/users-layout.component.ts
+++ b/examples/web/angular/nested-routes/src/pages/users-layout.component.ts
@@ -74,7 +74,6 @@ export class UsersLayoutComponent {
 
   readonly crumbs = computed(() => {
     const current = this.route.routeState().route;
-    if (!current) return null;
     const chain = this.utils.getChain(current.name) ?? [current.name];
     const names = ["home", ...chain];
     return names.map((name, i) => ({

--- a/examples/web/angular/persistent-params/src/params-toolbar.component.ts
+++ b/examples/web/angular/persistent-params/src/params-toolbar.component.ts
@@ -54,7 +54,6 @@ export class ParamsToolbarComponent {
 
   setParam(key: string, value: string): void {
     const current = this.route.routeState().route;
-    if (!current) return;
     void this.navigator.navigate(
       current.name,
       { ...current.params, [key]: value },

--- a/examples/web/angular/persistent-params/src/use-params.ts
+++ b/examples/web/angular/persistent-params/src/use-params.ts
@@ -4,7 +4,7 @@ import { injectRoute } from "@real-router/angular";
 export function useStringParam(key: string, fallback: string): Signal<string> {
   const route = injectRoute();
   return computed(() => {
-    const raw = route.routeState().route?.params[key];
+    const raw = route.routeState().route.params[key];
     return typeof raw === "string" ? raw : fallback;
   });
 }

--- a/examples/web/preact/animation-examples/motion-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/animation-examples/motion-animations/src/pages/ProductDetail.tsx
@@ -12,7 +12,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail() {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/preact/animation-examples/motion-animations/src/pages/ProductsList.tsx
+++ b/examples/web/preact/animation-examples/motion-animations/src/pages/ProductsList.tsx
@@ -25,7 +25,7 @@ type SortDirection = "asc" | "desc";
 // the cover on ProductDetail for the library-coordinated hero morph.
 export function ProductsList() {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/preact/animation-examples/motion-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/preact/animation-examples/motion-animations/src/pages/QueryDemo.tsx
@@ -15,7 +15,7 @@ type Filter = "all" | "letter" | "number" | "color";
 
 export function QueryDemo() {
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/preact/animation-examples/page-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/animation-examples/page-animations/src/pages/ProductDetail.tsx
@@ -18,7 +18,7 @@ export function ProductDetail() {
   useRouteAnimation(ref, { entryClass: "fade-in", exitClass: "fade-out" });
 
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/preact/animation-examples/page-animations/src/pages/ProductsList.tsx
+++ b/examples/web/preact/animation-examples/page-animations/src/pages/ProductsList.tsx
@@ -32,7 +32,7 @@ export function ProductsList() {
   useRouteAnimation(ref, { entryClass: "slide-in", exitClass: "slide-out" });
 
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/preact/animation-examples/page-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/preact/animation-examples/page-animations/src/pages/QueryDemo.tsx
@@ -22,7 +22,7 @@ export function QueryDemo() {
   useRouteAnimation(ref, { entryClass: "fade-in", exitClass: "fade-out" });
 
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/preact/animation-examples/route-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/animation-examples/route-animations/src/pages/ProductDetail.tsx
@@ -11,7 +11,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail() {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/preact/animation-examples/route-animations/src/pages/ProductsList.tsx
+++ b/examples/web/preact/animation-examples/route-animations/src/pages/ProductsList.tsx
@@ -20,7 +20,7 @@ type SortDirection = "asc" | "desc";
 
 export function ProductsList() {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/preact/animation-examples/route-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/preact/animation-examples/route-animations/src/pages/QueryDemo.tsx
@@ -14,7 +14,7 @@ type Filter = "all" | "letter" | "number" | "color";
 
 export function QueryDemo() {
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/preact/animation-examples/view-transitions/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/animation-examples/view-transitions/src/pages/ProductDetail.tsx
@@ -15,7 +15,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/preact/animation-examples/view-transitions/src/pages/ProductsList.tsx
+++ b/examples/web/preact/animation-examples/view-transitions/src/pages/ProductsList.tsx
@@ -22,7 +22,7 @@ type SortDirection = "asc" | "desc";
 
 export function ProductsList(): JSX.Element {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/preact/animation-examples/view-transitions/src/pages/QueryDemo.tsx
+++ b/examples/web/preact/animation-examples/view-transitions/src/pages/QueryDemo.tsx
@@ -21,7 +21,7 @@ export function QueryDemo(): JSX.Element {
   // leave `filter` frozen at "all" forever, and all buttons would look
   // like the initial active one.
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/preact/auth-guards/src/App.tsx
+++ b/examples/web/preact/auth-guards/src/App.tsx
@@ -11,11 +11,11 @@ import { Services } from "./pages/Services";
 import { Settings } from "./pages/Settings";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "preact";
 
 export function App(): JSX.Element {

--- a/examples/web/preact/auth-guards/src/pages/Dashboard.tsx
+++ b/examples/web/preact/auth-guards/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 interface DashboardProps {

--- a/examples/web/preact/auth-guards/src/pages/Login.tsx
+++ b/examples/web/preact/auth-guards/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { useState } from "preact/hooks";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 interface LoginProps {

--- a/examples/web/preact/auth-guards/src/pages/Settings.tsx
+++ b/examples/web/preact/auth-guards/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useNavigator } from "@real-router/preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "preact";
 

--- a/examples/web/preact/auth-guards/src/routes.ts
+++ b/examples/web/preact/auth-guards/src/routes.ts
@@ -1,5 +1,5 @@
-import { can } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Route } from "@real-router/core";

--- a/examples/web/preact/auth-guards/src/types.ts
+++ b/examples/web/preact/auth-guards/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/preact/auth-guards/tests/components.test.tsx
+++ b/examples/web/preact/auth-guards/tests/components.test.tsx
@@ -12,8 +12,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/preact/auth-guards/tests/router.test.ts
+++ b/examples/web/preact/auth-guards/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { publicRoutes, privateRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/preact/auth-guards/tests/setup.ts
+++ b/examples/web/preact/auth-guards/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/preact/basic/src/pages/Home.tsx
+++ b/examples/web/preact/basic/src/pages/Home.tsx
@@ -12,7 +12,7 @@ export function Home(): JSX.Element {
       <h1>Home</h1>
       <p>Welcome to the Real-Router basic example.</p>
       <p>
-        Current route: <strong>{route?.name ?? "—"}</strong>
+        Current route: <strong>{route.name}</strong>
       </p>
       <p>
         Use the sidebar to navigate between pages. Try clicking <em>Back</em>{" "}

--- a/examples/web/preact/combined/src/App.tsx
+++ b/examples/web/preact/combined/src/App.tsx
@@ -13,11 +13,11 @@ import { Settings } from "./pages/Settings";
 import { UsersLayout } from "./pages/UsersLayout";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "preact";
 
 const LazyDashboard = lazy(() => import("./pages/Dashboard"));

--- a/examples/web/preact/combined/src/pages/Dashboard.tsx
+++ b/examples/web/preact/combined/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
 import { useNavigator, useRoute } from "@real-router/preact";
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 interface DashboardProps {
@@ -18,7 +18,7 @@ export default function Dashboard({ onLogout }: DashboardProps): JSX.Element {
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>
@@ -47,9 +47,9 @@ export default function Dashboard({ onLogout }: DashboardProps): JSX.Element {
         <button
           onClick={() =>
             void navigator.navigate(
-              route?.name ?? "dashboard",
+              route.name,
               {
-                ...route?.params,
+                ...route.params,
                 lang: lang === "en" ? "ru" : "en",
               },
               { reload: true },

--- a/examples/web/preact/combined/src/pages/Login.tsx
+++ b/examples/web/preact/combined/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { useState } from "preact/hooks";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 interface LoginProps {

--- a/examples/web/preact/combined/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/combined/src/pages/ProductDetail.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/preact";
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 export function ProductDetail(): JSX.Element {

--- a/examples/web/preact/combined/src/pages/ProductList.tsx
+++ b/examples/web/preact/combined/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/preact";
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/preact/combined/src/pages/Settings.tsx
+++ b/examples/web/preact/combined/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "preact";
 

--- a/examples/web/preact/combined/src/pages/UsersLayout.tsx
+++ b/examples/web/preact/combined/src/pages/UsersLayout.tsx
@@ -29,13 +29,9 @@ function getLabel(name: string, params: Params): string {
   return name;
 }
 
-function Breadcrumbs(): JSX.Element | null {
+function Breadcrumbs(): JSX.Element {
   const { route } = useRoute();
   const utils = useRouteUtils();
-
-  if (!route) {
-    return null;
-  }
 
   const chain = utils.getChain(route.name) ?? [route.name];
   const crumbs = ["home", ...chain];

--- a/examples/web/preact/combined/src/routes.ts
+++ b/examples/web/preact/combined/src/routes.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { can } from "../../../shared/abilities";
-import { api } from "../../../shared/api";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { api } from "../../../../shared/api";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Params, Route } from "@real-router/core";

--- a/examples/web/preact/combined/src/types.ts
+++ b/examples/web/preact/combined/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/preact/combined/tests/components.test.tsx
+++ b/examples/web/preact/combined/tests/components.test.tsx
@@ -12,8 +12,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { publicRoutes, privateRoutes } from "../src/routes";

--- a/examples/web/preact/combined/tests/router.test.ts
+++ b/examples/web/preact/combined/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { privateRoutes, publicRoutes } from "../src/routes";
 

--- a/examples/web/preact/combined/tests/setup.ts
+++ b/examples/web/preact/combined/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/preact/data-loading/src/pages/ProductDetail.tsx
+++ b/examples/web/preact/data-loading/src/pages/ProductDetail.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/preact";
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 export function ProductDetail(): JSX.Element {

--- a/examples/web/preact/data-loading/src/pages/ProductList.tsx
+++ b/examples/web/preact/data-loading/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/preact";
 import { useSyncExternalStore } from "preact/compat";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "preact";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/preact/dynamic-routes/src/App.tsx
+++ b/examples/web/preact/dynamic-routes/src/App.tsx
@@ -27,7 +27,7 @@ export function App(): JSX.Element {
 
   const toggleAnalytics = async () => {
     if (analyticsEnabled) {
-      if (route?.name.startsWith("analytics")) {
+      if (route.name.startsWith("analytics")) {
         await navigator.navigate("home");
       }
 
@@ -41,7 +41,7 @@ export function App(): JSX.Element {
 
   const toggleAdmin = async () => {
     if (adminEnabled) {
-      if (route?.name.startsWith("admin")) {
+      if (route.name.startsWith("admin")) {
         await navigator.navigate("home");
       }
 

--- a/examples/web/preact/hash-routing/src/pages/Home.tsx
+++ b/examples/web/preact/hash-routing/src/pages/Home.tsx
@@ -18,7 +18,7 @@ export function Home(): JSX.Element {
         same route.
       </p>
       <p>
-        Current route: <strong>{route?.name ?? "—"}</strong>
+        Current route: <strong>{route.name}</strong>
       </p>
       <p>
         Current URL hash:{" "}

--- a/examples/web/preact/nested-routes/src/pages/UsersLayout.tsx
+++ b/examples/web/preact/nested-routes/src/pages/UsersLayout.tsx
@@ -33,13 +33,9 @@ function getLabel(name: string, params: Params): string {
   return name;
 }
 
-function Breadcrumbs(): JSX.Element | null {
+function Breadcrumbs(): JSX.Element {
   const { route } = useRoute();
   const utils = useRouteUtils();
-
-  if (!route) {
-    return null;
-  }
 
   const chain = utils.getChain(route.name) ?? [route.name];
   const crumbs = ["home", ...chain];

--- a/examples/web/preact/persistent-params/src/App.tsx
+++ b/examples/web/preact/persistent-params/src/App.tsx
@@ -17,14 +17,14 @@ function ParamsToolbar(): JSX.Element {
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const lang = (route?.params.lang as string | undefined) ?? "en";
-  const theme = (route?.params.theme as string | undefined) ?? "light";
+  const lang = (route.params.lang as string | undefined) ?? "en";
+  const theme = (route.params.theme as string | undefined) ?? "light";
 
   const navigate = (newParams: Record<string, string>) => {
     void navigator.navigate(
-      route?.name ?? "home",
+      route.name,
       {
-        ...route?.params,
+        ...route.params,
         ...newParams,
       },
       { reload: true },

--- a/examples/web/preact/persistent-params/src/pages/About.tsx
+++ b/examples/web/preact/persistent-params/src/pages/About.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "preact";
 
 export function About(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/preact/persistent-params/src/pages/Contacts.tsx
+++ b/examples/web/preact/persistent-params/src/pages/Contacts.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "preact";
 
 export function Contacts(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/preact/persistent-params/src/pages/Home.tsx
+++ b/examples/web/preact/persistent-params/src/pages/Home.tsx
@@ -4,8 +4,8 @@ import type { JSX } from "preact";
 
 export function Home(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
-  const theme = (route?.params.theme as string | undefined) ?? "light";
+  const lang = (route.params.lang as string | undefined) ?? "en";
+  const theme = (route.params.theme as string | undefined) ?? "light";
 
   return (
     <div>

--- a/examples/web/preact/search-schema/src/pages/Products.tsx
+++ b/examples/web/preact/search-schema/src/pages/Products.tsx
@@ -6,14 +6,14 @@ export function Products(): JSX.Element {
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const q = (route?.params.q as string | undefined) ?? "";
-  const page = (route?.params.page as number | undefined) ?? 1;
-  const sort = (route?.params.sort as string | undefined) ?? "name";
+  const q = (route.params.q as string | undefined) ?? "";
+  const page = (route.params.page as number | undefined) ?? 1;
+  const sort = (route.params.sort as string | undefined) ?? "name";
 
   const navigate = (
     params: Record<string, string | number | boolean | undefined>,
   ) => {
-    void navigator.navigate("products", { ...route?.params, ...params });
+    void navigator.navigate("products", { ...route.params, ...params });
   };
 
   return (

--- a/examples/web/react/animation-examples/motion-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/react/animation-examples/motion-animations/src/pages/ProductDetail.tsx
@@ -14,7 +14,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/react/animation-examples/motion-animations/src/pages/ProductsList.tsx
+++ b/examples/web/react/animation-examples/motion-animations/src/pages/ProductsList.tsx
@@ -27,7 +27,7 @@ type SortDirection = "asc" | "desc";
 // the cover on ProductDetail for the library-coordinated hero morph.
 export function ProductsList(): JSX.Element {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/react/animation-examples/motion-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/react/animation-examples/motion-animations/src/pages/QueryDemo.tsx
@@ -17,7 +17,7 @@ type Filter = "all" | "letter" | "number" | "color";
 
 export function QueryDemo(): JSX.Element {
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/react/animation-examples/page-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/react/animation-examples/page-animations/src/pages/ProductDetail.tsx
@@ -20,7 +20,7 @@ export function ProductDetail(): JSX.Element {
   useRouteAnimation(ref, { entryClass: "fade-in", exitClass: "fade-out" });
 
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/react/animation-examples/page-animations/src/pages/ProductsList.tsx
+++ b/examples/web/react/animation-examples/page-animations/src/pages/ProductsList.tsx
@@ -34,7 +34,7 @@ export function ProductsList(): JSX.Element {
   useRouteAnimation(ref, { entryClass: "slide-in", exitClass: "slide-out" });
 
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/react/animation-examples/page-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/react/animation-examples/page-animations/src/pages/QueryDemo.tsx
@@ -24,7 +24,7 @@ export function QueryDemo(): JSX.Element {
   useRouteAnimation(ref, { entryClass: "fade-in", exitClass: "fade-out" });
 
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/react/animation-examples/route-animations/src/pages/ProductDetail.tsx
+++ b/examples/web/react/animation-examples/route-animations/src/pages/ProductDetail.tsx
@@ -13,7 +13,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/react/animation-examples/route-animations/src/pages/ProductsList.tsx
+++ b/examples/web/react/animation-examples/route-animations/src/pages/ProductsList.tsx
@@ -22,7 +22,7 @@ type SortDirection = "asc" | "desc";
 
 export function ProductsList(): JSX.Element {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/react/animation-examples/route-animations/src/pages/QueryDemo.tsx
+++ b/examples/web/react/animation-examples/route-animations/src/pages/QueryDemo.tsx
@@ -16,7 +16,7 @@ type Filter = "all" | "letter" | "number" | "color";
 
 export function QueryDemo(): JSX.Element {
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/react/animation-examples/view-transitions/src/pages/ProductDetail.tsx
+++ b/examples/web/react/animation-examples/view-transitions/src/pages/ProductDetail.tsx
@@ -15,7 +15,7 @@ const COVERS: Partial<Record<string, { name: string; color: string }>> = {
 
 export function ProductDetail(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
-  const id = route?.params.id ?? "1";
+  const id = route.params.id ?? "1";
   const product = COVERS[id];
 
   if (!product) {

--- a/examples/web/react/animation-examples/view-transitions/src/pages/ProductsList.tsx
+++ b/examples/web/react/animation-examples/view-transitions/src/pages/ProductsList.tsx
@@ -22,7 +22,7 @@ type SortDirection = "asc" | "desc";
 
 export function ProductsList(): JSX.Element {
   const { route } = useRoute<{ sort?: SortDirection }>();
-  const sort: SortDirection = route?.params.sort === "desc" ? "desc" : "asc";
+  const sort: SortDirection = route.params.sort === "desc" ? "desc" : "asc";
 
   const items = useMemo(() => {
     const sorted = PRODUCTS.toSorted((left, right) =>

--- a/examples/web/react/animation-examples/view-transitions/src/pages/QueryDemo.tsx
+++ b/examples/web/react/animation-examples/view-transitions/src/pages/QueryDemo.tsx
@@ -21,7 +21,7 @@ export function QueryDemo(): JSX.Element {
   // leave `filter` frozen at "all" forever, and all buttons would look
   // like the initial active one.
   const { route } = useRoute<{ filter?: Filter }>();
-  const filter = route?.params.filter ?? "all";
+  const filter = route.params.filter ?? "all";
 
   const visible = useMemo(() => {
     return filter === "all"

--- a/examples/web/react/auth-guards/src/App.tsx
+++ b/examples/web/react/auth-guards/src/App.tsx
@@ -11,17 +11,20 @@ import { Services } from "./pages/Services";
 import { Settings } from "./pages/Settings";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "react";
 
 export function App(): JSX.Element {
   const navigator = useNavigator();
 
-  const user = useSyncExternalStore(store.subscribe, () => store.get("user"));
+  const user = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("user") as User | null,
+  );
 
   const links = user
     ? [

--- a/examples/web/react/auth-guards/src/pages/Dashboard.tsx
+++ b/examples/web/react/auth-guards/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 interface DashboardProps {
@@ -10,7 +10,10 @@ interface DashboardProps {
 }
 
 export function Dashboard({ onLogout }: DashboardProps): JSX.Element {
-  const user = useSyncExternalStore(store.subscribe, () => store.get("user"));
+  const user = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("user") as User | null,
+  );
 
   return (
     <div>

--- a/examples/web/react/auth-guards/src/pages/Login.tsx
+++ b/examples/web/react/auth-guards/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 interface LoginProps {

--- a/examples/web/react/auth-guards/src/pages/Settings.tsx
+++ b/examples/web/react/auth-guards/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useNavigator } from "@real-router/react";
 import { useEffect, useRef, useState } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "react";
 

--- a/examples/web/react/auth-guards/src/routes.ts
+++ b/examples/web/react/auth-guards/src/routes.ts
@@ -1,5 +1,5 @@
-import { can } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Route } from "@real-router/core";

--- a/examples/web/react/auth-guards/src/types.ts
+++ b/examples/web/react/auth-guards/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/react/auth-guards/tests/components.test.tsx
+++ b/examples/web/react/auth-guards/tests/components.test.tsx
@@ -12,8 +12,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/react/auth-guards/tests/router.test.ts
+++ b/examples/web/react/auth-guards/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { publicRoutes, privateRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/react/auth-guards/tests/setup.ts
+++ b/examples/web/react/auth-guards/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/react/basic/src/pages/Home.tsx
+++ b/examples/web/react/basic/src/pages/Home.tsx
@@ -12,7 +12,7 @@ export function Home(): JSX.Element {
       <h1>Home</h1>
       <p>Welcome to the Real-Router basic example.</p>
       <p>
-        Current route: <strong>{route?.name ?? "—"}</strong>
+        Current route: <strong>{route.name}</strong>
       </p>
       <p>
         Use the sidebar to navigate between pages. Try clicking <em>Back</em>{" "}

--- a/examples/web/react/combined/src/App.tsx
+++ b/examples/web/react/combined/src/App.tsx
@@ -13,11 +13,11 @@ import { Settings } from "./pages/Settings";
 import { UsersLayout } from "./pages/UsersLayout";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "react";
 
 const LazyDashboard = lazy(() => import("./pages/Dashboard"));
@@ -25,7 +25,10 @@ const LazyDashboard = lazy(() => import("./pages/Dashboard"));
 export function App(): JSX.Element {
   const navigator = useNavigator();
 
-  const user = useSyncExternalStore(store.subscribe, () => store.get("user"));
+  const user = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("user") as User | null,
+  );
 
   const privateLinks = [
     { routeName: "dashboard", label: "Dashboard" },

--- a/examples/web/react/combined/src/pages/Dashboard.tsx
+++ b/examples/web/react/combined/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
 import { useNavigator, useRoute } from "@real-router/react";
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 interface DashboardProps {
@@ -11,11 +11,14 @@ interface DashboardProps {
 }
 
 export default function Dashboard({ onLogout }: DashboardProps): JSX.Element {
-  const user = useSyncExternalStore(store.subscribe, () => store.get("user"));
+  const user = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("user") as User | null,
+  );
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>
@@ -44,9 +47,9 @@ export default function Dashboard({ onLogout }: DashboardProps): JSX.Element {
         <button
           onClick={() =>
             void navigator.navigate(
-              route?.name ?? "dashboard",
+              route.name,
               {
-                ...route?.params,
+                ...route.params,
                 lang: lang === "en" ? "ru" : "en",
               },
               { reload: true },

--- a/examples/web/react/combined/src/pages/Login.tsx
+++ b/examples/web/react/combined/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 interface LoginProps {

--- a/examples/web/react/combined/src/pages/ProductDetail.tsx
+++ b/examples/web/react/combined/src/pages/ProductDetail.tsx
@@ -1,14 +1,15 @@
 import { Link } from "@real-router/react";
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 export function ProductDetail(): JSX.Element {
-  const product = useSyncExternalStore(store.subscribe, () =>
-    store.get("products.detail"),
+  const product = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("products.detail") as Product | null | undefined,
   );
   const loading = useSyncExternalStore(
     store.subscribe,

--- a/examples/web/react/combined/src/pages/ProductList.tsx
+++ b/examples/web/react/combined/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/react";
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/react/combined/src/pages/Settings.tsx
+++ b/examples/web/react/combined/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "react";
 

--- a/examples/web/react/combined/src/pages/UsersLayout.tsx
+++ b/examples/web/react/combined/src/pages/UsersLayout.tsx
@@ -29,13 +29,9 @@ function getLabel(name: string, params: Params): string {
   return name;
 }
 
-function Breadcrumbs(): JSX.Element | null {
+function Breadcrumbs(): JSX.Element {
   const { route } = useRoute();
   const utils = useRouteUtils();
-
-  if (!route) {
-    return null;
-  }
 
   const chain = utils.getChain(route.name) ?? [route.name];
   const crumbs = ["home", ...chain];

--- a/examples/web/react/combined/src/routes.ts
+++ b/examples/web/react/combined/src/routes.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { can } from "../../../shared/abilities";
-import { api } from "../../../shared/api";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { api } from "../../../../shared/api";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Params, Route } from "@real-router/core";

--- a/examples/web/react/combined/src/types.ts
+++ b/examples/web/react/combined/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/react/combined/tests/components.test.tsx
+++ b/examples/web/react/combined/tests/components.test.tsx
@@ -13,8 +13,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/react/combined/tests/router.test.ts
+++ b/examples/web/react/combined/tests/router.test.ts
@@ -3,8 +3,8 @@ import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { privateRoutes, publicRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/react/combined/tests/setup.ts
+++ b/examples/web/react/combined/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/react/data-loading/src/pages/ProductDetail.tsx
+++ b/examples/web/react/data-loading/src/pages/ProductDetail.tsx
@@ -1,14 +1,15 @@
 import { Link } from "@real-router/react";
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 export function ProductDetail(): JSX.Element {
-  const product = useSyncExternalStore(store.subscribe, () =>
-    store.get("products.detail"),
+  const product = useSyncExternalStore(
+    store.subscribe,
+    () => store.get("products.detail") as Product | null | undefined,
   );
   const loading = useSyncExternalStore(
     store.subscribe,

--- a/examples/web/react/data-loading/src/pages/ProductList.tsx
+++ b/examples/web/react/data-loading/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/react";
 import { useSyncExternalStore } from "react";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "react";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/react/dynamic-routes/src/App.tsx
+++ b/examples/web/react/dynamic-routes/src/App.tsx
@@ -27,7 +27,7 @@ export function App(): JSX.Element {
 
   const toggleAnalytics = async () => {
     if (analyticsEnabled) {
-      if (route?.name.startsWith("analytics")) {
+      if (route.name.startsWith("analytics")) {
         await navigator.navigate("home");
       }
 
@@ -41,7 +41,7 @@ export function App(): JSX.Element {
 
   const toggleAdmin = async () => {
     if (adminEnabled) {
-      if (route?.name.startsWith("admin")) {
+      if (route.name.startsWith("admin")) {
         await navigator.navigate("home");
       }
 

--- a/examples/web/react/hash-routing/src/pages/Home.tsx
+++ b/examples/web/react/hash-routing/src/pages/Home.tsx
@@ -18,7 +18,7 @@ export function Home(): JSX.Element {
         same route.
       </p>
       <p>
-        Current route: <strong>{route?.name ?? "—"}</strong>
+        Current route: <strong>{route.name}</strong>
       </p>
       <p>
         Current URL hash:{" "}

--- a/examples/web/react/hmr/src/App.tsx
+++ b/examples/web/react/hmr/src/App.tsx
@@ -18,7 +18,7 @@ function HmrStatus(): JSX.Element {
 
   return (
     <p style={{ fontSize: "13px", color: "#888", marginTop: "16px" }}>
-      Current route: <strong>{route?.name ?? "—"}</strong>
+      Current route: <strong>{route.name}</strong>
     </p>
   );
 }

--- a/examples/web/react/legacy-entry/src/pages/Home.tsx
+++ b/examples/web/react/legacy-entry/src/pages/Home.tsx
@@ -10,7 +10,7 @@ export function Home(): JSX.Element {
       <h1>Home</h1>
       <p>Welcome to the Real-Router legacy-entry example.</p>
       <p>
-        Current route: <strong>{route?.name ?? "—"}</strong>
+        Current route: <strong>{route.name}</strong>
       </p>
       <p>
         This app uses <code>@real-router/react/legacy</code> — no{" "}

--- a/examples/web/react/navigation-api/src/components/AnimatedRoute.tsx
+++ b/examples/web/react/navigation-api/src/components/AnimatedRoute.tsx
@@ -6,7 +6,7 @@ export function AnimatedRoute({
   children,
 }: Readonly<{ children: ReactNode }>): JSX.Element {
   const { route } = useRoute();
-  const direction = route?.context.navigation?.direction ?? "unknown";
+  const direction = route.context.navigation?.direction ?? "unknown";
 
   const className =
     direction === "back"
@@ -16,11 +16,7 @@ export function AnimatedRoute({
         : "page fade";
 
   return (
-    <div
-      className={className}
-      key={route?.path ?? ""}
-      data-direction={direction}
-    >
+    <div className={className} key={route.path} data-direction={direction}>
       {children}
     </div>
   );

--- a/examples/web/react/navigation-api/src/pages/Product.tsx
+++ b/examples/web/react/navigation-api/src/pages/Product.tsx
@@ -9,7 +9,7 @@ const PRODUCT_IDS = [1, 2, 3, 5];
 export function Product(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
   const navigator = useNavigator();
-  const id = Number(route?.params.id ?? "1");
+  const id = Number(route.params.id ?? "1");
   const currentIndex = PRODUCT_IDS.indexOf(id);
   const prevId = currentIndex > 0 ? PRODUCT_IDS[currentIndex - 1] : undefined;
   const nextId =

--- a/examples/web/react/navigation-api/src/pages/ProductEdit.tsx
+++ b/examples/web/react/navigation-api/src/pages/ProductEdit.tsx
@@ -8,7 +8,7 @@ import type { JSX } from "react";
 export function ProductEdit(): JSX.Element {
   const { route } = useRoute<{ id: string }>();
   const navigator = useNavigator();
-  const id = route?.params.id ?? "";
+  const id = route.params.id ?? "";
 
   const draftKey = `draft:product:${id}`;
   const [notes, setNotes] = useState<string>(

--- a/examples/web/react/nested-routes/src/pages/UsersLayout.tsx
+++ b/examples/web/react/nested-routes/src/pages/UsersLayout.tsx
@@ -33,13 +33,9 @@ function getLabel(name: string, params: Params): string {
   return name;
 }
 
-function Breadcrumbs(): JSX.Element | null {
+function Breadcrumbs(): JSX.Element {
   const { route } = useRoute();
   const utils = useRouteUtils();
-
-  if (!route) {
-    return null;
-  }
 
   const chain = utils.getChain(route.name) ?? [route.name];
   const crumbs = ["home", ...chain];

--- a/examples/web/react/persistent-params/src/App.tsx
+++ b/examples/web/react/persistent-params/src/App.tsx
@@ -17,14 +17,14 @@ function ParamsToolbar(): JSX.Element {
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const lang = (route?.params.lang as string | undefined) ?? "en";
-  const theme = (route?.params.theme as string | undefined) ?? "light";
+  const lang = (route.params.lang as string | undefined) ?? "en";
+  const theme = (route.params.theme as string | undefined) ?? "light";
 
   const navigate = (newParams: Record<string, string>) => {
     void navigator.navigate(
-      route?.name ?? "home",
+      route.name,
       {
-        ...route?.params,
+        ...route.params,
         ...newParams,
       },
       { reload: true },

--- a/examples/web/react/persistent-params/src/pages/About.tsx
+++ b/examples/web/react/persistent-params/src/pages/About.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function About(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/react/persistent-params/src/pages/Contacts.tsx
+++ b/examples/web/react/persistent-params/src/pages/Contacts.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 export function Contacts(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
+  const lang = (route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/react/persistent-params/src/pages/Home.tsx
+++ b/examples/web/react/persistent-params/src/pages/Home.tsx
@@ -4,8 +4,8 @@ import type { JSX } from "react";
 
 export function Home(): JSX.Element {
   const { route } = useRoute();
-  const lang = (route?.params.lang as string | undefined) ?? "en";
-  const theme = (route?.params.theme as string | undefined) ?? "light";
+  const lang = (route.params.lang as string | undefined) ?? "en";
+  const theme = (route.params.theme as string | undefined) ?? "light";
 
   return (
     <div>

--- a/examples/web/react/search-schema/src/pages/Products.tsx
+++ b/examples/web/react/search-schema/src/pages/Products.tsx
@@ -6,14 +6,14 @@ export function Products(): JSX.Element {
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const q = (route?.params.q as string | undefined) ?? "";
-  const page = (route?.params.page as number | undefined) ?? 1;
-  const sort = (route?.params.sort as string | undefined) ?? "name";
+  const q = (route.params.q as string | undefined) ?? "";
+  const page = (route.params.page as number | undefined) ?? 1;
+  const sort = (route.params.sort as string | undefined) ?? "name";
 
   const navigate = (
     params: Record<string, string | number | boolean | undefined>,
   ) => {
-    void navigator.navigate("products", { ...route?.params, ...params });
+    void navigator.navigate("products", { ...route.params, ...params });
   };
 
   return (

--- a/examples/web/solid/auth-guards/src/App.tsx
+++ b/examples/web/solid/auth-guards/src/App.tsx
@@ -11,11 +11,11 @@ import { Services } from "./pages/Services";
 import { Settings } from "./pages/Settings";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "solid-js";
 
 export function App(): JSX.Element {

--- a/examples/web/solid/auth-guards/src/pages/Dashboard.tsx
+++ b/examples/web/solid/auth-guards/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 interface DashboardProps {

--- a/examples/web/solid/auth-guards/src/pages/Login.tsx
+++ b/examples/web/solid/auth-guards/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { createSignal, Show } from "solid-js";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 interface LoginProps {

--- a/examples/web/solid/auth-guards/src/pages/Settings.tsx
+++ b/examples/web/solid/auth-guards/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useNavigator } from "@real-router/solid";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "solid-js";
 

--- a/examples/web/solid/auth-guards/src/routes.ts
+++ b/examples/web/solid/auth-guards/src/routes.ts
@@ -1,5 +1,5 @@
-import { can } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Route } from "@real-router/core";

--- a/examples/web/solid/auth-guards/src/types.ts
+++ b/examples/web/solid/auth-guards/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/solid/auth-guards/tests/components.test.tsx
+++ b/examples/web/solid/auth-guards/tests/components.test.tsx
@@ -4,8 +4,8 @@ import { RouterProvider } from "@real-router/solid";
 import { render, screen, cleanup } from "@solidjs/testing-library";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/solid/auth-guards/tests/router.test.ts
+++ b/examples/web/solid/auth-guards/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { publicRoutes, privateRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/solid/auth-guards/tests/setup.ts
+++ b/examples/web/solid/auth-guards/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/solid/basic/src/pages/Home.tsx
+++ b/examples/web/solid/basic/src/pages/Home.tsx
@@ -13,7 +13,7 @@ export function Home(): JSX.Element {
       <h1>Home</h1>
       <p>Welcome to the Real-Router basic example.</p>
       <p>
-        Current route: <strong>{routeState().route?.name ?? "—"}</strong>
+        Current route: <strong>{routeState().route.name}</strong>
       </p>
       <p>
         Use the sidebar to navigate between pages. Try clicking <em>Back</em>{" "}

--- a/examples/web/solid/combined/src/App.tsx
+++ b/examples/web/solid/combined/src/App.tsx
@@ -13,11 +13,11 @@ import { Settings } from "./pages/Settings";
 import { UsersLayout } from "./pages/UsersLayout";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { Layout } from "../../shared/Layout";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 import type { JSX } from "solid-js";
 
 const LazyDashboard = lazy(() => import("./pages/Dashboard"));

--- a/examples/web/solid/combined/src/pages/Dashboard.tsx
+++ b/examples/web/solid/combined/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
 import { useNavigator, useRoute } from "@real-router/solid";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 interface DashboardProps {
@@ -26,7 +26,7 @@ export default function Dashboard(props: DashboardProps): JSX.Element {
   });
 
   const lang = () =>
-    (routeState().route?.params.lang as string | undefined) ?? "en";
+    (routeState().route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>
@@ -57,9 +57,9 @@ export default function Dashboard(props: DashboardProps): JSX.Element {
         <button
           onClick={() =>
             void navigator.navigate(
-              routeState().route?.name ?? "dashboard",
+              routeState().route.name,
               {
-                ...routeState().route?.params,
+                ...routeState().route.params,
                 lang: lang() === "en" ? "ru" : "en",
               },
               { reload: true },

--- a/examples/web/solid/combined/src/pages/Login.tsx
+++ b/examples/web/solid/combined/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { createSignal, Show } from "solid-js";
 
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 interface LoginProps {

--- a/examples/web/solid/combined/src/pages/ProductDetail.tsx
+++ b/examples/web/solid/combined/src/pages/ProductDetail.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/solid";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 export function ProductDetail(): JSX.Element {

--- a/examples/web/solid/combined/src/pages/ProductList.tsx
+++ b/examples/web/solid/combined/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/solid";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/solid/combined/src/pages/Settings.tsx
+++ b/examples/web/solid/combined/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 import type { JSX } from "solid-js";
 

--- a/examples/web/solid/combined/src/routes.ts
+++ b/examples/web/solid/combined/src/routes.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { can } from "../../../shared/abilities";
-import { api } from "../../../shared/api";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { api } from "../../../../shared/api";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Params, Route } from "@real-router/core";

--- a/examples/web/solid/combined/src/types.ts
+++ b/examples/web/solid/combined/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/solid/combined/tests/components.test.tsx
+++ b/examples/web/solid/combined/tests/components.test.tsx
@@ -4,8 +4,8 @@ import { RouterProvider } from "@real-router/solid";
 import { render, screen, cleanup } from "@solidjs/testing-library";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { App } from "../src/App";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { publicRoutes, privateRoutes } from "../src/routes";

--- a/examples/web/solid/combined/tests/router.test.ts
+++ b/examples/web/solid/combined/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { privateRoutes, publicRoutes } from "../src/routes";
 

--- a/examples/web/solid/combined/tests/setup.ts
+++ b/examples/web/solid/combined/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/solid/data-loading/src/pages/ProductDetail.tsx
+++ b/examples/web/solid/data-loading/src/pages/ProductDetail.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/solid";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 export function ProductDetail(): JSX.Element {

--- a/examples/web/solid/data-loading/src/pages/ProductList.tsx
+++ b/examples/web/solid/data-loading/src/pages/ProductList.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@real-router/solid";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 import type { JSX } from "solid-js";
 
 export function ProductList(): JSX.Element {

--- a/examples/web/solid/dynamic-routes/src/App.tsx
+++ b/examples/web/solid/dynamic-routes/src/App.tsx
@@ -29,7 +29,7 @@ export function App(): JSX.Element {
     if (analyticsEnabled()) {
       const route = routeState().route;
 
-      if (route?.name.startsWith("analytics")) {
+      if (route.name.startsWith("analytics")) {
         await navigator.navigate("home");
       }
 
@@ -45,7 +45,7 @@ export function App(): JSX.Element {
     if (adminEnabled()) {
       const route = routeState().route;
 
-      if (route?.name.startsWith("admin")) {
+      if (route.name.startsWith("admin")) {
         await navigator.navigate("home");
       }
 

--- a/examples/web/solid/hash-routing/src/pages/Home.tsx
+++ b/examples/web/solid/hash-routing/src/pages/Home.tsx
@@ -18,7 +18,7 @@ export function Home(): JSX.Element {
         same route.
       </p>
       <p>
-        Current route: <strong>{routeState().route?.name ?? "—"}</strong>
+        Current route: <strong>{routeState().route.name}</strong>
       </p>
       <p>
         Current URL hash:{" "}

--- a/examples/web/solid/persistent-params/src/App.tsx
+++ b/examples/web/solid/persistent-params/src/App.tsx
@@ -18,17 +18,17 @@ function ParamsToolbar(): JSX.Element {
   const navigator = useNavigator();
 
   const lang = () =>
-    (routeState().route?.params.lang as string | undefined) ?? "en";
+    (routeState().route.params.lang as string | undefined) ?? "en";
   const theme = () =>
-    (routeState().route?.params.theme as string | undefined) ?? "light";
+    (routeState().route.params.theme as string | undefined) ?? "light";
 
   const navigate = (newParams: Record<string, string>) => {
     const route = routeState().route;
 
     void navigator.navigate(
-      route?.name ?? "home",
+      route.name,
       {
-        ...route?.params,
+        ...route.params,
         ...newParams,
       },
       { reload: true },

--- a/examples/web/solid/persistent-params/src/pages/About.tsx
+++ b/examples/web/solid/persistent-params/src/pages/About.tsx
@@ -5,7 +5,7 @@ import type { JSX } from "solid-js";
 export function About(): JSX.Element {
   const routeState = useRoute();
   const lang = () =>
-    (routeState().route?.params.lang as string | undefined) ?? "en";
+    (routeState().route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/solid/persistent-params/src/pages/Contacts.tsx
+++ b/examples/web/solid/persistent-params/src/pages/Contacts.tsx
@@ -5,7 +5,7 @@ import type { JSX } from "solid-js";
 export function Contacts(): JSX.Element {
   const routeState = useRoute();
   const lang = () =>
-    (routeState().route?.params.lang as string | undefined) ?? "en";
+    (routeState().route.params.lang as string | undefined) ?? "en";
 
   return (
     <div>

--- a/examples/web/solid/persistent-params/src/pages/Home.tsx
+++ b/examples/web/solid/persistent-params/src/pages/Home.tsx
@@ -5,9 +5,9 @@ import type { JSX } from "solid-js";
 export function Home(): JSX.Element {
   const routeState = useRoute();
   const lang = () =>
-    (routeState().route?.params.lang as string | undefined) ?? "en";
+    (routeState().route.params.lang as string | undefined) ?? "en";
   const theme = () =>
-    (routeState().route?.params.theme as string | undefined) ?? "light";
+    (routeState().route.params.theme as string | undefined) ?? "light";
 
   return (
     <div>

--- a/examples/web/solid/search-schema/src/pages/Products.tsx
+++ b/examples/web/solid/search-schema/src/pages/Products.tsx
@@ -6,18 +6,18 @@ export function Products(): JSX.Element {
   const routeState = useRoute();
   const navigator = useNavigator();
 
-  const q = () => (routeState().route?.params.q as string | undefined) ?? "";
+  const q = () => (routeState().route.params.q as string | undefined) ?? "";
   const page = () =>
-    (routeState().route?.params.page as number | undefined) ?? 1;
+    (routeState().route.params.page as number | undefined) ?? 1;
   const sort = () =>
-    (routeState().route?.params.sort as string | undefined) ?? "name";
+    (routeState().route.params.sort as string | undefined) ?? "name";
 
   const navigate = (
     params: Record<string, string | number | boolean | undefined>,
   ) => {
     const route = routeState().route;
 
-    void navigator.navigate("products", { ...route?.params, ...params });
+    void navigator.navigate("products", { ...route.params, ...params });
   };
 
   return (

--- a/examples/web/solid/store-based-state/src/pages/UserPage.tsx
+++ b/examples/web/solid/store-based-state/src/pages/UserPage.tsx
@@ -59,7 +59,7 @@ function SignalComparison(): JSX.Element {
 
   createEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    routeState().route?.params.id;
+    routeState().route.params.id;
     setCount((c) => c + 1);
     console.log(`[Signal] effect ran — count=${count()}`);
   });
@@ -67,7 +67,7 @@ function SignalComparison(): JSX.Element {
   return (
     <div class="card">
       <strong>Signal comparison (useRoute → params.id)</strong>
-      <p>User ID: {(routeState().route?.params.id as string) ?? "—"}</p>
+      <p>User ID: {(routeState().route.params.id as string) ?? "—"}</p>
       <p style={{ "font-size": "13px", color: "#888" }}>
         Effect count: {count()} — re-runs on ANY param change
       </p>

--- a/examples/web/svelte/animation-examples/motion-animations/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/animation-examples/motion-animations/src/pages/ProductDetail.svelte
@@ -11,7 +11,7 @@
   };
 
   const { route } = useRoute<{ id: string }>();
-  const id = $derived(route.current?.params.id ?? "1");
+  const id = $derived(route.current.params.id ?? "1");
   const product = $derived(COVERS[id]);
 </script>
 

--- a/examples/web/svelte/animation-examples/motion-animations/src/pages/ProductsList.svelte
+++ b/examples/web/svelte/animation-examples/motion-animations/src/pages/ProductsList.svelte
@@ -21,7 +21,7 @@
   const { route } = useRoute<{ sort?: SortDirection }>();
 
   const sort: SortDirection = $derived(
-    route.current?.params.sort === "desc" ? "desc" : "asc",
+    route.current.params.sort === "desc" ? "desc" : "asc",
   );
 
   const items = $derived.by(() => {

--- a/examples/web/svelte/animation-examples/motion-animations/src/pages/QueryDemo.svelte
+++ b/examples/web/svelte/animation-examples/motion-animations/src/pages/QueryDemo.svelte
@@ -16,7 +16,7 @@
   const { route } = useRoute<{ filter?: Filter }>();
 
   const filter: Filter = $derived(
-    (route.current?.params.filter as Filter | undefined) ?? "all",
+    (route.current.params.filter as Filter | undefined) ?? "all",
   );
 
   const visible = $derived.by(() =>

--- a/examples/web/svelte/animation-examples/page-animations/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/animation-examples/page-animations/src/pages/ProductDetail.svelte
@@ -16,7 +16,7 @@
   useRouteAnimation(() => ref, { entryClass: "fade-in", exitClass: "fade-out" });
 
   const { route } = useRoute<{ id: string }>();
-  const id = $derived(route.current?.params.id ?? "1");
+  const id = $derived(route.current.params.id ?? "1");
   const product = $derived(COVERS[id]);
 </script>
 

--- a/examples/web/svelte/animation-examples/page-animations/src/pages/ProductsList.svelte
+++ b/examples/web/svelte/animation-examples/page-animations/src/pages/ProductsList.svelte
@@ -33,7 +33,7 @@
   const { route } = useRoute<{ sort?: SortDirection }>();
 
   const sort: SortDirection = $derived(
-    route.current?.params.sort === "desc" ? "desc" : "asc",
+    route.current.params.sort === "desc" ? "desc" : "asc",
   );
 
   const items = $derived.by(() => {

--- a/examples/web/svelte/animation-examples/page-animations/src/pages/QueryDemo.svelte
+++ b/examples/web/svelte/animation-examples/page-animations/src/pages/QueryDemo.svelte
@@ -24,7 +24,7 @@
   const { route } = useRoute<{ filter?: Filter }>();
 
   const filter: Filter = $derived(
-    (route.current?.params.filter as Filter | undefined) ?? "all",
+    (route.current.params.filter as Filter | undefined) ?? "all",
   );
 
   const visible = $derived.by(() =>

--- a/examples/web/svelte/animation-examples/route-animations/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/animation-examples/route-animations/src/pages/ProductDetail.svelte
@@ -11,7 +11,7 @@
   };
 
   const { route } = useRoute<{ id: string }>();
-  const id = $derived(route.current?.params.id ?? "1");
+  const id = $derived(route.current.params.id ?? "1");
   const product = $derived(COVERS[id]);
 </script>
 

--- a/examples/web/svelte/animation-examples/route-animations/src/pages/ProductsList.svelte
+++ b/examples/web/svelte/animation-examples/route-animations/src/pages/ProductsList.svelte
@@ -21,7 +21,7 @@
   const { route } = useRoute<{ sort?: SortDirection }>();
 
   const sort: SortDirection = $derived(
-    route.current?.params.sort === "desc" ? "desc" : "asc",
+    route.current.params.sort === "desc" ? "desc" : "asc",
   );
 
   const items = $derived.by(() => {

--- a/examples/web/svelte/animation-examples/route-animations/src/pages/QueryDemo.svelte
+++ b/examples/web/svelte/animation-examples/route-animations/src/pages/QueryDemo.svelte
@@ -16,7 +16,7 @@
   const { route } = useRoute<{ filter?: Filter }>();
 
   const filter: Filter = $derived(
-    (route.current?.params.filter as Filter | undefined) ?? "all",
+    (route.current.params.filter as Filter | undefined) ?? "all",
   );
 
   const visible = $derived.by(() =>

--- a/examples/web/svelte/animation-examples/view-transitions/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/animation-examples/view-transitions/src/pages/ProductDetail.svelte
@@ -14,7 +14,7 @@
 
   const { route } = useRoute<{ id: string }>();
 
-  const id = $derived(route.current?.params.id ?? "1");
+  const id = $derived(route.current.params.id ?? "1");
   const product = $derived(COVERS[id]);
 </script>
 

--- a/examples/web/svelte/animation-examples/view-transitions/src/pages/ProductsList.svelte
+++ b/examples/web/svelte/animation-examples/view-transitions/src/pages/ProductsList.svelte
@@ -21,7 +21,7 @@
   const { route } = useRoute<{ sort?: SortDirection }>();
 
   const sort: SortDirection = $derived(
-    route.current?.params.sort === "desc" ? "desc" : "asc",
+    route.current.params.sort === "desc" ? "desc" : "asc",
   );
 
   const items = $derived.by(() => {

--- a/examples/web/svelte/animation-examples/view-transitions/src/pages/QueryDemo.svelte
+++ b/examples/web/svelte/animation-examples/view-transitions/src/pages/QueryDemo.svelte
@@ -19,7 +19,7 @@
   // like the initial active one.
   const { route } = useRoute<{ filter?: Filter }>();
 
-  const filter: Filter = $derived(route.current?.params.filter ?? "all");
+  const filter: Filter = $derived(route.current.params.filter ?? "all");
 
   const visible = $derived(
     filter === "all"

--- a/examples/web/svelte/auth-guards/src/App.svelte
+++ b/examples/web/svelte/auth-guards/src/App.svelte
@@ -11,10 +11,10 @@
   import Services from "./pages/Services.svelte";
   import Contacts from "./pages/Contacts.svelte";
   import { publicRoutes, privateRoutes } from "./routes";
-  import { defineAbilities } from "../../../shared/abilities";
-  import { store } from "../../../shared/store";
+  import { defineAbilities } from "../../../../shared/abilities";
+  import { store } from "../../../../shared/store";
 
-  import type { User } from "../../../shared/api";
+  import type { User } from "../../../../shared/api";
   import type { AppDependencies } from "./types";
 
   let { router }: { router: Router<AppDependencies> } = $props();

--- a/examples/web/svelte/auth-guards/src/pages/Dashboard.svelte
+++ b/examples/web/svelte/auth-guards/src/pages/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { store } from "../../../../shared/store";
+  import { store } from "../../../../../shared/store";
 
-  import type { User } from "../../../../shared/api";
+  import type { User } from "../../../../../shared/api";
 
   let { onLogout }: { onLogout: () => Promise<void> } = $props();
 

--- a/examples/web/svelte/auth-guards/src/pages/Login.svelte
+++ b/examples/web/svelte/auth-guards/src/pages/Login.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { api } from "../../../../shared/api";
+  import { api } from "../../../../../shared/api";
 
-  import type { User } from "../../../../shared/api";
+  import type { User } from "../../../../../shared/api";
 
   let { onLogin }: { onLogin: (user: User) => Promise<void> } = $props();
 

--- a/examples/web/svelte/auth-guards/src/pages/Settings.svelte
+++ b/examples/web/svelte/auth-guards/src/pages/Settings.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { useNavigator } from "@real-router/svelte";
 
-  import { store } from "../../../../shared/store";
+  import { store } from "../../../../../shared/store";
 
   const navigator = useNavigator();
   let displayName = $state("");

--- a/examples/web/svelte/auth-guards/src/routes.ts
+++ b/examples/web/svelte/auth-guards/src/routes.ts
@@ -1,5 +1,5 @@
-import { can } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Route } from "@real-router/core";

--- a/examples/web/svelte/auth-guards/src/types.ts
+++ b/examples/web/svelte/auth-guards/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/svelte/auth-guards/tests/components.test.ts
+++ b/examples/web/svelte/auth-guards/tests/components.test.ts
@@ -11,8 +11,8 @@ import {
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import App from "../src/App.svelte";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/svelte/auth-guards/tests/router.test.ts
+++ b/examples/web/svelte/auth-guards/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { publicRoutes, privateRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/svelte/auth-guards/tests/setup.ts
+++ b/examples/web/svelte/auth-guards/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/svelte/basic/src/pages/Home.svelte
+++ b/examples/web/svelte/basic/src/pages/Home.svelte
@@ -9,7 +9,7 @@
   <h1>Home</h1>
   <p>Welcome to the Real-Router basic example.</p>
   <p>
-    Current route: <strong>{route.current?.name ?? "—"}</strong>
+    Current route: <strong>{route.current.name}</strong>
   </p>
   <p>
     Use the sidebar to navigate between pages. Try clicking <em>Back</em>

--- a/examples/web/svelte/combined/src/App.svelte
+++ b/examples/web/svelte/combined/src/App.svelte
@@ -14,10 +14,10 @@
   import Admin from "./pages/Admin.svelte";
   import Checkout from "./pages/Checkout.svelte";
   import { publicRoutes, privateRoutes } from "./routes";
-  import { defineAbilities } from "../../../shared/abilities";
-  import { store } from "../../../shared/store";
+  import { defineAbilities } from "../../../../shared/abilities";
+  import { store } from "../../../../shared/store";
 
-  import type { User } from "../../../shared/api";
+  import type { User } from "../../../../shared/api";
   import type { AppDependencies } from "./types";
 
   let { router }: { router: Router<AppDependencies> } = $props();

--- a/examples/web/svelte/combined/src/pages/Dashboard.svelte
+++ b/examples/web/svelte/combined/src/pages/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { useRoute, useNavigator } from "@real-router/svelte";
-  import { store } from "../../../../shared/store";
-  import type { User } from "../../../../shared/api";
+  import { store } from "../../../../../shared/store";
+  import type { User } from "../../../../../shared/api";
 
   let { onLogout }: { onLogout: () => Promise<void> } = $props();
 
@@ -13,7 +13,7 @@
     return store.subscribe(() => { user = store.get("user") as User | null; });
   });
 
-  const lang = $derived((route.current?.params.lang as string | undefined) ?? "en");
+  const lang = $derived((route.current.params.lang as string | undefined) ?? "en");
 </script>
 
 <div>
@@ -26,7 +26,7 @@
     </div>
   {/if}
   <div style="display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap">
-    <button onclick={() => void navigator.navigate(route.current?.name ?? "dashboard", { ...route.current?.params, lang: lang === "en" ? "ru" : "en" }, { reload: true })}>
+    <button onclick={() => void navigator.navigate(route.current.name, { ...route.current.params, lang: lang === "en" ? "ru" : "en" }, { reload: true })}>
       Toggle lang ({lang === "en" ? "→ RU" : "→ EN"})
     </button>
     <button class="danger" onclick={() => void onLogout()}>Logout</button>

--- a/examples/web/svelte/combined/src/pages/Login.svelte
+++ b/examples/web/svelte/combined/src/pages/Login.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { api } from "../../../../shared/api";
-  import type { User } from "../../../../shared/api";
+  import { api } from "../../../../../shared/api";
+  import type { User } from "../../../../../shared/api";
 
   let { onLogin }: { onLogin: (user: User) => Promise<void> } = $props();
 

--- a/examples/web/svelte/combined/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/combined/src/pages/ProductDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Link } from "@real-router/svelte";
-  import { store } from "../../../../shared/store";
-  import type { Product } from "../../../../shared/api";
+  import { store } from "../../../../../shared/store";
+  import type { Product } from "../../../../../shared/api";
 
   let product = $state(store.get("products.detail") as Product | null | undefined);
   let loading = $state(store.get("products.detail:loading") as boolean | undefined);

--- a/examples/web/svelte/combined/src/pages/ProductList.svelte
+++ b/examples/web/svelte/combined/src/pages/ProductList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Link } from "@real-router/svelte";
-  import { store } from "../../../../shared/store";
-  import type { Product } from "../../../../shared/api";
+  import { store } from "../../../../../shared/store";
+  import type { Product } from "../../../../../shared/api";
 
   let products = $state(store.get("products") as Product[] | null);
   let loading = $state(store.get("products:loading") as boolean | undefined);

--- a/examples/web/svelte/combined/src/pages/Settings.svelte
+++ b/examples/web/svelte/combined/src/pages/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { store } from "../../../../shared/store";
+  import { store } from "../../../../../shared/store";
 
   let displayName = $state("");
 

--- a/examples/web/svelte/combined/src/pages/UsersLayout.svelte
+++ b/examples/web/svelte/combined/src/pages/UsersLayout.svelte
@@ -20,18 +20,16 @@
 
 {#if nodeRoute.current}
   <div>
-    {#if route.current}
-      <nav class="breadcrumbs" aria-label="breadcrumb">
-        {#each ["home", ...(utils.getChain(route.current.name) ?? [route.current.name])] as name, i}
-          {#if i > 0}<span> › </span>{/if}
-          {#if i === ["home", ...(utils.getChain(route.current.name) ?? [route.current.name])].length - 1}
-            <span>{getLabel(name, route.current.params)}</span>
-          {:else}
-            <Link routeName={name}>{getLabel(name, route.current.params)}</Link>
-          {/if}
-        {/each}
-      </nav>
-    {/if}
+    <nav class="breadcrumbs" aria-label="breadcrumb">
+      {#each ["home", ...(utils.getChain(route.current.name) ?? [route.current.name])] as name, i}
+        {#if i > 0}<span> › </span>{/if}
+        {#if i === ["home", ...(utils.getChain(route.current.name) ?? [route.current.name])].length - 1}
+          <span>{getLabel(name, route.current.params)}</span>
+        {:else}
+          <Link routeName={name}>{getLabel(name, route.current.params)}</Link>
+        {/if}
+      {/each}
+    </nav>
     <div style="margin-top: 16px">
       <RouteView nodeName="users">
         {#snippet self()}

--- a/examples/web/svelte/combined/src/routes.ts
+++ b/examples/web/svelte/combined/src/routes.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { can } from "../../../shared/abilities";
-import { api } from "../../../shared/api";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { api } from "../../../../shared/api";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Params, Route } from "@real-router/core";

--- a/examples/web/svelte/combined/src/types.ts
+++ b/examples/web/svelte/combined/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/svelte/combined/tests/components.test.ts
+++ b/examples/web/svelte/combined/tests/components.test.ts
@@ -4,8 +4,8 @@ import { render, screen, cleanup, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import App from "../src/App.svelte";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { publicRoutes, privateRoutes } from "../src/routes";

--- a/examples/web/svelte/combined/tests/router.test.ts
+++ b/examples/web/svelte/combined/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { privateRoutes, publicRoutes } from "../src/routes";
 

--- a/examples/web/svelte/combined/tests/setup.ts
+++ b/examples/web/svelte/combined/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   store.clear();

--- a/examples/web/svelte/data-loading/src/pages/ProductDetail.svelte
+++ b/examples/web/svelte/data-loading/src/pages/ProductDetail.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { Link } from "@real-router/svelte";
-  import { store } from "../../../../shared/store";
+  import { store } from "../../../../../shared/store";
 
-  import type { Product } from "../../../../shared/api";
+  import type { Product } from "../../../../../shared/api";
 
   let product = $state(store.get("products.detail") as Product | null | undefined);
   let loading = $state(store.get("products.detail:loading") as boolean | undefined);

--- a/examples/web/svelte/data-loading/src/pages/ProductList.svelte
+++ b/examples/web/svelte/data-loading/src/pages/ProductList.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { Link } from "@real-router/svelte";
-  import { store } from "../../../../shared/store";
+  import { store } from "../../../../../shared/store";
 
-  import type { Product } from "../../../../shared/api";
+  import type { Product } from "../../../../../shared/api";
 
   let products = $state(store.get("products") as Product[] | null);
   let loading = $state(store.get("products:loading") as boolean | undefined);

--- a/examples/web/svelte/dynamic-routes/src/App.svelte
+++ b/examples/web/svelte/dynamic-routes/src/App.svelte
@@ -43,7 +43,7 @@
             checked={analyticsEnabled}
             onchange={async () => {
               if (analyticsEnabled) {
-                if (route.current?.name.startsWith("analytics")) {
+                if (route.current.name.startsWith("analytics")) {
                   await navigator.navigate("home");
                 }
                 routesApi.remove("analytics");
@@ -63,7 +63,7 @@
             checked={adminEnabled}
             onchange={async () => {
               if (adminEnabled) {
-                if (route.current?.name.startsWith("admin")) {
+                if (route.current.name.startsWith("admin")) {
                   await navigator.navigate("home");
                 }
                 routesApi.remove("admin");

--- a/examples/web/svelte/hash-routing/src/pages/Home.svelte
+++ b/examples/web/svelte/hash-routing/src/pages/Home.svelte
@@ -16,7 +16,7 @@
     same route.
   </p>
   <p>
-    Current route: <strong>{route.current?.name ?? "—"}</strong>
+    Current route: <strong>{route.current.name}</strong>
   </p>
   <p>
     Current URL hash:

--- a/examples/web/svelte/nested-routes/src/pages/UsersLayout.svelte
+++ b/examples/web/svelte/nested-routes/src/pages/UsersLayout.svelte
@@ -27,20 +27,18 @@
 </script>
 
 {#if route.current}
-  {#if globalRoute.current}
-    {@const chain = utils.getChain(globalRoute.current.name) ?? [globalRoute.current.name]}
-    {@const crumbs = ["home", ...chain]}
-    <nav class="breadcrumbs" aria-label="breadcrumb">
-      {#each crumbs as name, i}
-        {#if i > 0}<span> › </span>{/if}
-        {#if i === crumbs.length - 1}
-          <span>{getLabel(name, globalRoute.current.params)}</span>
-        {:else}
-          <Link routeName={name}>{getLabel(name, globalRoute.current.params)}</Link>
-        {/if}
-      {/each}
-    </nav>
-  {/if}
+  {@const chain = utils.getChain(globalRoute.current.name) ?? [globalRoute.current.name]}
+  {@const crumbs = ["home", ...chain]}
+  <nav class="breadcrumbs" aria-label="breadcrumb">
+    {#each crumbs as name, i}
+      {#if i > 0}<span> › </span>{/if}
+      {#if i === crumbs.length - 1}
+        <span>{getLabel(name, globalRoute.current.params)}</span>
+      {:else}
+        <Link routeName={name}>{getLabel(name, globalRoute.current.params)}</Link>
+      {/if}
+    {/each}
+  </nav>
 
   <!--
     `users` IS the list — no synthetic `list` child / forwardTo. The `self`

--- a/examples/web/svelte/persistent-params/src/pages/About.svelte
+++ b/examples/web/svelte/persistent-params/src/pages/About.svelte
@@ -2,7 +2,7 @@
   import { useRoute } from "@real-router/svelte";
 
   const { route } = useRoute();
-  const lang = $derived((route.current?.params.lang as string | undefined) ?? "en");
+  const lang = $derived((route.current.params.lang as string | undefined) ?? "en");
 </script>
 
 <div>

--- a/examples/web/svelte/persistent-params/src/pages/Contacts.svelte
+++ b/examples/web/svelte/persistent-params/src/pages/Contacts.svelte
@@ -2,7 +2,7 @@
   import { useRoute } from "@real-router/svelte";
 
   const { route } = useRoute();
-  const lang = $derived((route.current?.params.lang as string | undefined) ?? "en");
+  const lang = $derived((route.current.params.lang as string | undefined) ?? "en");
 </script>
 
 <div>

--- a/examples/web/svelte/persistent-params/src/pages/Home.svelte
+++ b/examples/web/svelte/persistent-params/src/pages/Home.svelte
@@ -2,8 +2,8 @@
   import { useRoute } from "@real-router/svelte";
 
   const { route } = useRoute();
-  const lang = $derived((route.current?.params.lang as string | undefined) ?? "en");
-  const theme = $derived((route.current?.params.theme as string | undefined) ?? "light");
+  const lang = $derived((route.current.params.lang as string | undefined) ?? "en");
+  const theme = $derived((route.current.params.theme as string | undefined) ?? "light");
 </script>
 
 <div>

--- a/examples/web/svelte/persistent-params/src/pages/ParamsToolbar.svelte
+++ b/examples/web/svelte/persistent-params/src/pages/ParamsToolbar.svelte
@@ -4,14 +4,14 @@
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  const lang = $derived((route.current?.params.lang as string | undefined) ?? "en");
-  const theme = $derived((route.current?.params.theme as string | undefined) ?? "light");
+  const lang = $derived((route.current.params.lang as string | undefined) ?? "en");
+  const theme = $derived((route.current.params.theme as string | undefined) ?? "light");
 
   const navigate = (newParams: Record<string, string>) => {
     void navigator.navigate(
-      route.current?.name ?? "home",
+      route.current.name,
       {
-        ...route.current?.params,
+        ...route.current.params,
         ...newParams,
       },
       { reload: true },

--- a/examples/web/svelte/reactive-source/src/pages/Home.svelte
+++ b/examples/web/svelte/reactive-source/src/pages/Home.svelte
@@ -12,7 +12,7 @@
     <code>@real-router/sources</code> to Svelte's reactivity system.
   </p>
   <p>
-    Current route: <strong>{route.current?.name ?? "—"}</strong>
+    Current route: <strong>{route.current.name}</strong>
   </p>
   <p>
     Navigate between pages and watch the monitor panel below update in real-time.

--- a/examples/web/svelte/search-schema/src/pages/Products.svelte
+++ b/examples/web/svelte/search-schema/src/pages/Products.svelte
@@ -4,7 +4,7 @@
   const { route } = useRoute();
   const navigator = useNavigator();
 
-  let params = $derived(route.current?.params ?? {});
+  let params = $derived(route.current.params);
   let query = $derived((params.q as string | undefined) ?? "");
   let page = $derived((params.page as number | undefined) ?? 1);
   let sort = $derived((params.sort as string | undefined) ?? "name");

--- a/examples/web/svelte/snippets-routing/src/pages/Home.svelte
+++ b/examples/web/svelte/snippets-routing/src/pages/Home.svelte
@@ -11,7 +11,7 @@
     the Svelte 5 pattern for declarative route matching.
   </p>
   <p>
-    Current route: <strong>{route.current?.name ?? "—"}</strong>
+    Current route: <strong>{route.current.name}</strong>
   </p>
   <p>
     Each <code>RouteView</code> renders the snippet matching the active route segment.

--- a/examples/web/vue/auth-guards/src/App.vue
+++ b/examples/web/vue/auth-guards/src/App.vue
@@ -12,11 +12,11 @@ import Services from "./pages/Services.vue";
 import Settings from "./pages/Settings.vue";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import Layout from "../../shared/Layout.vue";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 
 const navigator = useNavigator();
 

--- a/examples/web/vue/auth-guards/src/pages/Dashboard.vue
+++ b/examples/web/vue/auth-guards/src/pages/Dashboard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 
 const emit = defineEmits<{
   logout: [];

--- a/examples/web/vue/auth-guards/src/pages/Login.vue
+++ b/examples/web/vue/auth-guards/src/pages/Login.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 
 const emit = defineEmits<{
   login: [user: User];

--- a/examples/web/vue/auth-guards/src/pages/Settings.vue
+++ b/examples/web/vue/auth-guards/src/pages/Settings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onUnmounted, ref, watch, watchEffect } from "vue";
 import { useNavigator } from "@real-router/vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 const displayName = ref("");
 const navigator = useNavigator();

--- a/examples/web/vue/auth-guards/src/routes.ts
+++ b/examples/web/vue/auth-guards/src/routes.ts
@@ -1,5 +1,5 @@
-import { can } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Route } from "@real-router/core";

--- a/examples/web/vue/auth-guards/src/types.ts
+++ b/examples/web/vue/auth-guards/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/vue/auth-guards/tests/components.test.ts
+++ b/examples/web/vue/auth-guards/tests/components.test.ts
@@ -6,8 +6,8 @@ import { render, screen, waitFor } from "@testing-library/vue";
 import { afterEach, describe, it, expect } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import App from "../src/App.vue";
 import { publicRoutes, privateRoutes } from "../src/routes";
 

--- a/examples/web/vue/auth-guards/tests/router.test.ts
+++ b/examples/web/vue/auth-guards/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { afterEach, describe, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { publicRoutes, privateRoutes } from "../src/routes";
 
 import type { AppDependencies } from "../src/types";

--- a/examples/web/vue/auth-guards/tests/setup.ts
+++ b/examples/web/vue/auth-guards/tests/setup.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/vue";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   cleanup();

--- a/examples/web/vue/basic/src/pages/Home.vue
+++ b/examples/web/vue/basic/src/pages/Home.vue
@@ -10,7 +10,7 @@ const items = Array.from({ length: 100 }, (_, i) => i + 1);
     <h1>Home</h1>
     <p>Welcome to the Real-Router basic example.</p>
     <p>
-      Current route: <strong>{{ route?.name ?? "—" }}</strong>
+      Current route: <strong>{{ route.name }}</strong>
     </p>
     <p>
       Use the sidebar to navigate between pages. Try clicking <em>Back</em> and

--- a/examples/web/vue/combined/src/App.vue
+++ b/examples/web/vue/combined/src/App.vue
@@ -20,11 +20,11 @@ import Settings from "./pages/Settings.vue";
 import UsersLayout from "./pages/UsersLayout.vue";
 import { router } from "./router";
 import { publicRoutes, privateRoutes } from "./routes";
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import Layout from "../../shared/Layout.vue";
 
-import type { User } from "../../../shared/api";
+import type { User } from "../../../../shared/api";
 
 const LazyDashboard = defineAsyncComponent(
   () => import("./pages/Dashboard.vue"),

--- a/examples/web/vue/combined/src/pages/Dashboard.vue
+++ b/examples/web/vue/combined/src/pages/Dashboard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useNavigator, useRoute } from "@real-router/vue";
 import { computed, onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 
 const emit = defineEmits<{
   logout: [];
@@ -26,7 +26,7 @@ const { route } = useRoute();
 const navigator = useNavigator();
 
 const lang = computed(
-  () => (route.value?.params.lang as string | undefined) ?? "en",
+  () => (route.value.params.lang as string | undefined) ?? "en",
 );
 </script>
 
@@ -49,8 +49,8 @@ const lang = computed(
       <button
         @click="
           navigator.navigate(
-            route?.name ?? 'dashboard',
-            { ...route?.params, lang: lang === 'en' ? 'ru' : 'en' },
+            route.name,
+            { ...route.params, lang: lang === 'en' ? 'ru' : 'en' },
             { reload: true },
           )
         "

--- a/examples/web/vue/combined/src/pages/Login.vue
+++ b/examples/web/vue/combined/src/pages/Login.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { api } from "../../../../shared/api";
+import { api } from "../../../../../shared/api";
 
-import type { User } from "../../../../shared/api";
+import type { User } from "../../../../../shared/api";
 
 const emit = defineEmits<{
   login: [user: User];

--- a/examples/web/vue/combined/src/pages/ProductDetail.vue
+++ b/examples/web/vue/combined/src/pages/ProductDetail.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Link } from "@real-router/vue";
 import { onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 
 const product = shallowRef<Product | null | undefined>(
   store.get("products.detail") as Product | null | undefined,

--- a/examples/web/vue/combined/src/pages/ProductList.vue
+++ b/examples/web/vue/combined/src/pages/ProductList.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Link } from "@real-router/vue";
 import { onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 
 const products = shallowRef<Product[] | null>(
   store.get("products") as Product[] | null,

--- a/examples/web/vue/combined/src/pages/Settings.vue
+++ b/examples/web/vue/combined/src/pages/Settings.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onUnmounted, ref, watch } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
 const displayName = ref("");
 

--- a/examples/web/vue/combined/src/pages/UsersLayout.vue
+++ b/examples/web/vue/combined/src/pages/UsersLayout.vue
@@ -33,10 +33,6 @@ const { route } = useRoute();
 const utils = useRouteUtils();
 
 function getCrumbs() {
-  if (!route.value) {
-    return [];
-  }
-
   const chain = utils.getChain(route.value.name) ?? [route.value.name];
 
   return ["home", ...chain];
@@ -45,7 +41,7 @@ function getCrumbs() {
 
 <template>
   <div v-if="usersRoute">
-    <nav v-if="route" class="breadcrumbs" aria-label="breadcrumb">
+    <nav class="breadcrumbs" aria-label="breadcrumb">
       <template v-for="(name, i) in getCrumbs()" :key="name">
         <span v-if="i > 0"> › </span>
         <span v-if="i === getCrumbs().length - 1">{{

--- a/examples/web/vue/combined/src/routes.ts
+++ b/examples/web/vue/combined/src/routes.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { can } from "../../../shared/abilities";
-import { api } from "../../../shared/api";
-import { store } from "../../../shared/store";
+import { can } from "../../../../shared/abilities";
+import { api } from "../../../../shared/api";
+import { store } from "../../../../shared/store";
 
 import type { AppDependencies } from "./types";
 import type { GuardFnFactory, Params, Route } from "@real-router/core";

--- a/examples/web/vue/combined/src/types.ts
+++ b/examples/web/vue/combined/src/types.ts
@@ -1,4 +1,4 @@
-import type { Rule } from "../../../shared/abilities";
+import type { Rule } from "../../../../shared/abilities";
 
 export interface AppDependencies {
   abilities: Rule[];

--- a/examples/web/vue/combined/tests/components.test.ts
+++ b/examples/web/vue/combined/tests/components.test.ts
@@ -6,8 +6,8 @@ import { render, screen, waitFor } from "@testing-library/vue";
 import { afterEach, describe, it, expect } from "vitest";
 import { defineComponent, h } from "vue";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import App from "../src/App.vue";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { publicRoutes, privateRoutes } from "../src/routes";

--- a/examples/web/vue/combined/tests/router.test.ts
+++ b/examples/web/vue/combined/tests/router.test.ts
@@ -2,8 +2,8 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getDependenciesApi, getRoutesApi } from "@real-router/core/api";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { defineAbilities } from "../../../shared/abilities";
-import { store } from "../../../shared/store";
+import { defineAbilities } from "../../../../shared/abilities";
+import { store } from "../../../../shared/store";
 import { lifecyclePluginFactory } from "@real-router/lifecycle-plugin";
 import { privateRoutes, publicRoutes } from "../src/routes";
 

--- a/examples/web/vue/combined/tests/setup.ts
+++ b/examples/web/vue/combined/tests/setup.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/vue";
 
-import { store } from "../../../shared/store";
+import { store } from "../../../../shared/store";
 
 afterEach(() => {
   cleanup();

--- a/examples/web/vue/data-loading/src/pages/ProductDetail.vue
+++ b/examples/web/vue/data-loading/src/pages/ProductDetail.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Link } from "@real-router/vue";
 import { onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 
 const product = shallowRef<Product | null | undefined>(
   store.get("products.detail") as Product | null | undefined,

--- a/examples/web/vue/data-loading/src/pages/ProductList.vue
+++ b/examples/web/vue/data-loading/src/pages/ProductList.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Link } from "@real-router/vue";
 import { onMounted, onUnmounted, shallowRef } from "vue";
-import { store } from "../../../../shared/store";
+import { store } from "../../../../../shared/store";
 
-import type { Product } from "../../../../shared/api";
+import type { Product } from "../../../../../shared/api";
 
 const products = shallowRef<Product[] | null>(
   store.get("products") as Product[] | null,

--- a/examples/web/vue/dynamic-routes/src/App.vue
+++ b/examples/web/vue/dynamic-routes/src/App.vue
@@ -25,7 +25,7 @@ const adminEnabled = ref(false);
 
 async function toggleAnalytics() {
   if (analyticsEnabled.value) {
-    if (route.value?.name.startsWith("analytics")) {
+    if (route.value.name.startsWith("analytics")) {
       await navigator.navigate("home");
     }
 
@@ -39,7 +39,7 @@ async function toggleAnalytics() {
 
 async function toggleAdmin() {
   if (adminEnabled.value) {
-    if (route.value?.name.startsWith("admin")) {
+    if (route.value.name.startsWith("admin")) {
       await navigator.navigate("home");
     }
 

--- a/examples/web/vue/hash-routing/src/pages/Home.vue
+++ b/examples/web/vue/hash-routing/src/pages/Home.vue
@@ -19,7 +19,7 @@ const currentHash = computed(() => window.location.hash || "(empty)");
       route.
     </p>
     <p>
-      Current route: <strong>{{ route?.name ?? "—" }}</strong>
+      Current route: <strong>{{ route.name }}</strong>
     </p>
     <p>
       Current URL hash:

--- a/examples/web/vue/nested-routes/src/pages/UsersLayout.vue
+++ b/examples/web/vue/nested-routes/src/pages/UsersLayout.vue
@@ -39,7 +39,6 @@ const { route } = useRoute();
 const utils = useRouteUtils();
 
 const crumbs = computed(() => {
-  if (!route.value) return [];
   const chain = utils.getChain(route.value.name) ?? [route.value.name];
   return ["home", ...chain];
 });
@@ -47,7 +46,7 @@ const crumbs = computed(() => {
 
 <template>
   <div v-if="usersRoute">
-    <nav v-if="route" class="breadcrumbs" aria-label="breadcrumb">
+    <nav class="breadcrumbs" aria-label="breadcrumb">
       <template v-for="(name, i) in crumbs" :key="name">
         <span v-if="i > 0"> › </span>
         <span v-if="i === crumbs.length - 1">{{

--- a/examples/web/vue/persistent-params/src/App.vue
+++ b/examples/web/vue/persistent-params/src/App.vue
@@ -16,16 +16,16 @@ const { route } = useRoute();
 const navigator = useNavigator();
 
 const lang = computed(
-  () => (route.value?.params.lang as string | undefined) ?? "en",
+  () => (route.value.params.lang as string | undefined) ?? "en",
 );
 const theme = computed(
-  () => (route.value?.params.theme as string | undefined) ?? "light",
+  () => (route.value.params.theme as string | undefined) ?? "light",
 );
 
 function navigate(newParams: Record<string, string>) {
   void navigator.navigate(
-    route.value?.name ?? "home",
-    { ...route.value?.params, ...newParams },
+    route.value.name,
+    { ...route.value.params, ...newParams },
     { reload: true },
   );
 }

--- a/examples/web/vue/persistent-params/src/pages/About.vue
+++ b/examples/web/vue/persistent-params/src/pages/About.vue
@@ -4,7 +4,7 @@ import { computed } from "vue";
 
 const { route } = useRoute();
 const lang = computed(
-  () => (route.value?.params.lang as string | undefined) ?? "en",
+  () => (route.value.params.lang as string | undefined) ?? "en",
 );
 </script>
 

--- a/examples/web/vue/persistent-params/src/pages/Contacts.vue
+++ b/examples/web/vue/persistent-params/src/pages/Contacts.vue
@@ -4,7 +4,7 @@ import { computed } from "vue";
 
 const { route } = useRoute();
 const lang = computed(
-  () => (route.value?.params.lang as string | undefined) ?? "en",
+  () => (route.value.params.lang as string | undefined) ?? "en",
 );
 </script>
 

--- a/examples/web/vue/persistent-params/src/pages/Home.vue
+++ b/examples/web/vue/persistent-params/src/pages/Home.vue
@@ -4,10 +4,10 @@ import { computed } from "vue";
 
 const { route } = useRoute();
 const lang = computed(
-  () => (route.value?.params.lang as string | undefined) ?? "en",
+  () => (route.value.params.lang as string | undefined) ?? "en",
 );
 const theme = computed(
-  () => (route.value?.params.theme as string | undefined) ?? "light",
+  () => (route.value.params.theme as string | undefined) ?? "light",
 );
 </script>
 

--- a/examples/web/vue/plugin-installation/src/pages/Home.vue
+++ b/examples/web/vue/plugin-installation/src/pages/Home.vue
@@ -17,7 +17,7 @@ const { route } = useRoute();
         <strong>Router installed via:</strong> <code>app.use()</code> plugin
         pattern
       </p>
-      <p><strong>Current route:</strong> {{ route?.name ?? "—" }}</p>
+      <p><strong>Current route:</strong> {{ route.name }}</p>
       <p>
         <strong>Router has routes:</strong>
         {{ router.getState() !== null ? "Yes" : "No" }}

--- a/examples/web/vue/search-schema/src/pages/Products.vue
+++ b/examples/web/vue/search-schema/src/pages/Products.vue
@@ -5,7 +5,7 @@ import { computed } from "vue";
 const { route } = useRoute();
 const navigator = useNavigator();
 
-const params = computed(() => route.value?.params ?? {});
+const params = computed(() => route.value.params);
 const query = computed(() => (params.value.q as string | undefined) ?? "");
 const page = computed(() => (params.value.page as number | undefined) ?? 1);
 const sort = computed(

--- a/packages/angular/src/functions/injectRoute.ts
+++ b/packages/angular/src/functions/injectRoute.ts
@@ -2,8 +2,29 @@ import { injectOrThrow } from "./injectOrThrow";
 import { ROUTE } from "../providers";
 
 import type { RouteSignals } from "../types";
-import type { Params } from "@real-router/core";
+import type { Signal } from "@angular/core";
+import type { Params, State } from "@real-router/core";
+import type { RouteSnapshot } from "@real-router/sources";
 
-export function injectRoute<P extends Params = Params>(): RouteSignals<P> {
-  return injectOrThrow(ROUTE, "injectRoute") as RouteSignals<P>;
+export function injectRoute<P extends Params = Params>(): Omit<
+  RouteSignals<P>,
+  "routeState"
+> & {
+  readonly routeState: Signal<
+    Omit<RouteSnapshot<P>, "route"> & { route: State<P> }
+  >;
+} {
+  const signals = injectOrThrow(ROUTE, "injectRoute") as RouteSignals<P>;
+
+  if (!signals.routeState().route) {
+    throw new Error(
+      "injectRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return signals as Omit<RouteSignals<P>, "routeState"> & {
+    readonly routeState: Signal<
+      Omit<RouteSnapshot<P>, "route"> & { route: State<P> }
+    >;
+  };
 }

--- a/packages/angular/src/functions/injectRouteEnter.ts
+++ b/packages/angular/src/functions/injectRouteEnter.ts
@@ -94,8 +94,6 @@ export function injectRouteEnter(
 
     // Early-exit guards, top-down:
     //
-    //   - **Defensive**: `route` may be undefined during SSR or
-    //     pre-start hydration. Not testable from vitest, v8-ignored.
     //   - **Skip-initial**: `state.transition.from` is undefined only
     //     for the very first state committed by `router.start()`.
     //   - **Skip-same-route**: query-only navigations have
@@ -106,11 +104,6 @@ export function injectRouteEnter(
     //     signal only fires on real reference changes); `!previousRoute`
     //     is unreachable once `transition.from` is set (core populates
     //     them together). Both kept for parity with React; v8-ignored.
-    /* v8 ignore start */
-    if (!route) {
-      return;
-    }
-    /* v8 ignore stop */
     if (!route.transition.from) {
       return;
     }

--- a/packages/angular/tests/functional/inject-functions.test.ts
+++ b/packages/angular/tests/functional/inject-functions.test.ts
@@ -99,7 +99,7 @@ describe("inject functions", () => {
         const route = injectRoute();
 
         expect(route.navigator).toBe(getNavigator(router));
-        expect(route.routeState().route?.name).toBe("home");
+        expect(route.routeState().route.name).toBe("home");
       });
     });
 
@@ -115,6 +115,24 @@ describe("inject functions", () => {
       }).toThrow("injectRoute must be used within a provideRealRouter context");
     });
 
+    it("throws a clear error if router has not started yet", () => {
+      const unstartedRouter = createRouter(routes);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [provideRealRouter(unstartedRouter)],
+      });
+      const injector = TestBed.inject(Injector);
+
+      expect(() => {
+        runInInjectionContext(injector, () => {
+          injectRoute();
+        });
+      }).toThrow(
+        /injectRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
+      );
+    });
+
     it("propagates generic params type without runtime change", () => {
       type TypedParams = { id: string; tab: string } & Params;
 
@@ -122,10 +140,9 @@ describe("inject functions", () => {
 
       runInInjectionContext(injector, () => {
         const route = injectRoute<TypedParams>();
-        const params: TypedParams | undefined =
-          route.routeState().route?.params;
+        const params: TypedParams = route.routeState().route.params;
 
-        expect(route.routeState().route?.name).toBe("home");
+        expect(route.routeState().route.name).toBe("home");
         expect(params).toBeDefined();
       });
     });

--- a/packages/angular/tests/stress/concurrent-guards.stress.ts
+++ b/packages/angular/tests/stress/concurrent-guards.stress.ts
@@ -68,7 +68,7 @@ describe("concurrent navigation with async guards (Angular)", () => {
     const finalName = router.getState()?.name;
 
     expect(["slow", "fast"]).toContain(finalName);
-    expect(fixture.componentInstance.route.routeState().route?.name).toBe(
+    expect(fixture.componentInstance.route.routeState().route.name).toBe(
       finalName,
     );
 
@@ -96,7 +96,7 @@ describe("concurrent navigation with async guards (Angular)", () => {
 
     await Promise.all(promises);
 
-    expect(fixture.componentInstance.route.routeState().route?.name).toBe(
+    expect(fixture.componentInstance.route.routeState().route.name).toBe(
       router.getState()?.name,
     );
 

--- a/packages/angular/tests/stress/factory-n-routers.stress.ts
+++ b/packages/angular/tests/stress/factory-n-routers.stress.ts
@@ -34,7 +34,7 @@ describe("factory reuse with N distinct routers (Angular)", () => {
 
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.route.routeState().route?.name).toBe(
+      expect(fixture.componentInstance.route.routeState().route.name).toBe(
         "route0",
       );
 

--- a/packages/angular/tests/stress/factory-reuse.stress.ts
+++ b/packages/angular/tests/stress/factory-reuse.stress.ts
@@ -6,6 +6,7 @@ import { createStressRouter } from "./helpers";
 import { injectRoute } from "../../src/functions/injectRoute";
 import { provideRealRouter, ROUTE } from "../../src/providers";
 
+import type { RouteSignals } from "../../src/types";
 import type { Router } from "@real-router/core";
 
 describe("factory reuse (Angular)", () => {
@@ -78,7 +79,7 @@ describe("factory reuse (Angular)", () => {
     });
     const injector = TestBed.inject(Injector);
 
-    const routes: ReturnType<typeof injectRoute>[] = [];
+    const routes: RouteSignals[] = [];
 
     runInInjectionContext(injector, () => {
       for (let i = 0; i < 5; i++) {
@@ -99,7 +100,7 @@ describe("factory reuse (Angular)", () => {
     });
     const injector = TestBed.inject(Injector);
 
-    const routes: ReturnType<typeof injectRoute>[] = [];
+    const routes: RouteSignals[] = [];
 
     runInInjectionContext(injector, () => {
       for (let i = 0; i < 10; i++) {

--- a/packages/angular/tests/stress/rapid-start-stop.stress.ts
+++ b/packages/angular/tests/stress/rapid-start-stop.stress.ts
@@ -53,7 +53,7 @@ describe("rapid router start/stop cycles (Angular)", () => {
 
     await router.navigate("route1");
 
-    expect(fixture.componentInstance.route.routeState().route?.name).toBe(
+    expect(fixture.componentInstance.route.routeState().route.name).toBe(
       "route1",
     );
 

--- a/packages/preact/src/hooks/useRoute.tsx
+++ b/packages/preact/src/hooks/useRoute.tsx
@@ -3,14 +3,25 @@ import { useContext } from "preact/hooks";
 import { RouteContext } from "../context";
 
 import type { RouteContext as RouteContextType } from "../types";
-import type { Params } from "@real-router/core";
+import type { Params, State } from "@real-router/core";
 
-export const useRoute = <P extends Params = Params>(): RouteContextType<P> => {
+export const useRoute = <P extends Params = Params>(): Omit<
+  RouteContextType<P>,
+  "route"
+> & { route: State<P> } => {
   const routeContext = useContext(RouteContext);
 
   if (!routeContext) {
-    throw new Error("useRoute must be used within a RouteProvider");
+    throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeContext as RouteContextType<P>;
+  if (!routeContext.route) {
+    throw new Error(
+      "useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return routeContext as Omit<RouteContextType<P>, "route"> & {
+    route: State<P>;
+  };
 };

--- a/packages/preact/src/hooks/useRouteEnter.tsx
+++ b/packages/preact/src/hooks/useRouteEnter.tsx
@@ -121,9 +121,6 @@ export function useRouteEnter(
   useEffect(() => {
     // Early-exit guards, top-down:
     //
-    //   - **Defensive**: `route` / `previousRoute` may be undefined
-    //     during SSR or pre-start hydration. Not testable from vitest
-    //     (tests start the router before render), so v8-ignored.
     //   - **Skip-initial**: `state.transition.from` is undefined only
     //     for the very first state committed by `router.start()`.
     //   - **Skip-same-route**: query-only navigations have
@@ -132,11 +129,6 @@ export function useRouteEnter(
     //   - **Defensive dedupe**: same `route` ref between effect
     //     cleanup + re-run. Preact has no StrictMode, but we keep the
     //     guard for parity with React; v8-ignored.
-    /* v8 ignore start */
-    if (!route) {
-      return;
-    }
-    /* v8 ignore stop */
     if (!route.transition.from) {
       return;
     }

--- a/packages/preact/tests/functional/useRoute.test.tsx
+++ b/packages/preact/tests/functional/useRoute.test.tsx
@@ -44,13 +44,13 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
 
     await act(async () => {
       await router.navigate("items");
     });
 
-    expect(result.current.route?.name).toStrictEqual("items");
+    expect(result.current.route.name).toStrictEqual("items");
   });
 
   it("should return previousRoute after navigation", async () => {
@@ -61,18 +61,30 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
 
     await act(async () => {
       await router.navigate("home");
     });
 
-    expect(result.current.route?.name).toStrictEqual("home");
+    expect(result.current.route.name).toStrictEqual("home");
     expect(result.current.previousRoute?.name).toStrictEqual("test");
   });
 
   it("should throw error if router instance was not passed to provider", () => {
-    expect(() => renderHook(() => useRoute())).toThrow();
+    expect(() => renderHook(() => useRoute())).toThrow(
+      "useRoute must be used within a RouterProvider",
+    );
+  });
+
+  it("should throw a clear error if router has not started yet", () => {
+    const unstartedRouter = createTestRouterWithADefaultRouter();
+
+    expect(() =>
+      renderHook(() => useRoute(), { wrapper: wrapper(unstartedRouter) }),
+    ).toThrow(
+      /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
+    );
   });
 
   it("should propagate generic params type without runtime change", async () => {
@@ -84,9 +96,9 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    const params: TypedParams | undefined = result.current.route?.params;
+    const params: TypedParams = result.current.route.params;
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
     expect(params).toBeDefined();
   });
 });

--- a/packages/preact/tests/integration/RouterProvider.test.tsx
+++ b/packages/preact/tests/integration/RouterProvider.test.tsx
@@ -19,7 +19,7 @@ import type { FunctionComponent, ComponentChildren } from "preact";
 const RouteDisplay: FunctionComponent = () => {
   const { route } = useRoute();
 
-  return <div data-testid="route">{route?.name}</div>;
+  return <div data-testid="route">{route.name}</div>;
 };
 
 describe("RouterProvider - Integration Tests", () => {
@@ -342,7 +342,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <span data-testid="previous">{previousRoute?.name ?? "none"}</span>
             <span data-testid="has-router">yes</span>
           </div>
@@ -369,7 +369,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <button
               data-testid="navigate-btn"
               onClick={() => {
@@ -500,7 +500,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <span data-testid="count">{count}</span>
             <button
               data-testid="increment"
@@ -544,7 +544,7 @@ describe("RouterProvider - Integration Tests", () => {
       const ConditionalComponent: FunctionComponent = () => {
         const { route } = useRoute();
 
-        if (route?.name.startsWith("users")) {
+        if (route.name.startsWith("users")) {
           return <div data-testid="users-section">Users Section</div>;
         }
 
@@ -572,7 +572,7 @@ describe("RouterProvider - Integration Tests", () => {
       const Consumer1: FunctionComponent = () => {
         const { route } = useRoute();
 
-        return <div data-testid="consumer-1">{route?.name}</div>;
+        return <div data-testid="consumer-1">{route.name}</div>;
       };
 
       const Consumer2: FunctionComponent = () => {
@@ -584,7 +584,7 @@ describe("RouterProvider - Integration Tests", () => {
       const Consumer3: FunctionComponent = () => {
         const { route } = useRoute();
 
-        return <div data-testid="consumer-3">{route?.name}</div>;
+        return <div data-testid="consumer-3">{route.name}</div>;
       };
 
       render(
@@ -633,12 +633,6 @@ describe("RouterProvider - Integration Tests", () => {
 
     it("should handle router restart", async () => {
       await router.start("/users/list");
-
-      const RouteDisplay: FunctionComponent = () => {
-        const { route } = useRoute();
-
-        return <div data-testid="route">{route?.name ?? "no-route"}</div>;
-      };
 
       render(
         <RouterProvider router={router}>
@@ -716,11 +710,11 @@ describe("RouterProvider - Integration Tests", () => {
 
         useEffect(() => {
           return () => {
-            cleanupCalls.push(route?.name ?? "unknown");
+            cleanupCalls.push(route.name);
           };
-        }, [route?.name]);
+        }, [route.name]);
 
-        return <div data-testid="route">{route?.name}</div>;
+        return <div data-testid="route">{route.name}</div>;
       };
 
       render(

--- a/packages/preact/tests/stress/factory-reuse.stress.tsx
+++ b/packages/preact/tests/stress/factory-reuse.stress.tsx
@@ -89,7 +89,7 @@ describe("preact — factory reuse: 100 router instances, all disposed", () => {
     const ProbeA: FunctionComponent = () => {
       const { route } = useRoute();
 
-      lastFromA = route?.name ?? "";
+      lastFromA = route.name;
 
       return null;
     };
@@ -97,7 +97,7 @@ describe("preact — factory reuse: 100 router instances, all disposed", () => {
     const ProbeB: FunctionComponent = () => {
       const { route } = useRoute();
 
-      lastFromB = route?.name ?? "";
+      lastFromB = route.name;
 
       return null;
     };

--- a/packages/preact/tests/stress/route-deletion-midsession.stress.tsx
+++ b/packages/preact/tests/stress/route-deletion-midsession.stress.tsx
@@ -38,7 +38,7 @@ describe("preact — route deleted mid-session", () => {
     const RouteProbe: FunctionComponent = () => {
       const { route } = useRoute();
 
-      return <div data-testid="route-name">{route?.name ?? "null"}</div>;
+      return <div data-testid="route-name">{route.name}</div>;
     };
 
     const { getByTestId, queryByTestId } = render(

--- a/packages/react/src/hooks/useRoute.tsx
+++ b/packages/react/src/hooks/useRoute.tsx
@@ -5,14 +5,25 @@ import { useContext } from "react";
 import { RouteContext } from "../context";
 
 import type { RouteContext as RouteContextType } from "../types";
-import type { Params } from "@real-router/core";
+import type { Params, State } from "@real-router/core";
 
-export const useRoute = <P extends Params = Params>(): RouteContextType<P> => {
+export const useRoute = <P extends Params = Params>(): Omit<
+  RouteContextType<P>,
+  "route"
+> & { route: State<P> } => {
   const routeContext = useContext(RouteContext);
 
   if (!routeContext) {
-    throw new Error("useRoute must be used within a RouteProvider");
+    throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeContext as RouteContextType<P>;
+  if (!routeContext.route) {
+    throw new Error(
+      "useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return routeContext as Omit<RouteContextType<P>, "route"> & {
+    route: State<P>;
+  };
 };

--- a/packages/react/src/hooks/useRouteEnter.tsx
+++ b/packages/react/src/hooks/useRouteEnter.tsx
@@ -121,9 +121,6 @@ export function useRouteEnter(
   useEffect(() => {
     // Early-exit guards, top-down:
     //
-    //   - **Defensive**: `route` / `previousRoute` may be undefined
-    //     during SSR or pre-start hydration. Not testable from vitest
-    //     (tests start the router before render), so v8-ignored.
     //   - **Skip-initial**: `state.transition.from` is undefined only
     //     for the very first state committed by `router.start()`.
     //   - **Skip-same-route**: query-only navigations have
@@ -133,11 +130,6 @@ export function useRouteEnter(
     //     cleanup + re-run in dev's strict pass. Not testable from
     //     vitest (`NODE_ENV === "test"` disables React's strict-mode
     //     double-run), so v8-ignored.
-    /* v8 ignore start */
-    if (!route) {
-      return;
-    }
-    /* v8 ignore stop */
     if (!route.transition.from) {
       return;
     }

--- a/packages/react/tests/functional/useRoute.test.tsx
+++ b/packages/react/tests/functional/useRoute.test.tsx
@@ -57,13 +57,13 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
 
     await act(async () => {
       await router.navigate("items");
     });
 
-    expect(result.current.route?.name).toStrictEqual("items");
+    expect(result.current.route.name).toStrictEqual("items");
   });
 
   it("should return previousRoute after navigation", async () => {
@@ -74,19 +74,29 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
 
     await act(async () => {
       await router.navigate("home");
     });
 
-    expect(result.current.route?.name).toStrictEqual("home");
+    expect(result.current.route.name).toStrictEqual("home");
     expect(result.current.previousRoute?.name).toStrictEqual("test");
   });
 
   it("should throw error if router instance was not passed to provider", () => {
     expect(() => renderHook(() => useRoute())).toThrow(
-      "useRoute must be used within a RouteProvider",
+      "useRoute must be used within a RouterProvider",
+    );
+  });
+
+  it("should throw a clear error if router has not started yet", () => {
+    const unstartedRouter = createTestRouterWithADefaultRouter();
+
+    expect(() =>
+      renderHook(() => useRoute(), { wrapper: wrapper(unstartedRouter) }),
+    ).toThrow(
+      /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
     );
   });
 
@@ -99,9 +109,9 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    const params: TypedParams | undefined = result.current.route?.params;
+    const params: TypedParams = result.current.route.params;
 
-    expect(result.current.route?.name).toStrictEqual("test");
+    expect(result.current.route.name).toStrictEqual("test");
     expect(params).toBeDefined();
   });
 });

--- a/packages/react/tests/integration/RouterProvider.test.tsx
+++ b/packages/react/tests/integration/RouterProvider.test.tsx
@@ -20,7 +20,7 @@ import type { FC, ReactNode } from "react";
 const RouteDisplay: FC = () => {
   const { route } = useRoute();
 
-  return <div data-testid="route">{route?.name}</div>;
+  return <div data-testid="route">{route.name}</div>;
 };
 
 describe("RouterProvider - Integration Tests", () => {
@@ -344,7 +344,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <span data-testid="previous">{previousRoute?.name ?? "none"}</span>
             <span data-testid="has-router">yes</span>
           </div>
@@ -371,7 +371,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <button
               data-testid="navigate-btn"
               onClick={() => {
@@ -506,7 +506,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route?.name}</span>
+            <span data-testid="route">{route.name}</span>
             <span data-testid="count">{count}</span>
             <button
               data-testid="increment"
@@ -553,7 +553,7 @@ describe("RouterProvider - Integration Tests", () => {
       const ConditionalComponent: FC = () => {
         const { route } = useRoute();
 
-        if (route?.name.startsWith("users")) {
+        if (route.name.startsWith("users")) {
           return <div data-testid="users-section">Users Section</div>;
         }
 
@@ -581,7 +581,7 @@ describe("RouterProvider - Integration Tests", () => {
       const Consumer1: FC = () => {
         const { route } = useRoute();
 
-        return <div data-testid="consumer-1">{route?.name}</div>;
+        return <div data-testid="consumer-1">{route.name}</div>;
       };
 
       const Consumer2: FC = () => {
@@ -593,7 +593,7 @@ describe("RouterProvider - Integration Tests", () => {
       const Consumer3: FC = () => {
         const { route } = useRoute();
 
-        return <div data-testid="consumer-3">{route?.name}</div>;
+        return <div data-testid="consumer-3">{route.name}</div>;
       };
 
       render(
@@ -643,12 +643,6 @@ describe("RouterProvider - Integration Tests", () => {
 
     it("should handle router restart", async () => {
       await router.start("/users/list");
-
-      const RouteDisplay: FC = () => {
-        const { route } = useRoute();
-
-        return <div data-testid="route">{route?.name ?? "no-route"}</div>;
-      };
 
       render(
         <RouterProvider router={router}>
@@ -731,11 +725,11 @@ describe("RouterProvider - Integration Tests", () => {
 
         useEffect(() => {
           return () => {
-            cleanupCalls.push(route?.name ?? "unknown");
+            cleanupCalls.push(route.name);
           };
-        }, [route?.name]);
+        }, [route.name]);
 
-        return <div data-testid="route">{route?.name}</div>;
+        return <div data-testid="route">{route.name}</div>;
       };
 
       render(

--- a/packages/react/tests/performance/useRoute.test.tsx
+++ b/packages/react/tests/performance/useRoute.test.tsx
@@ -44,7 +44,7 @@ describe("useRoute - Performance Tests", { tags: ["performance"] }, () => {
       });
 
       expect(result.current.navigator).toBeDefined();
-      expect(result.current.route?.name).toBe("users.list");
+      expect(result.current.route.name).toBe("users.list");
     });
 
     it("should have undefined previousRoute on initial mount", async () => {
@@ -153,13 +153,13 @@ describe("useRoute - Performance Tests", { tags: ["performance"] }, () => {
         renderOptions: { wrapper },
       });
 
-      expect(result.current.route?.name).toBe("users.list");
+      expect(result.current.route.name).toBe("users.list");
 
       await act(async () => {
         await router.navigate("about");
       });
 
-      expect(result.current.route?.name).toBe("about");
+      expect(result.current.route.name).toBe("about");
     });
 
     it("should track previousRoute correctly", async () => {
@@ -176,14 +176,14 @@ describe("useRoute - Performance Tests", { tags: ["performance"] }, () => {
       });
 
       expect(result.current.previousRoute?.name).toBe("users.list");
-      expect(result.current.route?.name).toBe("about");
+      expect(result.current.route.name).toBe("about");
 
       await act(async () => {
         await router.navigate("home");
       });
 
       expect(result.current.previousRoute?.name).toBe("about");
-      expect(result.current.route?.name).toBe("home");
+      expect(result.current.route.name).toBe("home");
     });
 
     it("should include route params in route object", async () => {
@@ -197,8 +197,8 @@ describe("useRoute - Performance Tests", { tags: ["performance"] }, () => {
         await router.navigate("users.view", { id: "123" });
       });
 
-      expect(result.current.route?.name).toBe("users.view");
-      expect(result.current.route?.params).toStrictEqual({ id: "123" });
+      expect(result.current.route.name).toBe("users.view");
+      expect(result.current.route.params).toStrictEqual({ id: "123" });
     });
   });
 
@@ -363,7 +363,7 @@ describe("useRoute - Performance Tests", { tags: ["performance"] }, () => {
       });
 
       expect(ProfiledHook).toHaveRenderedTimes(4);
-      expect(result.current.route?.name).toBe("users.edit");
+      expect(result.current.route.name).toBe("users.edit");
       expect(result.current.previousRoute?.name).toBe("users.view");
     });
   });

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -77,7 +77,7 @@
     "@testing-library/user-event": "14.6.1",
     "babel-preset-solid": "1.9.3",
     "rimraf": "6.1.3",
-    "rollup": "4.60.1",
+    "rollup": "4.60.2",
     "rollup-plugin-dts": "6.4.1",
     "solid-js": "1.9.12",
     "vite-plugin-solid": "2.11.11",

--- a/packages/solid/src/hooks/useRoute.tsx
+++ b/packages/solid/src/hooks/useRoute.tsx
@@ -3,11 +3,11 @@ import { useContext } from "solid-js";
 import { RouteContext } from "../context";
 
 import type { RouteState } from "../types";
-import type { Params } from "@real-router/core";
+import type { Params, State } from "@real-router/core";
 import type { Accessor } from "solid-js";
 
 export const useRoute = <P extends Params = Params>(): Accessor<
-  RouteState<P>
+  Omit<RouteState<P>, "route"> & { route: State<P> }
 > => {
   const routeSignal = useContext(RouteContext);
 
@@ -15,5 +15,13 @@ export const useRoute = <P extends Params = Params>(): Accessor<
     throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeSignal as Accessor<RouteState<P>>;
+  if (!routeSignal().route) {
+    throw new Error(
+      "useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return routeSignal as Accessor<
+    Omit<RouteState<P>, "route"> & { route: State<P> }
+  >;
 };

--- a/packages/solid/src/hooks/useRouteEnter.tsx
+++ b/packages/solid/src/hooks/useRouteEnter.tsx
@@ -93,9 +93,6 @@ export function useRouteEnter(
 
     // Early-exit guards, top-down:
     //
-    //   - **Defensive**: `route` may be undefined during SSR or
-    //     pre-start hydration. Not testable from vitest (tests start
-    //     the router before render), so v8-ignored.
     //   - **Skip-initial**: `state.transition.from` is undefined only
     //     for the very first state committed by `router.start()`.
     //   - **Skip-same-route**: query-only navigations have
@@ -106,11 +103,6 @@ export function useRouteEnter(
     //     run once per dependency change); `!previousRoute` is unreachable
     //     once `transition.from` is set (the two are populated together by
     //     core). Both kept for parity with React; v8-ignored.
-    /* v8 ignore start */
-    if (!route) {
-      return;
-    }
-    /* v8 ignore stop */
     if (!route.transition.from) {
       return;
     }

--- a/packages/solid/tests/functional/useRoute.test.tsx
+++ b/packages/solid/tests/functional/useRoute.test.tsx
@@ -33,7 +33,7 @@ describe("useRoute hook", () => {
 
     const state = result();
 
-    expect(state.route?.name).toStrictEqual("test");
+    expect(state.route.name).toStrictEqual("test");
   });
 
   it("should update when route changes", async () => {
@@ -41,11 +41,11 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    expect(result().route?.name).toStrictEqual("test");
+    expect(result().route.name).toStrictEqual("test");
 
     await router.navigate("items");
 
-    expect(result().route?.name).toStrictEqual("items");
+    expect(result().route.name).toStrictEqual("items");
   });
 
   it("should update previousRoute after navigation", async () => {
@@ -56,17 +56,27 @@ describe("useRoute hook", () => {
     // Navigate to a known route first
     await router.navigate("home");
 
-    expect(result().route?.name).toStrictEqual("home");
+    expect(result().route.name).toStrictEqual("home");
 
     await router.navigate("items");
 
-    expect(result().route?.name).toStrictEqual("items");
+    expect(result().route.name).toStrictEqual("items");
     expect(result().previousRoute?.name).toStrictEqual("home");
   });
 
   it("should throw error if router instance was not passed to provider", () => {
     expect(() => renderHook(() => useRoute())).toThrow(
       "useRoute must be used within a RouterProvider",
+    );
+  });
+
+  it("should throw a clear error if router has not started yet", () => {
+    const unstartedRouter = createTestRouterWithADefaultRouter();
+
+    expect(() =>
+      renderHook(() => useRoute(), { wrapper: wrapper(unstartedRouter) }),
+    ).toThrow(
+      /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
     );
   });
 
@@ -82,7 +92,7 @@ describe("useRoute hook", () => {
 
         createEffect(() => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          routeState().route?.name;
+          routeState().route.name;
           effectRunCount++;
         });
       },
@@ -109,9 +119,9 @@ describe("useRoute hook", () => {
       wrapper: wrapper(router),
     });
 
-    const params: TypedParams | undefined = result().route?.params;
+    const params: TypedParams = result().route.params;
 
-    expect(result().route?.name).toStrictEqual("test");
+    expect(result().route.name).toStrictEqual("test");
     expect(params).toBeDefined();
   });
 });

--- a/packages/solid/tests/integration/RouterProvider.test.tsx
+++ b/packages/solid/tests/integration/RouterProvider.test.tsx
@@ -110,7 +110,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="current">{route().route?.name}</span>
+            <span data-testid="current">{route().route.name}</span>
             <span data-testid="previous">
               {route().previousRoute?.name ?? "none"}
             </span>
@@ -192,7 +192,7 @@ describe("RouterProvider - Integration Tests", () => {
 
         return (
           <div>
-            <span data-testid="route">{route().route?.name}</span>
+            <span data-testid="route">{route().route.name}</span>
             <button
               data-testid="navigate-btn"
               onClick={() => {
@@ -249,7 +249,7 @@ describe("RouterProvider - Integration Tests", () => {
       function RouteDisplay() {
         const route = useRoute();
 
-        return <div data-testid="route">{route().route?.name}</div>;
+        return <div data-testid="route">{route().route.name}</div>;
       }
 
       const { unmount } = render(() => (
@@ -273,13 +273,13 @@ describe("RouterProvider - Integration Tests", () => {
       function Consumer1() {
         const route = useRoute();
 
-        return <div data-testid="consumer-1">{route().route?.name}</div>;
+        return <div data-testid="consumer-1">{route().route.name}</div>;
       }
 
       function Consumer2() {
         const route = useRoute();
 
-        return <div data-testid="consumer-2">{route().route?.name}</div>;
+        return <div data-testid="consumer-2">{route().route.name}</div>;
       }
 
       render(() => (

--- a/packages/svelte/src/composables/useRoute.svelte.ts
+++ b/packages/svelte/src/composables/useRoute.svelte.ts
@@ -1,7 +1,21 @@
 import { ROUTE_KEY, getContextOrThrow } from "../context";
 
 import type { RouteContext } from "../types";
-import type { Params } from "@real-router/core";
+import type { Params, State } from "@real-router/core";
 
-export const useRoute = <P extends Params = Params>(): RouteContext<P> =>
-  getContextOrThrow<RouteContext>(ROUTE_KEY, "useRoute") as RouteContext<P>;
+export const useRoute = <P extends Params = Params>(): Omit<
+  RouteContext<P>,
+  "route"
+> & { route: { readonly current: State<P> } } => {
+  const ctx = getContextOrThrow<RouteContext>(ROUTE_KEY, "useRoute");
+
+  if (!ctx.route.current) {
+    throw new Error(
+      "useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return ctx as Omit<RouteContext<P>, "route"> & {
+    route: { readonly current: State<P> };
+  };
+};

--- a/packages/svelte/tests/functional/useRoute.test.ts
+++ b/packages/svelte/tests/functional/useRoute.test.ts
@@ -182,7 +182,19 @@ describe("useRoute composable", () => {
       render(RouteCapture, {
         props: { onCapture: () => {} },
       }),
-    ).toThrow();
+    ).toThrow("useRoute must be used within a RouterProvider");
+  });
+
+  it("should throw a clear error if router has not started yet", () => {
+    const unstartedRouter = createTestRouterWithADefaultRouter();
+
+    expect(() =>
+      renderWithRouter(unstartedRouter, RouteCapture, {
+        onCapture: () => {},
+      }),
+    ).toThrow(
+      /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
+    );
   });
 
   it("should propagate generic params type without runtime change", async () => {

--- a/packages/svelte/tests/integration/RouterProvider.test.ts
+++ b/packages/svelte/tests/integration/RouterProvider.test.ts
@@ -67,16 +67,14 @@ describe("RouterProvider - Integration Tests", () => {
   });
 
   describe("Edge Cases", () => {
-    it("should handle router not started", () => {
-      let routeContext: RouteContext | undefined;
-
-      renderWithRouter(router, RouteCapture, {
-        onCapture: (r: RouteContext) => {
-          routeContext = r;
-        },
-      });
-
-      expect(routeContext?.route.current?.name).toBeUndefined();
+    it("should throw a clear error when router not started", () => {
+      expect(() =>
+        renderWithRouter(router, RouteCapture, {
+          onCapture: () => {},
+        }),
+      ).toThrow(
+        /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
+      );
     });
 
     it("should handle unmount correctly", async () => {

--- a/packages/vue/src/composables/useRoute.ts
+++ b/packages/vue/src/composables/useRoute.ts
@@ -3,14 +3,26 @@ import { inject } from "vue";
 import { RouteKey } from "../context";
 
 import type { RouteContext } from "../types";
-import type { Params } from "@real-router/core";
+import type { Params, State } from "@real-router/core";
+import type { Ref } from "vue";
 
-export const useRoute = <P extends Params = Params>(): RouteContext<P> => {
+export const useRoute = <P extends Params = Params>(): Omit<
+  RouteContext<P>,
+  "route"
+> & { route: Readonly<Ref<State<P>>> } => {
   const routeContext = inject(RouteKey);
 
   if (!routeContext) {
     throw new Error("useRoute must be used within a RouterProvider");
   }
 
-  return routeContext as RouteContext<P>;
+  if (!routeContext.route.value) {
+    throw new Error(
+      "useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?",
+    );
+  }
+
+  return routeContext as Omit<RouteContext<P>, "route"> & {
+    route: Readonly<Ref<State<P>>>;
+  };
 };

--- a/packages/vue/src/composables/useRouteEnter.ts
+++ b/packages/vue/src/composables/useRouteEnter.ts
@@ -88,11 +88,10 @@ export function useRouteEnter(
 
     // Early-exit guards, top-down:
     //
-    //   - **Defensive + skip-initial**: `route` may be undefined during
-    //     SSR / pre-start hydration; `!transition.from` would catch the
-    //     first commit from `router.start()`. Vue's `watch` (default
-    //     `immediate: false`) does not fire on the initial state, so
-    //     both are unreachable in Vue (covered by React/Preact tests).
+    //   - **Skip-initial**: `!transition.from` catches the first commit
+    //     from `router.start()`. Vue's `watch` (default `immediate: false`)
+    //     does not fire on the initial state — kept for parity with
+    //     React/Preact and v8-ignored.
     //   - **Skip-same-route**: query-only navigations have
     //     `transition.from === route.name`. Opt-out via
     //     `skipSameRoute: false`.
@@ -102,9 +101,6 @@ export function useRouteEnter(
     //     `transition.from` is set (core populates them together). Both
     //     kept for parity with React; v8-ignored.
     /* v8 ignore start */
-    if (!newRoute) {
-      return;
-    }
     if (!newRoute.transition.from) {
       return;
     }

--- a/packages/vue/tests/functional/useRoute.test.ts
+++ b/packages/vue/tests/functional/useRoute.test.ts
@@ -5,11 +5,10 @@ import { defineComponent, h, watchSyncEffect } from "vue";
 import { useRoute, RouterProvider } from "../../src";
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
-import type { RouteContext } from "../../src/types";
 import type { Params, Router } from "@real-router/core";
 
-function mountWithRouter(router: Router, composable: () => RouteContext) {
-  let result: RouteContext;
+function mountWithRouter<R>(router: Router, composable: () => R) {
+  let result: R;
   const App = defineComponent({
     setup() {
       result = composable();
@@ -58,12 +57,12 @@ describe("useRoute composable", () => {
   it("should return current route", async () => {
     const { result } = mountWithRouter(router, () => useRoute());
 
-    expect(result.route.value?.name).toStrictEqual("test");
+    expect(result.route.value.name).toStrictEqual("test");
 
     await router.navigate("items");
     await flushPromises();
 
-    expect(result.route.value?.name).toStrictEqual("items");
+    expect(result.route.value.name).toStrictEqual("items");
   });
 
   it("should throw error if router instance was not passed to provider", () => {
@@ -77,7 +76,37 @@ describe("useRoute composable", () => {
           },
         }),
       ),
-    ).toThrow();
+    ).toThrow("useRoute must be used within a RouterProvider");
+  });
+
+  it("should throw a clear error if router has not started yet", () => {
+    const unstartedRouter = createTestRouterWithADefaultRouter();
+
+    expect(() =>
+      mount(
+        defineComponent({
+          setup: () => () =>
+            h(
+              RouterProvider,
+              { router: unstartedRouter },
+              {
+                default: () =>
+                  h(
+                    defineComponent({
+                      setup() {
+                        useRoute();
+
+                        return () => h("div");
+                      },
+                    }),
+                  ),
+              },
+            ),
+        }),
+      ),
+    ).toThrow(
+      /useRoute called with no active route\. Did you forget to await router\.start\(\) before rendering, or is the router stopped\/disposed\?/,
+    );
   });
 
   it("shallowRef tracks identity: re-assigning the same frozen snapshot does NOT fire effects", async () => {
@@ -91,9 +120,9 @@ describe("useRoute composable", () => {
         routeRef = ctx.route;
 
         watchSyncEffect(() => {
-          if (ctx.route.value) {
-            effectCount++;
-          }
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          ctx.route.value;
+          effectCount++;
         });
 
         return () => h("div");
@@ -130,7 +159,7 @@ describe("useRoute composable", () => {
 
     // And: re-rendering with a *new* shallow object containing the same
     // nested data DOES trigger — proving deep-equality is NOT used.
-    const cloned = { ...currentSnapshot! };
+    const cloned = { ...currentSnapshot };
 
     (routeRef!.value as unknown) = cloned;
     await flushPromises();
@@ -147,7 +176,7 @@ describe("useRoute composable", () => {
       setup() {
         const { route } = useRoute<TypedParams>();
 
-        typedParams = route.value?.params;
+        typedParams = route.value.params;
 
         return () => h("div");
       },

--- a/packages/vue/tests/integration/RouterProvider.test.ts
+++ b/packages/vue/tests/integration/RouterProvider.test.ts
@@ -148,7 +148,7 @@ describe("RouterProvider - Integration Tests", () => {
 
           return () =>
             h("div", [
-              h("span", { "data-testid": "route" }, route.value?.name),
+              h("span", { "data-testid": "route" }, route.value.name),
               h(
                 "span",
                 { "data-testid": "previous" },
@@ -183,7 +183,7 @@ describe("RouterProvider - Integration Tests", () => {
 
           return () =>
             h("div", [
-              h("span", { "data-testid": "route" }, route.value?.name),
+              h("span", { "data-testid": "route" }, route.value.name),
               h(
                 "button",
                 {
@@ -243,11 +243,7 @@ describe("RouterProvider - Integration Tests", () => {
           return () => {
             router2RenderCount++;
 
-            return h(
-              "span",
-              { "data-testid": "r2-route" },
-              route.value?.name ?? "none",
-            );
+            return h("span", { "data-testid": "r2-route" }, route.value.name);
           };
         },
       });
@@ -329,7 +325,7 @@ describe("RouterProvider - Integration Tests", () => {
         setup() {
           const { route } = useRoute();
 
-          return () => h("div", { "data-testid": "route" }, route.value?.name);
+          return () => h("div", { "data-testid": "route" }, route.value.name);
         },
       });
 

--- a/packages/vue/tests/stress/subscription-fanout.stress.ts
+++ b/packages/vue/tests/stress/subscription-fanout.stress.ts
@@ -89,9 +89,10 @@ describe("subscription-fanout stress tests (Vue)", () => {
         const { route } = useRoute();
 
         return () => {
-          if (route.value) {
-            routeRenders++;
-          }
+          // Read .value to register the watch dependency.
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          route.value;
+          routeRenders++;
 
           return h("div");
         };


### PR DESCRIPTION
## Summary

- Narrow `useRoute()` (and `injectRoute()` in Angular) so `route` is non-nullable; throw a clear lifecycle error when the router has no active state. Symmetric with `useRouter()`. `useRouteNode(name)` stays nullable — there `undefined` legitimately means "node inactive". Closes #535.
- Drop dead `route?.x` / `if (!route) return null` defensive code across all framework adapters' examples (~70 files) and update 6× CLAUDE.md, the wiki `useRoute` page, 6× Integration guides, and `useRouteNode` wiki with a contrast table.
- Bundled separate fix commit (`6e33b60b`): correct relative paths to top-level `examples/shared/` in 15 example apps (auth-guards / combined / data-loading × 5 frameworks). The platform reorg in `75e16000` moved examples one level deeper without updating these imports — 164 silent TS2307 errors. Drove the test of #535 in those examples.

### Before / After

```diff
- const { route } = useRoute<{ id: string }>();
- if (!route) return null;
- const id = route?.params.id ?? "fallback";
+ const { route } = useRoute<{ id: string }>();
+ const id = route.params.id;
```

If `route` is undefined (router pre-start / stopped / disposed), the hook now throws:

> `useRoute called with no active route. Did you forget to await router.start() before rendering, or is the router stopped/disposed?`

### Scope

| Adapter | Hook | Return narrowing |
|---|---|---|
| `@real-router/react` | `useRoute()` | `route: State<P>` |
| `@real-router/preact` | `useRoute()` | `route: State<P>` |
| `@real-router/solid` | `useRoute()` | `Accessor<{ route: State<P>; ... }>` |
| `@real-router/vue` | `useRoute()` | `route: Readonly<Ref<State<P>>>` |
| `@real-router/svelte` | `useRoute()` | `route: { current: State<P> }` |
| `@real-router/angular` | `injectRoute()` | `routeState: Signal<{ route: State<P>; ... }>` |

Each adapter ships a `minor` changeset (pre-1.0). For 1.x this would be a major bump.

## Test plan

- [x] `pnpm build` — 277/277 turbo tasks pass (was 262/277 with 15 baseline failures from the path issue)
- [x] All adapter test suites pass: react 444, preact 272, solid 264, vue 249, svelte 264, angular 191 — total 1684 tests
- [x] New test per adapter: `"throws a clear error if router has not started yet"` asserts the lifecycle error message
- [x] Updated `"throw error if router instance was not passed to provider"` test where the message was inconsistent ("RouteProvider" → "RouterProvider")
- [x] Lint clean across all adapters (`@typescript-eslint/no-unnecessary-condition` flagged the now-dead defensive code in `useRouteEnter` — removed)
- [x] Examples × 6 adapters × 8 platforms (web / electron / tauri) build cleanly with no `route?.` defenses left

## Migration

Drop `route?.x` and `if (!route) return null` checks on values returned by `useRoute()` — they are dead code under the new type. Mount the provider only after `await router.start()` resolves.