### PR TITLE
feat: hash support in URL plugins + <Link hash> across 6 adapters (#532)

### DIFF
--- a/.changeset/532-angular-link-hash.md
+++ b/.changeset/532-angular-link-hash.md
@@ -1,0 +1,23 @@
+---
+"@real-router/angular": minor
+---
+
+Add `hash` input to `[realLink]` directive (#532)
+
+The `realLink` directive now exposes a signal `hash` input
+(`input<string | undefined>(undefined)`) that builds a URL with the fragment
+via the URL plugin's `router.buildUrl(name, params, { hash })` extension and,
+on click, calls the `navigateWithHash` helper. The helper auto-bypasses
+SAME_STATES (`force: true, hashChange: true`) when the same route is
+navigated to with a different fragment, so anchor-style same-path links
+update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
+now reads the anchor target from `state.context.url.hash` (decoded, populated
+by the URL plugins) when available, falling back to `globalThis.location.hash`
+otherwise. Removes a race between the adapter's commit and the browser's hash
+update.
+
+```html
+<a realLink routeName="docs" hash="section">Docs</a>
+```

--- a/.changeset/532-angular-link-hash.md
+++ b/.changeset/532-angular-link-hash.md
@@ -2,21 +2,21 @@
 "@real-router/angular": minor
 ---
 
-Add `hash` input to `[realLink]` directive (#532)
+Add `hash` support to `[realLink]` and `injectIsActiveRoute` (#532)
 
-The `realLink` directive now exposes a signal `hash` input
-(`input<string | undefined>(undefined)`) that builds a URL with the fragment
-via the URL plugin's `router.buildUrl(name, params, { hash })` extension and,
-on click, calls the `navigateWithHash` helper. The helper auto-bypasses
-SAME_STATES (`force: true, hashChange: true`) when the same route is
-navigated to with a different fragment, so anchor-style same-path links
-update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
-now reads the anchor target from `state.context.url.hash` (decoded, populated
-by the URL plugins) when available, falling back to `globalThis.location.hash`
-otherwise. Removes a race between the adapter's commit and the browser's hash
-update.
+- The `realLink` directive exposes a signal `hash` input
+  (`input<string | undefined>(undefined)`) that builds a URL with the
+  fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the `navigateWithHash` helper. The helper
+  auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+  route is navigated to with a different fragment, so anchor-style same-path
+  links update both URL and `state.context.url.hashChanged`.
+- `injectIsActiveRoute(name, params, { strict?, ignoreQueryParams?, hash? })`
+  accepts an optional `hash` field. When provided, the returned
+  `Signal<boolean>` is `true` iff the route matches AND
+  `state.context.url.hash` equals the requested fragment exactly — distinct
+  hashes get distinct cache entries in `@real-router/sources` (see its
+  changeset).
 
 ```html
 <a realLink routeName="docs" hash="section">Docs</a>

--- a/.changeset/532-angular-scroll-restore-fix.md
+++ b/.changeset/532-angular-scroll-restore-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/angular": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) when
+available, falling back to `globalThis.location.hash` otherwise. Removes a
+race between the adapter's commit and the browser's hash update.

--- a/.changeset/532-browser-plugin-hash.md
+++ b/.changeset/532-browser-plugin-hash.md
@@ -1,0 +1,24 @@
+---
+"@real-router/browser-plugin": minor
+---
+
+Add URL fragment ("hash") support via `state.context.url` (#532)
+
+The plugin claims the shared `"url"` `state.context` namespace alongside its
+existing `"browser"` namespace. Subscribers can read the decoded fragment and
+the `hashChanged` signal from `state.context.url`.
+
+- `router.buildUrl(name, params, { hash })` and
+  `router.replaceHistoryState(name, params, { hash })` accept an options object
+  with the decoded fragment.
+- `router.navigate(name, params, { hash })` exposes tri-state `hash`:
+  `undefined` preserves, `""` clears, a non-empty value sets the fragment.
+- The popstate handler samples `location.hash` after the browser has updated
+  to the destination, detects hash-only navigation, and adds
+  `force: true, hashChange: true` to bypass SAME_STATES.
+- Cross-path navigation preserves the current fragment by default; the
+  previous `shouldPreserveHash` workaround that dropped the hash on path
+  change is removed.
+- `rollbackUrlToCurrentState` (popstate recovery) reads the fragment from
+  `state.context.url.hash` so guard rejection or unmatched URLs do not strip
+  the fragment.

--- a/.changeset/532-hash-plugin-limitation.md
+++ b/.changeset/532-hash-plugin-limitation.md
@@ -1,0 +1,15 @@
+---
+"@real-router/hash-plugin": minor
+---
+
+Document URL fragment limitation with one-time runtime warning (#532)
+
+`hash-plugin` uses `#` as the route delimiter, so URL fragments are
+structurally incompatible. The plugin now accepts the `hash` option on
+`buildUrl` / `navigate` for typing parity with `@real-router/browser-plugin`
+and `@real-router/navigation-plugin`, ignores it at runtime, and emits a
+single `console.warn` the first time any consumer surfaces a hash through
+either entry point.
+
+Use `@real-router/browser-plugin` or `@real-router/navigation-plugin` if you
+need URL fragment support.

--- a/.changeset/532-navigation-plugin-hash.md
+++ b/.changeset/532-navigation-plugin-hash.md
@@ -1,0 +1,26 @@
+---
+"@real-router/navigation-plugin": minor
+---
+
+Add URL fragment ("hash") support via `state.context.url` (#532)
+
+The plugin now publishes a shared `url` namespace under `state.context` containing
+the decoded fragment and a `hashChanged` signal. Subscribers can branch on
+`state.context.url.hashChanged` instead of disambiguating via the overloaded
+`force` flag.
+
+- `router.buildUrl(name, params, { hash })` accepts an options object with the
+  decoded fragment (no leading `#`).
+- `router.replaceHistoryState(name, params, { hash })` mirrors the same widening.
+- `router.navigate(name, params, { hash })` exposes a tri-state `hash` option:
+  `undefined` preserves the current fragment, `""` clears it, a non-empty value
+  sets it.
+- The `navigate` event handler detects `event.hashChange` and forwards
+  `force: true, hashChange: true` so same-path hash-only clicks are not swallowed
+  by the SAME_STATES short-circuit.
+- Cross-path navigation now preserves the current fragment by default, fixing
+  the previous `shouldPreserveHash` workaround which dropped the hash on every
+  path change.
+- Recovery (`syncUrlToRouterState`) reads the fragment from
+  `state.context.url.hash` so guard rejection or unmatched URLs do not strip the
+  fragment from the visible URL.

--- a/.changeset/532-preact-link-hash.md
+++ b/.changeset/532-preact-link-hash.md
@@ -2,17 +2,16 @@
 "@real-router/preact": minor
 ---
 
-Add `hash` prop to `<Link>` (#532)
+Add `hash` support to `<Link>` and `useIsActiveRoute` (#532)
 
-`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
-the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
-extension and, on click, calls the `navigateWithHash` helper. The helper
-auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
-route is navigated to with a different fragment, so anchor-style same-path
-links update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
-now reads the anchor target from `state.context.url.hash` (decoded, populated
-by the URL plugins) when available, falling back to `globalThis.location.hash`
-otherwise. Removes a race between the adapter's commit and the browser's hash
-update.
+- `<Link>` accepts an optional `hash?: string` prop that builds a URL with
+  the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the `navigateWithHash` helper. The helper
+  auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+  route is navigated to with a different fragment, so anchor-style same-path
+  links update both URL and `state.context.url.hashChanged`.
+- `useIsActiveRoute(name, params, strict?, ignoreQueryParams?, hash?)` gains
+  an optional fifth `hash` argument. When provided, the hook is `true` iff
+  the route matches AND `state.context.url.hash` equals the requested
+  fragment exactly — distinct hashes get distinct cache entries in
+  `@real-router/sources` (see its changeset).

--- a/.changeset/532-preact-link-hash.md
+++ b/.changeset/532-preact-link-hash.md
@@ -1,0 +1,18 @@
+---
+"@real-router/preact": minor
+---
+
+Add `hash` prop to `<Link>` (#532)
+
+`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
+the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+extension and, on click, calls the `navigateWithHash` helper. The helper
+auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+route is navigated to with a different fragment, so anchor-style same-path
+links update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
+now reads the anchor target from `state.context.url.hash` (decoded, populated
+by the URL plugins) when available, falling back to `globalThis.location.hash`
+otherwise. Removes a race between the adapter's commit and the browser's hash
+update.

--- a/.changeset/532-preact-scroll-restore-fix.md
+++ b/.changeset/532-preact-scroll-restore-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/preact": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) when
+available, falling back to `globalThis.location.hash` otherwise. Removes a
+race between the adapter's commit and the browser's hash update.

--- a/.changeset/532-react-link-hash.md
+++ b/.changeset/532-react-link-hash.md
@@ -1,0 +1,18 @@
+---
+"@real-router/react": minor
+---
+
+Add `hash` prop to `<Link>` (#532)
+
+`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
+the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+extension and, on click, calls the new `navigateWithHash` helper. The helper
+auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+route is navigated to with a different fragment, so anchor-style same-path
+links update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety fix in scroll-restoration: `createScrollRestoration` now
+reads the anchor target from `state.context.url.hash` (decoded, populated by
+the URL plugins) rather than `globalThis.location.hash`, falling back to the
+DOM only when no URL plugin is installed. This avoids race conditions between
+React's commit and the browser's hash update.

--- a/.changeset/532-react-link-hash.md
+++ b/.changeset/532-react-link-hash.md
@@ -2,17 +2,16 @@
 "@real-router/react": minor
 ---
 
-Add `hash` prop to `<Link>` (#532)
+Add `hash` support to `<Link>` and `useIsActiveRoute` (#532)
 
-`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
-the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
-extension and, on click, calls the new `navigateWithHash` helper. The helper
-auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
-route is navigated to with a different fragment, so anchor-style same-path
-links update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety fix in scroll-restoration: `createScrollRestoration` now
-reads the anchor target from `state.context.url.hash` (decoded, populated by
-the URL plugins) rather than `globalThis.location.hash`, falling back to the
-DOM only when no URL plugin is installed. This avoids race conditions between
-React's commit and the browser's hash update.
+- `<Link>` accepts an optional `hash?: string` prop that builds a URL with
+  the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the new `navigateWithHash` helper. The
+  helper auto-bypasses SAME_STATES (`force: true, hashChange: true`) when
+  the same route is navigated to with a different fragment, so anchor-style
+  same-path links update both URL and `state.context.url.hashChanged`.
+- `useIsActiveRoute(name, params, strict?, ignoreQueryParams?, hash?)` gains
+  an optional fifth `hash` argument. When provided, the hook is `true` iff
+  the route matches AND `state.context.url.hash` equals the requested
+  fragment exactly — distinct hashes get distinct cache entries in
+  `@real-router/sources` (see its changeset).

--- a/.changeset/532-react-scroll-restore-fix.md
+++ b/.changeset/532-react-scroll-restore-fix.md
@@ -1,0 +1,11 @@
+---
+"@real-router/react": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) rather than
+`globalThis.location.hash`, falling back to the DOM only when no URL plugin
+is installed. This avoids race conditions between React's commit and the
+browser's hash update.

--- a/.changeset/532-solid-link-hash.md
+++ b/.changeset/532-solid-link-hash.md
@@ -2,17 +2,16 @@
 "@real-router/solid": minor
 ---
 
-Add `hash` prop to `<Link>` (#532)
+Add `hash` support to `<Link>` and `useIsActiveRoute` (#532)
 
-`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
-the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
-extension and, on click, calls the `navigateWithHash` helper. The helper
-auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
-route is navigated to with a different fragment, so anchor-style same-path
-links update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
-now reads the anchor target from `state.context.url.hash` (decoded, populated
-by the URL plugins) when available, falling back to `globalThis.location.hash`
-otherwise. Removes a race between the adapter's commit and the browser's hash
-update.
+- `<Link>` accepts an optional `hash?: string` prop that builds a URL with
+  the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the `navigateWithHash` helper. The helper
+  auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+  route is navigated to with a different fragment, so anchor-style same-path
+  links update both URL and `state.context.url.hashChanged`.
+- `useIsActiveRoute(name, params, strict?, ignoreQueryParams?, hash?)` gains
+  an optional fifth `hash` argument. When provided, the hook is `true` iff
+  the route matches AND `state.context.url.hash` equals the requested
+  fragment exactly — distinct hashes get distinct cache entries in
+  `@real-router/sources` (see its changeset).

--- a/.changeset/532-solid-link-hash.md
+++ b/.changeset/532-solid-link-hash.md
@@ -1,0 +1,18 @@
+---
+"@real-router/solid": minor
+---
+
+Add `hash` prop to `<Link>` (#532)
+
+`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
+the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+extension and, on click, calls the `navigateWithHash` helper. The helper
+auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+route is navigated to with a different fragment, so anchor-style same-path
+links update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
+now reads the anchor target from `state.context.url.hash` (decoded, populated
+by the URL plugins) when available, falling back to `globalThis.location.hash`
+otherwise. Removes a race between the adapter's commit and the browser's hash
+update.

--- a/.changeset/532-solid-scroll-restore-fix.md
+++ b/.changeset/532-solid-scroll-restore-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/solid": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) when
+available, falling back to `globalThis.location.hash` otherwise. Removes a
+race between the adapter's commit and the browser's hash update.

--- a/.changeset/532-sources-hash-active.md
+++ b/.changeset/532-sources-hash-active.md
@@ -1,0 +1,34 @@
+---
+"@real-router/sources": minor
+---
+
+`createActiveRouteSource` accepts optional `hash` to compute hash-aware active state (#532)
+
+`ActiveRouteSourceOptions` gains an optional `hash` field. When defined, the
+source treats a route as active iff:
+
+1. `router.isActiveRoute(name, params, strict, ignoreQueryParams)` returns
+   `true`, AND
+2. `state.context.url.hash` (decoded, populated by the URL plugins) equals
+   the requested fragment exactly.
+
+The cache key now includes `hash`, so a Link pointing to `/settings#account`
+shares its source only with consumers using the same routeName + params +
+hash. Sources with `hash === undefined` retain the legacy route-only active
+semantics — no behavior change for callers that don't pass the new option.
+
+Hash-plugin runtimes leave `state.context.url` undefined, so any non-undefined
+`hash` option produces `false` there — consistent with the documented
+limitation that hash-plugin doesn't support URL fragments.
+
+This unlocks tab-style UI in `<Link hash>` across all six framework adapters:
+the matching variant lights up `activeClassName="active"` automatically, no
+manual workaround needed.
+
+`stabilizeState` (used by `createRouteSource`) now also compares
+`state.context.url.hash`. Previously it short-circuited on `path` only — so
+`useRoute()` consumers would not re-render on same-path-different-hash
+transitions (the hash flipped in the URL, but the rendered tab content
+stayed stale). Treating hash as render identity fixes tab-style UIs that
+subscribe via `useRoute()` instead of (or in addition to) `<Link>`'s
+hash-aware active state.

--- a/.changeset/532-svelte-link-hash.md
+++ b/.changeset/532-svelte-link-hash.md
@@ -1,0 +1,18 @@
+---
+"@real-router/svelte": minor
+---
+
+Add `hash` prop to `<Link>` (#532)
+
+`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
+the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+extension and, on click, calls the `navigateWithHash` helper. The helper
+auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+route is navigated to with a different fragment, so anchor-style same-path
+links update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
+now reads the anchor target from `state.context.url.hash` (decoded, populated
+by the URL plugins) when available, falling back to `globalThis.location.hash`
+otherwise. Removes a race between the adapter's commit and the browser's hash
+update.

--- a/.changeset/532-svelte-link-hash.md
+++ b/.changeset/532-svelte-link-hash.md
@@ -2,17 +2,16 @@
 "@real-router/svelte": minor
 ---
 
-Add `hash` prop to `<Link>` (#532)
+Add `hash` support to `<Link>` and `useIsActiveRoute` (#532)
 
-`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
-the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
-extension and, on click, calls the `navigateWithHash` helper. The helper
-auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
-route is navigated to with a different fragment, so anchor-style same-path
-links update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
-now reads the anchor target from `state.context.url.hash` (decoded, populated
-by the URL plugins) when available, falling back to `globalThis.location.hash`
-otherwise. Removes a race between the adapter's commit and the browser's hash
-update.
+- `<Link>` accepts an optional `hash?: string` prop that builds a URL with
+  the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the `navigateWithHash` helper. The helper
+  auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+  route is navigated to with a different fragment, so anchor-style same-path
+  links update both URL and `state.context.url.hashChanged`.
+- `useIsActiveRoute(name, params, strict, ignoreQueryParams, hash?)` gains
+  an optional fifth `hash` argument. When provided, the composable's
+  `current` is `true` iff the route matches AND `state.context.url.hash`
+  equals the requested fragment exactly — distinct hashes get distinct
+  cache entries in `@real-router/sources` (see its changeset).

--- a/.changeset/532-svelte-scroll-restore-fix.md
+++ b/.changeset/532-svelte-scroll-restore-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/svelte": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) when
+available, falling back to `globalThis.location.hash` otherwise. Removes a
+race between the adapter's commit and the browser's hash update.

--- a/.changeset/532-vue-link-hash.md
+++ b/.changeset/532-vue-link-hash.md
@@ -1,0 +1,18 @@
+---
+"@real-router/vue": minor
+---
+
+Add `hash` prop to `<Link>` (#532)
+
+`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
+the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+extension and, on click, calls the `navigateWithHash` helper. The helper
+auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+route is navigated to with a different fragment, so anchor-style same-path
+links update both URL and `state.context.url.hashChanged`.
+
+Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
+now reads the anchor target from `state.context.url.hash` (decoded, populated
+by the URL plugins) when available, falling back to `globalThis.location.hash`
+otherwise. Removes a race between the adapter's commit and the browser's hash
+update.

--- a/.changeset/532-vue-link-hash.md
+++ b/.changeset/532-vue-link-hash.md
@@ -2,17 +2,17 @@
 "@real-router/vue": minor
 ---
 
-Add `hash` prop to `<Link>` (#532)
+Add `hash` support to `<Link>` and `useIsActiveRoute` (#532)
 
-`<Link>` now accepts an optional `hash?: string` prop that builds a URL with
-the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
-extension and, on click, calls the `navigateWithHash` helper. The helper
-auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
-route is navigated to with a different fragment, so anchor-style same-path
-links update both URL and `state.context.url.hashChanged`.
-
-Plus an SSR-safety improvement in scroll-restoration: `createScrollRestoration`
-now reads the anchor target from `state.context.url.hash` (decoded, populated
-by the URL plugins) when available, falling back to `globalThis.location.hash`
-otherwise. Removes a race between the adapter's commit and the browser's hash
-update.
+- `<Link>` accepts an optional `hash?: string` prop that builds a URL with
+  the fragment via the URL plugin's `router.buildUrl(name, params, { hash })`
+  extension and, on click, calls the `navigateWithHash` helper. The helper
+  auto-bypasses SAME_STATES (`force: true, hashChange: true`) when the same
+  route is navigated to with a different fragment, so anchor-style same-path
+  links update both URL and `state.context.url.hashChanged`.
+- `useIsActiveRoute(name, params, strict?, ignoreQueryParams?, hash?)` gains
+  an optional fifth `hash` argument. When provided, the returned
+  `ShallowRef<boolean>` is `true` iff the route matches AND
+  `state.context.url.hash` equals the requested fragment exactly — distinct
+  hashes get distinct cache entries in `@real-router/sources` (see its
+  changeset).

--- a/.changeset/532-vue-scroll-restore-fix.md
+++ b/.changeset/532-vue-scroll-restore-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/vue": patch
+---
+
+SSR-safe anchor lookup in `createScrollRestoration` (#532)
+
+`createScrollRestoration` now reads the anchor target from
+`state.context.url.hash` (decoded, populated by the URL plugins) when
+available, falling back to `globalThis.location.hash` otherwise. Removes a
+race between the adapter's commit and the browser's hash update.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,7 +16,7 @@ export default [
   {
     name: "@real-router/react (ESM)",
     path: "packages/react/dist/esm/index.mjs",
-    limit: "3.1 kB",
+    limit: "5 kB",
     ignore: [
       "react",
       "react-dom",
@@ -28,7 +28,7 @@ export default [
   {
     name: "@real-router/preact (ESM)",
     path: "packages/preact/dist/esm/index.mjs",
-    limit: "3 kB",
+    limit: "5 kB",
     ignore: [
       "preact",
       "preact/hooks",
@@ -41,7 +41,7 @@ export default [
   {
     name: "@real-router/solid (ESM)",
     path: "packages/solid/dist/esm/index.mjs",
-    limit: "3.5 kB",
+    limit: "5 kB",
     ignore: [
       "solid-js",
       "solid-js/store",
@@ -54,7 +54,7 @@ export default [
   {
     name: "@real-router/vue (ESM)",
     path: "packages/vue/dist/esm/index.mjs",
-    limit: "4 kB",
+    limit: "5 kB",
     ignore: [
       "vue",
       "@real-router/core",
@@ -65,7 +65,7 @@ export default [
   {
     name: "@real-router/angular (FESM2022)",
     path: "packages/angular/dist/fesm2022/real-router-angular.mjs",
-    limit: "4.1 kB",
+    limit: "5 kB",
     ignore: [
       "@angular/core",
       "@angular/common",
@@ -100,7 +100,7 @@ export default [
   {
     name: "@real-router/navigation-plugin (ESM)",
     path: "packages/navigation-plugin/dist/esm/index.mjs",
-    limit: "3.5 kB",
+    limit: "4 kB",
     ignore: ["@real-router/core"],
   },
   {
@@ -112,7 +112,7 @@ export default [
   {
     name: "@real-router/hash-plugin (ESM)",
     path: "packages/hash-plugin/dist/esm/index.mjs",
-    limit: "3 kB",
+    limit: "3.5 kB",
     ignore: ["@real-router/core"],
   },
   {

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -2638,3 +2638,58 @@ The biggest wins are on the heavy-params fixtures (search-params, defaultParams)
 - `getPluginApi(router)`: same return type, now WeakMap-cached per router.
 
 `@real-router/core` and `@real-router/types` bumped `minor` (PluginApi extension); `@real-router/validation-plugin` `minor` (matches the typed surface). The three URL plugins are `patch` (internal call-site migration; no API change).
+
+## URL Fragment ("hash") Support — Plugin-Layer Design (#532)
+
+### Problem
+
+Pre-#532, URL fragments lived in three workarounds:
+
+1. `shouldPreserveHash = !fromState || fromState.path === toState.path` in navigation-plugin & browser-plugin's `onTransitionSuccess` — hash dropped on cross-path navigation, no way to set/clear explicitly.
+2. `urlToPath()` in `shared/browser-env/url-utils.ts` stripped hash before matching → handler never saw the fragment from `event.destination.url`.
+3. Same-path hash-click was swallowed by core's `SAME_STATES` rejection (`navigate-handler.ts` swallowed the error silently) → URL bar updated but `router.subscribe` listeners never fired.
+
+### Solution
+
+Hash treated as **URL-layer** state, owned by URL plugins (browser/navigation), not by core. Symmetric to #497 (scroll restoration utility): viewport-concerns in dom-utils, URL-concerns in plugins, routing-concerns in core.
+
+Three coordinated additions:
+
+- **`state.context.url`** — shared namespace claimed by both URL plugins. Type `{ hash: string; hashChanged: boolean }`. Hash storage form: decoded, no leading `#` (symmetric to params, no leading `?`).
+- **`NavigationOptions.hash` augmentation** — tri-state in plugins' `index.ts`: `undefined` preserves current browser hash, `""` clears, non-empty sets. Plugins read in `onTransitionSuccess`.
+- **`NavigationOptions.hashChange` (@internal)** — flag set by URL plugins on browser-driven hash-only nav (`event.hashChange === true` in navigation-plugin; popstate hashChange detection in browser-plugin). Combined with `force: true` to bypass SAME_STATES; subscribers disambiguate via `state.context.url.hashChanged`, not via the overloaded `force` flag.
+
+### Why not in core
+
+Hash is a URL-layer concept. Memory-plugin / NativeScript / SSR runtimes have no URL → no hash. Adding `hash` to core State would force every non-URL runtime to carry an empty `hash: ""` field and reason about identity it doesn't own. Same line that scroll restoration drew (#497).
+
+### Hash-aware active state & state stabilization
+
+Two follow-ups in `@real-router/sources`:
+
+- `ActiveRouteSourceOptions.hash` — when defined, source is active iff route matches AND `state.context.url.hash` equals requested hash. Cache key includes hash; subscribe path detects hash flip via `state.context.url.hashChanged`. Hash-plugin runtime (no `url` namespace) returns `false` for any non-undefined `hash` — consistent with documented limitation.
+- `stabilizeState` compares `state.context.url.hash` in addition to `path`, so `useRoute()` consumers re-render on same-path-different-hash navigation (tab-style UIs).
+
+### `<Link hash>` API surface
+
+6 adapters get a `hash?: string` prop on `<Link>` / `[realLink]` directive.
+
+- Default `activeClassName="active"` is hash-aware: only the matching variant lights up — tab-style UIs work without manual workaround.
+- Click handler routes through `navigateWithHash` (`shared/dom-utils/link-utils.ts`). When `hash` differs from `state.context.url.hash` on the same route+params, helper auto-adds `force: true, hashChange: true` → bypasses SAME_STATES.
+- Solid's fast-path `routeSelector` is bypassed when `hash` is set (selector is hash-agnostic, slow path through `createActiveRouteSource` is required).
+
+### Encoding contract
+
+- Decoded form in `state.context.url.hash` (no `%` escapes, no leading `#`).
+- Encoded at URL build time via `encodeURI(s).replace(/#/g, "%23")`: preserves RFC-3986 fragment sub-delims (`&`, `=`, `?`, `:`, `@`, etc.) while escaping `%` and `#`. `encodeURIComponent` was rejected — it over-encodes sub-delims.
+- Decoded via `decodeURIComponent` with try/catch fallback to raw input for malformed `%XX` sequences.
+
+### F5 / cold-load: hash is read lazily, not primed
+
+Hash handling is **separate** from navigation-plugin's existing `navigationType` priming (which uses `browser.getActivationType()` to recover the cross-document `navigation.activation.navigationType` so the very first transition reports `reload`/`push`/`traverse`/`replace` correctly — see #531). That priming is Navigation-API-only and does not touch the URL fragment.
+
+For hash, both URL plugins use a **lazy read** in `onTransitionSuccess`: on the first transition (`!fromState`), `getDecodedHash(browser)` is called to obtain the previous hash. By the time `onTransitionSuccess` fires, `location.hash` already reflects the destination URL — F5 on `/page#section`, fresh URL bar entry, and cross-document back/forward all read the correct value. An earlier draft captured the hash in the plugin constructor; this failed in tests where the mock URL is set after plugin construction, and offered no benefit over the lazy read.
+
+### Hash-plugin limitation
+
+`#` is the route delimiter in hash-plugin → URL fragments are structurally incompatible. `pluginBuildUrl` accepts `hash` option for typing parity (TS interface merge needs identical signatures across all 3 URL plugins) but ignores it at runtime + emits one-time `console.warn`. Inline `let warned = false` pattern — existing `createWarnOnce` from `shared/browser-env/ssr-fallback.ts` has SSR-specific signature `(context) => (method) => void` and didn't fit.

--- a/examples/web/react/link-hash/README.md
+++ b/examples/web/react/link-hash/README.md
@@ -1,0 +1,66 @@
+# `<Link hash>` — Tab UI Demo
+
+Dogfood for issue [#532 — URL fragment ("hash") support in URL plugins](https://github.com/greydragon888/real-router/issues/532).
+
+This example demonstrates **tab-style UI driven by `state.context.url.hash`** —
+URL fragment as bookmarkable tab state, with no scroll-restoration involvement.
+For anchor-link scrolling and `scrollIntoView` behavior see the
+`scroll-restoration` example (issue #534).
+
+## Run
+
+```bash
+pnpm install
+pnpm bundle                                 # rebuild shared/dom-utils dist
+pnpm -F react-link-hash-example dev
+```
+
+Then open <http://localhost:5173>.
+
+## What it shows
+
+| API | Demonstrated by | Source |
+|-----|---|---|
+| `<Link hash="profile">` | Tab navigation in `Settings` page | `src/pages/Settings.tsx` |
+| `state.context.url.hash` | Active tab read from router state, not React local state | `src/pages/Settings.tsx` |
+| Auto-force on same-route different-hash | Clicking `<Link hash="account">` while at `/settings#profile` updates URL and re-publishes the namespace (would otherwise be SAME_STATES) | `navigateWithHash` helper in `shared/dom-utils/link-utils.ts` |
+| Tri-state `opts.hash` | Three buttons in `HashControls`: set / clear / preserve | `src/pages/HashControls.tsx` |
+| Cross-path preserve | `<Link routeName="dashboard">` (no `hash` prop) keeps the current fragment | `Dashboard` page reads `state.context.url.hash` |
+| F5 priming | Refresh `/settings#account` keeps the active tab "account" | Plugin constructor reads `getDecodedHash(browser)` |
+| Hash-plugin warn-once | Append `?plugin=hash` and the example switches to `@real-router/hash-plugin`. Console emits one `[@real-router/hash-plugin] hash option is ignored …` warning regardless of how many `<Link hash>` clicks happen | `src/main.tsx` plugin selector |
+
+## Plugin selector
+
+The example bundles **both** `@real-router/browser-plugin` and
+`@real-router/hash-plugin` and selects one at startup:
+
+- **Default**: `browser-plugin`. URLs look like `/settings#profile`.
+  `state.context.url` is populated, `<Link hash>` works end-to-end.
+- **`?plugin=hash`**: `hash-plugin`. URLs look like
+  `/index.html#!/settings`. `<Link hash>` is silently ignored at runtime; a
+  one-time `console.warn` documents the limitation.
+
+This is the documented limitation from #532: hash-plugin uses `#` as the route
+delimiter, so URL fragments are structurally incompatible. Use `browser-plugin`
+or `navigation-plugin` for fragment support.
+
+## E2E tests
+
+```bash
+pnpm -F react-link-hash-example test:e2e
+```
+
+Five scenarios:
+
+1. Tab switching updates the URL hash without scroll jumps.
+2. F5 priming preserves the active tab.
+3. Cross-path navigation preserves the current hash.
+4. `opts.hash = ""` explicitly clears the fragment.
+5. `?plugin=hash` emits exactly one warn-once, regardless of click count.
+
+## See also
+
+- [issue #532](https://github.com/greydragon888/real-router/issues/532) — design
+- [Wiki: Hash](https://github.com/greydragon888/real-router/wiki/Hash) — full API reference (after Stage 4)
+- `examples/web/react/scroll-restoration/` — anchor scrolling demo (issue #534)
+- `examples/web/react/hash-routing/` — page-level routing via `hash-plugin` (different feature)

--- a/examples/web/react/link-hash/e2e/link-hash.spec.ts
+++ b/examples/web/react/link-hash/e2e/link-hash.spec.ts
@@ -1,0 +1,642 @@
+import { expect, test } from "@playwright/test";
+
+// =============================================================================
+// Section 1: Tab UI base
+// =============================================================================
+
+test.describe("Section 1: Tab UI base", () => {
+  test("home page loads at /", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/$/);
+    await expect(
+      page.getByRole("heading", { name: /Link hash/i }),
+    ).toBeVisible();
+  });
+
+  test("Settings without hash → default tab Profile", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("clicking through all tabs cycles correctly", async ({ page }) => {
+    await page.goto("/settings");
+
+    await page.getByTestId("tab-account").click();
+    await expect(page).toHaveURL(/\/settings#account$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+
+    await page.getByTestId("tab-billing").click();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+
+    await page.getByTestId("tab-profile").click();
+    await expect(page).toHaveURL(/\/settings#profile$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("clicking already-active tab is a no-op (URL and state unchanged)", async ({
+    page,
+  }) => {
+    await page.goto("/settings#profile");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+
+    // navigateWithHash sees current === new → no force, navigate goes through
+    // core's SAME_STATES check and is rejected silently. URL must stay.
+    await page.getByTestId("tab-profile").click();
+    await page.waitForTimeout(50);
+
+    await expect(page).toHaveURL(/\/settings#profile$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+});
+
+// =============================================================================
+// Section 2: F5 / cold-load priming
+// =============================================================================
+
+test.describe("Section 2: F5 / cold-load priming", () => {
+  test("direct URL with hash sets active tab on first render", async ({
+    page,
+  }) => {
+    await page.goto("/settings#billing");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+  });
+
+  test("F5 on /settings#account preserves active tab", async ({ page }) => {
+    await page.goto("/settings#account");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/settings#account$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+  });
+
+  test("/settings without hash → Profile default tab", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("/settings#unknownTab → 'Unknown tab.' fallback content", async ({
+    page,
+  }) => {
+    await page.goto("/settings#unknownTab");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "unknownTab",
+    );
+    await expect(page.getByTestId("active-tab")).toContainText("Unknown tab");
+  });
+});
+
+// =============================================================================
+// Section 3: Cross-path preserve
+// =============================================================================
+
+test.describe("Section 3: Cross-path preserve", () => {
+  test("Settings#account → Dashboard (body link) preserves hash", async ({
+    page,
+  }) => {
+    await page.goto("/settings#account");
+    await page.getByTestId("link-dashboard").click();
+    await expect(page).toHaveURL(/\/dashboard#account$/);
+    await expect(page.getByTestId("dashboard-hash")).toHaveText("account");
+  });
+
+  test("Dashboard 'Back to Settings' preserves hash", async ({ page }) => {
+    await page.goto("/dashboard#billing");
+    await page.getByRole("link", { name: "Back to Settings" }).click();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+  });
+
+  test("Settings#profile → Home (sidebar) preserves hash in URL", async ({
+    page,
+  }) => {
+    await page.goto("/settings#profile");
+    await page
+      .getByRole("link", { name: "Home", exact: true })
+      .first()
+      .click();
+    // browser-plugin's tri-state default preserves the current fragment on
+    // cross-path navigation; URL keeps `#profile`.
+    await expect(page).toHaveURL(/\/#profile$/);
+  });
+
+  test("Dashboard (no hash) → Settings has no fragment, default tab", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await page
+      .getByRole("link", { name: "Settings", exact: true })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+});
+
+// =============================================================================
+// Section 4: Programmatic tri-state demo (HashControls)
+// =============================================================================
+
+test.describe("Section 4: Programmatic tri-state", () => {
+  test("Set hash='billing' button creates fragment", async ({ page }) => {
+    await page.goto("/settings");
+    await page.getByTestId("action-set-billing").click();
+
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+    await expect(page.getByTestId("current-hash")).toHaveText("billing");
+  });
+
+  test("Set already-active hash is a no-op (URL stays)", async ({ page }) => {
+    await page.goto("/settings#billing");
+    await expect(page.getByTestId("current-hash")).toHaveText("billing");
+
+    await page.getByTestId("action-set-billing").click();
+    await page.waitForTimeout(50);
+
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("current-hash")).toHaveText("billing");
+  });
+
+  test("Clear button (opts.hash='') removes fragment", async ({ page }) => {
+    await page.goto("/settings#account");
+    await page.getByTestId("action-clear").click();
+
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByTestId("current-hash")).toHaveText("(empty)");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("Preserve button (opts.hash omitted) keeps current hash", async ({
+    page,
+  }) => {
+    await page.goto("/settings#account");
+    await page.getByTestId("action-preserve").click();
+    await page.waitForTimeout(50);
+
+    await expect(page).toHaveURL(/\/settings#account$/);
+    await expect(page.getByTestId("current-hash")).toHaveText("account");
+  });
+});
+
+// =============================================================================
+// Section 5: Auto-force / SAME_STATES bypass
+// =============================================================================
+
+test.describe("Section 5: Auto-force on same-path-different-hash", () => {
+  test("each same-route tab click flips data-tab attribute (router.subscribe fires)", async ({
+    page,
+  }) => {
+    await page.goto("/settings#profile");
+
+    // Count attribute mutations on `active-tab[data-tab]`. Each successful
+    // tab switch must trigger router.subscribe → re-render → attribute write.
+    // Without auto-force, SAME_STATES would swallow the navigation and the
+    // counter would stay at 0.
+    await page.evaluate(() => {
+      const target = document.querySelector("[data-testid='active-tab']");
+      if (!target) return;
+      let count = 0;
+      const observer = new MutationObserver(() => {
+        count += 1;
+      });
+      observer.observe(target, {
+        attributes: true,
+        attributeFilter: ["data-tab"],
+      });
+      (globalThis as unknown as { __tabFlips: () => number }).__tabFlips = () =>
+        count;
+    });
+
+    await page.getByTestId("tab-account").click();
+    await page.getByTestId("tab-billing").click();
+    await page.getByTestId("tab-profile").click();
+    await page.getByTestId("tab-account").click();
+
+    const flips = await page.evaluate(
+      () =>
+        (globalThis as unknown as { __tabFlips: () => number }).__tabFlips(),
+    );
+    // Four distinct tab switches → four data-tab attribute changes.
+    expect(flips).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// =============================================================================
+// Section 6: state.context.url.hashChanged signal
+// =============================================================================
+
+test.describe("Section 6: state.context.url and hashChanged", () => {
+  test("Home snapshot exposes hash and hashChanged fields", async ({
+    page,
+  }) => {
+    // Land on /settings#account first → state.context.url is populated.
+    await page.goto("/settings#account");
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+
+    // Cross-path nav to / via sidebar — fragment is preserved by tri-state
+    // default; on the new transition, hashChanged compares against the
+    // PUBLISHED previous hash ("account") → equals → hashChanged: false.
+    await page
+      .getByRole("link", { name: "Home", exact: true })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/#account$/);
+
+    const snapshot = page.getByTestId("state-context-url");
+    await expect(snapshot).toContainText('"hash": "account"');
+    await expect(snapshot).toContainText('"hashChanged": false');
+  });
+
+  test("hashChanged is true after a same-path hash switch", async ({
+    page,
+  }) => {
+    await page.goto("/settings#profile");
+    // Switch from #profile to #account on the same route — hashChanged: true.
+    await page.getByTestId("tab-account").click();
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+    await expect(page).toHaveURL(/\/settings#account$/);
+
+    // No direct visualization on Settings page, but the data-tab flip is the
+    // observable signal — it only flips when state.context.url updates with
+    // a different hash. Coverage of the boolean shape is in the previous
+    // test (snapshot on Home).
+  });
+});
+
+// =============================================================================
+// Section 7: F5 priming for routes without fragments
+// =============================================================================
+
+test.describe("Section 7: F5 priming — additional routes", () => {
+  test("F5 on /dashboard with no hash → URL stays without fragment", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await page.reload();
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
+
+  test("F5 on / preserves no hash", async ({ page }) => {
+    await page.goto("/");
+    await page.reload();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test("F5 on /dashboard#anchor preserves the fragment", async ({ page }) => {
+    await page.goto("/dashboard#myAnchor");
+    await page.reload();
+    await expect(page).toHaveURL(/\/dashboard#myAnchor$/);
+    await expect(page.getByTestId("dashboard-hash")).toHaveText("myAnchor");
+  });
+});
+
+// =============================================================================
+// Section 8: Browser back/forward with hash history
+// =============================================================================
+
+test.describe("Section 8: Browser back/forward navigation", () => {
+  test("history walk through tabs + cross-path; back/forward restore each step", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.getByTestId("tab-account").click();
+    await expect(page).toHaveURL(/\/settings#account$/);
+
+    await page.getByTestId("tab-billing").click();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+
+    await page
+      .getByRole("link", { name: "Dashboard", exact: true })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/dashboard#billing$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/settings#account$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "account",
+    );
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/dashboard#billing$/);
+    await expect(page.getByTestId("dashboard-hash")).toHaveText("billing");
+  });
+});
+
+// =============================================================================
+// Section 9: Modifier keys / shouldNavigate guard
+// =============================================================================
+
+test.describe("Section 9: Modifier keys", () => {
+  test("Ctrl/Cmd-click on tab does not change current page URL", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/settings#profile");
+
+    // Modifier-click triggers shouldNavigate → returns false → handler does
+    // not preventDefault, browser handles the click natively (typically opens
+    // new tab). We assert the CURRENT page state is unchanged regardless of
+    // whether a popup actually opened.
+    const popupPromise = context
+      .waitForEvent("page", { timeout: 1000 })
+      .catch(() => null);
+
+    await page
+      .getByTestId("tab-account")
+      .click({ modifiers: ["ControlOrMeta"] });
+
+    const popup = await popupPromise;
+    if (popup) {
+      await popup.close();
+    }
+
+    await expect(page).toHaveURL(/\/settings#profile$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("Shift-click on tab does not change current page URL", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/settings#profile");
+
+    const popupPromise = context
+      .waitForEvent("page", { timeout: 1000 })
+      .catch(() => null);
+
+    await page.getByTestId("tab-account").click({ modifiers: ["Shift"] });
+
+    const popup = await popupPromise;
+    if (popup) {
+      await popup.close();
+    }
+
+    await expect(page).toHaveURL(/\/settings#profile$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+});
+
+// =============================================================================
+// Section 10: URL fragment encoding
+// =============================================================================
+
+test.describe("Section 10: URL fragment encoding", () => {
+  test("encoded URL fragment is decoded in state.context.url.hash", async ({
+    page,
+  }) => {
+    // a%20b%26c — encoded form of "a b&c"
+    await page.goto("/settings#a%20b%26c");
+    // No tab matches; the active-tab section uses the decoded value.
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "a b&c",
+    );
+
+    // Confirm decoded form via Home snapshot — preserve cross-path.
+    await page
+      .getByRole("link", { name: "Home", exact: true })
+      .first()
+      .click();
+    const snapshot = page.getByTestId("state-context-url");
+    await expect(snapshot).toContainText('"hash": "a b&c"');
+  });
+
+  test("malformed escape (#%ZZ) does not throw; the page renders", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => {
+      errors.push(err.message);
+    });
+
+    await page.goto("/settings#%ZZ");
+    await expect(page.getByTestId("active-tab")).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Section 11: hash-plugin warn-once limitation
+// =============================================================================
+
+test.describe("Section 11: hash-plugin warn-once", () => {
+  test("?plugin=hash switches runtime; tab content stays default; URL has no fragment", async ({
+    page,
+  }) => {
+    await page.goto("/?plugin=hash");
+    // hash-plugin uses `#!/` as the route delimiter; we don't pin the rest
+    // of the URL — outer/inner query handling is plugin-internal.
+    await expect(page).toHaveURL(/#!\//);
+
+    await page
+      .getByRole("link", { name: "Settings", exact: true })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/#!\/settings/);
+
+    const urlBefore = page.url();
+    await page.getByTestId("tab-account").click();
+    await page.waitForTimeout(100);
+    const urlAfter = page.url();
+
+    // hash-plugin uses # for the route delimiter — <Link hash> is silently
+    // ignored, so URL must NOT change to include a sub-fragment.
+    expect(urlAfter).toBe(urlBefore);
+
+    // Without state.context.url, activeTab falls back to DEFAULT_TAB.
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "profile",
+    );
+  });
+
+  test("emits exactly one warn across many <Link hash> tab clicks", async ({
+    page,
+  }) => {
+    const warnings: string[] = [];
+
+    page.on("console", (msg) => {
+      if (msg.type() === "warning") {
+        warnings.push(msg.text());
+      }
+    });
+
+    await page.goto("/?plugin=hash");
+    await page
+      .getByRole("link", { name: "Settings", exact: true })
+      .first()
+      .click();
+
+    await page.getByTestId("tab-profile").click();
+    await page.getByTestId("tab-account").click();
+    await page.getByTestId("tab-billing").click();
+
+    const hashPluginWarnings = warnings.filter((w) =>
+      w.includes("@real-router/hash-plugin"),
+    );
+
+    expect(hashPluginWarnings.length).toBe(1);
+    expect(hashPluginWarnings[0]).toContain("`hash` option is ignored");
+  });
+
+  test("HashControls programmatic call shares the single warn (no extra warns)", async ({
+    page,
+  }) => {
+    const warnings: string[] = [];
+
+    page.on("console", (msg) => {
+      if (msg.type() === "warning") {
+        warnings.push(msg.text());
+      }
+    });
+
+    await page.goto("/?plugin=hash");
+    await page
+      .getByRole("link", { name: "Settings", exact: true })
+      .first()
+      .click();
+
+    // Mix Link clicks and programmatic HashControls invocations.
+    await page.getByTestId("tab-profile").click();
+    await page.getByTestId("tab-account").click();
+    await page.getByTestId("action-set-billing").click();
+    await page.getByTestId("action-clear").click();
+    await page.getByTestId("action-preserve").click();
+
+    const hashPluginWarnings = warnings.filter((w) =>
+      w.includes("@real-router/hash-plugin"),
+    );
+
+    // warn-once across the entire session, regardless of entry point.
+    expect(hashPluginWarnings.length).toBe(1);
+  });
+
+  test("red plugin-limitation hint visible under HashControls in hash-plugin runtime", async ({
+    page,
+  }) => {
+    await page.goto("/?plugin=hash");
+    await page
+      .getByRole("link", { name: "Settings", exact: true })
+      .first()
+      .click();
+
+    // Hint paragraph in HashControls.tsx renders only when pluginKind === "hash".
+    await expect(page.getByText(/silently dropped/i).first()).toBeVisible();
+  });
+});
+
+// =============================================================================
+// Section 12: Switch back to browser-plugin
+// =============================================================================
+
+test.describe("Section 12: Switch back to browser-plugin", () => {
+  test("removing ?plugin=hash and reloading restores browser-plugin behavior", async ({
+    page,
+  }) => {
+    // Start in hash-plugin runtime
+    await page.goto("/?plugin=hash");
+    await expect(page).toHaveURL(/#!/);
+
+    // Fresh navigation without ?plugin=hash → main.tsx re-evaluates plugin
+    // selector at startup → browser-plugin
+    await page.goto("/");
+    await expect(page).not.toHaveURL(/#!/);
+
+    // Tab UI works again; observe console for any leftover warnings.
+    const warningsAfterSwitch: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "warning") {
+        warningsAfterSwitch.push(msg.text());
+      }
+    });
+
+    await page.goto("/settings");
+    await page.getByTestId("tab-billing").click();
+    await expect(page).toHaveURL(/\/settings#billing$/);
+    await expect(page.getByTestId("active-tab")).toHaveAttribute(
+      "data-tab",
+      "billing",
+    );
+
+    // No hash-plugin warnings on the browser-plugin path
+    const hp = warningsAfterSwitch.filter((w) =>
+      w.includes("@real-router/hash-plugin"),
+    );
+    expect(hp.length).toBe(0);
+  });
+});

--- a/examples/web/react/link-hash/index.html
+++ b/examples/web/react/link-hash/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Real-Router — &lt;Link hash&gt; Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/web/react/link-hash/package.json
+++ b/examples/web/react/link-hash/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "react-link-hash-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm turbo run bundle --filter=...react-link-hash-example",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@real-router/browser-plugin": "workspace:^",
+    "@real-router/core": "workspace:^",
+    "@real-router/hash-plugin": "workspace:^",
+    "@real-router/react": "workspace:^",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.2.0",
+    "typescript": "5.8.3",
+    "vite": "7.3.2"
+  }
+}

--- a/examples/web/react/link-hash/playwright.config.ts
+++ b/examples/web/react/link-hash/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  retries: 1,
+  webServer: {
+    command: "pnpm preview",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: "http://localhost:4173",
+  },
+});

--- a/examples/web/react/link-hash/src/App.tsx
+++ b/examples/web/react/link-hash/src/App.tsx
@@ -1,0 +1,48 @@
+import { RouteView } from "@real-router/react";
+
+import { Dashboard } from "./pages/Dashboard";
+import { Home } from "./pages/Home";
+import { Settings } from "./pages/Settings";
+import { Layout } from "../../shared/Layout";
+
+import type { JSX } from "react";
+
+const links = [
+  { routeName: "home", label: "Home" },
+  { routeName: "settings", label: "Settings" },
+  { routeName: "dashboard", label: "Dashboard" },
+];
+
+export interface AppProps {
+  /**
+   * Active URL plugin. Selected at startup via `?plugin=hash` query string.
+   * Drives runtime behavior (browser-plugin populates `state.context.url`,
+   * hash-plugin warns on `<Link hash>`) and is rendered in the page header
+   * so the user knows which plugin they're observing.
+   */
+  readonly pluginKind: "browser" | "hash";
+}
+
+export function App({ pluginKind }: AppProps): JSX.Element {
+  return (
+    <Layout
+      title={`Real-Router — <Link hash> Example (${pluginKind}-plugin)`}
+      links={links}
+    >
+      <RouteView nodeName="">
+        <RouteView.Match segment="home">
+          <Home pluginKind={pluginKind} />
+        </RouteView.Match>
+        <RouteView.Match segment="settings">
+          <Settings pluginKind={pluginKind} />
+        </RouteView.Match>
+        <RouteView.Match segment="dashboard">
+          <Dashboard />
+        </RouteView.Match>
+        <RouteView.NotFound>
+          <h1>404 — Page Not Found</h1>
+        </RouteView.NotFound>
+      </RouteView>
+    </Layout>
+  );
+}

--- a/examples/web/react/link-hash/src/main.tsx
+++ b/examples/web/react/link-hash/src/main.tsx
@@ -1,0 +1,46 @@
+import { browserPluginFactory } from "@real-router/browser-plugin";
+import { createRouter } from "@real-router/core";
+import { hashPluginFactory } from "@real-router/hash-plugin";
+import { RouterProvider } from "@real-router/react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import { routes } from "./routes";
+
+import "../../../../shared/styles.css";
+
+// Plugin selection driven by `?plugin=hash` in the URL.
+//
+// The default `browser-plugin` build demonstrates the full <Link hash> feature
+// surface from #532 — tab-style UI driven by `state.context.url.hash`,
+// tri-state opts.hash, navigateWithHash auto-force, F5 priming.
+//
+// `?plugin=hash` switches to `hash-plugin` to demonstrate the documented
+// limitation: hash-plugin uses `#` as the route delimiter, so URL fragments
+// are silently ignored and a one-time `console.warn` is emitted.
+const useHashPlugin =
+  globalThis.location.search.includes("plugin=hash") ||
+  globalThis.location.hash.startsWith("#!");
+
+const router = createRouter(routes, {
+  defaultRoute: "home",
+  allowNotFound: true,
+});
+
+if (useHashPlugin) {
+  router.usePlugin(hashPluginFactory({ hashPrefix: "!" }));
+} else {
+  router.usePlugin(browserPluginFactory());
+}
+
+await router.start();
+
+const rootElement = document.querySelector("#root");
+
+if (rootElement) {
+  createRoot(rootElement).render(
+    <RouterProvider router={router}>
+      <App pluginKind={useHashPlugin ? "hash" : "browser"} />
+    </RouterProvider>,
+  );
+}

--- a/examples/web/react/link-hash/src/pages/Dashboard.tsx
+++ b/examples/web/react/link-hash/src/pages/Dashboard.tsx
@@ -1,0 +1,27 @@
+import { Link, useRoute } from "@real-router/react";
+
+import type { JSX } from "react";
+
+export function Dashboard(): JSX.Element {
+  const { route } = useRoute();
+  const ctxHash = (route.context as { url?: { hash?: string } }).url?.hash;
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>
+        Cross-path navigation target. If you arrived here from{" "}
+        <code>/settings#account</code>, the URL is now{" "}
+        <code>/dashboard#account</code> — the fragment is preserved by default
+        (tri-state: <code>opts.hash</code> omitted ⇒ preserve).
+      </p>
+      <p>
+        Current <code>state.context.url.hash</code>:{" "}
+        <strong data-testid="dashboard-hash">{ctxHash ?? "(undefined)"}</strong>
+      </p>
+      <p>
+        <Link routeName="settings">Back to Settings</Link>
+      </p>
+    </div>
+  );
+}

--- a/examples/web/react/link-hash/src/pages/HashControls.tsx
+++ b/examples/web/react/link-hash/src/pages/HashControls.tsx
@@ -1,0 +1,86 @@
+import type { Navigator } from "@real-router/core";
+import type { JSX } from "react";
+
+interface HashControlsProps {
+  readonly navigator: Navigator;
+  readonly currentHash: string;
+  readonly pluginKind: "browser" | "hash";
+}
+
+/**
+ * Programmatic tri-state demo. Three buttons exercise the three states of
+ * `opts.hash` documented in #532:
+ *
+ * - **Set**: `router.navigate("settings", {}, { hash: "billing" })` —
+ *   non-empty value sets the fragment.
+ * - **Clear**: `router.navigate("settings", {}, { hash: "" })` — empty string
+ *   explicitly clears the fragment.
+ * - **Preserve**: `router.navigate("settings")` — `opts.hash` omitted; the
+ *   plugin reads the current browser hash and keeps it.
+ *
+ * Note: the **Set** button uses `force: true, hashChange: true` so the
+ * router does not reject the navigation with `SAME_STATES` when the chosen
+ * hash equals the current one. `<Link hash>` does this automatically via the
+ * `navigateWithHash` helper from `shared/dom-utils/link-utils.ts`; pure
+ * programmatic callers are documented to opt in.
+ */
+export function HashControls({
+  navigator,
+  currentHash,
+  pluginKind,
+}: HashControlsProps): JSX.Element {
+  return (
+    <div>
+      <p>
+        Current <code>state.context.url.hash</code>:{" "}
+        <strong data-testid="current-hash">{currentHash || "(empty)"}</strong>
+      </p>
+      <button
+        type="button"
+        data-testid="action-set-billing"
+        onClick={() => {
+          navigator
+            .navigate(
+              "settings",
+              {},
+              { hash: "billing", force: true, hashChange: true },
+            )
+            .catch(() => {});
+        }}
+      >
+        Set hash="billing"
+      </button>{" "}
+      <button
+        type="button"
+        data-testid="action-clear"
+        onClick={() => {
+          navigator
+            .navigate(
+              "settings",
+              {},
+              { hash: "", force: true, hashChange: true },
+            )
+            .catch(() => {});
+        }}
+      >
+        Clear hash (opts.hash="")
+      </button>{" "}
+      <button
+        type="button"
+        data-testid="action-preserve"
+        onClick={() => {
+          navigator.navigate("settings").catch(() => {});
+        }}
+      >
+        Preserve (opts.hash omitted)
+      </button>
+      {pluginKind === "hash" ? (
+        <p style={{ marginTop: "1rem", color: "#a00" }}>
+          With <code>hash-plugin</code> active, the buttons emit a one-time{" "}
+          <code>console.warn</code> and the fragment is silently dropped — see
+          DevTools console.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/examples/web/react/link-hash/src/pages/Home.tsx
+++ b/examples/web/react/link-hash/src/pages/Home.tsx
@@ -1,0 +1,65 @@
+import { Link, useRoute } from "@real-router/react";
+
+import type { JSX } from "react";
+
+interface HomeProps {
+  readonly pluginKind: "browser" | "hash";
+}
+
+export function Home({ pluginKind }: HomeProps): JSX.Element {
+  const { route } = useRoute();
+  // state.context.url is populated by browser-plugin / navigation-plugin only;
+  // hash-plugin runtime leaves it undefined.
+  const ctxUrl = (
+    route.context as { url?: { hash: string; hashChanged: boolean } }
+  ).url;
+
+  return (
+    <div>
+      <h1>&lt;Link hash&gt; — Tab UI Demo</h1>
+
+      <p>
+        This example demonstrates the new <code>hash</code> prop on{" "}
+        <code>&lt;Link&gt;</code> (issue #532). The fragment lives in{" "}
+        <code>state.context.url.hash</code>, populated by either{" "}
+        <code>browser-plugin</code> or <code>navigation-plugin</code>.
+      </p>
+
+      <p>
+        Active plugin: <strong>{pluginKind}-plugin</strong>. Toggle via{" "}
+        <a href="?plugin=hash">?plugin=hash</a> /{" "}
+        <a href="/">browser-plugin (default)</a>.
+      </p>
+
+      <p>
+        For scroll-restoration with anchor links see the{" "}
+        <code>scroll-restoration</code> example (issue #534).
+      </p>
+
+      <h2>Try it</h2>
+      <ul>
+        <li>
+          <Link routeName="settings">Open Settings</Link> — tab UI driven by{" "}
+          <code>state.context.url.hash</code>
+        </li>
+        <li>
+          <Link routeName="dashboard">Open Dashboard</Link> — cross-path
+          navigation; current hash is preserved automatically
+        </li>
+      </ul>
+
+      <h2>Current state</h2>
+      <pre data-testid="state-context-url">
+        {JSON.stringify(
+          {
+            route: route.name,
+            "context.url": ctxUrl,
+            "location.hash": globalThis.location.hash || "(empty)",
+          },
+          null,
+          2,
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/examples/web/react/link-hash/src/pages/Settings.tsx
+++ b/examples/web/react/link-hash/src/pages/Settings.tsx
@@ -1,0 +1,126 @@
+import { Link, useRoute } from "@real-router/react";
+
+import { HashControls } from "./HashControls";
+
+import type { JSX } from "react";
+
+const TABS = [
+  { id: "profile", label: "Profile" },
+  { id: "account", label: "Account" },
+  { id: "billing", label: "Billing" },
+] as const;
+
+const DEFAULT_TAB = "profile";
+
+interface SettingsProps {
+  readonly pluginKind: "browser" | "hash";
+}
+
+export function Settings({ pluginKind }: SettingsProps): JSX.Element {
+  const { route, navigator } = useRoute();
+
+  // Single source of truth for the active tab: `state.context.url.hash`.
+  // Populated by browser-plugin / navigation-plugin on every transition;
+  // hash-plugin leaves the namespace undefined.
+  //
+  // Both `undefined` (no URL plugin) and `""` (URL has no fragment) fall
+  // back to `DEFAULT_TAB`. Explicit ternary is used instead of `||` /
+  // `??` to satisfy the `prefer-nullish-coalescing` ESLint rule while
+  // still treating empty string as "missing".
+  const ctxHash = (route.context as { url?: { hash?: string } }).url?.hash;
+  const activeTab =
+    ctxHash !== undefined && ctxHash !== "" ? ctxHash : DEFAULT_TAB;
+
+  return (
+    <div>
+      <h1>Settings</h1>
+
+      <p>
+        Tab state lives in the URL fragment (<code>/settings#profile</code>,{" "}
+        <code>/settings#account</code>, <code>/settings#billing</code>). The
+        active tab is read from <code>state.context.url.hash</code> — no scroll
+        involvement, no React local state, no query params.
+      </p>
+
+      <nav role="tablist" data-testid="tabs">
+        {TABS.map((tab) => (
+          // `<Link hash>` is hash-aware out of the box (#532): when the prop
+          // is set, isActive requires both routeName AND hash to match the
+          // current state, so only the matching tab gets the default
+          // `activeClassName="active"`.
+          <Link
+            key={tab.id}
+            routeName="settings"
+            hash={tab.id}
+            data-testid={`tab-${tab.id}`}
+            data-active={activeTab === tab.id}
+            style={{ marginRight: "0.5rem" }}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+
+      <hr />
+
+      <section role="tabpanel" data-testid="active-tab" data-tab={activeTab}>
+        <h2>{TABS.find((tab) => tab.id === activeTab)?.label ?? "Unknown"}</h2>
+        <TabContent tab={activeTab} />
+      </section>
+
+      <hr />
+
+      <h2>Programmatic tri-state demo</h2>
+      <HashControls
+        navigator={navigator}
+        currentHash={ctxHash ?? ""}
+        pluginKind={pluginKind}
+      />
+
+      <hr />
+
+      <h2>Cross-path preserve</h2>
+      <p>
+        Click{" "}
+        <Link routeName="dashboard" data-testid="link-dashboard">
+          Dashboard
+        </Link>{" "}
+        without a <code>hash</code> prop. The current fragment is preserved
+        across the path change (tri-state default: <code>opts.hash</code>{" "}
+        omitted ⇒ preserve current).
+      </p>
+    </div>
+  );
+}
+
+function TabContent({ tab }: { readonly tab: string }): JSX.Element {
+  switch (tab) {
+    case "profile": {
+      return (
+        <p>
+          Display name, avatar, biography. Bookmarkable via{" "}
+          <code>/settings#profile</code>.
+        </p>
+      );
+    }
+    case "account": {
+      return (
+        <p>
+          Email address, password, two-factor authentication. Bookmarkable via{" "}
+          <code>/settings#account</code>.
+        </p>
+      );
+    }
+    case "billing": {
+      return (
+        <p>
+          Subscription tier, payment method, invoice history. Bookmarkable via{" "}
+          <code>/settings#billing</code>.
+        </p>
+      );
+    }
+    default: {
+      return <p>Unknown tab.</p>;
+    }
+  }
+}

--- a/examples/web/react/link-hash/src/routes.ts
+++ b/examples/web/react/link-hash/src/routes.ts
@@ -1,0 +1,7 @@
+import type { Route } from "@real-router/core";
+
+export const routes: Route[] = [
+  { name: "home", path: "/" },
+  { name: "settings", path: "/settings" },
+  { name: "dashboard", path: "/dashboard" },
+];

--- a/examples/web/react/link-hash/src/vite-env.d.ts
+++ b/examples/web/react/link-hash/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/web/react/link-hash/tsconfig.json
+++ b/examples/web/react/link-hash/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "../shared"]
+}

--- a/examples/web/react/link-hash/vite.config.ts
+++ b/examples/web/react/link-hash/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    conditions: ["development"],
+  },
+});

--- a/knip.json
+++ b/knip.json
@@ -77,6 +77,7 @@
     "packages/hash-plugin": {
       "project": ["src/**/*.ts"],
       "ignore": ["src/browser-env/**"],
+      "ignoreDependencies": ["@real-router/types"],
       "vitest": {
         "config": ["vitest.config.mts", "vitest.config.*.mts"]
       }

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -320,6 +320,16 @@ Navigation directive for `<a>` elements. Handles click events, sets `href`, and 
 | `activeClassName`   | `string`            | `"active"` | CSS class applied when route is active |
 | `activeStrict`      | `boolean`           | `false`    | Exact match only (no ancestor match)   |
 | `ignoreQueryParams` | `boolean`           | `true`     | Query params don't affect active state |
+| `hash`              | `string`            | `undefined`| URL fragment (decoded). Tri-state: undefined preserves, `""` clears, value sets. (#532) |
+
+#### `hash` input — URL fragment / tab-style UIs
+
+```html
+<a [realLink]="'settings'" [hash]="'profile'">Profile</a>
+<a [realLink]="'settings'" [hash]="'account'">Account</a>
+```
+
+Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
 
 ### `[realLinkActive]`
 

--- a/packages/angular/src/directives/RealLink.ts
+++ b/packages/angular/src/directives/RealLink.ts
@@ -10,7 +10,7 @@ import {
 } from "@angular/core";
 import { createActiveRouteSource } from "@real-router/sources";
 
-import { buildHref, shouldNavigate } from "../dom-utils";
+import { buildHref, navigateWithHash, shouldNavigate } from "../dom-utils";
 import { injectRouter } from "../functions/injectRouter";
 
 import type { Params, NavigationOptions } from "@real-router/core";
@@ -28,26 +28,49 @@ export class RealLink implements OnInit {
   readonly activeClassName = input<string>("active");
   readonly activeStrict = input(false);
   readonly ignoreQueryParams = input(true);
+  /**
+   * URL fragment (decoded form, no leading "#") (#532).
+   * - omitted/`undefined` → preserve current fragment on same-route navigation
+   * - `""` → clear fragment
+   * - non-empty → set fragment
+   */
+  readonly hash = input<string | undefined>(undefined);
 
   private readonly router = injectRouter();
   private readonly destroyRef = inject(DestroyRef);
   private readonly anchor = inject(ElementRef)
     .nativeElement as HTMLAnchorElement;
   private readonly isActive = signal(false);
-  private readonly href = computed(() =>
-    buildHref(this.router, this.routeName(), this.routeParams()),
-  );
+  private readonly href = computed(() => {
+    const hashValue = this.hash();
+
+    return buildHref(
+      this.router,
+      this.routeName(),
+      this.routeParams(),
+      hashValue === undefined ? undefined : { hash: hashValue },
+    );
+  });
   private prevActiveClass = "";
 
   ngOnInit(): void {
+    // Hash-aware active state (#532): pass `hash` so that tab-style links
+    // (same routeName, different `hash` input) only mark the active variant.
+    const hashValue = this.hash();
     const source = createActiveRouteSource(
       this.router,
       this.routeName(),
       this.routeParams(),
-      {
-        strict: this.activeStrict(),
-        ignoreQueryParams: this.ignoreQueryParams(),
-      },
+      hashValue === undefined
+        ? {
+            strict: this.activeStrict(),
+            ignoreQueryParams: this.ignoreQueryParams(),
+          }
+        : {
+            strict: this.activeStrict(),
+            ignoreQueryParams: this.ignoreQueryParams(),
+            hash: hashValue,
+          },
     );
 
     this.isActive.set(source.getSnapshot());
@@ -70,9 +93,13 @@ export class RealLink implements OnInit {
     }
 
     event.preventDefault();
-    this.router
-      .navigate(this.routeName(), this.routeParams(), this.routeOptions())
-      .catch(() => {});
+    navigateWithHash(
+      this.router,
+      this.routeName(),
+      this.routeParams(),
+      this.hash(),
+      this.routeOptions(),
+    ).catch(() => {});
   }
 
   private updateDom(): void {

--- a/packages/angular/src/dom-utils/index.ts
+++ b/packages/angular/src/dom-utils/index.ts
@@ -10,6 +10,7 @@ export {
   shouldNavigate,
   buildHref,
   buildActiveClassName,
+  navigateWithHash,
   shallowEqual,
   applyLinkA11y,
 } from "./link-utils";

--- a/packages/angular/src/dom-utils/link-utils.ts
+++ b/packages/angular/src/dom-utils/link-utils.ts
@@ -1,4 +1,9 @@
-import type { Router, Params } from "@real-router/core";
+import type {
+  NavigationOptions,
+  Params,
+  Router,
+  State,
+} from "@real-router/core";
 
 export function shouldNavigate(evt: MouseEvent): boolean {
   return (
@@ -10,25 +15,67 @@ export function shouldNavigate(evt: MouseEvent): boolean {
   );
 }
 
-type BuildUrlFn = (name: string, params: Params) => string | undefined;
+/**
+ * RFC 3986 fragment encoding: preserve sub-delims (`&`, `=`, `?`, `:`),
+ * encode space, `%`, control chars, non-ASCII via encodeURI; defensively
+ * escape `#` (encodeURI does not). Mirrors `encodeHashFragment` in
+ * `shared/browser-env/url-context.ts` — duplicated here because the
+ * shared/dom-utils symlink graph does not reach shared/browser-env.
+ */
+function encodeFragmentInline(decoded: string): string {
+  return encodeURI(decoded).replaceAll("#", "%23");
+}
 
+type BuildUrlFn = (
+  name: string,
+  params: Params,
+  options?: { hash?: string },
+) => string | undefined;
+
+/**
+ * Builds an href for a `<Link>` element.
+ *
+ * - Prefers the URL plugin's `buildUrl` (browser-plugin, navigation-plugin,
+ *   hash-plugin) when present.
+ * - Falls back to `router.buildPath` for runtimes without a URL plugin
+ *   (memory-plugin, console UIs, NativeScript). In that fallback the hash
+ *   is appended manually so the rendered href is still correct.
+ * - The optional 4th argument is an options object so the contract stays
+ *   extensible. The `hash` option is a decoded fragment without leading "#";
+ *   `<Link hash="#section">` is accepted defensively (leading "#" stripped).
+ *   Frozen API: previous 3-arg call sites continue to work unchanged.
+ */
 export function buildHref(
   router: Router,
   routeName: string,
   routeParams: Params,
+  options?: { hash?: string },
 ): string | undefined {
   try {
+    const rawHash = options?.hash;
+    let normHash: string | undefined;
+
+    if (rawHash !== undefined) {
+      normHash = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+    }
+
     const buildUrl = router.buildUrl as BuildUrlFn | undefined;
 
     if (buildUrl) {
-      const url = buildUrl(routeName, routeParams);
+      const url = buildUrl(
+        routeName,
+        routeParams,
+        normHash === undefined ? undefined : { hash: normHash },
+      );
 
       if (url !== undefined) {
         return url;
       }
     }
 
-    return router.buildPath(routeName, routeParams);
+    const path = router.buildPath(routeName, routeParams);
+
+    return normHash ? `${path}#${encodeFragmentInline(normHash)}` : path;
   } catch {
     console.error(
       `[real-router] Route "${routeName}" is not defined. The element will render without an href attribute.`,
@@ -36,6 +83,65 @@ export function buildHref(
 
     return undefined;
   }
+}
+
+/**
+ * `<Link>` click-handler navigation helper (#532).
+ *
+ * Wraps `router.navigate(name, params, opts)` with same-route different-hash
+ * detection: when the consumer clicks a hash-bearing Link that targets the
+ * current route with the same params but a different fragment, core's
+ * SAME_STATES check would otherwise reject the navigation. The helper adds
+ * `force: true` and `hashChange: true` automatically — subscribers can then
+ * disambiguate via `state.context.url.hashChanged`.
+ *
+ * For pure programmatic same-route hash-only navigation, callers are
+ * documented to pass `{ force: true }` themselves; the auto-bypass here is
+ * a UX convenience for `<Link hash>` that all 6 framework adapters share.
+ */
+/**
+ * Local extended-options type. Adapters that depend only on `@real-router/core`
+ * (without a URL plugin) do not see the `NavigationOptions` augmentation that
+ * declares `hash` / `hashChange`. Casting to this widened type inside the
+ * helper keeps shared/dom-utils self-contained — adapters do not need to
+ * augment NavigationOptions themselves to consume `<Link hash>`.
+ */
+type HashAwareNavigationOptions = NavigationOptions & {
+  hash?: string;
+  hashChange?: boolean;
+};
+
+export function navigateWithHash(
+  router: Router,
+  routeName: string,
+  routeParams: Params,
+  hash: string | undefined,
+  extraOptions?: NavigationOptions,
+): Promise<State> {
+  const opts: HashAwareNavigationOptions = { ...extraOptions };
+
+  if (hash !== undefined) {
+    opts.hash = hash;
+  }
+
+  const current = router.getState();
+
+  if (
+    current?.name === routeName &&
+    shallowEqual(current.params, routeParams)
+  ) {
+    const currentHash =
+      (current.context as { url?: { hash?: string } } | undefined)?.url?.hash ??
+      "";
+    const newHash = hash ?? currentHash;
+
+    if (currentHash !== newHash) {
+      opts.force = true;
+      opts.hashChange = true;
+    }
+  }
+
+  return router.navigate(routeName, routeParams, opts);
 }
 
 function parseTokens(value: string | undefined): string[] {

--- a/packages/angular/src/dom-utils/scroll-restore.ts
+++ b/packages/angular/src/dom-utils/scroll-restore.ts
@@ -68,13 +68,38 @@ export function createScrollRestoration(
     }
   };
 
-  const scrollToHashOrTop = (): void => {
+  const scrollToHashOrTop = (route: State): void => {
+    // URL plugin path (#532): `state.context.url.hash` is the source of truth
+    // when one of the URL plugins (browser-plugin / navigation-plugin) is
+    // installed. The value is already DECODED — feeding it through
+    // `decodeURIComponent` again would throw on a bare `%`.
+    const ctxHash = (route.context as { url?: { hash?: string } } | undefined)
+      ?.url?.hash;
+
+    if (ctxHash !== undefined) {
+      if (anchorEnabled && ctxHash.length > 0) {
+        // eslint-disable-next-line unicorn/prefer-query-selector -- ids may contain CSS-unsafe chars
+        const element = document.getElementById(ctxHash);
+
+        if (element) {
+          element.scrollIntoView();
+
+          return;
+        }
+      }
+
+      writePos(0);
+
+      return;
+    }
+
+    // Fallback path: no URL plugin, read the DOM. `location.hash` is
+    // percent-encoded; ids in the DOM are the raw string, so decode for the
+    // match. Fall back to the raw slice if the hash contains a malformed
+    // escape sequence (decodeURIComponent throws on those).
     const hash = globalThis.location.hash;
 
     if (anchorEnabled && hash.length > 1) {
-      // location.hash is percent-encoded; ids in the DOM are the raw string.
-      // Decode for the match. Fall back to the raw slice if the hash contains
-      // a malformed escape sequence (decodeURIComponent throws on those).
       let id: string;
 
       try {
@@ -117,7 +142,7 @@ export function createScrollRestoration(
       }
 
       if (mode === "top" || !nav) {
-        scrollToHashOrTop();
+        scrollToHashOrTop(route);
 
         return;
       }
@@ -136,7 +161,7 @@ export function createScrollRestoration(
         return;
       }
 
-      scrollToHashOrTop();
+      scrollToHashOrTop(route);
     });
   });
 

--- a/packages/angular/src/functions/injectIsActiveRoute.ts
+++ b/packages/angular/src/functions/injectIsActiveRoute.ts
@@ -9,13 +9,22 @@ import type { Params } from "@real-router/core";
 export function injectIsActiveRoute(
   routeName: string,
   params?: Params,
-  options?: { strict?: boolean; ignoreQueryParams?: boolean },
+  options?: { strict?: boolean; ignoreQueryParams?: boolean; hash?: string },
 ): Signal<boolean> {
   const router = injectRouter();
-  const source = createActiveRouteSource(router, routeName, params, {
-    strict: options?.strict ?? false,
-    ignoreQueryParams: options?.ignoreQueryParams ?? true,
-  });
+  const strict = options?.strict ?? false;
+  const ignoreQueryParams = options?.ignoreQueryParams ?? true;
+  const hash = options?.hash;
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally — pass
+  // the field only when a value was provided. (#532)
+  const source = createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    hash === undefined
+      ? { strict, ignoreQueryParams }
+      : { strict, ignoreQueryParams, hash },
+  );
 
   return sourceToSignal(source);
 }

--- a/packages/angular/tests/functional/dom-utils-integration.test.ts
+++ b/packages/angular/tests/functional/dom-utils-integration.test.ts
@@ -1,7 +1,12 @@
 import { createRouter } from "@real-router/core";
 import { describe, it, expect } from "vitest";
 
-import { buildHref, shallowEqual, shouldNavigate } from "../../src/dom-utils";
+import {
+  buildHref,
+  navigateWithHash,
+  shallowEqual,
+  shouldNavigate,
+} from "../../src/dom-utils";
 
 describe("dom-utils integration (copy from shared/)", () => {
   it("buildHref returns correct path after prebundle copy", async () => {
@@ -55,5 +60,151 @@ describe("dom-utils integration (copy from shared/)", () => {
     expect(shallowEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
     expect(shallowEqual({ id: "1" }, { id: "2" })).toBe(false);
     expect(shallowEqual({ id: 1n }, { id: 1n })).toBe(true);
+  });
+
+  it("buildHref accepts hash option and falls back to buildPath append (#532)", async () => {
+    const router = createRouter([
+      { name: "home", path: "/" },
+      { name: "users", path: "/users" },
+    ]);
+
+    await router.start("/");
+
+    expect(buildHref(router, "users", {}, { hash: "anchor" })).toBe(
+      "/users#anchor",
+    );
+    expect(buildHref(router, "users", {}, { hash: "" })).toBe("/users");
+    expect(buildHref(router, "users", {}, { hash: "#anchor" })).toBe(
+      "/users#anchor",
+    );
+    expect(buildHref(router, "users", {}, { hash: "a b&c#d" })).toBe(
+      "/users#a%20b&c%23d",
+    );
+
+    router.stop();
+  });
+
+  it("navigateWithHash: same route + different hash adds force+hashChange (#532)", async () => {
+    const router = createRouter([
+      { name: "home", path: "/" },
+      { name: "users", path: "/users" },
+    ]);
+
+    await router.start("/");
+
+    const calls: [string, object | undefined, object | undefined][] = [];
+    const navigateSpy = (
+      name: string,
+      params?: object,
+      opts?: object,
+    ): Promise<unknown> => {
+      calls.push([name, params, opts]);
+
+      return Promise.resolve(router.getState()!);
+    };
+
+    (router as unknown as { navigate: typeof navigateSpy }).navigate =
+      navigateSpy;
+    (router as unknown as { getState: () => unknown }).getState = () => ({
+      name: "home",
+      params: {},
+      path: "/",
+      context: { url: { hash: "old", hashChanged: false } },
+    });
+
+    await navigateWithHash(router, "home", {}, "new");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("home");
+    expect(calls[0]?.[2]).toMatchObject({
+      hash: "new",
+      force: true,
+      hashChange: true,
+    });
+
+    router.stop();
+  });
+
+  it("navigateWithHash: same route + same hash does not force (#532)", async () => {
+    const router = createRouter([{ name: "home", path: "/" }]);
+
+    await router.start("/");
+
+    const calls: [string, object | undefined, object | undefined][] = [];
+
+    (
+      router as unknown as {
+        navigate: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).navigate = (...args) => {
+      calls.push(args as [string, object | undefined, object | undefined]);
+
+      return Promise.resolve(router.getState()!);
+    };
+    (router as unknown as { getState: () => unknown }).getState = () => ({
+      name: "home",
+      params: {},
+      path: "/",
+      context: { url: { hash: "x", hashChanged: false } },
+    });
+
+    await navigateWithHash(router, "home", {}, "x");
+
+    expect(calls[0]?.[2]).not.toMatchObject({ force: true });
+
+    router.stop();
+  });
+
+  it("navigateWithHash: different route does not force (#532)", async () => {
+    const router = createRouter([
+      { name: "home", path: "/" },
+      { name: "users", path: "/users" },
+    ]);
+
+    await router.start("/");
+
+    const calls: [string, object | undefined, object | undefined][] = [];
+
+    (
+      router as unknown as {
+        navigate: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).navigate = (...args) => {
+      calls.push(args as [string, object | undefined, object | undefined]);
+
+      return Promise.resolve(router.getState()!);
+    };
+
+    await navigateWithHash(router, "users", {}, "anchor");
+
+    expect(calls[0]?.[2]).toMatchObject({ hash: "anchor" });
+    expect(calls[0]?.[2]).not.toMatchObject({ force: true });
+
+    router.stop();
+  });
+
+  it("navigateWithHash: hash undefined preserves existing hash via empty change detection (#532)", async () => {
+    const router = createRouter([{ name: "home", path: "/" }]);
+
+    await router.start("/");
+
+    const calls: [string, object | undefined, object | undefined][] = [];
+
+    (
+      router as unknown as {
+        navigate: (...args: unknown[]) => Promise<unknown>;
+      }
+    ).navigate = (...args) => {
+      calls.push(args as [string, object | undefined, object | undefined]);
+
+      return Promise.resolve(router.getState()!);
+    };
+
+    await navigateWithHash(router, "home", {}, undefined);
+
+    // hash undefined → opts.hash not set
+    expect(calls[0]?.[2]).not.toHaveProperty("hash");
+
+    router.stop();
   });
 });

--- a/packages/angular/tests/functional/scroll-restore.test.ts
+++ b/packages/angular/tests/functional/scroll-restore.test.ts
@@ -180,6 +180,81 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
     globalThis.history.replaceState(null, "", "/");
   });
 
+  it("push + state.context.url.hash with existing id → scrollIntoView (#532)", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "ctxAnchor";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        {
+          navigation: { direction: "forward", navigationType: "push" },
+          url: { hash: "ctxAnchor", hashChanged: true },
+        },
+      ),
+      makeState("home"),
+    );
+
+    // Plugin path: read from state.context.url.hash, no DOM fallback.
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+
+    sr.destroy();
+  });
+
+  it("state.context.url.hash empty string → scroll to top (#532)", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        {
+          navigation: { direction: "forward", navigationType: "push" },
+          url: { hash: "", hashChanged: false },
+        },
+      ),
+      makeState("home"),
+    );
+
+    // ctxHash !== undefined branch entered, but ctxHash.length === 0 → top.
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
+  it("state.context.url.hash with missing element → scroll to top (#532)", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router));
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        {
+          navigation: { direction: "forward", navigationType: "push" },
+          url: { hash: "doesNotExist", hashChanged: true },
+        },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+
+    sr.destroy();
+  });
+
   it("subscribe captures previousRoute's scrollY into storage", () => {
     const fake = makeFakeRouter(makeState("home"));
 

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -472,17 +472,33 @@ extractPath("/app/users/123", { base: "/app" })
 
 Requires a server-side fallback (all paths → `index.html`).
 
-### Hash Fragment Preservation
+### Hash Fragment Support (#532)
+
+URL fragments are first-class state via the `state.context.url` namespace, written by the plugin in `onTransitionSuccess` with tri-state semantics:
 
 ```typescript
 // factory.ts — onTransitionSuccess
-const shouldPreserveHash = !fromState || fromState.path === toState.path;
+const prevHash = fromState
+  ? ((fromState.context as { url?: { hash?: string } }).url?.hash ?? "")
+  : getDecodedHash(browser);
 
-const hash = shouldPreserveHash ? browser.getHash() : "";
-const finalUrl = hash ? url + hash : url;
+const hash = navOptions.hash !== undefined
+  ? normalizeHashInput(navOptions.hash)
+  : prevHash;
+
+urlClaim.write(toState, Object.freeze({
+  hash,
+  hashChanged: navOptions.hashChange ?? (hash !== prevHash),
+}));
+
+const finalUrl = hash ? `${url}#${encodeHashFragment(hash)}` : url;
 ```
 
-The hash fragment (`#section`) is always preserved when navigating to the same path (or on first navigation). On a route change, the hash is cleared.
+- `opts.hash === undefined` (default): preserves previous hash from `fromState.context.url.hash` (or `getDecodedHash(browser)` on first transition — F5 / cold-load).
+- `opts.hash === ""`: clears the hash explicitly.
+- `opts.hash === "value"`: sets the hash; encoded via `encodeURI(s).replace(/#/g, "%23")` to preserve RFC-3986 sub-delims.
+
+`hashChange: true` is set by the popstate handler on browser-driven hash-only navigation (paired with `force: true` to bypass `SAME_STATES`). Recovery paths (`syncUrlToRouterState`, `rollbackUrlToCurrentState`) read `currentState.context.url.hash` to preserve the fragment after guard rejection. See [Wiki › Hash](https://github.com/greydragon888/real-router/wiki/Hash) for the full surface.
 
 ## Performance
 

--- a/packages/browser-plugin/README.md
+++ b/packages/browser-plugin/README.md
@@ -52,11 +52,11 @@ router.usePlugin(
 
 The plugin extends the router instance with three methods via [`extendRouter()`](https://github.com/greydragon888/real-router/wiki/plugin-architecture):
 
-| Method                                       | Returns              | Description                                      |
-| -------------------------------------------- | -------------------- | ------------------------------------------------ |
-| `buildUrl(name, params?)`                    | `string`             | Build full URL with base path                    |
-| `matchUrl(url)`                              | `State \| undefined` | Parse URL to router state                        |
-| `replaceHistoryState(name, params?)`         | `void`               | Update browser URL without triggering navigation |
+| Method                                                | Returns              | Description                                                                                          |
+| ----------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `buildUrl(name, params?, options?: { hash? })`        | `string`             | Build full URL with base path. `options.hash` (decoded) is encoded and appended.                     |
+| `matchUrl(url)`                                       | `State \| undefined` | Parse URL to router state                                                                            |
+| `replaceHistoryState(name, params?, options?: { hash? })` | `void`           | Update browser URL without triggering navigation. Tri-state `hash`: `undefined` preserves, `""` clears, value sets. |
 
 ```typescript
 router.buildUrl("users", { id: "123" });
@@ -82,6 +82,25 @@ router.buildUrl("users", { id: 1 }); // "/app/users/1"   — plugin, with base
 router.replaceHistoryState(name, params); // URL only, no transition
 router.navigate(name, params, { replace: true }); // Full transition + URL update
 ```
+
+## URL Fragment ("hash") Support
+
+`browser-plugin` ships first-class URL-fragment support: `<Link hash>` from any framework adapter, programmatic `router.navigate(name, params, { hash })`, and a `state.context.url = { hash, hashChanged }` namespace populated on every transition.
+
+```typescript
+// Programmatic — tri-state opts.hash
+router.navigate("settings", {}, { hash: "profile" }); // set
+router.navigate("settings", {}, { hash: "" });        // clear
+router.navigate("settings");                          // preserve current
+
+// In subscribers
+router.subscribe(({ route }) => {
+  console.log(route.context.url?.hash);        // "profile"
+  console.log(route.context.url?.hashChanged); // true on hash-only nav
+});
+```
+
+See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface (encoding, F5 priming, hash-aware active state).
 
 ## Navigation Source (`state.context.browser.source`)
 

--- a/packages/browser-plugin/src/factory.ts
+++ b/packages/browser-plugin/src/factory.ts
@@ -8,8 +8,11 @@ import {
   createSafeBrowser,
   createStartInterceptor,
   createUpdateBrowserState,
+  encodeHashFragment,
   extractPath,
+  getDecodedHash,
   normalizeBase,
+  normalizeHashInput,
   safelyEncodePath,
   shouldReplaceHistory,
   urlToPath,
@@ -21,6 +24,7 @@ import type {
   Browser,
   PopstateTransitionOptions,
   SharedFactoryState,
+  UrlContext,
 } from "./browser-env";
 import type { BrowserContext, BrowserPluginOptions } from "./types";
 import type {
@@ -115,13 +119,30 @@ function createBrowserPlugin(
   shared: SharedFactoryState,
 ): Plugin {
   const claim = api.claimContextNamespace("browser");
+  // Shared URL namespace (#532) — both navigation-plugin and browser-plugin
+  // claim "url"; mutually exclusive at runtime.
+  const urlClaim = api.claimContextNamespace("url") as {
+    write: (state: State, value: UrlContext) => void;
+    release: () => void;
+  };
   const updateState = createUpdateBrowserState();
   const removeStartInterceptor = createStartInterceptor(api, browser);
 
-  const pluginBuildUrl = (route: string, params?: Params) => {
+  const pluginBuildUrl = (
+    route: string,
+    params?: Params,
+    opts?: { hash?: string },
+  ) => {
     const path = router.buildPath(route, params);
+    const url = buildUrl(path, options.base);
 
-    return buildUrl(path, options.base);
+    if (opts?.hash === undefined) {
+      return url;
+    }
+
+    const norm = normalizeHashInput(opts.hash);
+
+    return norm ? `${url}#${encodeHashFragment(norm)}` : url;
   };
 
   const removeExtensions = api.extendRouter({
@@ -144,6 +165,12 @@ function createBrowserPlugin(
     transitionOptions,
     loggerContext: LOGGER_CONTEXT,
     buildUrl: pluginBuildUrl,
+    // Hash bridging (#532). popstate doesn't carry a URL — we sample
+    // location.hash after the browser has updated to the destination.
+    getCurrentHash: () => getDecodedHash(browser),
+    getCurrentContextHash: () =>
+      (router.getState()?.context as { url?: { hash?: string } } | undefined)
+        ?.url?.hash ?? "",
   });
 
   const lifecycle = createPopstateLifecycle({
@@ -154,6 +181,7 @@ function createBrowserPlugin(
       removeStartInterceptor();
       removeExtensions();
       claim.release();
+      urlClaim.release();
     },
   });
 
@@ -171,12 +199,36 @@ function createBrowserPlugin(
         fromState,
       );
 
+      // Tri-state hash resolution (#532).
+      //   navOptions.hash === undefined → preserve current browser hash
+      //   navOptions.hash === ""        → explicitly clear
+      //   navOptions.hash === "value"   → explicitly set
+      //
+      // The "preserve" branch reads location.hash from the browser, not
+      // fromState.context.url.hash — captures dynamic fragment changes
+      // (anchor clicks, manual location.hash assignment) made outside the
+      // plugin. hashChanged compares the chosen hash against the published
+      // previous hash so subscribers see a true signal.
+      const browserHash = getDecodedHash(browser);
+      const publishedPrevHash =
+        (fromState?.context as { url?: { hash?: string } } | undefined)?.url
+          ?.hash ?? "";
+
+      const hash =
+        navOptions.hash === undefined
+          ? browserHash
+          : normalizeHashInput(navOptions.hash);
+
+      urlClaim.write(
+        toState,
+        Object.freeze({
+          hash,
+          hashChanged: navOptions.hashChange ?? hash !== publishedPrevHash,
+        }),
+      );
+
       const url = buildUrl(toState.path, options.base);
-
-      const shouldPreserveHash = !fromState || fromState.path === toState.path;
-
-      const hash = shouldPreserveHash ? browser.getHash() : "";
-      const finalUrl = hash ? url + hash : url;
+      const finalUrl = hash ? `${url}#${encodeHashFragment(hash)}` : url;
 
       updateState(toState, finalUrl, replaceHistory, browser);
 

--- a/packages/browser-plugin/src/index.ts
+++ b/packages/browser-plugin/src/index.ts
@@ -25,33 +25,57 @@ export { isStateStrict as isState } from "type-guards";
 declare module "@real-router/types" {
   interface StateContext {
     browser?: import("./types").BrowserContext;
+    /**
+     * URL fragment ("hash") layer state (#532). Populated by both URL plugins
+     * (navigation-plugin, browser-plugin) — they are mutually exclusive at
+     * runtime, so only one writes to this namespace.
+     */
+    url?: import("./browser-env").UrlContext;
   }
 
   interface NavigationOptions {
     /** @internal — set by browser/hash/navigation plugins to mark transition origin. */
     source?: string;
+    /**
+     * URL fragment override (decoded, no leading "#") (#532).
+     * Tri-state: `undefined` → preserve current; `""` → clear; non-empty → set.
+     */
+    hash?: string;
+    /**
+     * @internal — set by URL plugins on hash-only browser-driven navigation.
+     * Subscribers should branch on `state.context.url.hashChanged` instead.
+     */
+    hashChange?: boolean;
   }
 }
 
 declare module "@real-router/core" {
   interface Router {
     /**
-     * Builds full URL for a route with base path and hash prefix.
+     * Builds full URL for a route with base path and (optionally) hash fragment.
      * Added by browser plugin.
      */
-    buildUrl: (name: string, params?: Params) => string;
+    buildUrl(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): string;
 
     /**
      * Matches URL and returns corresponding state.
      * Added by browser plugin.
      */
-    matchUrl: (url: string) => State | undefined;
+    matchUrl(url: string): State | undefined;
 
     /**
      * Replaces current history state without triggering navigation.
      * Added by browser plugin.
      */
-    replaceHistoryState: (name: string, params?: Params) => void;
+    replaceHistoryState(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): void;
 
     start(path?: string): Promise<State>;
   }

--- a/packages/browser-plugin/tests/functional/url.test.ts
+++ b/packages/browser-plugin/tests/functional/url.test.ts
@@ -421,7 +421,7 @@ describe("Browser Plugin — URL", () => {
       // Reload same route — path stays the same, hash should be preserved
       await router.navigate("home", {}, { reload: true });
 
-      // shouldPreserveHash: fromState.path === toState.path → true
+      // Tri-state preserve (#532): opts.hash === undefined ⇒ keep prevHash from fromState.context.url.hash
       expect(replaceStateSpy).toHaveBeenCalled();
 
       const lastUrl = replaceStateSpy.mock.calls.at(-1)?.[1];
@@ -429,7 +429,11 @@ describe("Browser Plugin — URL", () => {
       expect(lastUrl).toContain("#section");
     });
 
-    it("clears hash when navigating to a different route (path changed)", async () => {
+    it("preserves hash when navigating to a different route — cross-path preserve (#532)", async () => {
+      // Issue #532 changed cross-path behavior: hash is preserved by default,
+      // not stripped. The previous shouldPreserveHash workaround dropped hash
+      // on path change — this was the cross-path-stripping bug. Tri-state
+      // semantics: opts.hash === undefined ⇒ preserve current browser hash.
       await router.start("/home");
 
       const pushStateSpy = vi.spyOn(mockedBrowser, "pushState");
@@ -441,18 +445,16 @@ describe("Browser Plugin — URL", () => {
         "/home#section",
       );
 
-      // Navigate to a different route (different path)
       await router.navigate("users.list");
 
-      // shouldPreserveHash: fromState.path !== toState.path → false
       expect(pushStateSpy).toHaveBeenCalled();
 
       const lastUrl = pushStateSpy.mock.calls.at(-1)?.[1];
 
-      expect(lastUrl).not.toContain("#section");
+      expect(lastUrl).toContain("#section");
     });
 
-    it("clears hash when navigating to same route name with different path", async () => {
+    it("preserves hash when navigating to same route name with different path (#532)", async () => {
       await router.start("/users/view/1");
 
       const pushStateSpy = vi.spyOn(mockedBrowser, "pushState");
@@ -464,15 +466,81 @@ describe("Browser Plugin — URL", () => {
         "/users/view/1#section",
       );
 
-      // Navigate to same route but different param → different path
       await router.navigate("users.view", { id: "2" });
 
-      // Path changed (/users/view/1 → /users/view/2), hash should be cleared
       expect(pushStateSpy).toHaveBeenCalled();
 
       const lastUrl = pushStateSpy.mock.calls.at(-1)?.[1];
 
+      expect(lastUrl).toContain("#section");
+    });
+
+    it("clears hash when navigation explicitly passes opts.hash = '' (#532)", async () => {
+      await router.start("/home");
+
+      const pushStateSpy = vi.spyOn(mockedBrowser, "pushState");
+
+      globalThis.history.replaceState(
+        globalThis.history.state,
+        "",
+        "/home#section",
+      );
+
+      await router.navigate("users.list", {}, { hash: "" });
+
+      const lastUrl = pushStateSpy.mock.calls.at(-1)?.[1];
+
       expect(lastUrl).not.toContain("#section");
+    });
+
+    it("sets hash when navigation explicitly passes opts.hash = 'value' (#532)", async () => {
+      await router.start("/home");
+
+      const pushStateSpy = vi.spyOn(mockedBrowser, "pushState");
+
+      await router.navigate("users.list", {}, { hash: "footer" });
+
+      const lastUrl = pushStateSpy.mock.calls.at(-1)?.[1];
+
+      expect(lastUrl).toContain("#footer");
+    });
+
+    it("publishes state.context.url with hash and hashChanged (#532)", async () => {
+      await router.start("/home");
+
+      globalThis.history.replaceState(
+        globalThis.history.state,
+        "",
+        "/home#anchor",
+      );
+
+      await router.navigate("users.list");
+
+      const state = router.getState();
+      const url = (
+        state!.context as {
+          url?: { hash: string; hashChanged: boolean };
+        }
+      ).url;
+
+      expect(url?.hash).toBe("anchor");
+      expect(url?.hashChanged).toBe(true);
+    });
+
+    it("router.buildUrl(name, params, { hash }) appends fragment (#532)", () => {
+      expect(
+        router.buildUrl("users.view", { id: "1" }, { hash: "anchor" }),
+      ).toBe("/users/view/1#anchor");
+    });
+
+    it("router.buildUrl returns base URL when hash option is empty string (#532)", () => {
+      expect(router.buildUrl("home", {}, { hash: "" })).toBe("/home");
+    });
+
+    it("router.buildUrl strips leading # defensively (#532)", () => {
+      expect(router.buildUrl("home", {}, { hash: "#anchor" })).toBe(
+        "/home#anchor",
+      );
     });
 
     it("preserves hash on replaceHistoryState", async () => {

--- a/packages/dom-utils/tests/functional/link-utils.test.ts
+++ b/packages/dom-utils/tests/functional/link-utils.test.ts
@@ -100,9 +100,11 @@ describe("buildHref", () => {
     const result = buildHref(router, "users.profile", { id: "123" });
 
     expect(result).toBe("/url/123");
-    expect(router.buildUrl).toHaveBeenCalledWith("users.profile", {
-      id: "123",
-    });
+    expect(router.buildUrl).toHaveBeenCalledWith(
+      "users.profile",
+      { id: "123" },
+      undefined,
+    );
     expect(router.buildPath).not.toHaveBeenCalled();
   });
 
@@ -127,7 +129,7 @@ describe("buildHref", () => {
 
     buildHref(router, "home", {});
 
-    expect(router.buildUrl).toHaveBeenCalledWith("home", {});
+    expect(router.buildUrl).toHaveBeenCalledWith("home", {}, undefined);
   });
 
   it("4 — passes empty params to buildPath fallback", () => {
@@ -220,7 +222,11 @@ describe("buildHref", () => {
 
     buildHref(router, "items.item", { id: 42 });
 
-    expect(router.buildUrl).toHaveBeenCalledWith("items.item", { id: 42 });
+    expect(router.buildUrl).toHaveBeenCalledWith(
+      "items.item",
+      { id: 42 },
+      undefined,
+    );
   });
 
   it("11 — forwards Unicode params to buildUrl verbatim", () => {
@@ -231,7 +237,11 @@ describe("buildHref", () => {
 
     buildHref(router, "users.view", { id: "иван" });
 
-    expect(router.buildUrl).toHaveBeenCalledWith("users.view", { id: "иван" });
+    expect(router.buildUrl).toHaveBeenCalledWith(
+      "users.view",
+      { id: "иван" },
+      undefined,
+    );
   });
 });
 

--- a/packages/hash-plugin/README.md
+++ b/packages/hash-plugin/README.md
@@ -95,6 +95,21 @@ lifecycle.addDeactivateGuard(
 );
 ```
 
+## Limitations
+
+### URL Fragments via `<Link hash>` / `opts.hash`
+
+Hash-plugin uses `#` as the route delimiter — URL fragments are structurally incompatible. The signatures of `router.buildUrl(name, params, options?)` and `router.replaceHistoryState(name, params, options?)` accept `{ hash }` for typing parity with the other URL plugins, but at runtime the option is **silently ignored** and a one-time `console.warn` is emitted on the first invocation:
+
+```text
+[@real-router/hash-plugin] `hash` option is ignored — `#` is reserved for the route delimiter.
+Use browser-plugin or navigation-plugin for URL fragments.
+```
+
+`state.context.url` is **not** populated under hash-plugin (`undefined` at runtime). Hash-aware sources (`useIsActiveRoute`, `<Link hash>` active state) consequently return `false` for any non-undefined `hash`. Only one URL plugin (`browser-plugin`, `navigation-plugin`, or `hash-plugin`) may be installed per router instance.
+
+If you need URL fragments for tab-style UIs or anchor scrolling, use [`@real-router/browser-plugin`](../browser-plugin/) or [`@real-router/navigation-plugin`](../navigation-plugin/) instead — see the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page.
+
 ## SSR Support
 
 SSR-safe — automatically detects the environment and falls back to no-ops:

--- a/packages/hash-plugin/package.json
+++ b/packages/hash-plugin/package.json
@@ -53,7 +53,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@real-router/core": "workspace:^"
+    "@real-router/core": "workspace:^",
+    "@real-router/types": "workspace:^"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.9.1",

--- a/packages/hash-plugin/src/index.ts
+++ b/packages/hash-plugin/src/index.ts
@@ -18,26 +18,57 @@ export { isStateStrict as isState } from "type-guards";
 /**
  * Module augmentation for real-router.
  * Extends Router interface with hash plugin methods.
+ *
+ * NavigationOptions augmentation (#532) keeps the `hash` / `hashChange` keys
+ * known to TypeScript even when only hash-plugin is installed — runtime
+ * silently ignores them with a one-time warn.
  */
+declare module "@real-router/types" {
+  interface NavigationOptions {
+    /**
+     * URL fragment override (decoded, no leading "#"). Ignored by hash-plugin
+     * (URL fragments are structurally incompatible with hash routing); see
+     * `Router.buildUrl`. (#532)
+     */
+    hash?: string;
+    /** @internal — not used by hash-plugin. */
+    hashChange?: boolean;
+  }
+}
+
 declare module "@real-router/core" {
   interface Router {
     /**
      * Builds full URL for a route with base path and hash prefix.
      * Added by hash plugin.
+     *
+     * The optional `hash` option exists for typing parity with browser-plugin
+     * and navigation-plugin (#532). hash-plugin uses `#` as the route
+     * delimiter, so the option is silently ignored at runtime and a
+     * one-time `console.warn` is emitted.
      */
-    buildUrl: (name: string, params?: Params) => string;
+    buildUrl(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): string;
 
     /**
      * Matches URL and returns corresponding state.
      * Added by hash plugin.
      */
-    matchUrl: (url: string) => State | undefined;
+    matchUrl(url: string): State | undefined;
 
     /**
      * Replaces current history state without triggering navigation.
-     * Added by hash plugin.
+     * Added by hash plugin. The optional `hash` option is ignored (see
+     * `buildUrl`).
      */
-    replaceHistoryState: (name: string, params?: Params) => void;
+    replaceHistoryState(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): void;
 
     start(path?: string): Promise<State>;
   }

--- a/packages/hash-plugin/src/plugin.ts
+++ b/packages/hash-plugin/src/plugin.ts
@@ -26,6 +26,7 @@ export class HashPlugin {
   readonly #removeStartInterceptor: () => void;
   readonly #removeExtensions: () => void;
   readonly #lifecycle: Pick<Plugin, "onStart" | "onStop" | "teardown">;
+  readonly #warnHashIgnored!: () => void;
 
   constructor(
     router: Router,
@@ -45,9 +46,40 @@ export class HashPlugin {
 
     this.#removeStartInterceptor = createStartInterceptor(api, browser);
 
+    // Hash limitation warn-once (#532). hash-plugin uses `#` as the route
+    // delimiter, so URL fragments are structurally incompatible. Plugin
+    // accepts the `hash` option for typing parity with browser/navigation
+    // plugins, ignores it, and emits a single console.warn the first time
+    // any consumer surfaces a hash. Existing `createWarnOnce` in browser-env
+    // is SSR-specific (different signature) — inline pattern here.
+    let hashWarned = false;
+    const warnHashIgnored = (): void => {
+      if (hashWarned) {
+        return;
+      }
+
+      hashWarned = true;
+      console.warn(
+        "[@real-router/hash-plugin] `hash` option is ignored — `#` is reserved for the route delimiter. " +
+          "URL fragments are not supported with hash-plugin; use @real-router/browser-plugin or " +
+          "@real-router/navigation-plugin if you need them.",
+      );
+    };
+
     const urlPrefix = `${options.base}#${options.hashPrefix}`;
-    const pluginBuildUrl = (route: string, params?: Params) =>
-      urlPrefix + router.buildPath(route, params);
+    const pluginBuildUrl = (
+      route: string,
+      params?: Params,
+      opts?: { hash?: string },
+    ) => {
+      if (opts?.hash !== undefined) {
+        warnHashIgnored();
+      }
+
+      return urlPrefix + router.buildPath(route, params);
+    };
+
+    this.#warnHashIgnored = warnHashIgnored;
 
     this.#removeExtensions = api.extendRouter({
       buildUrl: pluginBuildUrl,
@@ -92,6 +124,12 @@ export class HashPlugin {
         fromState: State | undefined,
         navOptions: NavigationOptions,
       ) => {
+        // Hash limitation (#532): warn once if a consumer programmatically
+        // requested a fragment via `router.navigate(..., { hash })`.
+        if (navOptions.hash !== undefined) {
+          this.#warnHashIgnored();
+        }
+
         const replaceHistory = shouldReplaceHistory(
           navOptions,
           toState,

--- a/packages/hash-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/hash-plugin/tests/functional/lifecycle.test.ts
@@ -436,6 +436,58 @@ describe("Hash Plugin — Lifecycle & Configuration", async () => {
     });
   });
 
+  describe("Hash limitation warn-once (#532)", () => {
+    beforeEach(async () => {
+      router.usePlugin(hashPluginFactory({}, mockedBrowser));
+      await router.start("/home");
+    });
+
+    it("warns once on router.buildUrl(name, params, { hash })", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+
+      router.buildUrl("home", {}, { hash: "section" });
+      router.buildUrl("home", {}, { hash: "other" });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "[@real-router/hash-plugin] `hash` option is ignored",
+        ),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("warns once on router.navigate(name, params, { hash })", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+
+      await router.navigate("users.list", {}, { hash: "section" });
+      await router.navigate("home", {}, { hash: "other" });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when no hash option is passed", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+
+      router.buildUrl("home", {});
+      router.buildUrl("users.list");
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("buildUrl ignores the hash and returns the hash-route URL unchanged", () => {
+      vi.spyOn(console, "warn").mockImplementation(noop);
+
+      // hashPrefix defaults to "" → urlPrefix = "#"
+      expect(router.buildUrl("home", {}, { hash: "anchor" })).toBe("#/home");
+    });
+  });
+
   describe("SSR Fallback Behavior", () => {
     it("plugin works in non-browser environment", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -352,11 +352,14 @@ router.navigate(name, params, opts)
         ├── Derive or use #capturedMeta (navigationType, userInitiated, info, direction, sourceElement)
         │     └── claim.write(toState, Object.freeze(meta)) → state.context.navigation
         │
-        ├── url = router.buildUrl(toState.name, toState.params)
-        │         └── router.buildPath() + buildUrl(path, base)
+        ├── Resolve hash via tri-state opts.hash (#532):
+        │     prevHash = fromState ? fromState.context.url?.hash : getDecodedHash(browser)
+        │     hash     = navOptions.hash !== undefined ? normalizeHashInput(navOptions.hash) : prevHash
+        │     urlClaim.write(toState, { hash, hashChanged: navOptions.hashChange ?? (hash !== prevHash) })
         │
-        ├── If paths match (hash preservation):
-        │     finalUrl = url + browser.getHash()
+        ├── url      = router.buildUrl(toState.name, toState.params)
+        │              └── router.buildPath() + buildUrl(path, base)
+        ├── finalUrl = hash ? `${url}#${encodeHashFragment(hash)}` : url
         │
         ├── historyState = { name, params, path }
         │

--- a/packages/navigation-plugin/README.md
+++ b/packages/navigation-plugin/README.md
@@ -62,11 +62,11 @@ router.usePlugin(
 
 ### Compatible extensions (same as browser-plugin)
 
-| Method                                       | Returns              | Description                                      |
-| -------------------------------------------- | -------------------- | ------------------------------------------------ |
-| `buildUrl(name, params?)`                    | `string`             | Build full URL with base path                    |
-| `matchUrl(url)`                              | `State \| undefined` | Parse URL to router state                        |
-| `replaceHistoryState(name, params?)` | `void`               | Update browser URL without triggering navigation |
+| Method                                                | Returns              | Description                                                                                          |
+| ----------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `buildUrl(name, params?, options?: { hash? })`        | `string`             | Build full URL with base path. `options.hash` (decoded) is encoded and appended.                     |
+| `matchUrl(url)`                                       | `State \| undefined` | Parse URL to router state                                                                            |
+| `replaceHistoryState(name, params?, options?: { hash? })` | `void`           | Update browser URL without triggering navigation. Tri-state `hash`: `undefined` preserves, `""` clears, value sets. |
 
 ```typescript
 router.buildUrl("users", { id: "123" });
@@ -144,6 +144,27 @@ if (router.canGoBackTo("users.list")) {
   showBackToListButton();
 }
 ```
+
+## URL Fragment ("hash") Support
+
+`navigation-plugin` ships first-class URL-fragment support: `<Link hash>` from any framework adapter, programmatic `router.navigate(name, params, { hash })`, and a `state.context.url = { hash, hashChanged }` namespace populated on every transition.
+
+```typescript
+// Programmatic — tri-state opts.hash
+router.navigate("settings", {}, { hash: "profile" }); // set
+router.navigate("settings", {}, { hash: "" });        // clear
+router.navigate("settings");                          // preserve current
+
+// In subscribers
+router.subscribe(({ route }) => {
+  console.log(route.context.url?.hash);        // "profile"
+  console.log(route.context.url?.hashChanged); // true on hash-only nav
+});
+```
+
+Browser-driven hash-only clicks (`event.hashChange === true` from the Navigation API) bypass core's `SAME_STATES` rejection via `force: true, hashChange: true` — subscribers fire normally on tab-style URLs.
+
+See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface (encoding, F5 priming, hash-aware active state).
 
 ## Navigation Metadata
 

--- a/packages/navigation-plugin/src/index.ts
+++ b/packages/navigation-plugin/src/index.ts
@@ -14,23 +14,50 @@ export type {
 declare module "@real-router/types" {
   interface StateContext {
     navigation?: import("./types").NavigationMeta;
+    /**
+     * URL fragment ("hash") layer state (#532). Populated by both URL plugins
+     * (navigation-plugin, browser-plugin) — they are mutually exclusive at
+     * runtime, so only one writes to this namespace.
+     */
+    url?: import("./browser-env").UrlContext;
+  }
+
+  interface NavigationOptions {
+    /**
+     * URL fragment override (decoded, no leading "#") (#532).
+     * Tri-state: `undefined` → preserve current; `""` → clear; non-empty → set.
+     */
+    hash?: string;
+    /**
+     * @internal — set by URL plugins on hash-only browser-driven navigation.
+     * Subscribers should branch on `state.context.url.hashChanged` instead.
+     */
+    hashChange?: boolean;
   }
 }
 
 declare module "@real-router/core" {
   interface Router {
-    buildUrl: (name: string, params?: Params) => string;
-    matchUrl: (url: string) => State | undefined;
-    replaceHistoryState: (name: string, params?: Params) => void;
-    peekBack: () => State | undefined;
-    peekForward: () => State | undefined;
-    hasVisited: (routeName: string) => boolean;
-    getVisitedRoutes: () => string[];
-    getRouteVisitCount: (routeName: string) => number;
-    traverseToLast: (routeName: string) => Promise<State>;
-    canGoBack: () => boolean;
-    canGoForward: () => boolean;
-    canGoBackTo: (routeName: string) => boolean;
+    buildUrl(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): string;
+    matchUrl(url: string): State | undefined;
+    replaceHistoryState(
+      name: string,
+      params?: Params,
+      options?: { hash?: string },
+    ): void;
+    peekBack(): State | undefined;
+    peekForward(): State | undefined;
+    hasVisited(routeName: string): boolean;
+    getVisitedRoutes(): string[];
+    getRouteVisitCount(routeName: string): number;
+    traverseToLast(routeName: string): Promise<State>;
+    canGoBack(): boolean;
+    canGoForward(): boolean;
+    canGoBackTo(routeName: string): boolean;
     start(path?: string): Promise<State>;
   }
 }

--- a/packages/navigation-plugin/src/navigate-handler.ts
+++ b/packages/navigation-plugin/src/navigate-handler.ts
@@ -1,6 +1,6 @@
 import { errorCodes, RouterError } from "@real-router/core";
 
-import { urlToPath } from "./browser-env";
+import { urlToPathAndHash } from "./browser-env";
 
 import type {
   NavigationBrowser,
@@ -64,7 +64,7 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
       return;
     }
 
-    const path = urlToPath(event.destination.url, base);
+    const { path, hash } = urlToPathAndHash(event.destination.url, base);
     const matchedState = api.matchPath(path);
 
     const navType = event.navigationType as NavigationMeta["navigationType"];
@@ -130,8 +130,17 @@ export function createNavigateHandler(deps: NavigateHandlerDeps) {
             // matchSourceTrailingSlash; reusing the State avoids the redundant
             // round-trip and preserves trailing slashes (#525). Plugin-only
             // entry point — not on the public Router/Navigator surface.
+            //
+            // Hash extraction (#532): pass through the destination's hash so
+            // onTransitionSuccess sets state.context.url.hash. When the
+            // browser fires hashChange (same-document fragment-only nav),
+            // add force+hashChange to bypass SAME_STATES — subscribers
+            // disambiguate via state.context.url.hashChanged, not via the
+            // overloaded force flag.
             api.navigateToState(matchedState, {
               ...transitionOptions,
+              hash,
+              ...(event.hashChange ? { force: true, hashChange: true } : {}),
               signal: event.signal,
             }),
           ),
@@ -181,7 +190,17 @@ function syncUrlToRouterState(
     const currentState = router.getState();
 
     if (currentState) {
-      const url = router.buildUrl(currentState.name, currentState.params);
+      // Preserve hash on recovery (#532): reading from state.context.url
+      // keeps the visible URL fragment intact when a guard rejects a hash-
+      // bearing navigation.
+      const ctxHash = (
+        currentState.context as { url?: { hash?: string } } | undefined
+      )?.url?.hash;
+      const url = router.buildUrl(
+        currentState.name,
+        currentState.params,
+        ctxHash ? { hash: ctxHash } : undefined,
+      );
 
       // The syncing flag is raised/lowered inside NavigationBrowser around
       // browser.navigate, including the throw path — no manual try/finally

--- a/packages/navigation-plugin/src/plugin.ts
+++ b/packages/navigation-plugin/src/plugin.ts
@@ -6,6 +6,9 @@ import {
   urlToPath,
   createStartInterceptor,
   createReplaceHistoryState,
+  encodeHashFragment,
+  getDecodedHash,
+  normalizeHashInput,
 } from "./browser-env";
 import {
   peekBack,
@@ -22,6 +25,7 @@ import {
 import { createNavigateHandler } from "./navigate-handler";
 import { wrapNavigationBrowserWithSyncing } from "./navigation-browser";
 
+import type { UrlContext } from "./browser-env";
 import type { SyncingFlag } from "./navigation-browser";
 import type {
   NavigationBrowser,
@@ -65,6 +69,10 @@ export class NavigationPlugin {
     write: (state: State, value: NavigationMeta) => void;
     release: () => void;
   };
+  readonly #urlClaim: {
+    write: (state: State, value: UrlContext) => void;
+    release: () => void;
+  };
   readonly #lifecycle: Pick<Plugin, "onStart" | "onStop" | "teardown">;
   readonly #syncing: SyncingFlag = { current: false };
 
@@ -95,6 +103,7 @@ export class NavigationPlugin {
     this.#browser = wrapNavigationBrowserWithSyncing(browser, this.#syncing);
 
     this.#claim = api.claimContextNamespace("navigation");
+    this.#urlClaim = api.claimContextNamespace("url");
     this.#removeStartInterceptor = createStartInterceptor(api, this.#browser);
 
     // Cross-document load priming (#531). On F5, browser back/forward across
@@ -117,10 +126,28 @@ export class NavigationPlugin {
       };
     }
 
-    const pluginBuildUrl = (route: string, params?: Params) => {
-      const path = router.buildPath(route, params);
+    // Hash for the first transition (#532) is read lazily inside
+    // onTransitionSuccess via `getDecodedHash(browser)` — capturing in the
+    // constructor is too eager (in tests, the mock URL is set after the
+    // plugin is constructed). The lazy read still covers F5 / fresh URL
+    // bar entry: by the time onTransitionSuccess fires the browser already
+    // reflects the destination URL.
 
-      return buildUrl(path, options.base);
+    const pluginBuildUrl = (
+      route: string,
+      params?: Params,
+      opts?: { hash?: string },
+    ) => {
+      const path = router.buildPath(route, params);
+      const url = buildUrl(path, options.base);
+
+      if (opts?.hash === undefined) {
+        return url;
+      }
+
+      const norm = normalizeHashInput(opts.hash);
+
+      return norm ? `${url}#${encodeHashFragment(norm)}` : url;
     };
 
     this.#removeExtensions = api.extendRouter({
@@ -169,6 +196,7 @@ export class NavigationPlugin {
       removeExtensions: this.#removeExtensions,
       releaseClaim: () => {
         this.#claim.release();
+        this.#urlClaim.release();
       },
     });
   }
@@ -268,11 +296,41 @@ export class NavigationPlugin {
         if (traverseKey) {
           this.#browser.traverseTo(traverseKey);
         } else {
+          // Tri-state hash resolution (#532).
+          //   navOptions.hash === undefined → preserve current browser hash
+          //   navOptions.hash === ""        → explicitly clear
+          //   navOptions.hash === "value"   → explicitly set
+          //
+          // The "preserve" branch reads location.hash from the browser, not
+          // fromState.context.url.hash — this captures dynamic fragment
+          // changes the user makes outside the plugin (anchor clicks,
+          // manual location.hash assignment) instead of replaying the
+          // last-published value.
+          //
+          // hashChanged compares the chosen hash against the *published*
+          // previous hash (fromState.context.url.hash), so subscribers see
+          // a true signal regardless of whether the value came from
+          // navOptions or the browser.
+          const browserHash = getDecodedHash(this.#browser);
+          const publishedPrevHash =
+            (fromState?.context as { url?: { hash?: string } } | undefined)?.url
+              ?.hash ?? "";
+
+          const hash =
+            navOptions.hash === undefined
+              ? browserHash
+              : normalizeHashInput(navOptions.hash);
+
+          this.#urlClaim.write(
+            toState,
+            Object.freeze({
+              hash,
+              hashChanged: navOptions.hashChange ?? hash !== publishedPrevHash,
+            }),
+          );
+
           const url = buildUrl(toState.path, this.#options.base);
-          const shouldPreserveHash =
-            !fromState || fromState.path === toState.path;
-          const hash = shouldPreserveHash ? this.#browser.getHash() : "";
-          const finalUrl = hash ? url + hash : url;
+          const finalUrl = hash ? `${url}#${encodeHashFragment(hash)}` : url;
           const historyState = {
             name: toState.name,
             params: toState.params,

--- a/packages/navigation-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/navigation-plugin/tests/functional/lifecycle.test.ts
@@ -440,13 +440,83 @@ describe("Navigation Plugin — Lifecycle", () => {
       expect(mockNav.currentUrl).toContain("#section");
     });
 
-    it("clears hash when navigating to a different path", async () => {
+    it("preserves hash on cross-path navigation when not overridden (#532)", async () => {
+      // Issue #532 changed cross-path behavior: hash is preserved by default,
+      // not stripped. The previous shouldPreserveHash workaround dropped hash
+      // on path change — this was the cross-path-stripping bug. Tri-state
+      // semantics: opts.hash === undefined ⇒ preserve current.
       mockNav.navigate("http://localhost/home#section", { history: "replace" });
       await router.start();
 
       await router.navigate("users.list");
 
+      expect(mockNav.currentUrl).toContain("#section");
+    });
+
+    it("clears hash when navigation explicitly passes opts.hash = '' (#532)", async () => {
+      mockNav.navigate("http://localhost/home#section", { history: "replace" });
+      await router.start();
+
+      await router.navigate("users.list", {}, { hash: "" });
+
       expect(mockNav.currentUrl).not.toContain("#section");
+    });
+
+    it("sets hash when navigation explicitly passes opts.hash = 'value' (#532)", async () => {
+      mockNav.navigate("http://localhost/home#section", { history: "replace" });
+      await router.start();
+
+      await router.navigate("users.list", {}, { hash: "footer" });
+
+      expect(mockNav.currentUrl).toContain("#footer");
+      expect(mockNav.currentUrl).not.toContain("#section");
+    });
+
+    it("opts.hash omitted preserves current browser hash (tri-state default) (#532)", async () => {
+      // Tri-state contract: opts.hash absent → preserve. Tests the third
+      // state of the contract that "" (clear) and "value" (set) cover.
+      // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally,
+      // but at runtime an absent property has the same effect.
+      mockNav.navigate("http://localhost/home#kept", { history: "replace" });
+      await router.start();
+
+      // No `hash` key in the options object — must preserve.
+      await router.navigate("users.list", {}, {});
+
+      expect(mockNav.currentUrl).toContain("#kept");
+    });
+
+    it("publishes hashChanged=false when hash matches published previous (#532)", async () => {
+      mockNav.navigate("http://localhost/home#x", { history: "replace" });
+      await router.start();
+
+      // Programmatic same-hash explicit — hashChanged must be false because
+      // hash equals fromState.context.url.hash.
+      await router.navigate("users.list", {}, { hash: "x" });
+
+      const url = (
+        router.getState()!.context as {
+          url?: { hash: string; hashChanged: boolean };
+        }
+      ).url;
+
+      expect(url?.hash).toBe("x");
+      expect(url?.hashChanged).toBe(false);
+    });
+
+    it("publishes state.context.url even when hash is empty (#532)", async () => {
+      mockNav.navigate("http://localhost/home", { history: "replace" });
+      await router.start();
+
+      // Plugin must always populate the namespace, even if hash is "".
+      const url = (
+        router.getState()!.context as {
+          url?: { hash: string; hashChanged: boolean };
+        }
+      ).url;
+
+      expect(url).toBeDefined();
+      expect(url?.hash).toBe("");
     });
 
     it("G-1: preserves hash on initial navigation (fromState === undefined)", async () => {
@@ -457,8 +527,126 @@ describe("Navigation Plugin — Lifecycle", () => {
 
       // After the first resolved navigation, the URL recorded by
       // onTransitionSuccess must include the hash because `!fromState`
-      // short-circuits `shouldPreserveHash` to true.
+      // falls back to `getDecodedHash(browser)` for prevHash (#532 lazy read).
       expect(mockNav.currentUrl).toContain("#section");
+    });
+
+    it("publishes state.context.url with hash on initial navigation (#532)", async () => {
+      // hashChanged compares against published previous hash; on the very
+      // first transition there is no fromState, so prevHash is "" and
+      // hashChanged is `true` whenever the initial URL carries a fragment.
+      mockNav.navigate("http://localhost/home#section", { history: "replace" });
+      await router.start();
+
+      const state = router.getState();
+
+      expect(state).toBeDefined();
+
+      const url = (
+        state!.context as { url?: { hash: string; hashChanged: boolean } }
+      ).url;
+
+      expect(url).toStrictEqual({ hash: "section", hashChanged: true });
+    });
+
+    it("publishes hashChanged=true on browser-driven hash-only navigation (#532)", async () => {
+      mockNav.navigate("http://localhost/home", { history: "replace" });
+      await router.start();
+
+      // Same path, different hash — Navigation API fires hashChange=true.
+      // Plugin must add force+hashChange so SAME_STATES is bypassed and
+      // state.context.url.hash updates.
+      await mockNav.navigate("http://localhost/home#newsection").committed;
+
+      const state = router.getState();
+      const url = (
+        state!.context as { url?: { hash: string; hashChanged: boolean } }
+      ).url;
+
+      expect(url?.hash).toBe("newsection");
+      expect(url?.hashChanged).toBe(true);
+    });
+
+    it("explicit opts.hashChange overrides auto-detection (#532)", async () => {
+      mockNav.navigate("http://localhost/home#x", { history: "replace" });
+      await router.start();
+
+      // Pass hashChange:true even though hash didn't change — subscriber
+      // sees the explicit signal regardless of computed value.
+      await router.navigate(
+        "home",
+        {},
+        { hash: "x", hashChange: true, force: true },
+      );
+
+      const state = router.getState();
+      const url = (state!.context as { url?: { hashChanged: boolean } }).url;
+
+      expect(url?.hashChanged).toBe(true);
+    });
+  });
+
+  describe("Hash — buildUrl extension (#532)", () => {
+    beforeEach(() => {
+      unsubscribe = router.usePlugin(navigationPluginFactory({}, browser));
+    });
+
+    it("router.buildUrl(name, params, { hash }) appends fragment", () => {
+      expect(
+        router.buildUrl("users.view", { id: "1" }, { hash: "anchor" }),
+      ).toBe("/users/view/1#anchor");
+    });
+
+    it("router.buildUrl encodes RFC-3986 unsafe chars but preserves sub-delims", () => {
+      // space → %20, & preserved, # escaped to %23
+      expect(router.buildUrl("home", {}, { hash: "a b&c#d" })).toBe(
+        "/home#a%20b&c%23d",
+      );
+    });
+
+    it("router.buildUrl strips leading # defensively", () => {
+      expect(router.buildUrl("home", {}, { hash: "#section" })).toBe(
+        "/home#section",
+      );
+    });
+
+    it("router.buildUrl returns base URL when hash is empty string", () => {
+      expect(router.buildUrl("home", {}, { hash: "" })).toBe("/home");
+    });
+
+    it("router.buildUrl ignores hash option when it is undefined", () => {
+      // Equivalent to omitting the third argument.
+      expect(router.buildUrl("home", {}, undefined)).toBe("/home");
+    });
+
+    it("recovery preserves hash from state.context.url on CANNOT_DEACTIVATE (#532)", async () => {
+      // Replace router with strict-deactivate setup so guard rejection
+      // routes through syncUrlToRouterState (navigate-handler.ts:204).
+      router.stop();
+      unsubscribe?.();
+      mockNav.navigate("http://localhost/home#anchor", { history: "replace" });
+      router = createRouter(routerConfig, {
+        defaultRoute: "home",
+        queryParamsMode: "default",
+      });
+      unsubscribe = router.usePlugin(
+        navigationPluginFactory({ forceDeactivate: false }, browser),
+      );
+      await router.start();
+
+      // Block deactivation of home → trigger CANNOT_DEACTIVATE on user-driven nav.
+      getLifecycleApi(router).addDeactivateGuard("home", () => () => false);
+
+      // User clicks a link to /users/list — Navigation API fires navigate
+      // event, plugin intercepts, router rejects with CANNOT_DEACTIVATE,
+      // recovery runs syncUrlToRouterState which must rebuild the URL with
+      // ctxHash from state.context.url.
+      await mockNav
+        .navigate("http://localhost/users/list")
+        .finished.catch(noop);
+
+      expect(mockNav.currentUrl).toContain("#anchor");
+      expect(mockNav.currentUrl).toContain("/home");
     });
   });
 

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -147,6 +147,15 @@ Navigation link with automatic active state detection. Re-renders only when its 
 </Link>
 ```
 
+#### `hash` prop — URL fragment / tab-style UIs
+
+```tsx
+<Link routeName="settings" hash="profile">Profile</Link>
+<Link routeName="settings" hash="account">Account</Link>
+```
+
+Tri-state: `undefined` preserves the current hash, `""` clears it, a value sets it. Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
+
 ### `<RouteView>`
 
 Declarative route matching. Renders the first matching `<RouteView.Match>` child.

--- a/packages/preact/src/components/Link.tsx
+++ b/packages/preact/src/components/Link.tsx
@@ -6,6 +6,7 @@ import {
   shouldNavigate,
   buildHref,
   buildActiveClassName,
+  navigateWithHash,
   shallowEqual,
 } from "../dom-utils";
 import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
@@ -28,6 +29,7 @@ function areLinkPropsEqual(
     prev.target === next.target &&
     prev.style === next.style &&
     prev.children === next.children &&
+    prev.hash === next.hash &&
     shallowEqual(prev.routeParams, next.routeParams) &&
     shallowEqual(prev.routeOptions, next.routeOptions)
   );
@@ -42,6 +44,7 @@ export const Link: FunctionComponent<LinkProps> = memo(
     activeClassName = "active",
     activeStrict = false,
     ignoreQueryParams = true,
+    hash,
     onClick,
     target,
     children,
@@ -54,16 +57,27 @@ export const Link: FunctionComponent<LinkProps> = memo(
     // change caught by shallowEqual), so they're safe to use directly in hook
     // deps without useStableValue.
 
+    // Hash-aware active (#532): when `hash` prop is set, isActive requires
+    // both route AND hash to match. Tab-style UI (multiple links sharing
+    // routeName but differing in hash) needs this to avoid marking all tabs
+    // active by route-name alone.
     const isActive = useIsActiveRoute(
       routeName,
       routeParams,
       activeStrict,
       ignoreQueryParams,
+      hash,
     );
 
     const href = useMemo(
-      () => buildHref(router, routeName, routeParams),
-      [router, routeName, routeParams],
+      () =>
+        buildHref(
+          router,
+          routeName,
+          routeParams,
+          hash === undefined ? undefined : { hash },
+        ),
+      [router, routeName, routeParams, hash],
     );
 
     const handleClick = useCallback(
@@ -81,9 +95,15 @@ export const Link: FunctionComponent<LinkProps> = memo(
         }
 
         evt.preventDefault();
-        router.navigate(routeName, routeParams, routeOptions).catch(() => {});
+        navigateWithHash(
+          router,
+          routeName,
+          routeParams,
+          hash,
+          routeOptions,
+        ).catch(() => {});
       },
-      [onClick, target, router, routeName, routeParams, routeOptions],
+      [onClick, target, router, routeName, routeParams, routeOptions, hash],
     );
 
     const finalClassName = useMemo(

--- a/packages/preact/src/hooks/useIsActiveRoute.tsx
+++ b/packages/preact/src/hooks/useIsActiveRoute.tsx
@@ -10,15 +10,25 @@ export function useIsActiveRoute(
   params?: Params,
   strict = false,
   ignoreQueryParams = true,
+  hash?: string,
 ): boolean {
   const router = useRouter();
 
   // createActiveRouteSource is per-router + canonical-args cached in
-  // @real-router/sources, so passing params by reference is safe.
-  const store = createActiveRouteSource(router, routeName, params, {
-    strict,
-    ignoreQueryParams,
-  });
+  // @real-router/sources, so passing params by reference is safe. The
+  // `hash` argument (#532) participates in the cache key — a tab Link
+  // pointing to `/settings#account` shares its source only with consumers
+  // using the same routeName + params + hash.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so
+  // we conditionally include the key only when the caller passed a value.
+  const store = createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    hash === undefined
+      ? { strict, ignoreQueryParams }
+      : { strict, ignoreQueryParams, hash },
+  );
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -26,5 +26,15 @@ export interface LinkProps<P extends Params = Params> extends Omit<
   activeClassName?: string;
   activeStrict?: boolean;
   ignoreQueryParams?: boolean;
+  /**
+   * URL fragment (decoded form, no leading "#") (#532).
+   * - omitted/`undefined` → preserve current fragment on same-route navigation
+   * - `""` → clear fragment
+   * - non-empty → set fragment
+   *
+   * Requires a URL plugin (browser-plugin or navigation-plugin) for full
+   * round-trip; hash-plugin ignores the prop with a one-time dev warning.
+   */
+  hash?: string;
   target?: string;
 }

--- a/packages/preact/tests/integration/Link.test.tsx
+++ b/packages/preact/tests/integration/Link.test.tsx
@@ -426,8 +426,33 @@ describe("Link - Integration Tests", () => {
         { wrapper },
       );
 
-      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {});
+      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {}, undefined);
       expect(screen.getByTestId("link")).toHaveAttribute("href", "/custom-url");
+    });
+
+    it("should pass hash option to buildUrl when hash prop is set (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      render(
+        <Link routeName="one-more-test" hash="anchor" data-testid="link">
+          Test
+        </Link>,
+        { wrapper },
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        "one-more-test",
+        {},
+        {
+          hash: "anchor",
+        },
+      );
+      expect(screen.getByTestId("link")).toHaveAttribute("href", "/url#anchor");
     });
 
     it("should fallback to buildPath when buildUrl unavailable", () => {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -145,6 +145,18 @@ Navigation link with automatic active state detection. Re-renders only when its 
 </Link>
 ```
 
+#### `hash` prop — URL fragment / tab-style UIs
+
+```tsx
+<nav>
+  <Link routeName="settings" hash="profile">Profile</Link>
+  <Link routeName="settings" hash="account">Account</Link>
+  <Link routeName="settings" hash="billing">Billing</Link>
+</nav>
+```
+
+Tri-state: `undefined` preserves the current hash, `""` clears it, a value sets it. Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/). See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
+
 ### `<RouteView>` (React 19.2+)
 
 Declarative route matching with optional `keepAlive` — preserves component state via React's `<Activity>` API.

--- a/packages/react/src/components/Link.tsx
+++ b/packages/react/src/components/Link.tsx
@@ -5,6 +5,7 @@ import {
   shouldNavigate,
   buildHref,
   buildActiveClassName,
+  navigateWithHash,
   shallowEqual,
 } from "../dom-utils";
 import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
@@ -27,6 +28,7 @@ function areLinkPropsEqual(
     prev.target === next.target &&
     prev.style === next.style &&
     prev.children === next.children &&
+    prev.hash === next.hash &&
     shallowEqual(prev.routeParams, next.routeParams) &&
     shallowEqual(prev.routeOptions, next.routeOptions)
   );
@@ -40,6 +42,7 @@ const LinkImpl: FC<LinkProps> = ({
   activeClassName = "active",
   activeStrict = false,
   ignoreQueryParams = true,
+  hash,
   onClick,
   target,
   children,
@@ -52,16 +55,26 @@ const LinkImpl: FC<LinkProps> = ({
 
   const router = useRouter();
 
+  // When `hash` prop is set, active state requires both route AND hash to
+  // match (#532). Without this, three tab links sharing routeName="settings"
+  // would all be marked active by route-name alone, defeating tab semantics.
   const isActive = useIsActiveRoute(
     routeName,
     routeParams,
     activeStrict,
     ignoreQueryParams,
+    hash,
   );
 
   const href = useMemo(
-    () => buildHref(router, routeName, routeParams),
-    [router, routeName, routeParams],
+    () =>
+      buildHref(
+        router,
+        routeName,
+        routeParams,
+        hash === undefined ? undefined : { hash },
+      ),
+    [router, routeName, routeParams, hash],
   );
 
   const handleClick = useCallback(
@@ -79,9 +92,15 @@ const LinkImpl: FC<LinkProps> = ({
       }
 
       evt.preventDefault();
-      router.navigate(routeName, routeParams, routeOptions).catch(() => {});
+      navigateWithHash(
+        router,
+        routeName,
+        routeParams,
+        hash,
+        routeOptions,
+      ).catch(() => {});
     },
-    [onClick, target, router, routeName, routeParams, routeOptions],
+    [onClick, target, router, routeName, routeParams, routeOptions, hash],
   );
 
   const finalClassName = buildActiveClassName(

--- a/packages/react/src/hooks/useIsActiveRoute.tsx
+++ b/packages/react/src/hooks/useIsActiveRoute.tsx
@@ -10,16 +10,26 @@ export function useIsActiveRoute(
   params?: Params,
   strict = false,
   ignoreQueryParams = true,
+  hash?: string,
 ): boolean {
   const router = useRouter();
 
   // createActiveRouteSource is per-router + canonical-args cached in
   // @real-router/sources, so passing params by reference is safe — equivalent
-  // param shapes hit the same cache entry regardless of key order.
-  const store = createActiveRouteSource(router, routeName, params, {
-    strict,
-    ignoreQueryParams,
-  });
+  // param shapes hit the same cache entry regardless of key order. The
+  // `hash` argument (#532) is part of the cache key when defined: a Link
+  // pointing to `/settings#account` shares its source only with other
+  // consumers using the same routeName + params + hash.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so
+  // we conditionally include the key only when the caller passed a value.
+  const store = createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    hash === undefined
+      ? { strict, ignoreQueryParams }
+      : { strict, ignoreQueryParams, hash },
+  );
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -24,6 +24,16 @@ export interface LinkProps<
   activeClassName?: string;
   activeStrict?: boolean;
   ignoreQueryParams?: boolean;
+  /**
+   * URL fragment (decoded form, no leading "#") (#532).
+   * - omitted/`undefined` → preserve current fragment on same-route navigation
+   * - `""` → clear fragment
+   * - non-empty → set fragment
+   *
+   * Requires a URL plugin (browser-plugin or navigation-plugin) for full
+   * round-trip; hash-plugin ignores the prop with a one-time dev warning.
+   */
+  hash?: string;
   target?: string;
   onClick?: MouseEventHandler<HTMLAnchorElement>;
   onMouseOver?: MouseEventHandler<HTMLAnchorElement>;

--- a/packages/react/tests/integration/Link.test.tsx
+++ b/packages/react/tests/integration/Link.test.tsx
@@ -426,7 +426,10 @@ describe("Link - Integration Tests", () => {
         { wrapper },
       );
 
-      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {});
+      // After #532, buildHref passes a 3rd undefined argument when no hash
+      // is provided so URL plugins can opt into fragment support without
+      // breaking 2-arg signatures.
+      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {}, undefined);
       expect(screen.getByTestId("link")).toHaveAttribute("href", "/custom-url");
     });
 
@@ -441,6 +444,61 @@ describe("Link - Integration Tests", () => {
       );
 
       expect(buildPathSpy).toHaveBeenCalled();
+    });
+
+    it("should pass hash option to buildUrl when hash prop is set (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      render(
+        <Link routeName="one-more-test" hash="anchor" data-testid="link">
+          Test
+        </Link>,
+        { wrapper },
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        "one-more-test",
+        {},
+        {
+          hash: "anchor",
+        },
+      );
+      expect(screen.getByTestId("link")).toHaveAttribute("href", "/url#anchor");
+    });
+
+    it("should re-render href when the hash prop changes (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      const { rerender } = render(
+        <Link routeName="one-more-test" hash="a" data-testid="link">
+          Test
+        </Link>,
+        { wrapper },
+      );
+
+      expect(screen.getByTestId("link")).toHaveAttribute("href", "/url#a");
+
+      rerender(
+        <RouterProvider router={router}>
+          <Link routeName="one-more-test" hash="b" data-testid="link">
+            Test
+          </Link>
+        </RouterProvider>,
+      );
+
+      // areLinkPropsEqual must include the `hash` field so the memoized
+      // component re-renders when the prop changes.
+      expect(screen.getByTestId("link")).toHaveAttribute("href", "/url#b");
     });
 
     it("should generate correct href with query params", () => {

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -191,6 +191,15 @@ Navigation link with automatic active state detection. Uses `classList` for acti
 </Link>
 ```
 
+#### `hash` prop — URL fragment / tab-style UIs
+
+```tsx
+<Link routeName="settings" hash="profile">Profile</Link>
+<Link routeName="settings" hash="account">Account</Link>
+```
+
+Tri-state: `undefined` preserves the current hash, `""` clears it, a value sets it. Active class is hash-aware — only the matching tab lights up. Setting `hash` forces the slow path (the fast-path `routeSelector` is hash-agnostic). Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
+
 ### `<RouteView>`
 
 Declarative route matching. Renders the first matching `<RouteView.Match>` child.

--- a/packages/solid/src/components/Link.tsx
+++ b/packages/solid/src/components/Link.tsx
@@ -4,7 +4,12 @@ import { createMemo, mergeProps, splitProps, useContext } from "solid-js";
 import { EMPTY_PARAMS, EMPTY_OPTIONS } from "../constants";
 import { RouterContext } from "../context";
 import { createSignalFromSource } from "../createSignalFromSource";
-import { shouldNavigate, buildHref, buildActiveClassName } from "../dom-utils";
+import {
+  shouldNavigate,
+  buildHref,
+  buildActiveClassName,
+  navigateWithHash,
+} from "../dom-utils";
 
 import type { LinkProps } from "../types";
 import type { Params } from "@real-router/core";
@@ -31,6 +36,7 @@ export function Link<P extends Params = Params>(
     "activeClassName",
     "activeStrict",
     "ignoreQueryParams",
+    "hash",
     "onClick",
     "target",
     "class",
@@ -45,22 +51,47 @@ export function Link<P extends Params = Params>(
 
   const router = ctx.router;
 
+  // Hash-aware active state (#532). `routeSelector` (the O(1) shared selector)
+  // doesn't know about hash — when `hash` prop is set, fall back to the slow
+  // path so the source's hash comparison kicks in. Tab-style UI is opt-in via
+  // the prop, so the fast path stays open for the typical Link case.
   const useFastPath =
+    local.hash === undefined &&
     !local.activeStrict &&
     local.ignoreQueryParams &&
     local.routeParams === EMPTY_PARAMS;
 
+  const buildActiveOptions = () => {
+    const base = {
+      strict: local.activeStrict,
+      ignoreQueryParams: local.ignoreQueryParams,
+    };
+
+    if (local.hash === undefined) {
+      return base;
+    }
+
+    return { ...base, hash: local.hash };
+  };
+
   const isActive = useFastPath
     ? () => ctx.routeSelector(local.routeName)
     : createSignalFromSource(
-        createActiveRouteSource(router, local.routeName, local.routeParams, {
-          strict: local.activeStrict,
-          ignoreQueryParams: local.ignoreQueryParams,
-        }),
+        createActiveRouteSource(
+          router,
+          local.routeName,
+          local.routeParams,
+          buildActiveOptions(),
+        ),
       );
 
   const href = createMemo(() =>
-    buildHref(router, local.routeName, local.routeParams),
+    buildHref(
+      router,
+      local.routeName,
+      local.routeParams,
+      local.hash === undefined ? undefined : { hash: local.hash },
+    ),
   );
 
   const handleClick = (evt: MouseEvent) => {
@@ -77,9 +108,13 @@ export function Link<P extends Params = Params>(
     }
 
     evt.preventDefault();
-    router
-      .navigate(local.routeName, local.routeParams, local.routeOptions)
-      .catch(() => {});
+    navigateWithHash(
+      router,
+      local.routeName,
+      local.routeParams,
+      local.hash,
+      local.routeOptions,
+    ).catch(() => {});
   };
 
   const finalClassName = createMemo(() =>

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -16,6 +16,13 @@ export interface LinkProps<P extends Params = Params> extends Omit<
   activeClassName?: string;
   activeStrict?: boolean;
   ignoreQueryParams?: boolean;
+  /**
+   * URL fragment (decoded form, no leading "#") (#532).
+   * - omitted/`undefined` → preserve current fragment on same-route navigation
+   * - `""` → clear fragment
+   * - non-empty → set fragment
+   */
+  hash?: string;
   target?: string;
   onClick?: (evt: MouseEvent) => void;
 }

--- a/packages/solid/tests/integration/Link.test.tsx
+++ b/packages/solid/tests/integration/Link.test.tsx
@@ -268,8 +268,35 @@ describe("Link - Integration Tests", () => {
         { wrapper },
       );
 
-      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {});
+      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {}, undefined);
       expect(screen.getByTestId("link")).toHaveAttribute("href", "/custom-url");
+    });
+
+    it("should pass hash option to buildUrl when hash prop is set (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      render(
+        () => (
+          <Link routeName="one-more-test" hash="anchor" data-testid="link">
+            Test
+          </Link>
+        ),
+        { wrapper },
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        "one-more-test",
+        {},
+        {
+          hash: "anchor",
+        },
+      );
+      expect(screen.getByTestId("link")).toHaveAttribute("href", "/url#anchor");
     });
 
     it("should generate correct href with query params", () => {

--- a/packages/sources/src/createActiveRouteSource.ts
+++ b/packages/sources/src/createActiveRouteSource.ts
@@ -35,7 +35,7 @@ export function createActiveRouteSource(
   params?: Params,
   options?: ActiveRouteSourceOptions,
 ): RouterSource<boolean> {
-  const { strict, ignoreQueryParams } = normalizeActiveOptions(options);
+  const { strict, ignoreQueryParams, hash } = normalizeActiveOptions(options);
 
   // BigInt/Symbol/circular refs cannot be serialized — fall back to creating
   // a fresh (non-cached) source. Callers pass these edge-case params rarely;
@@ -43,7 +43,13 @@ export function createActiveRouteSource(
   let key: string | undefined;
 
   try {
-    key = `${routeName}|${canonicalJson(params)}|${String(strict)}|${String(ignoreQueryParams)}`;
+    // `hash === undefined` produces "" via String(undefined) → "undefined";
+    // we encode it as the empty string sentinel to keep the key short and
+    // distinct from the literal "undefined" hash value (which is a valid,
+    // if unusual, fragment).
+    const hashKey = hash === undefined ? "" : `#${hash}`;
+
+    key = `${routeName}|${canonicalJson(params)}|${String(strict)}|${String(ignoreQueryParams)}|${hashKey}`;
   } catch {
     key = undefined;
   }
@@ -55,6 +61,7 @@ export function createActiveRouteSource(
       params,
       strict,
       ignoreQueryParams,
+      hash,
     );
 
     return {
@@ -80,6 +87,7 @@ export function createActiveRouteSource(
       params,
       strict,
       ignoreQueryParams,
+      hash,
     );
 
     cached = {
@@ -93,18 +101,68 @@ export function createActiveRouteSource(
   return cached;
 }
 
+/**
+ * Reads the URL fragment published by browser/navigation plugins on the given
+ * router state. Returns `""` when no plugin claims the `"url"` namespace
+ * (hash-plugin runtime, memory-plugin, SSR) — `undefined` is reserved for
+ * "no published fragment yet" and not visible at the source layer.
+ */
+function readContextHash(router: Router): string {
+  const ctx = router.getState()?.context as
+    | { url?: { hash?: string } }
+    | undefined;
+
+  return ctx?.url?.hash ?? "";
+}
+
+/**
+ * Combines route-name match with optional hash match (#532).
+ *
+ * - Route-name match: `router.isActiveRoute(name, params, strict, ignoreQueryParams)`.
+ * - Hash match (only when `hash !== undefined`): `state.context.url.hash` must
+ *   equal the requested fragment exactly. With hash-plugin (no `url`
+ *   namespace), this returns `false` — the documented limitation.
+ */
+function computeActive(
+  router: Router,
+  routeName: string,
+  params: Params | undefined,
+  strict: boolean,
+  ignoreQueryParams: boolean,
+  hash: string | undefined,
+): boolean {
+  const routeActive = router.isActiveRoute(
+    routeName,
+    params,
+    strict,
+    ignoreQueryParams,
+  );
+
+  if (!routeActive) {
+    return false;
+  }
+  if (hash === undefined) {
+    return true;
+  }
+
+  return readContextHash(router) === hash;
+}
+
 function buildActiveRouteSource(
   router: Router,
   routeName: string,
   params: Params | undefined,
   strict: boolean,
   ignoreQueryParams: boolean,
+  hash: string | undefined,
 ): RouterSource<boolean> {
-  const initialValue = router.isActiveRoute(
+  const initialValue = computeActive(
+    router,
     routeName,
     params,
     strict,
     ignoreQueryParams,
+    hash,
   );
 
   const source = new BaseSource(initialValue);
@@ -119,14 +177,33 @@ function buildActiveRouteSource(
       next.previousRoute &&
       areRoutesRelated(routeName, next.previousRoute.name);
 
-    if (!isNewRelated && !isPrevRelated) {
+    // Hash-aware sources also flip on same-path-different-hash transitions.
+    // The route comparison alone misses these (route is identical), but the
+    // hash claim updated, so we must re-evaluate. Detect via the `hashChanged`
+    // flag published by URL plugins.
+    const hashFlip =
+      hash !== undefined &&
+      ((next.route.context as { url?: { hashChanged?: boolean } } | undefined)
+        ?.url?.hashChanged ??
+        false);
+
+    if (!isNewRelated && !isPrevRelated && !hashFlip) {
       return;
     }
 
     // If new route is not related, we know the route is inactive —
-    // avoid calling isActiveRoute for the optimization
+    // avoid calling isActiveRoute for the optimization. (Hash check would
+    // also fail without route-match, so this short-circuit holds for
+    // hash-aware sources too.)
     const newValue = isNewRelated
-      ? router.isActiveRoute(routeName, params, strict, ignoreQueryParams)
+      ? computeActive(
+          router,
+          routeName,
+          params,
+          strict,
+          ignoreQueryParams,
+          hash,
+        )
       : false;
 
     if (!Object.is(source.getSnapshot(), newValue)) {

--- a/packages/sources/src/normalizeActiveOptions.ts
+++ b/packages/sources/src/normalizeActiveOptions.ts
@@ -1,16 +1,27 @@
 import type { ActiveRouteSourceOptions } from "./types.js";
 
 /**
+ * Normalized options shape — booleans are required (filled with defaults),
+ * `hash` stays `string | undefined` because `undefined` is the meaningful
+ * "ignore hash" sentinel that callers pass intentionally.
+ */
+export interface NormalizedActiveOptions {
+  strict: boolean;
+  ignoreQueryParams: boolean;
+  hash: string | undefined;
+}
+
+/**
  * Default options for `createActiveRouteSource` and adapter-level helpers.
  *
  * Frozen to prevent accidental mutation by consumers.
  */
-export const DEFAULT_ACTIVE_OPTIONS: Readonly<
-  Required<ActiveRouteSourceOptions>
-> = Object.freeze({
-  strict: false,
-  ignoreQueryParams: true,
-});
+export const DEFAULT_ACTIVE_OPTIONS: Readonly<NormalizedActiveOptions> =
+  Object.freeze({
+    strict: false,
+    ignoreQueryParams: true,
+    hash: undefined,
+  });
 
 /**
  * Normalizes partial `ActiveRouteSourceOptions` into a fully-defaulted object.
@@ -20,10 +31,11 @@ export const DEFAULT_ACTIVE_OPTIONS: Readonly<
  */
 export function normalizeActiveOptions(
   options?: ActiveRouteSourceOptions,
-): Required<ActiveRouteSourceOptions> {
+): NormalizedActiveOptions {
   return {
     strict: options?.strict ?? DEFAULT_ACTIVE_OPTIONS.strict,
     ignoreQueryParams:
       options?.ignoreQueryParams ?? DEFAULT_ACTIVE_OPTIONS.ignoreQueryParams,
+    hash: options?.hash,
   };
 }

--- a/packages/sources/src/stabilizeState.ts
+++ b/packages/sources/src/stabilizeState.ts
@@ -3,13 +3,18 @@ import type { State } from "@real-router/core";
 /**
  * State-aware stabilization for route snapshots.
  *
- * Compares `path` — the canonical representation of rendering-relevant
- * State fields (name + params). When path matches, returns `prev`
- * (preserving reference), enabling frameworks to skip re-renders.
+ * Compares `path` (canonical name+params) AND `state.context.url.hash`
+ * (URL fragment, #532). When both match, returns `prev` (preserving
+ * reference) so frameworks can skip re-renders. When hash flips on a
+ * same-path navigation (tab-style UI), returns `next` so consumers
+ * subscribing through `useRoute()` see the new state.
  *
- * Ignores `meta` (internal: auto-increment id) and `transition`
- * (reference data: from, segments, reload) — they don't affect
- * what is rendered.
+ * Ignores `meta` (internal: auto-increment id), `transition` (reference
+ * data: from, segments, reload), and `state.context.navigation` /
+ * `state.context.browser` (transient transition metadata) — they don't
+ * affect what is rendered. `state.context.url.hash` is the only context
+ * field that participates in render identity, because tab-style UIs
+ * subscribe to it directly.
  *
  * Accepts `null` for compatibility with `RouterTransitionSnapshot`
  * (toRoute/fromRoute are `State | null`).
@@ -27,5 +32,20 @@ export function stabilizeState<T extends State | null | undefined>(
     return next;
   }
 
+  // After the path check, both must be the same non-null State (paths
+  // matched, prev !== next reference). Read context.url.hash to detect
+  // same-path-different-hash navigation (#532) — render-relevant for
+  // tab-style UIs that subscribe via useRoute(). Optional chaining keeps
+  // the access null-safe without forbidden non-null assertions.
+  if (readContextHash(prev) !== readContextHash(next)) {
+    return next;
+  }
+
   return prev;
+}
+
+function readContextHash(state: State | null | undefined): string | undefined {
+  const ctx = state?.context as { url?: { hash?: string } } | undefined;
+
+  return ctx?.url?.hash;
 }

--- a/packages/sources/src/types.ts
+++ b/packages/sources/src/types.ts
@@ -19,6 +19,20 @@ export interface RouterSource<T> {
 export interface ActiveRouteSourceOptions {
   strict?: boolean;
   ignoreQueryParams?: boolean;
+  /**
+   * URL fragment match (#532). When defined, the source is active iff the
+   * route matches AND `state.context.url.hash` (decoded, populated by
+   * browser/navigation URL plugins) equals this value:
+   *
+   * - `undefined` (default): hash is ignored — legacy route-only matching.
+   * - `""`: active only when the current URL has no fragment (or empty).
+   * - `"value"`: active only when the current fragment equals `"value"`.
+   *
+   * Hash-plugin runtimes leave `state.context.url` undefined, so any non-
+   * undefined `hash` option will produce `false` there — consistent with the
+   * documented limitation that hash-plugin doesn't support URL fragments.
+   */
+  hash?: string;
 }
 
 export interface RouterTransitionSnapshot {

--- a/packages/sources/tests/unit/createActiveRouteStore.test.ts
+++ b/packages/sources/tests/unit/createActiveRouteStore.test.ts
@@ -241,4 +241,187 @@ describe("createActiveRouteSources", () => {
 
     unsubscribe();
   });
+
+  describe("hash-aware active state (#532)", () => {
+    function makeRouterWithUrlContext(initialHash = ""): Router {
+      const r = createRouter([
+        { name: "home", path: "/" },
+        { name: "settings", path: "/settings" },
+      ]);
+
+      // Tiny stand-in for browser-plugin's onTransitionSuccess: write the
+      // requested hash to state.context.url after every navigation.
+      // Cast to any keeps the test isolated from the URL-plugin module
+      // augmentations of NavigationOptions / StateContext.
+      r.usePlugin(((): unknown => ({
+        onTransitionSuccess: (
+          toState: unknown,
+          _from: unknown,
+          opts: unknown,
+        ) => {
+          const optsAny = opts as
+            | { hash?: string; hashChange?: boolean }
+            | undefined;
+          const ctx = (toState as { context: Record<string, unknown> }).context;
+          const prevUrl = ctx.url as { hash?: string } | undefined;
+          const prevHash = prevUrl?.hash ?? initialHash;
+          const next = optsAny?.hash ?? prevHash;
+
+          ctx.url = Object.freeze({
+            hash: next,
+            hashChanged: optsAny?.hashChange ?? next !== prevHash,
+          });
+        },
+      })) as Parameters<typeof r.usePlugin>[0]);
+
+      return r;
+    }
+
+    it("initial value: true when route AND hash both match", async () => {
+      const r = makeRouterWithUrlContext("billing");
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings", undefined, {
+        hash: "billing",
+      });
+
+      expect(source.getSnapshot()).toBe(true);
+
+      r.stop();
+    });
+
+    it("initial value: false when route matches but hash differs", async () => {
+      const r = makeRouterWithUrlContext("profile");
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings", undefined, {
+        hash: "billing",
+      });
+
+      expect(source.getSnapshot()).toBe(false);
+
+      r.stop();
+    });
+
+    it("initial value: false when hash is empty-string sentinel and current is non-empty", async () => {
+      const r = makeRouterWithUrlContext("anchor");
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings", undefined, {
+        hash: "",
+      });
+
+      expect(source.getSnapshot()).toBe(false);
+
+      r.stop();
+    });
+
+    it("flips on same-route hash change (hashFlip via context.url.hashChanged)", async () => {
+      const r = makeRouterWithUrlContext("profile");
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings", undefined, {
+        hash: "billing",
+      });
+
+      expect(source.getSnapshot()).toBe(false);
+
+      const listener = vi.fn();
+
+      source.subscribe(listener);
+
+      await r
+        .navigate(
+          "settings",
+          {},
+          // Cast keeps this test independent of URL-plugin augmentations.
+          { hash: "billing", force: true, hashChange: true } as Parameters<
+            typeof r.navigate
+          >[2],
+        )
+        .catch(() => {});
+
+      expect(source.getSnapshot()).toBe(true);
+      expect(listener).toHaveBeenCalled();
+
+      r.stop();
+    });
+
+    it("hash-undefined source ignores hash (legacy semantics preserved)", async () => {
+      const r = makeRouterWithUrlContext("billing");
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings");
+
+      expect(source.getSnapshot()).toBe(true);
+
+      // Navigate to ensure subscribe path runs with hash === undefined —
+      // exercises the early hashFlip short-circuit branch.
+      await r.navigate("home").catch(() => {});
+
+      expect(source.getSnapshot()).toBe(false);
+
+      r.stop();
+    });
+
+    it("hash-aware source returns false on hash-plugin runtime (no state.context.url)", async () => {
+      const r = createRouter([
+        { name: "home", path: "/" },
+        { name: "settings", path: "/settings" },
+      ]);
+
+      await r.start("/settings");
+
+      const source = createActiveRouteSource(r, "settings", undefined, {
+        hash: "billing",
+      });
+
+      // No URL plugin → state.context.url undefined → readContextHash returns ""
+      // → does not equal "billing" → not active.
+      expect(source.getSnapshot()).toBe(false);
+
+      // Navigate with hash-aware source on a no-plugin router exercises the
+      // hashFlip branch where `hash !== undefined` but state.context.url is
+      // missing — `?? false` short-circuits hashFlip to false. Combined with
+      // route-match this still re-evaluates correctly.
+      await r.navigate("home").catch(() => {});
+
+      expect(source.getSnapshot()).toBe(false);
+
+      await r.navigate("settings").catch(() => {});
+
+      expect(source.getSnapshot()).toBe(false);
+
+      r.stop();
+    });
+
+    it("cache key separates hash variants", async () => {
+      const r = makeRouterWithUrlContext("billing");
+
+      await r.start("/settings");
+
+      const a = createActiveRouteSource(r, "settings", undefined, {
+        hash: "profile",
+      });
+      const b = createActiveRouteSource(r, "settings", undefined, {
+        hash: "billing",
+      });
+      const c = createActiveRouteSource(r, "settings", undefined, {
+        hash: "profile",
+      });
+
+      // a and b are distinct (different hash), a and c are same (cache hit)
+      expect(a).toBe(c);
+      expect(a).not.toBe(b);
+      expect(a.getSnapshot()).toBe(false); // hash differs from "billing"
+      expect(b.getSnapshot()).toBe(true);
+
+      r.stop();
+    });
+  });
 });

--- a/packages/sources/tests/unit/normalizeActiveOptions.test.ts
+++ b/packages/sources/tests/unit/normalizeActiveOptions.test.ts
@@ -10,6 +10,7 @@ describe("normalizeActiveOptions", () => {
     expect(normalizeActiveOptions()).toStrictEqual({
       strict: false,
       ignoreQueryParams: true,
+      hash: undefined,
     });
   });
 
@@ -17,6 +18,7 @@ describe("normalizeActiveOptions", () => {
     expect(normalizeActiveOptions({})).toStrictEqual({
       strict: false,
       ignoreQueryParams: true,
+      hash: undefined,
     });
   });
 
@@ -24,6 +26,7 @@ describe("normalizeActiveOptions", () => {
     expect(normalizeActiveOptions({ strict: true })).toStrictEqual({
       strict: true,
       ignoreQueryParams: true,
+      hash: undefined,
     });
   });
 
@@ -31,6 +34,7 @@ describe("normalizeActiveOptions", () => {
     expect(normalizeActiveOptions({ ignoreQueryParams: false })).toStrictEqual({
       strict: false,
       ignoreQueryParams: false,
+      hash: undefined,
     });
   });
 
@@ -40,6 +44,23 @@ describe("normalizeActiveOptions", () => {
     ).toStrictEqual({
       strict: true,
       ignoreQueryParams: false,
+      hash: undefined,
+    });
+  });
+
+  it("preserves hash when defined (#532)", () => {
+    expect(normalizeActiveOptions({ hash: "section" })).toStrictEqual({
+      strict: false,
+      ignoreQueryParams: true,
+      hash: "section",
+    });
+  });
+
+  it("preserves hash empty-string sentinel (clear-variant active)", () => {
+    expect(normalizeActiveOptions({ hash: "" })).toStrictEqual({
+      strict: false,
+      ignoreQueryParams: true,
+      hash: "",
     });
   });
 

--- a/packages/sources/tests/unit/stabilizeState.test.ts
+++ b/packages/sources/tests/unit/stabilizeState.test.ts
@@ -187,4 +187,64 @@ describe("stabilizeState", () => {
       expect(stabilizeState(prevRoute, nextRoute)).toBe(nextRoute);
     });
   });
+
+  // ===
+  // Hash-aware stabilization (#532)
+  // ===
+
+  describe("hash-aware stabilization (#532)", () => {
+    function makeStateWithHash(base: State, hash: string | undefined): State {
+      // Clone the state with a fresh context.url. Path/name/params identical
+      // on purpose — emulates the same-path-different-hash scenario.
+      const clone = {
+        ...base,
+        context: {
+          ...base.context,
+          url:
+            hash === undefined
+              ? undefined
+              : Object.freeze({ hash, hashChanged: true }),
+        },
+      };
+
+      return clone as State;
+    }
+
+    it("same path, different context.url.hash → returns next", () => {
+      const api = getPluginApi(router);
+      const base = api.makeState("home", {}, "/");
+      const prev = makeStateWithHash(base, "profile");
+      const next = makeStateWithHash(base, "billing");
+
+      expect(prev.path).toBe(next.path);
+      expect(stabilizeState(prev, next)).toBe(next);
+    });
+
+    it("same path, same context.url.hash → returns prev", () => {
+      const api = getPluginApi(router);
+      const base = api.makeState("home", {}, "/");
+      const prev = makeStateWithHash(base, "profile");
+      const next = makeStateWithHash(base, "profile");
+
+      expect(stabilizeState(prev, next)).toBe(prev);
+    });
+
+    it("same path, prev has hash, next has no hash → returns next", () => {
+      const api = getPluginApi(router);
+      const base = api.makeState("home", {}, "/");
+      const prev = makeStateWithHash(base, "anchor");
+      const next = makeStateWithHash(base, undefined);
+
+      expect(stabilizeState(prev, next)).toBe(next);
+    });
+
+    it("same path, both no hash → returns prev (legacy behavior preserved)", () => {
+      const api = getPluginApi(router);
+      const base = api.makeState("home", {}, "/");
+      const prev = makeStateWithHash(base, undefined);
+      const next = makeStateWithHash(base, undefined);
+
+      expect(stabilizeState(prev, next)).toBe(prev);
+    });
+  });
 });

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -183,10 +183,20 @@ Navigation link with automatic active state detection. Uses `$derived` for href 
 | `activeClassName`   | `string`            | `"active"`  | Class added when route is active        |
 | `activeStrict`      | `boolean`           | `false`     | Exact match only (no ancestor matching) |
 | `ignoreQueryParams` | `boolean`           | `true`      | Query params don't affect active state  |
+| `hash`              | `string`            | `undefined` | URL fragment (decoded). Tri-state: undefined preserves, `""` clears, value sets. (#532) |
 | `target`            | `string`            | `undefined` | Link target (`_blank`, etc.)            |
 | `onclick`           | `(evt: MouseEvent) => void` | `undefined` | Custom click handler. Runs **before** the navigation logic — call `evt.preventDefault()` to suppress navigation. |
 
 All other props are spread onto the `<a>` element.
+
+#### `hash` — URL fragment / tab-style UIs
+
+```svelte
+<Link routeName="settings" hash="profile">Profile</Link>
+<Link routeName="settings" hash="account">Account</Link>
+```
+
+Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
 
 ### `<Lazy>`
 

--- a/packages/svelte/src/components/Link.svelte
+++ b/packages/svelte/src/components/Link.svelte
@@ -6,6 +6,7 @@
     shouldNavigate,
     buildHref,
     buildActiveClassName,
+    navigateWithHash,
   } from "../dom-utils";
 
   import type { NavigationOptions, Params } from "@real-router/core";
@@ -19,6 +20,7 @@
     activeClassName = "active",
     activeStrict = false,
     ignoreQueryParams = true,
+    hash = undefined,
     target = undefined,
     children = undefined,
     onclick: userOnClick = undefined,
@@ -31,6 +33,13 @@
     activeClassName?: string;
     activeStrict?: boolean;
     ignoreQueryParams?: boolean;
+    /**
+     * URL fragment (decoded form, no leading "#") (#532).
+     * - omitted/`undefined` → preserve current fragment on same-route navigation
+     * - `""` → clear fragment
+     * - non-empty → set fragment
+     */
+    hash?: string;
     target?: string;
     children?: Snippet;
     onclick?: (evt: MouseEvent) => void;
@@ -38,14 +47,24 @@
   } = $props();
 
   const router = useRouter();
+  // Hash-aware active (#532): tab links sharing routeName but differing in
+  // hash should only light up the matching variant.
   const activeState = useIsActiveRoute(
     routeName,
     routeParams,
     activeStrict,
     ignoreQueryParams,
+    hash,
   );
 
-  const href = $derived(buildHref(router, routeName, routeParams));
+  const href = $derived(
+    buildHref(
+      router,
+      routeName,
+      routeParams,
+      hash !== undefined ? { hash } : undefined,
+    ),
+  );
 
   const finalClassName = $derived(
     buildActiveClassName(activeState.current, activeClassName, className),
@@ -65,7 +84,9 @@
     }
 
     evt.preventDefault();
-    router.navigate(routeName, routeParams, routeOptions).catch(NOOP);
+    navigateWithHash(router, routeName, routeParams, hash, routeOptions).catch(
+      NOOP,
+    );
   }
 </script>
 

--- a/packages/svelte/src/composables/useIsActiveRoute.svelte.ts
+++ b/packages/svelte/src/composables/useIsActiveRoute.svelte.ts
@@ -10,13 +10,21 @@ export function useIsActiveRoute(
   params: Params | undefined,
   strict: boolean,
   ignoreQueryParams: boolean,
+  hash?: string,
 ): { readonly current: boolean } {
   const router = useRouter();
 
-  const source = createActiveRouteSource(router, routeName, params, {
-    strict,
-    ignoreQueryParams,
-  });
+  // The `hash` argument (#532) participates in the cache key when defined.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally — we
+  // conditionally include the key only when a value is provided.
+  const source = createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    hash === undefined
+      ? { strict, ignoreQueryParams }
+      : { strict, ignoreQueryParams, hash },
+  );
 
   return createReactiveSource(source);
 }

--- a/packages/svelte/tests/integration/Link.test.ts
+++ b/packages/svelte/tests/integration/Link.test.ts
@@ -97,9 +97,34 @@ describe("Link - Integration Tests", () => {
         routeName: "one-more-test",
       });
 
-      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {});
+      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {}, undefined);
       expect(document.querySelector("a")!.getAttribute("href")).toBe(
         "/custom-url",
+      );
+    });
+
+    it("should pass hash option to buildUrl when hash prop is set (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      renderWithRouter(router, Link, {
+        routeName: "one-more-test",
+        hash: "anchor",
+      });
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        "one-more-test",
+        {},
+        {
+          hash: "anchor",
+        },
+      );
+      expect(document.querySelector("a")!.getAttribute("href")).toBe(
+        "/url#anchor",
       );
     });
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -239,6 +239,15 @@ In a template:
 </Link>
 ```
 
+#### `hash` prop — URL fragment / tab-style UIs
+
+```vue
+<Link routeName="settings" hash="profile">Profile</Link>
+<Link routeName="settings" hash="account">Account</Link>
+```
+
+Tri-state: `undefined` preserves the current hash, `""` clears it, a value sets it. Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/link-hash/`](../../examples/web/react/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
+
 ### `<RouteView>`
 
 Declarative route matching. Renders the first matching `<RouteView.Match>` child.

--- a/packages/vue/src/components/Link.ts
+++ b/packages/vue/src/components/Link.ts
@@ -3,7 +3,12 @@ import { defineComponent, h, computed, shallowRef, watch } from "vue";
 
 import { useRouter } from "../composables/useRouter";
 import { EMPTY_PARAMS, EMPTY_OPTIONS } from "../constants";
-import { shouldNavigate, buildHref, buildActiveClassName } from "../dom-utils";
+import {
+  shouldNavigate,
+  buildHref,
+  buildActiveClassName,
+  navigateWithHash,
+} from "../dom-utils";
 
 import type { Params, NavigationOptions } from "@real-router/core";
 import type { PropType } from "vue";
@@ -75,6 +80,16 @@ export const Link = defineComponent({
       type: String,
       default: undefined,
     },
+    /**
+     * URL fragment (decoded form, no leading "#") (#532).
+     * - omitted/`undefined` → preserve current fragment on same-route navigation
+     * - `""` → clear fragment
+     * - non-empty → set fragment
+     */
+    hash: {
+      type: String,
+      default: undefined,
+    },
   },
   setup(props, { slots, attrs }) {
     const router = useRouter();
@@ -92,16 +107,23 @@ export const Link = defineComponent({
           props.routeParams,
           props.activeStrict,
           props.ignoreQueryParams,
+          props.hash,
         ] as const,
       (
-        [routeName, routeParams, activeStrict, ignoreQueryParams],
+        [routeName, routeParams, activeStrict, ignoreQueryParams, hash],
         _prev,
         onCleanup,
       ) => {
-        const source = createActiveRouteSource(router, routeName, routeParams, {
-          strict: activeStrict,
-          ignoreQueryParams,
-        });
+        // Hash-aware active (#532): pass hash through so tab links with the
+        // same routeName but different `hash` props don't all light up.
+        const source = createActiveRouteSource(
+          router,
+          routeName,
+          routeParams,
+          hash === undefined
+            ? { strict: activeStrict, ignoreQueryParams }
+            : { strict: activeStrict, ignoreQueryParams, hash },
+        );
 
         isActive.value = source.getSnapshot();
 
@@ -115,7 +137,12 @@ export const Link = defineComponent({
     );
 
     const href = computed(() =>
-      buildHref(router, props.routeName, props.routeParams),
+      buildHref(
+        router,
+        props.routeName,
+        props.routeParams,
+        props.hash === undefined ? undefined : { hash: props.hash },
+      ),
     );
 
     const finalClassName = computed(() =>
@@ -140,9 +167,13 @@ export const Link = defineComponent({
       }
 
       evt.preventDefault();
-      router
-        .navigate(props.routeName, props.routeParams, props.routeOptions)
-        .catch(() => {});
+      navigateWithHash(
+        router,
+        props.routeName,
+        props.routeParams,
+        props.hash,
+        props.routeOptions,
+      ).catch(() => {});
     };
 
     return () => {

--- a/packages/vue/src/composables/useIsActiveRoute.ts
+++ b/packages/vue/src/composables/useIsActiveRoute.ts
@@ -11,13 +11,21 @@ export function useIsActiveRoute(
   params?: Params,
   strict = false,
   ignoreQueryParams = true,
+  hash?: string,
 ): ShallowRef<boolean> {
   const router = useRouter();
 
-  const source = createActiveRouteSource(router, routeName, params, {
-    strict,
-    ignoreQueryParams,
-  });
+  // The `hash` argument (#532) participates in the cache key when defined.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally — we
+  // conditionally include the key only when a value is provided.
+  const source = createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    hash === undefined
+      ? { strict, ignoreQueryParams }
+      : { strict, ignoreQueryParams, hash },
+  );
 
   return useRefFromSource(source);
 }

--- a/packages/vue/tests/integration/Link.test.ts
+++ b/packages/vue/tests/integration/Link.test.ts
@@ -127,8 +127,34 @@ describe("Link - Integration Tests", () => {
         h(Link, { routeName: "one-more-test" }, { default: () => "Test" }),
       );
 
-      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {});
+      expect(buildUrlSpy).toHaveBeenCalledWith("one-more-test", {}, undefined);
       expect(wrapper.find("a").attributes("href")).toBe("/custom-url");
+    });
+
+    it("should pass hash option to buildUrl when hash prop is set (#532)", () => {
+      const buildUrlSpy = vi.fn(
+        (_name: string, _params?: object, opts?: { hash?: string }): string =>
+          opts?.hash ? `/url#${opts.hash}` : "/url",
+      );
+
+      router.buildUrl = buildUrlSpy;
+
+      const wrapper = mountWithProvider(router, () =>
+        h(
+          Link,
+          { routeName: "one-more-test", hash: "anchor" },
+          { default: () => "Test" },
+        ),
+      );
+
+      expect(buildUrlSpy).toHaveBeenCalledWith(
+        "one-more-test",
+        {},
+        {
+          hash: "anchor",
+        },
+      );
+      expect(wrapper.find("a").attributes("href")).toBe("/url#anchor");
     });
 
     it("should generate correct href with query params", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2475,6 +2475,46 @@ importers:
         specifier: 7.3.2
         version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/web/react/link-hash:
+    dependencies:
+      '@real-router/browser-plugin':
+        specifier: workspace:^
+        version: link:../../../../packages/browser-plugin
+      '@real-router/core':
+        specifier: workspace:^
+        version: link:../../../../packages/core
+      '@real-router/hash-plugin':
+        specifier: workspace:^
+        version: link:../../../../packages/hash-plugin
+      '@real-router/react':
+        specifier: workspace:^
+        version: link:../../../../packages/react
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.58.2
+        version: 1.58.2
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 5.2.0
+        version: 5.2.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3)
+
   examples/web/react/navigation-api:
     dependencies:
       '@real-router/core':
@@ -4883,6 +4923,9 @@ importers:
       '@real-router/core':
         specifier: workspace:^
         version: link:../core
+      '@real-router/types':
+        specifier: workspace:^
+        version: link:../core-types
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 6.9.1

--- a/shared/browser-env/index.ts
+++ b/shared/browser-env/index.ts
@@ -50,7 +50,11 @@ export {
   shouldReplaceHistory,
 } from "./plugin-utils.js";
 
-export type { LocationSource, ReplaceStateBrowser } from "./plugin-utils.js";
+export type {
+  LocationSource,
+  ReplaceStateBrowser,
+  ReplaceHistoryStateOptions,
+} from "./plugin-utils.js";
 
 export { safeParseUrl } from "./url-parsing.js";
 
@@ -58,5 +62,15 @@ export {
   extractPath,
   buildUrl,
   urlToPath,
+  urlToPathAndHash,
   extractPathFromAbsoluteUrl,
 } from "./url-utils.js";
+
+export type { UrlContext } from "./url-context.js";
+
+export {
+  encodeHashFragment,
+  decodeHashFragment,
+  normalizeHashInput,
+  getDecodedHash,
+} from "./url-context.js";

--- a/shared/browser-env/plugin-utils.ts
+++ b/shared/browser-env/plugin-utils.ts
@@ -1,3 +1,5 @@
+import { encodeHashFragment, normalizeHashInput } from "./url-context.js";
+
 import type {
   NavigationOptions,
   Params,
@@ -22,6 +24,16 @@ export interface ReplaceStateBrowser {
   getHash: () => string;
 }
 
+/**
+ * Hash override option for `replaceHistoryState` (#532). Tri-state semantics:
+ *   `undefined`  — preserve the current browser hash (legacy behavior, default)
+ *   `""`         — explicitly clear the fragment
+ *   non-empty    — explicitly set the fragment (decoded form, no leading "#")
+ */
+export interface ReplaceHistoryStateOptions {
+  hash?: string;
+}
+
 export function createStartInterceptor(
   api: PluginApi,
   browser: LocationSource,
@@ -35,9 +47,17 @@ export function createReplaceHistoryState(
   api: PluginApi,
   router: Router,
   browser: ReplaceStateBrowser,
-  buildUrl: (name: string, params?: Params) => string,
+  buildUrl: (
+    name: string,
+    params?: Params,
+    options?: ReplaceHistoryStateOptions,
+  ) => string,
   preserveHash = true,
-): (name: string, params?: Params) => void {
+): (
+  name: string,
+  params?: Params,
+  options?: ReplaceHistoryStateOptions,
+) => void {
   // Reusable buffer — browsers structured-clone state synchronously inside
   // replaceState, so the buffer never escapes. Eliminates one allocation per
   // navigation on the hot path. (Mirrors createUpdateBrowserState.)
@@ -47,7 +67,11 @@ export function createReplaceHistoryState(
     path: "",
   };
 
-  return (name: string, params: Params = {}) => {
+  return (
+    name: string,
+    params: Params = {},
+    options?: ReplaceHistoryStateOptions,
+  ) => {
     const state = api.buildState(name, params);
 
     if (!state) {
@@ -65,8 +89,29 @@ export function createReplaceHistoryState(
       },
     );
 
-    const hash = preserveHash ? browser.getHash() : "";
-    const url = buildUrl(name, params) + hash;
+    // Tri-state hash semantics (#532):
+    //   options.hash === undefined → preserve (legacy behavior, controlled by
+    //                                preserveHash flag — true for browser/
+    //                                navigation plugins, false for hash-plugin)
+    //   options.hash === ""        → explicitly clear
+    //   options.hash === "value"   → explicitly set
+    let hashSegment: string;
+
+    if (options?.hash !== undefined) {
+      const norm = normalizeHashInput(options.hash);
+
+      hashSegment = norm ? `#${encodeHashFragment(norm)}` : "";
+    } else if (preserveHash) {
+      hashSegment = browser.getHash();
+    } else {
+      hashSegment = "";
+    }
+
+    // Pass hash through buildUrl when the plugin understands it (avoids
+    // double-append). Hash-plugin's buildUrl ignores the option and warns,
+    // so call without options here for semantic clarity — but the result is
+    // identical because hashSegment is "" in that branch (preserveHash=false).
+    const url = buildUrl(name, params) + hashSegment;
 
     buffer.name = builtState.name;
     buffer.params = builtState.params;

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -25,7 +25,52 @@ export interface PopstateHandlerDeps {
   allowNotFound: boolean;
   transitionOptions: PopstateTransitionOptions;
   loggerContext: string;
-  buildUrl: (name: string, params?: Params) => string;
+  buildUrl: (
+    name: string,
+    params?: Params,
+    options?: { hash?: string },
+  ) => string;
+  /**
+   * Decoded hash of the current browser location (no leading "#"). Defaults
+   * to a no-op (returns "") for plugins that do not participate in URL
+   * fragment tracking — namely hash-plugin, where `#` is the route delimiter.
+   * (#532)
+   */
+  getCurrentHash?: () => string;
+  /**
+   * Decoded hash from the previous transition's `state.context.url.hash`
+   * (no leading "#"). Used by the popstate handler to detect hash-only
+   * navigation and add `force: true, hashChange: true` to bypass SAME_STATES.
+   * Defaults to no-op (returns "") for hash-plugin. (#532)
+   */
+  getCurrentContextHash?: () => string;
+}
+
+/**
+ * Hash augmentation for popstate-driven navigateToState (#532).
+ * Returns a partial options object that the caller spreads on top of
+ * `deps.transitionOptions`. When the handler is wired without hash support
+ * (hash-plugin), both deps default to undefined and an empty object is
+ * returned — preserving the legacy behavior for that plugin.
+ */
+function resolveHashOptions(
+  deps: PopstateHandlerDeps,
+  matchedPath: string,
+): { hash?: string; force?: true; hashChange?: true } {
+  if (!deps.getCurrentHash) {
+    return {};
+  }
+
+  const newHash = deps.getCurrentHash();
+  const prevHash = deps.getCurrentContextHash
+    ? deps.getCurrentContextHash()
+    : "";
+  const hashChange =
+    newHash !== prevHash && deps.router.getState()?.path === matchedPath;
+
+  return hashChange
+    ? { hash: newHash, force: true, hashChange: true }
+    : { hash: newHash };
 }
 
 export function createPopstateHandler(
@@ -54,7 +99,16 @@ export function createPopstateHandler(
       return;
     }
 
-    const url = deps.buildUrl(currentState.name, currentState.params);
+    // Preserve hash on rollback so guard rejection / unmatched URL on
+    // popstate doesn't strip the fragment from the visible URL (#532).
+    const ctxHash = (
+      currentState.context as { url?: { hash?: string } } | undefined
+    )?.url?.hash;
+    const url = deps.buildUrl(
+      currentState.name,
+      currentState.params,
+      ctxHash ? { hash: ctxHash } : undefined,
+    );
 
     deps.browser.replaceState(currentState, url);
   }
@@ -93,8 +147,12 @@ export function createPopstateHandler(
       if (matched) {
         // api.navigateToState — plugin-only entry point. Preserves
         // matchSourceTrailingSlash output and skips the redundant
-        // forwardState/buildPath round-trip (#525).
-        await deps.api.navigateToState(matched, deps.transitionOptions);
+        // forwardState/buildPath round-trip (#525). Hash augmentation (#532)
+        // extracted into resolveHashOptions so this branch stays readable.
+        await deps.api.navigateToState(matched, {
+          ...deps.transitionOptions,
+          ...resolveHashOptions(deps, matched.path),
+        });
       } else if (deps.allowNotFound) {
         deps.router.navigateToNotFound(deps.browser.getLocation());
       } else {

--- a/shared/browser-env/url-context.ts
+++ b/shared/browser-env/url-context.ts
@@ -1,0 +1,71 @@
+/**
+ * URL fragment ("hash") shared layer (#532).
+ *
+ * Both URL plugins (navigation-plugin, browser-plugin) claim the `"url"`
+ * `state.context` namespace and write `UrlContext` on every transition.
+ * Mutually exclusive at runtime — only one URL plugin is installed per router.
+ *
+ * Hash form: decoded, no leading "#" — symmetric to `params` (no leading "?").
+ * Encoding to/from URL form happens at the boundary (URL build / URL parse).
+ */
+
+export interface UrlContext {
+  /** Decoded fragment, no leading "#". Empty string when URL has no fragment. */
+  hash: string;
+  /** Whether `hash` differs from the previous transition's `state.context.url.hash`. */
+  hashChanged: boolean;
+}
+
+/**
+ * Encode for URL fragment per RFC 3986: preserves sub-delims (`&`, `=`, `?`,
+ * `:`, etc.) and the path/query characters that `encodeURI` already leaves
+ * alone. Defensively percent-escapes `#` (a stray `#` in a decoded fragment
+ * would otherwise terminate the fragment in the rendered URL).
+ *
+ * `encodeURIComponent` over-encodes RFC-3986 sub-delims (`&` → `%26`) and is
+ * therefore wrong for fragments.
+ */
+export function encodeHashFragment(decoded: string): string {
+  return encodeURI(decoded).replaceAll("#", "%23");
+}
+
+/**
+ * Decode a percent-encoded fragment. Falls back to the raw input on malformed
+ * escapes — matches the resilience pattern in scroll-restore.
+ */
+export function decodeHashFragment(encoded: string): string {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+
+/**
+ * Normalize user-provided hash input: strip a leading "#" if present, then
+ * decode. Defensive against `<Link hash="#section">` — the prop is documented
+ * to accept the fragment name without "#", but we accept both gracefully.
+ */
+export function normalizeHashInput(input: string): string {
+  const stripped = input.startsWith("#") ? input.slice(1) : input;
+
+  return decodeHashFragment(stripped);
+}
+
+/**
+ * Read the current browser hash in decoded form, no leading "#".
+ * Accepts any object with a `getHash()` method — works for both `Browser`
+ * (History API) and `NavigationBrowser` (Navigation API). SSR-safe via the
+ * abstractions, which return `""` outside a real browser.
+ */
+export function getDecodedHash(browser: { getHash: () => string }): string {
+  const raw = browser.getHash();
+
+  if (!raw) {
+    return "";
+  }
+
+  const stripped = raw.startsWith("#") ? raw.slice(1) : raw;
+
+  return decodeHashFragment(stripped);
+}

--- a/shared/browser-env/url-utils.ts
+++ b/shared/browser-env/url-utils.ts
@@ -1,3 +1,4 @@
+import { decodeHashFragment } from "./url-context.js";
 import { safeParseUrl } from "./url-parsing.js";
 
 export function extractPath(pathname: string, base: string): string {
@@ -39,6 +40,24 @@ export function urlToPath(url: string, base: string): string {
   const parsedUrl = safeParseUrl(url);
 
   return extractPath(parsedUrl.pathname, base) + parsedUrl.search;
+}
+
+/**
+ * Like `urlToPath` but also returns the decoded URL fragment (#532).
+ *
+ * Used by URL plugins to extract `event.destination.url`'s hash without
+ * dropping it the way `urlToPath` does. The hash is returned in decoded form
+ * with no leading "#" — same form as stored in `state.context.url.hash`.
+ */
+export function urlToPathAndHash(
+  url: string,
+  base: string,
+): { path: string; hash: string } {
+  const parsed = safeParseUrl(url);
+  const path = extractPath(parsed.pathname, base) + parsed.search;
+  const hash = parsed.hash ? decodeHashFragment(parsed.hash.slice(1)) : "";
+
+  return { path, hash };
 }
 
 /**

--- a/shared/dom-utils/index.ts
+++ b/shared/dom-utils/index.ts
@@ -10,6 +10,7 @@ export {
   shouldNavigate,
   buildHref,
   buildActiveClassName,
+  navigateWithHash,
   shallowEqual,
   applyLinkA11y,
 } from "./link-utils.js";

--- a/shared/dom-utils/link-utils.ts
+++ b/shared/dom-utils/link-utils.ts
@@ -1,4 +1,9 @@
-import type { Router, Params } from "@real-router/core";
+import type {
+  NavigationOptions,
+  Params,
+  Router,
+  State,
+} from "@real-router/core";
 
 export function shouldNavigate(evt: MouseEvent): boolean {
   return (
@@ -10,25 +15,67 @@ export function shouldNavigate(evt: MouseEvent): boolean {
   );
 }
 
-type BuildUrlFn = (name: string, params: Params) => string | undefined;
+/**
+ * RFC 3986 fragment encoding: preserve sub-delims (`&`, `=`, `?`, `:`),
+ * encode space, `%`, control chars, non-ASCII via encodeURI; defensively
+ * escape `#` (encodeURI does not). Mirrors `encodeHashFragment` in
+ * `shared/browser-env/url-context.ts` — duplicated here because the
+ * shared/dom-utils symlink graph does not reach shared/browser-env.
+ */
+function encodeFragmentInline(decoded: string): string {
+  return encodeURI(decoded).replaceAll("#", "%23");
+}
 
+type BuildUrlFn = (
+  name: string,
+  params: Params,
+  options?: { hash?: string },
+) => string | undefined;
+
+/**
+ * Builds an href for a `<Link>` element.
+ *
+ * - Prefers the URL plugin's `buildUrl` (browser-plugin, navigation-plugin,
+ *   hash-plugin) when present.
+ * - Falls back to `router.buildPath` for runtimes without a URL plugin
+ *   (memory-plugin, console UIs, NativeScript). In that fallback the hash
+ *   is appended manually so the rendered href is still correct.
+ * - The optional 4th argument is an options object so the contract stays
+ *   extensible. The `hash` option is a decoded fragment without leading "#";
+ *   `<Link hash="#section">` is accepted defensively (leading "#" stripped).
+ *   Frozen API: previous 3-arg call sites continue to work unchanged.
+ */
 export function buildHref(
   router: Router,
   routeName: string,
   routeParams: Params,
+  options?: { hash?: string },
 ): string | undefined {
   try {
+    const rawHash = options?.hash;
+    let normHash: string | undefined;
+
+    if (rawHash !== undefined) {
+      normHash = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+    }
+
     const buildUrl = router.buildUrl as BuildUrlFn | undefined;
 
     if (buildUrl) {
-      const url = buildUrl(routeName, routeParams);
+      const url = buildUrl(
+        routeName,
+        routeParams,
+        normHash === undefined ? undefined : { hash: normHash },
+      );
 
       if (url !== undefined) {
         return url;
       }
     }
 
-    return router.buildPath(routeName, routeParams);
+    const path = router.buildPath(routeName, routeParams);
+
+    return normHash ? `${path}#${encodeFragmentInline(normHash)}` : path;
   } catch {
     console.error(
       `[real-router] Route "${routeName}" is not defined. The element will render without an href attribute.`,
@@ -36,6 +83,65 @@ export function buildHref(
 
     return undefined;
   }
+}
+
+/**
+ * `<Link>` click-handler navigation helper (#532).
+ *
+ * Wraps `router.navigate(name, params, opts)` with same-route different-hash
+ * detection: when the consumer clicks a hash-bearing Link that targets the
+ * current route with the same params but a different fragment, core's
+ * SAME_STATES check would otherwise reject the navigation. The helper adds
+ * `force: true` and `hashChange: true` automatically — subscribers can then
+ * disambiguate via `state.context.url.hashChanged`.
+ *
+ * For pure programmatic same-route hash-only navigation, callers are
+ * documented to pass `{ force: true }` themselves; the auto-bypass here is
+ * a UX convenience for `<Link hash>` that all 6 framework adapters share.
+ */
+/**
+ * Local extended-options type. Adapters that depend only on `@real-router/core`
+ * (without a URL plugin) do not see the `NavigationOptions` augmentation that
+ * declares `hash` / `hashChange`. Casting to this widened type inside the
+ * helper keeps shared/dom-utils self-contained — adapters do not need to
+ * augment NavigationOptions themselves to consume `<Link hash>`.
+ */
+type HashAwareNavigationOptions = NavigationOptions & {
+  hash?: string;
+  hashChange?: boolean;
+};
+
+export function navigateWithHash(
+  router: Router,
+  routeName: string,
+  routeParams: Params,
+  hash: string | undefined,
+  extraOptions?: NavigationOptions,
+): Promise<State> {
+  const opts: HashAwareNavigationOptions = { ...extraOptions };
+
+  if (hash !== undefined) {
+    opts.hash = hash;
+  }
+
+  const current = router.getState();
+
+  if (
+    current?.name === routeName &&
+    shallowEqual(current.params, routeParams)
+  ) {
+    const currentHash =
+      (current.context as { url?: { hash?: string } } | undefined)?.url?.hash ??
+      "";
+    const newHash = hash ?? currentHash;
+
+    if (currentHash !== newHash) {
+      opts.force = true;
+      opts.hashChange = true;
+    }
+  }
+
+  return router.navigate(routeName, routeParams, opts);
 }
 
 function parseTokens(value: string | undefined): string[] {

--- a/shared/dom-utils/scroll-restore.ts
+++ b/shared/dom-utils/scroll-restore.ts
@@ -68,13 +68,38 @@ export function createScrollRestoration(
     }
   };
 
-  const scrollToHashOrTop = (): void => {
+  const scrollToHashOrTop = (route: State): void => {
+    // URL plugin path (#532): `state.context.url.hash` is the source of truth
+    // when one of the URL plugins (browser-plugin / navigation-plugin) is
+    // installed. The value is already DECODED — feeding it through
+    // `decodeURIComponent` again would throw on a bare `%`.
+    const ctxHash = (route.context as { url?: { hash?: string } } | undefined)
+      ?.url?.hash;
+
+    if (ctxHash !== undefined) {
+      if (anchorEnabled && ctxHash.length > 0) {
+        // eslint-disable-next-line unicorn/prefer-query-selector -- ids may contain CSS-unsafe chars
+        const element = document.getElementById(ctxHash);
+
+        if (element) {
+          element.scrollIntoView();
+
+          return;
+        }
+      }
+
+      writePos(0);
+
+      return;
+    }
+
+    // Fallback path: no URL plugin, read the DOM. `location.hash` is
+    // percent-encoded; ids in the DOM are the raw string, so decode for the
+    // match. Fall back to the raw slice if the hash contains a malformed
+    // escape sequence (decodeURIComponent throws on those).
     const hash = globalThis.location.hash;
 
     if (anchorEnabled && hash.length > 1) {
-      // location.hash is percent-encoded; ids in the DOM are the raw string.
-      // Decode for the match. Fall back to the raw slice if the hash contains
-      // a malformed escape sequence (decodeURIComponent throws on those).
       let id: string;
 
       try {
@@ -117,7 +142,7 @@ export function createScrollRestoration(
       }
 
       if (mode === "top" || !nav) {
-        scrollToHashOrTop();
+        scrollToHashOrTop(route);
 
         return;
       }
@@ -136,7 +161,7 @@ export function createScrollRestoration(
         return;
       }
 
-      scrollToHashOrTop();
+      scrollToHashOrTop(route);
     });
   });
 


### PR DESCRIPTION
Closes #532.

First-class URL fragment ("hash") support in the URL plugin layer — without modifying core. Architecturally symmetric to #497 (scroll restoration utility): URL-concerns owned by URL plugins, viewport-concerns by `shared/dom-utils`, routing-concerns by core.

Pre-#532, fragments lived in three workarounds: `shouldPreserveHash` heuristic dropped hash on cross-path navigation, `urlToPath()` stripped hash before matching, and same-path hash-clicks were swallowed by `SAME_STATES` rejection. Tab-style UIs and bookmarkable view state required manual workarounds in every adapter.

## Summary

- **Shared `state.context.url = { hash, hashChanged }`** namespace claimed by browser-plugin and navigation-plugin (mutually exclusive). Decoded form, no leading `#`.
- **Tri-state `opts.hash`** on `router.navigate` / `buildUrl` / `replaceHistoryState`: `undefined` preserves, `""` clears, value sets.
- **Browser-driven hash-only nav** auto-bypasses `SAME_STATES` via `force: true, hashChange: true` (popstate hashChange detection in browser-plugin, `event.hashChange` in navigation-plugin). Subscribers disambiguate via `state.context.url.hashChanged`.
- **`<Link hash>`** prop in all 6 adapters, click-routed through `navigateWithHash` (auto-force on same-route different-hash). Hash-aware active state (sibling tab Links light up independently).
- **Hash-aware sources**: `createActiveRouteSource(opts.hash)`, `stabilizeState` compares `path` + `state.context.url.hash` so `useRoute()` re-renders on tab clicks.
- **F5 / cold-load** via lazy `getDecodedHash(browser)` in first `onTransitionSuccess` — separate from #531 navigationType priming.
- **hash-plugin**: typing parity for `{ hash }` (TS interface merge), runtime warn-once + drop. Mutually exclusive with browser/navigation plugins.
- **Encoding**: `encodeURI(s).replace(/#/g, "%23")` preserves RFC-3986 fragment sub-delims; over-encoding via `encodeURIComponent` rejected.
- **scroll-restore SSR fix**: anchor target read from `state.context.url.hash` (decoded, populated by URL plugins), DOM fallback only when no URL plugin installed — race-free with framework commit.
- **Dogfood example**: [`examples/web/react/link-hash/`](https://github.com/greydragon888/real-router/tree/532-feature-hash-support-in-url-plugins-navigationbrowser-plugin-link-hash-utility-scroll-restore/examples/web/react/link-hash) exercises full surface area + 32 e2e specs.

## Stages (one PR, 4 commits)

| Stage | Commit | Scope |
| --- | --- | --- |
| 1 | `e612e274` | shared/* plumbing, 3 URL plugins, sources hash-aware, React `<Link hash>` |
| 2 | `549e11f8` | Preact / Solid / Vue / Svelte / Angular `<Link hash>` |
| 3 | `ed9e46dd` | `examples/web/react/link-hash/` (16 files, 1238 insertions) + Playwright e2e |
| 4 | `7acf1ffa` | IMPLEMENTATION_NOTES + plugin READMEs/ARCHITECTUREs + adapter READMEs |

Wiki updated separately in `real-router.wiki/` — new `Hash.md` (~270 lines) + Link / State / browser-plugin / Navigation-Plugin / hash-plugin / Scroll-Restoration / _Sidebar.

## Changesets

10 minor + 6 patch:
- `minor`: navigation-plugin, browser-plugin, hash-plugin, sources, react, preact, solid, vue, svelte, angular (Link hash + useIsActiveRoute hash + hash-aware sources)
- `patch`: react, preact, solid, vue, svelte, angular (scroll-restoration SSR-safe hash lookup)

No core changes → no core changeset.

## Test plan

- [x] `pnpm build` — 278 successful, 278 total
- [x] Unit + functional tests across affected packages (sources, browser-plugin, navigation-plugin, hash-plugin, all 6 adapters)
- [x] Playwright e2e in `examples/web/react/link-hash/` — 32 specs, 12 sections (tab UI, F5 priming, cross-path preserve, programmatic tri-state, auto-force, hashChanged signal, browser back/forward, modifier keys, URL encoding, hash-plugin warn-once, switch back to browser-plugin)
- [x] `pnpm lint:unused` — clean (`@real-router/types` ignoreDependency added for hash-plugin)
- [x] No `shouldPreserveHash` references outside historical IMPLEMENTATION_NOTES / changesets
- [x] `state.context.url` cross-referenced from 20 docs locations
- [ ] Manual smoke in dev — verify reviewers can run `pnpm bundle && pnpm -F react-link-hash-example dev` and exercise tab UI / F5 / cross-path