### PR TITLE
fix(navigation-plugin): report navigationType correctly after cross-document load (#531)

### DIFF
--- a/.changeset/navigation-plugin-531-fix.md
+++ b/.changeset/navigation-plugin-531-fix.md
@@ -1,0 +1,13 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Report `navigationType` correctly after cross-document load (#531)
+
+After F5 (`location.reload()`), browser back/forward across the JS context boundary, or a fresh URL bar entry, the plugin used to emit the initial transition with `state.context.navigation.navigationType === "replace"` regardless of how the document was actually loaded. The fallback in `onTransitionSuccess` derived the type only from `navOptions`, which always resolves to `"replace"` on the very first transition.
+
+The plugin now reads `navigation.activation.navigationType` ([Baseline 2026](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationactivation-navigationtype): Chrome 123+, Edge 123+, Firefox 147+, Safari 26.2+) in its constructor and primes `state.context.navigation` for the first transition. Affected types correctly reported now: `"reload"`, `"traverse"` (cross-document back/forward), `"push"` (typed URL / external link), `"replace"`. On browsers without `navigation.activation` the plugin falls back to the existing derivation.
+
+Fixes scroll position restoration after F5 in `createScrollRestoration` (`shared/dom-utils/scroll-restore.ts`) — the `"reload"` branch is now reachable end-to-end, not just under synthetic fake-router tests.
+
+The new `NavigationBrowser.getActivationType()` method has a no-op SSR fallback returning `undefined`.

--- a/packages/navigation-plugin/README.md
+++ b/packages/navigation-plugin/README.md
@@ -202,6 +202,21 @@ type NavigationDirection = "forward" | "back" | "unknown";
 
 Exported from the package for use in type annotations.
 
+### Cross-document loads (F5, back/forward across page boundaries)
+
+After a cross-document navigation — F5, browser back/forward across the JS context boundary, a fresh URL bar entry — the plugin reads [`navigation.activation.navigationType`](https://developer.mozilla.org/en-US/docs/Web/API/NavigationActivation/navigationType) (Baseline 2026: Chrome 123+, Firefox 147+, Safari 26.2+) and primes `state.context.navigation` for the first transition:
+
+| `navigation.activation.navigationType` | `state.context.navigation.navigationType` | `direction` |
+| -------------------------------------- | ----------------------------------------- | ----------- |
+| `"reload"`                             | `"reload"`                                | `"unknown"` |
+| `"traverse"`                           | `"traverse"`                              | `"unknown"` |
+| `"push"`                               | `"push"`                                  | `"forward"` |
+| `"replace"`                            | `"replace"`                               | `"unknown"` |
+
+`userInitiated` is always `false` for the primed first transition — the browser does not expose whether F5 came from a key press or `location.reload()`.
+
+On browsers without `navigation.activation` (Chrome 102–122, custom mocks), the first transition falls back to `"replace"`.
+
 ### `buildUrl` vs `buildPath`
 
 ```typescript

--- a/packages/navigation-plugin/src/navigation-browser.ts
+++ b/packages/navigation-plugin/src/navigation-browser.ts
@@ -48,5 +48,7 @@ export function createNavigationBrowser(base: string): NavigationBrowser {
     get currentEntry() {
       return nav.currentEntry;
     },
+
+    getActivationType: () => nav.activation?.navigationType,
   };
 }

--- a/packages/navigation-plugin/src/plugin.ts
+++ b/packages/navigation-plugin/src/plugin.ts
@@ -87,6 +87,26 @@ export class NavigationPlugin {
     this.#claim = api.claimContextNamespace("navigation");
     this.#removeStartInterceptor = createStartInterceptor(api, browser);
 
+    // Cross-document load priming (#531). On F5, browser back/forward across
+    // a page boundary, or a fresh URL bar entry, the prior JS context is
+    // discarded — the navigate event handler never sees the activation.
+    // Without this, deriveNavigationType in onTransitionSuccess falls through
+    // to "replace" for every initial transition, breaking scroll restore on
+    // reload (#497) and any consumer branching on navigationType.
+    // navigation.activation reflects the cross-document navigation that
+    // activated this document; it stays constant across same-document
+    // navigations, so this only affects the FIRST transition.
+    const activationType = browser.getActivationType();
+
+    if (activationType) {
+      this.#capturedMeta = {
+        navigationType: activationType,
+        userInitiated: false,
+        direction: activationType === "push" ? "forward" : "unknown",
+        sourceElement: null,
+      };
+    }
+
     const pluginBuildUrl = (route: string, params?: Params) => {
       const path = router.buildPath(route, params);
 

--- a/packages/navigation-plugin/src/ssr-fallback.ts
+++ b/packages/navigation-plugin/src/ssr-fallback.ts
@@ -43,5 +43,6 @@ export const createNavigationFallbackBrowser = (
       return [];
     },
     currentEntry: null,
+    getActivationType: () => undefined,
   };
 };

--- a/packages/navigation-plugin/src/types.ts
+++ b/packages/navigation-plugin/src/types.ts
@@ -35,6 +35,12 @@ export interface NavigationBrowser {
   addNavigateListener: (fn: (evt: NavigateEvent) => void) => () => void;
   entries: () => NavigationHistoryEntry[];
   currentEntry: NavigationHistoryEntry | null;
+  /**
+   * Type of the cross-document navigation that activated this document.
+   * Reads `navigation.activation.navigationType` (Baseline 2026 — Chrome 123+, Firefox 147+, Safari 26.2+).
+   * Returns `undefined` when activation is unavailable (older browsers, SSR).
+   */
+  getActivationType: () => NavigationMeta["navigationType"] | undefined;
 }
 
 /**

--- a/packages/navigation-plugin/tests/functional/navigation-browser.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigation-browser.test.ts
@@ -151,6 +151,32 @@ describe("createNavigationBrowser", () => {
     });
   });
 
+  describe("getActivationType", () => {
+    it("returns nav.activation.navigationType when activation is set", () => {
+      (mockNav as unknown as { activation: NavigationActivation }).activation =
+        {
+          entry: { url: "http://localhost/" } as NavigationHistoryEntry,
+          from: null,
+          navigationType: "reload",
+        };
+      browser = createNavigationBrowser("");
+
+      expect(browser.getActivationType()).toBe("reload");
+    });
+
+    it("returns undefined when nav.activation is null (older browser)", () => {
+      (mockNav as unknown as { activation: null }).activation = null;
+      browser = createNavigationBrowser("");
+
+      expect(browser.getActivationType()).toBeUndefined();
+    });
+
+    it("returns undefined when nav.activation is missing (no support)", () => {
+      // Pre-Chrome-123 browsers expose `navigation` without `activation`.
+      expect(browser.getActivationType()).toBeUndefined();
+    });
+  });
+
   describe("addNavigateListener", () => {
     it("registers listener and returns cleanup function", () => {
       const handler = vi.fn();

--- a/packages/navigation-plugin/tests/functional/navigation-meta-activation.test.ts
+++ b/packages/navigation-plugin/tests/functional/navigation-meta-activation.test.ts
@@ -1,0 +1,170 @@
+import { createRouter } from "@real-router/core";
+import { getLifecycleApi } from "@real-router/core/api";
+import { describe, afterEach, it, expect } from "vitest";
+
+import { navigationPluginFactory } from "../../src";
+import { MockNavigation } from "../helpers/mockNavigation";
+import {
+  createMockNavigationBrowser,
+  routerConfig,
+} from "../helpers/testUtils";
+
+import type { NavigationMeta } from "../../src/types";
+import type { Router, Unsubscribe } from "@real-router/core";
+
+/**
+ * #531 — cross-document load priming via navigation.activation.
+ *
+ * Each test creates its own router/plugin so that mockNav.activation can be set
+ * BEFORE usePlugin() — the plugin reads activation in its constructor and
+ * primes #capturedMeta exactly once.
+ */
+describe("Navigation Plugin — activation priming (#531)", () => {
+  let router: Router | undefined;
+  let unsubscribe: Unsubscribe | undefined;
+
+  afterEach(() => {
+    router?.stop();
+    unsubscribe?.();
+    router = undefined;
+    unsubscribe = undefined;
+  });
+
+  function setup(activationType?: NavigationType): {
+    router: Router;
+    mockNav: MockNavigation;
+  } {
+    const mockNav = new MockNavigation("http://localhost/");
+
+    if (activationType) {
+      mockNav.activation = {
+        entry: mockNav.currentEntry!,
+        from: null,
+        navigationType: activationType,
+      };
+    }
+
+    const browser = createMockNavigationBrowser(mockNav);
+    const newRouter = createRouter(routerConfig, {
+      defaultRoute: "home",
+      queryParamsMode: "default",
+    });
+
+    unsubscribe = newRouter.usePlugin(navigationPluginFactory({}, browser));
+    router = newRouter;
+
+    return { router: newRouter, mockNav };
+  }
+
+  describe("primes #capturedMeta from navigation.activation.navigationType", () => {
+    it('activation "reload" → first transition has navigationType "reload"', async () => {
+      const { router } = setup("reload");
+
+      const state = await router.start();
+
+      expect(state.context.navigation).toStrictEqual({
+        navigationType: "reload",
+        userInitiated: false,
+        direction: "unknown",
+        sourceElement: null,
+      });
+    });
+
+    it('activation "traverse" → first transition has navigationType "traverse"', async () => {
+      const { router } = setup("traverse");
+
+      const state = await router.start();
+
+      expect(state.context.navigation).toStrictEqual({
+        navigationType: "traverse",
+        userInitiated: false,
+        direction: "unknown",
+        sourceElement: null,
+      });
+    });
+
+    it('activation "push" → first transition has navigationType "push" + direction "forward"', async () => {
+      const { router } = setup("push");
+
+      const state = await router.start();
+
+      expect(state.context.navigation).toStrictEqual({
+        navigationType: "push",
+        userInitiated: false,
+        direction: "forward",
+        sourceElement: null,
+      });
+    });
+
+    it('activation "replace" → first transition has navigationType "replace"', async () => {
+      const { router } = setup("replace");
+
+      const state = await router.start();
+
+      expect(state.context.navigation).toStrictEqual({
+        navigationType: "replace",
+        userInitiated: false,
+        direction: "unknown",
+        sourceElement: null,
+      });
+    });
+
+    it("activation null (older browser / SSR fallback) → first transition falls back to deriveNavigationType", async () => {
+      const { router } = setup();
+
+      const state = await router.start();
+
+      // No activation → deriveNavigationType returns "replace" for initial load.
+      // This pins the legacy fallback path so we don't regress on browsers
+      // without navigation.activation (Chrome 102–122, custom browsers).
+      expect(state.context.navigation?.navigationType).toBe("replace");
+    });
+  });
+
+  describe("primed meta is consumed exactly once", () => {
+    it("subsequent same-document programmatic navigation derives meta normally", async () => {
+      const { router } = setup("reload");
+
+      const first = await router.start();
+
+      expect(first.context.navigation?.navigationType).toBe("reload");
+
+      const second = await router.navigate("users.list");
+
+      // Activation only describes the cross-document load — second
+      // (same-document) transition must derive meta from navOptions.
+      expect(second.context.navigation?.navigationType).toBe("push");
+      expect(second.context.navigation?.direction).toBe("forward");
+    });
+
+    it("primed meta is frozen after write", async () => {
+      const { router } = setup("reload");
+
+      const state = await router.start();
+
+      expect(Object.isFrozen(state.context.navigation)).toBe(true);
+    });
+  });
+
+  describe("primed meta is visible in guards (onTransitionStart)", () => {
+    it('activation "reload" → activation guard sees navigationType "reload"', async () => {
+      const { router } = setup("reload");
+
+      const lifecycle = getLifecycleApi(router);
+      let metaInGuard: NavigationMeta | undefined;
+
+      // Initial URL "http://localhost/" matches the "index" route, not "home"
+      // — defaultRoute is only consulted when no route matches.
+      lifecycle.addActivateGuard("index", () => (toState) => {
+        metaInGuard = toState.context.navigation;
+
+        return true;
+      });
+
+      await router.start();
+
+      expect(metaInGuard).toBeDefined();
+      expect(metaInGuard?.navigationType).toBe("reload");
+    });
+  });
+});

--- a/packages/navigation-plugin/tests/helpers/testUtils.ts
+++ b/packages/navigation-plugin/tests/helpers/testUtils.ts
@@ -61,6 +61,7 @@ export function createMockNavigationBrowser(
       };
     },
     entries: () => mock.entries(),
+    getActivationType: () => mock.activation?.navigationType,
   };
 
   return Object.defineProperty(browser, "currentEntry", {


### PR DESCRIPTION
## Summary

- Read `navigation.activation.navigationType` ([Baseline 2026](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationactivation-navigationtype)) once in the plugin constructor and prime `#capturedMeta` for the first transition. Fixes `state.context.navigation.navigationType` reporting `"replace"` instead of `"reload"` / `"traverse"` / `"push"` after F5, cross-document back/forward, or fresh URL bar entry.
- New `NavigationBrowser.getActivationType()` abstraction method (real impl reads `nav.activation?.navigationType`; SSR fallback returns `undefined`).
- Fixes scroll position restoration after F5 in `shared/dom-utils/scroll-restore.ts` — the `"reload"` branch is now reachable end-to-end, not just under synthetic fake-router tests.

## Why activation, not `PerformanceNavigationTiming`

The original [issue plan](https://github.com/greydragon888/real-router/issues/531) suggested `performance.getEntriesByType("navigation")[0].type`. After spec review this branch uses `navigation.activation.navigationType` instead:

- Returns the exact 4 strings we need (`"push" | "reload" | "replace" | "traverse"`) — no fallthrough to `deriveNavigationType` for `replace` vs. `push` disambiguation on initial load.
- Part of Navigation API → plugin already requires `"navigation" in globalThis`, no second web API.
- On Chrome 102–122 (`navigation` exists, `activation` does not), `getActivationType()` returns `undefined` and the legacy `deriveNavigationType` path runs unchanged.

Trade-offs (see issue comment for full rationale):
- `userInitiated: false` always — browser does not expose F5 vs. `location.reload()`.
- `direction: "unknown"` for `traverse` — `from.index` vs. `entry.index` comparison is a possible follow-up.

## Test plan

- [x] `pnpm -F @real-router/navigation-plugin test -- --run` — 212/212 pass, 100% coverage maintained
- [x] `pnpm -F @real-router/navigation-plugin lint` + `type-check` — clean
- [x] `pnpm -F @real-router/navigation-plugin bundle` — ESM 9.41 kB / CJS produced
- [x] `pnpm build` — full graph 277/277 successful
- [x] Branch coverage for `getActivationType`: activation set / null / missing
- [ ] **Follow-up:** Playwright e2e for F5 scroll restoration in `examples/web/react/navigation-api/` — requires adding a long-page route to the example; tracked separately

Closes #531.