### PR TITLE
feat: scroll-restoration behavior + storageKey + React example (#534)

### DIFF
--- a/.changeset/scroll-restore-options-angular.md
+++ b/.changeset/scroll-restore-options-angular.md
@@ -1,0 +1,7 @@
+---
+"@real-router/angular": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+`provideRealRouter(router, { scrollRestoration })` now accepts `behavior?: ScrollBehavior` and `storageKey?: string`. The git-tracked `packages/angular/src/dom-utils/scroll-restore.ts` copy is synced with `shared/dom-utils/`. Mode `"manual"` renamed to `"native"` (semantic clarity — utility hands off to browser-native restore, opposite of DOM `history.scrollRestoration === "manual"`).

--- a/.changeset/scroll-restore-options-preact.md
+++ b/.changeset/scroll-restore-options-preact.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preact": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+See `@real-router/react` changeset for full details. The `RouterProvider` now forwards `behavior?: ScrollBehavior` and `storageKey?: string` from `scrollRestoration` options to `createScrollRestoration`. Mode `"manual"` renamed to `"native"` (semantic clarity — utility hands off to browser-native restore, opposite of DOM `history.scrollRestoration === "manual"`).

--- a/.changeset/scroll-restore-options-react.md
+++ b/.changeset/scroll-restore-options-react.md
@@ -1,0 +1,13 @@
+---
+"@real-router/react": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+`createScrollRestoration` (`shared/dom-utils/`) gains three changes:
+
+- **Mode rename `manual` → `native`** for clarity. The previous name was misleading because it had the OPPOSITE meaning of DOM `history.scrollRestoration === "manual"`: utility's mode meant "utility does nothing, browser handles natively", while DOM `"manual"` means "browser does nothing, app handles". Renamed to `"native"` to match the actual semantic ("hand off to browser-native restore").
+- **`behavior?: ScrollBehavior`** — forwarded to `scrollTo({ behavior })` and `scrollIntoView({ behavior })`. Values: `"auto"` (default), `"instant"`, `"smooth"`. See [MDN ScrollToOptions.behavior](https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior).
+- **`storageKey?: string`** — sessionStorage key for scroll-store, default `"real-router:scroll"`. Override for namespace-isolation between independent `RouterProvider` instances (micro-frontends, embedded widgets, testing setups).
+
+`RouterProvider` now forwards all three options. Default behavior unchanged.

--- a/.changeset/scroll-restore-options-solid.md
+++ b/.changeset/scroll-restore-options-solid.md
@@ -1,0 +1,7 @@
+---
+"@real-router/solid": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+`scrollRestoration` prop now accepts `behavior?: ScrollBehavior` and `storageKey?: string`. Solid forwards the entire `props.scrollRestoration` object to `createScrollRestoration`, so no provider-side changes were needed. Mode `"manual"` renamed to `"native"` (semantic clarity — utility hands off to browser-native restore, opposite of DOM `history.scrollRestoration === "manual"`).

--- a/.changeset/scroll-restore-options-svelte.md
+++ b/.changeset/scroll-restore-options-svelte.md
@@ -1,0 +1,7 @@
+---
+"@real-router/svelte": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+`<RouterProvider>` derives `srBehavior` and `srStorageKey` from `scrollRestoration` props and forwards them to `createScrollRestoration`. Mode `"manual"` renamed to `"native"` (semantic clarity — utility hands off to browser-native restore, opposite of DOM `history.scrollRestoration === "manual"`).

--- a/.changeset/scroll-restore-options-vue.md
+++ b/.changeset/scroll-restore-options-vue.md
@@ -1,0 +1,7 @@
+---
+"@real-router/vue": minor
+---
+
+Scroll restoration: rename `mode: "manual"` → `"native"`, add `behavior` and `storageKey` options (#534)
+
+`<RouterProvider>` now watches `scrollRestoration?.behavior` and `scrollRestoration?.storageKey` as primitive deps and forwards them to `createScrollRestoration` on remount. Mode `"manual"` renamed to `"native"` (semantic clarity — utility hands off to browser-native restore, opposite of DOM `history.scrollRestoration === "manual"`).

--- a/examples/web/react/scroll-restoration/README.md
+++ b/examples/web/react/scroll-restoration/README.md
@@ -1,0 +1,78 @@
+# Real-Router — Scroll Restoration Example
+
+> Dedicated React-only example exercising every behavioral branch of `createScrollRestoration` (#497). Covers all three modes (`restore` / `top` / `native`), all three behavior values (`auto` / `instant` / `smooth`), all four `navigationType` values (`push` / `replace` / `traverse` / `reload`), anchor scrolling (4 entry points after #531/#532), custom `scrollContainer`, and `pagehide` save + F5 restore.
+
+## Quick start
+
+```bash
+pnpm bundle                                            # rebuild shared/dom-utils dist
+pnpm -F react-scroll-restoration-example dev           # http://localhost:5173
+pnpm -F react-scroll-restoration-example build         # tsc -b + vite build
+pnpm -F react-scroll-restoration-example test:e2e      # 13 tests / 7 describe blocks
+```
+
+The floating **Scroll Meter** in the bottom-right corner shows live `scrollY`, the published `state.context.navigation` direction / navigationType, and the `sessionStorage` scroll-restore store keyed by `state.name + ":" + canonicalJson(state.params)`. Stable Playwright selectors live on `[data-testid="scroll-meter"]` (with `data-scroll-y` attribute for rAF-stable reads) and per-route `[data-testid="nav-*"]`.
+
+## Why not a plugin
+
+`createScrollRestoration` lives in `shared/dom-utils/`, not as a `@real-router/scroll-plugin`. Reasons:
+
+- Router-core is DOM-agnostic — `window.scrollY` is a DOM concern.
+- All routing-layer inputs the utility needs (`direction`, `navigationType`) are already published by `navigation-plugin` via `state.context.navigation`. A plugin would duplicate an existing channel without adding value.
+- Symmetric to `createRouteAnnouncer` — both are framework-agnostic DOM helpers wired into `RouterProvider` per adapter.
+
+See [Wiki › Scroll Restoration](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full architectural rationale.
+
+## Behavior matrix
+
+| Event                                                       | mode: "restore"                          | mode: "top"               | mode: "native"     |
+| ----------------------------------------------------------- | ---------------------------------------- | ------------------------- | ------------------ |
+| forward push на новый path (`<Link>` без `hash`)            | top                                      | top                       | браузерный дефолт  |
+| forward push с `<Link hash>` cross-path¹                    | scroll к anchor (hash сохранён в URL)    | scroll к anchor           | браузерный дефолт  |
+| same-path `<Link hash>` (anchor click)¹                     | scroll к anchor (auto-force, transition) | scroll к anchor           | браузерный дефолт  |
+| back / forward (traverse)                                   | restore                                  | top                       | браузерный дефолт  |
+| programmatic replace (`navigate(..., { replace: true })`)   | no-op                                    | top                       | браузерный дефолт  |
+| programmatic reload (`navigate(..., { reload: true })`)     | restore                                  | top или anchor            | браузерный дефолт  |
+| **F5 / `page.reload()` (cross-document) после #531**        | **save + restore работают²**             | top или anchor на initial | браузерный дефолт  |
+| initial goto с hash (`goto('/p#a')`)                        | scroll к anchor (после #531 priming)     | scroll к anchor           | браузерный дефолт  |
+
+> Note: `native` mode означает «утилита **отключена**, browser handles restore natively». Это противоположность DOM-значению `history.scrollRestoration === "manual"` — там browser НЕ восстанавливает, и app должно делать сам. Утилита в `native` mode не трогает `history.scrollRestoration`, оно остаётся `"auto"`, и браузер делает restore через свой built-in mechanism.
+
+¹ After #532 hash is stored decoded in `state.context.url.hash`; tri-state `opts.hash`: `undefined` preserves, `""` clears, value sets. Same-path `<Link hash>` auto-bypasses `SAME_STATES` via `navigateWithHash` (adds `force: true, hashChange: true`).
+
+² After #531 navigation-plugin reads `navigation.activation.navigationType` via `browser.getActivationType()` on initial load and primes `state.context.navigation.navigationType = "reload"` for F5. The utility takes the restore branch and writes saved scrollY back from `sessionStorage`.
+
+## Scenarios (7 base, 13 tests with sub-tests)
+
+| #   | Scenario               | Sub-tests | What it exercises                                                          |
+| --- | ---------------------- | --------- | -------------------------------------------------------------------------- |
+| 1   | Restore on back        | —         | `direction === "back"` → `writePos(loadStore()[keyOf(route)])`             |
+| 2   | Top on forward push    | —         | `default` branch → `scrollToHashOrTop` → `writePos(0)`                     |
+| 3   | Anchor scrolling       | 4 (a/b/c/d) | initial goto / cross-path `<Link hash>` / same-path auto-force / cyrillic |
+| 4   | Replace no-op          | —         | `navigationType === "replace"` early return; store key under previousRoute |
+| 5   | Mode + behavior toggle | 12 (a-l)  | top scroll-to-top on Back / native UI persistence / top replace→top / top F5→top / native scrollRestoration=auto / native no store writes / behavior=smooth → scrollTo / native: Chromium native restore on Back / **5i** cross-path hash with no matching id → scroll=0 / **5j** same-path hash with no matching id → scroll=0 / **5k** behavior=smooth → scrollIntoView / **5l** active link no-op (SAME_STATES) |
+| 6   | Custom `scrollContainer` | 2       | virtual-scroller save+restore / **6b** null fallback to window across routes (multi-route flow) |
+| 7   | F5 persistence         | 3 (a/b/c) | save via `pagehide`, F5 restore via #531 priming, programmatic reload      |
+
+## Plugin dependencies
+
+| Plugin            | In example | Alternative    | Effect of substitution                                                                                                                                                                        |
+| ----------------- | ---------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| navigation-plugin | yes        | browser-plugin | browser-plugin does not publish `state.context.navigation` → utility degrades to top semantics (`!nav → scrollToHashOrTop` branch); scenarios **1, 4, 7b, 7c** stop working. Scenario 5 and 7a are plugin-agnostic. |
+
+navigation-plugin and browser-plugin are **interchangeable** (not complementary) URL-navigation sources. We pick navigation-plugin because only it publishes `direction` and `navigationType`. Scenarios 5 (mode toggle) and 7a (`pagehide` save) are plugin-agnostic.
+
+## Out of scope
+
+- **SSR + hydration** — covered by `examples/web/react/ssr/` and `ssg/`. The utility is a no-op in SSR (`typeof window === "undefined"` early-return).
+- **Keep-alive virtual lists** — not part of #497.
+- **Multiple nested `scrollContainer`** — not supported by the utility (one container per RouterProvider).
+- **Other 5 framework adapters** — basic opt-in is already in `examples/web/{preact,solid,vue,svelte,angular}/basic/`; syntax differs only by template form. Wiki has copy-paste blocks for all 6 adapters.
+- **View Transitions API** — separate concern (#498).
+
+## Implementation notes
+
+- **Scroll measurement tolerance** — Playwright reads scrollY through `[data-testid="scroll-meter"][data-scroll-y]`. rAF jitter and hi-DPI rounding make ±20px the safe tolerance; `expect.poll(...).toSatisfy(y => Math.abs(y - target) < 20)` is the pattern. `toBeCloseTo(val, -1)` only gives ±5 — too tight.
+- **Mode switching reload** — sense: utility is constructed once on RouterProvider mount; hot-swap is not supported. Mode is persisted in `localStorage["scroll-restoration-mode"]`, applied on next mount. Documented UX quirk: switching with non-zero scroll on `/settings` may "jump" to a saved position after reload (the utility's `restore` branch writePos's the previously-captured `settings:{}` key).
+- **Custom scrollContainer applies globally** — `scrollContainer: () => document.getElementById("virtual-scroller")` returns `null` on routes without that element. `readPos` / `writePos` lazy-resolve and fall back to `window`. Demonstrated as a feature on Scenario 6.
+- **`pagehide` save edge-case** — save runs in `pagehide` listener which fires on tab close / reload / cross-document navigate. Within one document, between routes, save runs through `router.subscribe(({ previousRoute }) => putPos(...))`. Edge case: navigating away from `/gallery`, the Gallery component unmounts before the subscribe callback's `readPos()` runs → `getContainer()` returns `null` → falls back to `window.scrollY` (=0 on the freshly-mounted next route). Acceptable trade-off for an example; documented in the plan.

--- a/examples/web/react/scroll-restoration/e2e/scroll-restoration.spec.ts
+++ b/examples/web/react/scroll-restoration/e2e/scroll-restoration.spec.ts
@@ -1,0 +1,690 @@
+import { expect, test } from "@playwright/test";
+
+import type { Page } from "@playwright/test";
+
+/**
+ * 13 tests across 7 describe blocks. See ../README.md for the behavior
+ * matrix and ../../../../.claude/plan-scroll-restoration-examples-ru.md
+ * for design rationale.
+ *
+ * Tolerance: scroll values can drift ±5-15px due to rAF timing and hi-DPI
+ * rounding. We use `expect.poll(() => Math.abs(y - target)).toBeLessThan(20)`
+ * — `toBeCloseTo(val, -1)` only gives ±5 (too tight), `toSatisfy` is not in
+ * Playwright's matcher set.
+ */
+
+const TOL = 20;
+
+const readScrollY = async (page: Page): Promise<number> => {
+  return page.evaluate(() => window.scrollY);
+};
+
+const readContainerTop = async (page: Page): Promise<number> => {
+  return page
+    .locator("#virtual-scroller")
+    .evaluate((el: HTMLElement) => el.scrollTop);
+};
+
+const expectScrollNear = async (page: Page, target: number): Promise<void> => {
+  await expect
+    .poll(async () => Math.abs((await readScrollY(page)) - target))
+    .toBeLessThan(TOL);
+};
+
+const expectContainerNear = async (
+  page: Page,
+  target: number,
+): Promise<void> => {
+  await expect
+    .poll(async () => Math.abs((await readContainerTop(page)) - target))
+    .toBeLessThan(TOL);
+};
+
+test.beforeEach(async ({ page }) => {
+  // One-shot reset on test start. Note: do NOT use `addInitScript` for this
+  // — it runs on every new document, including `page.reload()`, which would
+  // erase the position saved by `pagehide` and break Scenario 7a/7b.
+  await page.goto("/");
+  await page.evaluate(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    history.scrollRestoration = "auto";
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 1 — Restore on back
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 1: restore on back", () => {
+  test("scroll position restored on browser Back", async ({ page }) => {
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 3000));
+    await expectScrollNear(page, 3000);
+
+    // Click via dispatchEvent — bypasses Playwright's auto-scroll-into-view
+    // which would otherwise change scrollY before the click event reaches
+    // the React handler. The router's subscribe callback captures
+    // `window.scrollY` at the moment of navigation.
+    await page.locator('[data-testid="article-card-15"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/15$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/articles$/);
+    await expectScrollNear(page, 3000);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 2 — Top on forward push
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 2: top on forward push", () => {
+  test("forward navigation lands at scrollY 0", async ({ page }) => {
+    await page.goto("/docs");
+    await page.evaluate(() => window.scrollTo(0, 2000));
+    await expectScrollNear(page, 2000);
+
+    await page.click('[data-testid="nav-articles"]');
+    await expect(page).toHaveURL(/\/articles$/);
+    await expectScrollNear(page, 0);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 3 — Anchor scrolling (4 sub-tests after #531/#532)
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 3: anchor scrolling", () => {
+  test("3a — initial goto with anchor scrolls to heading", async ({ page }) => {
+    await page.goto("/docs#getting-started");
+    await page.waitForLoadState("networkidle");
+
+    const heading = page.locator("#getting-started");
+    await expect(heading).toBeInViewport();
+    expect(await readScrollY(page)).toBeGreaterThan(0);
+  });
+
+  test("3b — cross-path <Link hash> preserves hash and scrolls", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.click('[data-testid="link-docs-installation"]');
+    await expect(page).toHaveURL(/\/docs#installation$/);
+
+    const heading = page.locator("#installation");
+    await expect(heading).toBeInViewport();
+  });
+
+  test("3c — same-path <Link hash> auto-force triggers anchor scroll", async ({
+    page,
+  }) => {
+    await page.goto("/docs#api");
+    await expect(page.locator("#api")).toBeInViewport();
+
+    await page.click('[data-testid="toc-examples"]');
+    await expect(page).toHaveURL(/\/docs#examples$/);
+    await expect(page.locator("#examples")).toBeInViewport();
+  });
+
+  test("3d — cyrillic id decoded from state.context.url.hash", async ({
+    page,
+  }) => {
+    // Browser percent-encodes Cyrillic in URL bar; URL plugin decodes it
+    // into state.context.url.hash. Utility uses the decoded form directly.
+    await page.goto(
+      "/docs#%D1%81%D0%B5%D0%BA%D1%86%D0%B8%D1%8F-5",
+    );
+    await page.waitForLoadState("networkidle");
+
+    const heading = page.locator('h2[id="секция-5"]');
+    await expect(heading).toBeInViewport();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 4 — Replace no-op
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 4: replace is no-op for scroll", () => {
+  test("replace preserves scrollY and stores under previousRoute key", async ({
+    page,
+  }) => {
+    await page.goto("/articles/1");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 1500));
+    await expectScrollNear(page, 1500);
+
+    await page.locator('[data-testid="replace-next"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/2$/);
+
+    await expectScrollNear(page, 1500);
+
+    const store: Record<string, number> = await page.evaluate(() =>
+      JSON.parse(sessionStorage.getItem("real-router:scroll") ?? "{}"),
+    );
+    expect(store['articles.article:{"id":"1"}']).toBeGreaterThan(1480);
+    expect(store['articles.article:{"id":"2"}']).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 5 — Mode toggle (2 sub-tests)
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 5: mode toggle", () => {
+  test("5a — top mode scrolls to top on Back", async ({ page }) => {
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-top"]');
+    await page.waitForLoadState("networkidle");
+
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 3000));
+    await expectScrollNear(page, 3000);
+
+    await page.locator('[data-testid="article-card-1"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/1$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/articles$/);
+    // top mode → back goes to top, NOT restored
+    await expectScrollNear(page, 0);
+  });
+
+  test("5b — native mode persists to localStorage and updates UI", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-native"]');
+
+    expect(
+      await page.evaluate(() =>
+        localStorage.getItem("scroll-restoration-mode"),
+      ),
+    ).toBe("native");
+
+    // ModeToggle's `onModeChange` callback updates App's state →
+    // RouterProvider remounts via `key` → util destroyed + recreated in
+    // native mode. The toggle visually reflects the new mode.
+    await expect(page.locator('[data-testid="mode-native"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    await expect(page.locator('[data-testid="mode-restore"]')).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+  });
+
+  test("5c — top mode: replace scrolls to top (NOT preserve scrollY)", async ({
+    page,
+  }) => {
+    // In `top` mode the utility's first branch (`mode === "top"`) wins
+    // before the replace-early-return check fires. So replace navigation
+    // ends up at scrollY = 0, contrary to `restore` mode (Scenario 4).
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-top"]');
+    await expect(page.locator('[data-testid="mode-top"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+
+    await page.goto("/articles/1");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 1500));
+    await expectScrollNear(page, 1500);
+
+    await page.locator('[data-testid="replace-next"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/2$/);
+
+    // top mode: scroll resets to 0, not preserved
+    await expectScrollNear(page, 0);
+  });
+
+  test("5d — top mode: F5 scrolls to top (NOT restore)", async ({ page }) => {
+    // After page.reload(), main.tsx reads localStorage = "top" → util in
+    // top mode → first branch → scrollToHashOrTop. Saved position in
+    // sessionStorage is ignored.
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-top"]');
+    await expect(page.locator('[data-testid="mode-top"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 2500));
+    await expectScrollNear(page, 2500);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    // top mode on cold load → scroll = 0 even though pagehide saved 2500
+    await expectScrollNear(page, 0);
+  });
+
+  test("5e — native mode leaves history.scrollRestoration at auto", async ({
+    page,
+  }) => {
+    // beforeEach reset history.scrollRestoration to "auto". Switching to
+    // native mode remounts RouterProvider with mode=native → utility
+    // returns NOOP_INSTANCE before touching history.scrollRestoration.
+    // The "auto" set in beforeEach survives the remount — browser handles
+    // scroll restore natively from this point on.
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-native"]');
+    await expect(page.locator('[data-testid="mode-native"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+
+    expect(await page.evaluate(() => history.scrollRestoration)).toBe("auto");
+  });
+
+  test("5g — behavior toggle persists and forwards 'smooth' to scrollTo", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+
+    // 1. Click behavior-smooth → localStorage + React state updated.
+    await page.click('[data-testid="behavior-smooth"]');
+    await expect(
+      page.locator('[data-testid="behavior-smooth"]'),
+    ).toHaveAttribute("data-active", "true");
+    expect(
+      await page.evaluate(() =>
+        localStorage.getItem("scroll-restoration-behavior"),
+      ),
+    ).toBe("smooth");
+
+    // 2. Install scrollTo spy AFTER the remount has settled (waitForTimeout
+    // guards against the transient unmount/remount window).
+    await page.waitForTimeout(100);
+    await page.evaluate(() => {
+      (window as unknown as { __scrollCalls: ScrollToOptions[] }).__scrollCalls =
+        [];
+      const orig = window.scrollTo.bind(window);
+      window.scrollTo = ((...args: [ScrollToOptions] | [number, number]) => {
+        if (typeof args[0] === "object") {
+          (
+            window as unknown as { __scrollCalls: ScrollToOptions[] }
+          ).__scrollCalls.push(args[0]);
+        }
+
+        // eslint-disable-next-line prefer-spread -- forwarding rest args
+        return orig.apply(window, args as never);
+      }) as typeof window.scrollTo;
+    });
+
+    // 3. Trigger forward push — utility should call scrollTo({ behavior: "smooth" }).
+    await page.click('[data-testid="nav-articles"]');
+    await expect(page).toHaveURL(/\/articles$/);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __scrollCalls: ScrollToOptions[] })
+              .__scrollCalls.length,
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    const calls: ScrollToOptions[] = await page.evaluate(
+      () =>
+        (window as unknown as { __scrollCalls: ScrollToOptions[] })
+          .__scrollCalls,
+    );
+    expect(calls.some((c) => c.behavior === "smooth")).toBe(true);
+  });
+
+  test("5f — native mode: utility does not subscribe (no store writes)", async ({
+    page,
+  }) => {
+    // Switch to native via toggle → RouterProvider remount → util NOOP.
+    // No router.subscribe handler attached, so SPA navigation does not
+    // write to the scroll-restore store.
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-native"]');
+    await expect(page.locator('[data-testid="mode-native"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+
+    // Clear any leftover entries from previous (restore-mode) mounts
+    await page.evaluate(() => sessionStorage.removeItem("real-router:scroll"));
+
+    // Now exercise SPA navigation in-app (no full reload — utility in
+    // native mode is currently mounted and should be NOOP).
+    await page.click('[data-testid="nav-articles"]');
+    await expect(page).toHaveURL(/\/articles$/);
+    await page.evaluate(() => window.scrollTo(0, 1000));
+    await page
+      .locator('[data-testid="article-card-15"]')
+      .dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/15$/);
+
+    // No router.subscribe in native mode → store untouched
+    const store = await page.evaluate(() =>
+      JSON.parse(sessionStorage.getItem("real-router:scroll") ?? "{}"),
+    );
+    expect(Object.keys(store)).toEqual([]);
+  });
+
+  test("5h — native mode: Chromium browser-native restore preserves scrollY on Back", async ({
+    page,
+    browserName,
+  }) => {
+    // In `native` mode the utility returns NOOP_INSTANCE without touching
+    // `history.scrollRestoration`. The DOM property stays at the browser
+    // default `"auto"`, which means **the browser** is in charge of scroll
+    // restore on back/forward. In Chromium this works identically to
+    // `restore` mode — Chromium's built-in restore kicks in and lands the
+    // user back at the saved position.
+    //
+    // This test validates the contract: "native" === "hand off to browser".
+    // It explicitly skips on engines where `history.scrollRestoration: auto`
+    // does NOT restore scroll on SPA back (some Firefox/Safari versions),
+    // because that behavior is OUT of utility's control by design.
+    test.skip(
+      browserName !== "chromium",
+      "Chromium-only: native scroll restore on history traversal",
+    );
+
+    await page.goto("/settings");
+    await page.click('[data-testid="mode-native"]');
+    await expect(page.locator('[data-testid="mode-native"]')).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    expect(await page.evaluate(() => history.scrollRestoration)).toBe("auto");
+
+    // Clear any leftover entries that the previous (default = restore) mount
+    // wrote on its `pagehide` before remount swapped in the NOOP native mode.
+    await page.evaluate(() => sessionStorage.removeItem("real-router:scroll"));
+
+    // Navigate to a long page, scroll down, click into a child route, then
+    // press Back. Chromium's native auto-restore should bring us back to
+    // ~3000px even though the utility never wrote to sessionStorage.
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 3000));
+    await expectScrollNear(page, 3000);
+
+    // Verify utility's store is empty after our SPA navigation — proving
+    // the restore (if it works) is from Chromium native, not from us.
+    const store = await page.evaluate(() =>
+      JSON.parse(sessionStorage.getItem("real-router:scroll") ?? "{}"),
+    );
+    expect(Object.keys(store)).toEqual([]);
+
+    await page.locator('[data-testid="article-card-15"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/15$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/articles$/);
+
+    // Browser-native restore: Chromium remembers scrollY across SPA history
+    // entries when scrollRestoration === "auto". This proves "native" mode
+    // does not block native restore.
+    await expectScrollNear(page, 3000);
+  });
+
+  test("5i — cross-path <Link hash> with non-existent id falls through to scrollY=0", async ({
+    page,
+  }) => {
+    // ctxHash !== undefined branch: utility tries getElementById(ctxHash) →
+    // returns null → falls through to writePos(0). Validates the
+    // "anchor-or-top" contract: no matching element means top.
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 1500));
+    await expectScrollNear(page, 1500);
+
+    await page.click('[data-testid="link-docs-missing"]');
+    await expect(page).toHaveURL(/\/docs#no-such-section$/);
+    // No <h2 id="no-such-section"> exists in DOM → writePos(0)
+    await expectScrollNear(page, 0);
+  });
+
+  test("5j — same-path <Link hash> with non-existent id resets to scrollY=0", async ({
+    page,
+  }) => {
+    // Same-path different-hash via navigateWithHash adds force+hashChange,
+    // bypasses SAME_STATES → transition fires → utility's subscribe
+    // callback runs through the push-fallthrough → scrollToHashOrTop →
+    // ctxHash defined but element missing → writePos(0). Documents that
+    // hash-only nav with broken anchor IS a scroll reset, not a no-op.
+    // (Tab UI authors must provide matching id elements to avoid jumps.)
+    await page.goto("/docs#getting-started");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("#getting-started")).toBeInViewport();
+    const startScroll = await readScrollY(page);
+    expect(startScroll).toBeGreaterThan(0);
+
+    await page.click('[data-testid="toc-missing"]');
+    await expect(page).toHaveURL(/\/docs#no-such-section$/);
+    // No matching id → writePos(0)
+    await expectScrollNear(page, 0);
+  });
+
+  test("5k — behavior 'smooth' is forwarded to anchor scrollIntoView", async ({
+    page,
+  }) => {
+    // 5g covers behavior=smooth → window.scrollTo. This test covers the
+    // OTHER call site: Element.prototype.scrollIntoView for hash anchors.
+    await page.goto("/settings");
+    await page.click('[data-testid="behavior-smooth"]');
+    await expect(
+      page.locator('[data-testid="behavior-smooth"]'),
+    ).toHaveAttribute("data-active", "true");
+
+    // Navigate to Home where the link-docs-installation lives.
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Wait for remount to settle, then patch scrollIntoView globally so we
+    // capture the call from utility's rAF (after the click below).
+    await page.evaluate(() => {
+      (
+        window as unknown as { __siCalls: ScrollIntoViewOptions[] }
+      ).__siCalls = [];
+      const orig = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = function (
+        this: Element,
+        arg?: boolean | ScrollIntoViewOptions,
+      ) {
+        if (typeof arg === "object" && arg !== null) {
+          (
+            window as unknown as { __siCalls: ScrollIntoViewOptions[] }
+          ).__siCalls.push(arg);
+        }
+        return orig.call(this, arg);
+      } as Element["scrollIntoView"];
+    });
+
+    // Cross-path <Link hash> on a page that exists → utility runs
+    // scrollIntoView with the configured behavior. Use dispatchEvent to
+    // bypass Playwright's auto-scroll-into-view, which would otherwise
+    // call scrollIntoView itself and pollute our spy.
+    await page
+      .locator('[data-testid="link-docs-installation"]')
+      .dispatchEvent("click");
+    await expect(page).toHaveURL(/\/docs#installation$/);
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __siCalls: ScrollIntoViewOptions[] })
+              .__siCalls.length,
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    const calls: ScrollIntoViewOptions[] = await page.evaluate(
+      () =>
+        (window as unknown as { __siCalls: ScrollIntoViewOptions[] }).__siCalls,
+    );
+    expect(calls.some((c) => c.behavior === "smooth")).toBe(true);
+  });
+
+  test("5l — clicking active sidebar link is a SAME_STATES no-op (utility not invoked)", async ({
+    page,
+  }) => {
+    // Click the same nav link the user is already on. Core's same-states
+    // rejection prevents transition → router.subscribe callback never fires
+    // → utility's rAF never runs. ScrollY is preserved as-is.
+    //
+    // This is a regression baseline: any future change to navigateWithHash
+    // or core's same-states logic that accidentally promotes plain Link
+    // clicks to forced transitions would break this.
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 800));
+    await expectScrollNear(page, 800);
+
+    // dispatchEvent bypasses Playwright's auto-scroll-into-view + visibility
+    // checks; we want to test the SAME_STATES path purely.
+    await page
+      .locator('[data-testid="nav-articles"]')
+      .dispatchEvent("click");
+    // URL unchanged
+    await expect(page).toHaveURL(/\/articles$/);
+    // ScrollY unchanged — utility never ran
+    await expectScrollNear(page, 800);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 6b — scrollContainer null fallback (cross-route)
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// Scenario 6 — Custom scrollContainer
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 6: custom scrollContainer", () => {
+  test("scroll inside #virtual-scroller is captured + restored, window untouched", async ({
+    page,
+  }) => {
+    await page.goto("/gallery");
+    await page
+      .locator("#virtual-scroller")
+      .evaluate((el: HTMLElement) => el.scrollTo(0, 2000));
+
+    await expectContainerNear(page, 2000);
+    expect(await readScrollY(page)).toBeLessThan(50);
+
+    await page.click('[data-testid="nav-home"]');
+    await expect(page).toHaveURL(/\/$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/gallery$/);
+    await expectContainerNear(page, 2000);
+  });
+
+  test("6b — scrollContainer null fallback: window scroll on routes without container", async ({
+    page,
+  }) => {
+    // scrollContainer is `() => document.getElementById("virtual-scroller")`,
+    // global to RouterProvider. On routes that don't render that div the
+    // getter returns null and `readPos`/`writePos` lazy-fall back to
+    // window. This test exercises BOTH paths in one flow:
+    //
+    //   /articles  →  window scroll captured under "articles:{}"
+    //       ↓
+    //   /gallery   →  container scrollTop captured under "gallery:{}"
+    //       ↓ Back
+    //   /articles  →  window scroll restored from "articles:{}"
+    //       ↓ Forward
+    //   /gallery   →  container scrollTop restored from "gallery:{}"
+    //
+    // Demonstrates that fallback is not just a graceful degradation but a
+    // correct two-target solution working transparently across routes.
+    await page.goto("/articles");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 1200));
+    await expectScrollNear(page, 1200);
+
+    // dispatchEvent bypasses Playwright auto-scroll-into-view; sidebar
+    // anchors stay in viewport but click checks may still flake when
+    // ScrollMeter overlays.
+    await page.locator('[data-testid="nav-gallery"]').dispatchEvent("click");
+    await expect(page).toHaveURL(/\/gallery$/);
+    await page
+      .locator("#virtual-scroller")
+      .evaluate((el: HTMLElement) => el.scrollTo(0, 800));
+    await expectContainerNear(page, 800);
+
+    // Back to /articles → window restored
+    await page.goBack();
+    await expect(page).toHaveURL(/\/articles$/);
+    await expectScrollNear(page, 1200);
+
+    // Forward to /gallery → container restored
+    await page.goForward();
+    await expect(page).toHaveURL(/\/gallery$/);
+    await expectContainerNear(page, 800);
+
+    // Both keys live in store under their own routes
+    const store: Record<string, number> = await page.evaluate(() =>
+      JSON.parse(sessionStorage.getItem("real-router:scroll") ?? "{}"),
+    );
+    expect(store["articles:{}"]).toBeGreaterThan(1180);
+    expect(store["gallery:{}"]).toBeGreaterThan(780);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Scenario 7 — Persistence across F5 (3 sub-tests after #531)
+// ----------------------------------------------------------------------------
+
+test.describe("Scenario 7: F5 persistence", () => {
+  test("7a — pagehide saves position before reload", async ({ page }) => {
+    await page.goto("/articles");
+    await page.evaluate(() => window.scrollTo(0, 2500));
+    await expectScrollNear(page, 2500);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const stored: number = await page.evaluate(() => {
+      const raw = sessionStorage.getItem("real-router:scroll") ?? "{}";
+      const store = JSON.parse(raw) as Record<string, number>;
+
+      return store["articles:{}"] ?? 0;
+    });
+    expect(stored).toBeGreaterThan(2480);
+  });
+
+  test("7b — F5 restore (after #531 priming)", async ({ page }) => {
+    await page.goto("/articles");
+    await page.evaluate(() => window.scrollTo(0, 2500));
+    await expectScrollNear(page, 2500);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    // After #531 priming, navigation-plugin emits navigationType:"reload"
+    // on the first transition after F5 → utility's restore branch runs.
+    // Userland `applyInitialF5Restore` in main.tsx bridges the race where
+    // the utility subscribes after `router.start()` already fired its first
+    // TRANSITION_SUCCESS.
+    await expectScrollNear(page, 2500);
+  });
+
+  test("7c — programmatic reload restores from store", async ({ page }) => {
+    await page.goto("/articles/3");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() => window.scrollTo(0, 1800));
+    await expectScrollNear(page, 1800);
+
+    await page
+      .locator('[data-testid="programmatic-reload"]')
+      .dispatchEvent("click");
+    await expect(page).toHaveURL(/\/articles\/3$/);
+    await expectScrollNear(page, 1800);
+  });
+});

--- a/examples/web/react/scroll-restoration/index.html
+++ b/examples/web/react/scroll-restoration/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Real-Router — Scroll Restoration Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/web/react/scroll-restoration/package.json
+++ b/examples/web/react/scroll-restoration/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react-scroll-restoration-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm turbo run bundle --filter=...react-scroll-restoration-example",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@real-router/core": "workspace:^",
+    "@real-router/navigation-plugin": "workspace:^",
+    "@real-router/react": "workspace:^",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.2.0",
+    "typescript": "5.8.3",
+    "vite": "7.3.2"
+  }
+}

--- a/examples/web/react/scroll-restoration/playwright.config.ts
+++ b/examples/web/react/scroll-restoration/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  retries: 1,
+  webServer: {
+    command: "pnpm preview",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: "http://localhost:4173",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/examples/web/react/scroll-restoration/src/App.tsx
+++ b/examples/web/react/scroll-restoration/src/App.tsx
@@ -1,0 +1,113 @@
+import { Link, RouteView, RouterProvider } from "@real-router/react";
+import { useState } from "react";
+
+import { DirectionBadge } from "./components/DirectionBadge";
+import { ScrollMeter } from "./components/ScrollMeter";
+import { Article } from "./pages/Article";
+import { Articles } from "./pages/Articles";
+import { Documentation } from "./pages/Documentation";
+import { Gallery } from "./pages/Gallery";
+import { Home } from "./pages/Home";
+import { Settings } from "./pages/Settings";
+
+import type { Router } from "@real-router/core";
+import type { JSX } from "react";
+
+type Mode = "restore" | "top" | "native";
+
+interface AppProps {
+  readonly router: Router;
+  readonly initialMode: Mode;
+  readonly initialBehavior: ScrollBehavior;
+}
+
+const NAV_LINKS = [
+  { routeName: "home", label: "Home", testId: "nav-home" },
+  { routeName: "docs", label: "Docs", testId: "nav-docs" },
+  { routeName: "articles", label: "Articles", testId: "nav-articles" },
+  { routeName: "gallery", label: "Gallery", testId: "nav-gallery" },
+  { routeName: "settings", label: "Settings", testId: "nav-settings" },
+] as const;
+
+export function App({
+  router,
+  initialMode,
+  initialBehavior,
+}: AppProps): JSX.Element {
+  const [mode, setMode] = useState<Mode>(initialMode);
+  const [behavior, setBehavior] = useState<ScrollBehavior>(initialBehavior);
+
+  return (
+    // `key={`${mode}:${behavior}`}` forces RouterProvider to remount when
+    // either changes. The utility's `useEffect` cleanup runs (destroys old
+    // instance), then the new effect creates a fresh utility with updated
+    // options. Router itself stays the same.
+    <RouterProvider
+      key={`${mode}:${behavior}`}
+      router={router}
+      scrollRestoration={{
+        mode,
+        behavior,
+        // scrollContainer applies to the whole RouterProvider; lazy resolve
+        // returns null on routes without #virtual-scroller → utility falls
+        // back to window. Demonstrated as a feature in Scenario 6.
+        scrollContainer: () => document.querySelector("#virtual-scroller"),
+      }}
+    >
+      <div className="app">
+        <header className="header">
+          Real-Router — Scroll Restoration Demo
+          <DirectionBadge />
+        </header>
+        <aside className="sidebar" data-testid="sidebar">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.routeName}
+              routeName={link.routeName}
+              data-testid={link.testId}
+              activeStrict={false}
+              ignoreQueryParams={true}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </aside>
+        <main className="content">
+          <RouteView nodeName="">
+            <RouteView.Match segment="home">
+              <Home />
+            </RouteView.Match>
+            <RouteView.Match segment="docs">
+              <Documentation />
+            </RouteView.Match>
+            <RouteView.Match segment="articles">
+              <RouteView nodeName="articles">
+                <RouteView.Self>
+                  <Articles />
+                </RouteView.Self>
+                <RouteView.Match segment="article">
+                  <Article />
+                </RouteView.Match>
+              </RouteView>
+            </RouteView.Match>
+            <RouteView.Match segment="gallery">
+              <Gallery />
+            </RouteView.Match>
+            <RouteView.Match segment="settings">
+              <Settings
+                mode={mode}
+                onModeChange={setMode}
+                behavior={behavior}
+                onBehaviorChange={setBehavior}
+              />
+            </RouteView.Match>
+            <RouteView.NotFound>
+              <h1>404 — Page Not Found</h1>
+            </RouteView.NotFound>
+          </RouteView>
+        </main>
+        <ScrollMeter />
+      </div>
+    </RouterProvider>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/BehaviorToggle.tsx
+++ b/examples/web/react/scroll-restoration/src/components/BehaviorToggle.tsx
@@ -1,0 +1,47 @@
+import type { JSX } from "react";
+
+const BEHAVIOR_KEY = "scroll-restoration-behavior";
+
+interface BehaviorToggleProps {
+  readonly behavior: ScrollBehavior;
+  readonly onBehaviorChange: (behavior: ScrollBehavior) => void;
+}
+
+/**
+ * Three-way toggle for the `behavior` option passed to `scrollTo` and
+ * `scrollIntoView`. Mirrors the same React-state-driven remount pattern as
+ * ModeToggle: persists to localStorage AND calls `onBehaviorChange`, which
+ * triggers RouterProvider remount via `key`.
+ *
+ * - `auto` (default) — browser-defined, usually instant.
+ * - `instant` — explicit instant jump (no animation).
+ * - `smooth` — animated transition. Best paired with `mode: "top"` or
+ *   anchor scroll; smooth `restore` on Back can feel disorienting.
+ */
+export function BehaviorToggle({
+  behavior,
+  onBehaviorChange,
+}: BehaviorToggleProps): JSX.Element {
+  const switchTo = (next: ScrollBehavior): void => {
+    globalThis.localStorage.setItem(BEHAVIOR_KEY, next);
+    onBehaviorChange(next);
+  };
+
+  return (
+    <div className="mode-toggle" role="group" aria-label="scroll behavior">
+      {(["auto", "instant", "smooth"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          data-testid={`behavior-${option}`}
+          data-active={option === behavior}
+          onClick={() => {
+            switchTo(option);
+          }}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/DirectionBadge.tsx
+++ b/examples/web/react/scroll-restoration/src/components/DirectionBadge.tsx
@@ -1,0 +1,23 @@
+import { useRoute } from "@real-router/react";
+
+import type { JSX } from "react";
+
+interface NavigationContext {
+  direction?: "forward" | "back" | "unknown";
+  navigationType?: "push" | "replace" | "traverse" | "reload";
+}
+
+/**
+ * Compact badge showing the last navigation's direction + type. Stable
+ * Playwright marker that navigation-plugin actually publishes context.
+ */
+export function DirectionBadge(): JSX.Element {
+  const { route } = useRoute();
+  const nav = (route.context as { navigation?: NavigationContext }).navigation;
+
+  return (
+    <span className="direction-badge" data-testid="direction-badge">
+      {nav?.direction ?? "—"} / {nav?.navigationType ?? "—"}
+    </span>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/ModeToggle.tsx
+++ b/examples/web/react/scroll-restoration/src/components/ModeToggle.tsx
@@ -1,0 +1,47 @@
+import type { JSX } from "react";
+
+const MODE_KEY = "scroll-restoration-mode";
+
+type Mode = "restore" | "top" | "native";
+
+interface ModeToggleProps {
+  readonly mode: Mode;
+  readonly onModeChange: (mode: Mode) => void;
+}
+
+/**
+ * Three-way mode toggle. Calls `onModeChange` (which updates App state +
+ * remounts RouterProvider via `key`) AND persists to localStorage so the
+ * next cold load picks the right mode.
+ */
+export function ModeToggle({
+  mode,
+  onModeChange,
+}: ModeToggleProps): JSX.Element {
+  const switchTo = (nextMode: Mode): void => {
+    globalThis.localStorage.setItem(MODE_KEY, nextMode);
+    onModeChange(nextMode);
+  };
+
+  return (
+    <div
+      className="mode-toggle"
+      role="group"
+      aria-label="scroll restoration mode"
+    >
+      {(["restore", "top", "native"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          data-testid={`mode-${option}`}
+          data-active={option === mode}
+          onClick={() => {
+            switchTo(option);
+          }}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/ProgrammaticReloadDemo.tsx
+++ b/examples/web/react/scroll-restoration/src/components/ProgrammaticReloadDemo.tsx
@@ -1,0 +1,32 @@
+import { useNavigator, useRoute } from "@real-router/react";
+
+import type { JSX } from "react";
+
+/**
+ * Scenario 7c — Programmatic reload. navigate(name, params, { reload: true })
+ * with same path triggers `deriveNavigationType → "reload"`, which makes the
+ * utility's rAF callback take the restore branch and writePos from store.
+ */
+export function ProgrammaticReloadDemo(): JSX.Element {
+  const navigator = useNavigator();
+  const { route } = useRoute<{ id: string }>();
+
+  const onClick = (): void => {
+    navigator
+      .navigate("articles.article", { id: route.params.id }, { reload: true })
+      .catch(() => {
+        /* noop */
+      });
+  };
+
+  return (
+    <button
+      type="button"
+      className="demo-button"
+      data-testid="programmatic-reload"
+      onClick={onClick}
+    >
+      Programmatic reload (same id, reload: true)
+    </button>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/ReplaceDemo.tsx
+++ b/examples/web/react/scroll-restoration/src/components/ReplaceDemo.tsx
@@ -1,0 +1,37 @@
+import { useNavigator, useRoute } from "@real-router/react";
+
+import type { JSX } from "react";
+
+/**
+ * Scenario 4 — Replace no-op. Calling navigate(..., { replace: true }) on
+ * the current article navigates to the next id without resetting scroll.
+ *
+ * Utility writes putPos(keyOf(previousRoute), readPos()) BEFORE the rAF
+ * callback's replace early-return — so position is saved under the OLD
+ * params key, not the new one. Demonstrated via ScrollMeter store output.
+ */
+export function ReplaceDemo(): JSX.Element {
+  const navigator = useNavigator();
+  const { route } = useRoute<{ id: string }>();
+  const currentId = Number(route.params.id);
+  const nextId = String(currentId + 1);
+
+  const onClick = (): void => {
+    navigator
+      .navigate("articles.article", { id: nextId }, { replace: true })
+      .catch(() => {
+        /* noop — UI handles error via RouterErrorBoundary if needed */
+      });
+  };
+
+  return (
+    <button
+      type="button"
+      className="demo-button"
+      data-testid="replace-next"
+      onClick={onClick}
+    >
+      Next article (replace) → /articles/{nextId}
+    </button>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/components/ScrollMeter.tsx
+++ b/examples/web/react/scroll-restoration/src/components/ScrollMeter.tsx
@@ -1,0 +1,134 @@
+import { useRouter } from "@real-router/react";
+import { useEffect, useState } from "react";
+
+import type { JSX } from "react";
+
+interface NavigationContext {
+  navigationType?: "push" | "replace" | "traverse" | "reload";
+  direction?: "forward" | "back" | "unknown";
+}
+
+interface UrlContext {
+  hash?: string;
+  hashChanged?: boolean;
+}
+
+interface MeterSnapshot {
+  scrollY: number;
+  containerScrollTop: number | null;
+  navigationType: string;
+  direction: string;
+  hash: string;
+  hashChanged: boolean;
+  store: Record<string, number>;
+}
+
+const STORE_KEY = "real-router:scroll";
+
+function readStore(): Record<string, number> {
+  try {
+    const raw = globalThis.sessionStorage.getItem(STORE_KEY);
+
+    if (!raw) {
+      return {};
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, number>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function readContainerTop(): number | null {
+  const element = document.querySelector("#virtual-scroller");
+
+  return element ? element.scrollTop : null;
+}
+
+/**
+ * Floating panel showing live scrollY, navigation context, and the
+ * sessionStorage scroll-restore store. Doubles as a stable Playwright anchor:
+ * `data-scroll-y` attribute is more rAF-stable than `evaluate(() => scrollY)`.
+ */
+export function ScrollMeter(): JSX.Element {
+  const router = useRouter();
+  const [snapshot, setSnapshot] = useState<MeterSnapshot>(() =>
+    buildSnapshot(router),
+  );
+
+  useEffect(() => {
+    const update = (): void => {
+      setSnapshot(buildSnapshot(router));
+    };
+
+    const unsubscribe = router.subscribe(update);
+
+    const tick = (): void => {
+      update();
+    };
+
+    window.addEventListener("scroll", tick, { passive: true });
+    const interval = globalThis.setInterval(tick, 200);
+
+    return () => {
+      unsubscribe();
+      window.removeEventListener("scroll", tick);
+      globalThis.clearInterval(interval);
+    };
+  }, [router]);
+
+  return (
+    <aside
+      className="scroll-meter"
+      data-testid="scroll-meter"
+      data-scroll-y={Math.round(snapshot.scrollY)}
+      data-container-top={
+        snapshot.containerScrollTop === null
+          ? "null"
+          : Math.round(snapshot.containerScrollTop)
+      }
+      data-direction={snapshot.direction}
+      data-nav-type={snapshot.navigationType}
+      data-hash={snapshot.hash}
+      data-hash-changed={String(snapshot.hashChanged)}
+    >
+      <h4>Scroll Meter</h4>
+      <dl>
+        <dt>scrollY</dt>
+        <dd>{Math.round(snapshot.scrollY)}</dd>
+        <dt>container</dt>
+        <dd>{snapshot.containerScrollTop ?? "—"}</dd>
+        <dt>navType</dt>
+        <dd>{snapshot.navigationType}</dd>
+        <dt>direction</dt>
+        <dd>{snapshot.direction}</dd>
+        <dt>hash</dt>
+        <dd>{snapshot.hash || "—"}</dd>
+      </dl>
+      <pre data-testid="scroll-meter-store">
+        {JSON.stringify(snapshot.store, null, 2)}
+      </pre>
+    </aside>
+  );
+}
+
+function buildSnapshot(router: ReturnType<typeof useRouter>): MeterSnapshot {
+  const route = router.getState();
+  const nav = (route?.context as { navigation?: NavigationContext } | undefined)
+    ?.navigation;
+  const url = (route?.context as { url?: UrlContext } | undefined)?.url;
+
+  return {
+    scrollY: window.scrollY,
+    containerScrollTop: readContainerTop(),
+    navigationType: nav?.navigationType ?? "—",
+    direction: nav?.direction ?? "—",
+    hash: url?.hash ?? "",
+    hashChanged: url?.hashChanged ?? false,
+    store: readStore(),
+  };
+}

--- a/examples/web/react/scroll-restoration/src/main.tsx
+++ b/examples/web/react/scroll-restoration/src/main.tsx
@@ -1,0 +1,168 @@
+import { createRouter } from "@real-router/core";
+import { navigationPluginFactory } from "@real-router/navigation-plugin";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import { routes } from "./routes";
+
+import "../../../../shared/styles.css";
+import "./styles.css";
+
+// Mode + behavior persisted in localStorage. Switching them remounts the
+// RouterProvider via React `key` — utility is destroyed and recreated.
+const MODE_KEY = "scroll-restoration-mode";
+const BEHAVIOR_KEY = "scroll-restoration-behavior";
+
+type Mode = "restore" | "top" | "native";
+
+function readMode(): Mode {
+  const raw = globalThis.localStorage.getItem(MODE_KEY);
+
+  return raw === "top" || raw === "native" ? raw : "restore";
+}
+
+function readBehavior(): ScrollBehavior {
+  const raw = globalThis.localStorage.getItem(BEHAVIOR_KEY);
+
+  return raw === "instant" || raw === "smooth" ? raw : "auto";
+}
+
+function decodeHashSafe(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Initial scroll handling for cold load.
+ *
+ * `createScrollRestoration` subscribes to the router AFTER `router.start()`
+ * has already fired its first TRANSITION_SUCCESS. The initial route's
+ * `state.context.url.hash` (anchor) and `state.context.navigation.navigationType`
+ * ("reload" after F5 via #531 priming) never reach the utility's rAF callback.
+ * Runtime navigation (`<Link hash>`, back/forward, programmatic) still goes
+ * through the utility normally.
+ *
+ * For cold load we add a userland scroll fixup that mirrors the utility's
+ * decision tree:
+ *  1. If hash present → scrollIntoView (anchor scroll on direct entry).
+ *  2. Else if `navigation.activation.navigationType === "reload"` → read
+ *     position from `sessionStorage["real-router:scroll"][keyOf(route)]` and
+ *     scroll there (F5 restore).
+ */
+type RouterLike = ReturnType<typeof createRouter>;
+
+function applyInitialAnchorScroll(): void {
+  if (globalThis.location.hash.length <= 1) {
+    return;
+  }
+
+  const id = decodeHashSafe(globalThis.location.hash.slice(1));
+
+  // Poll for the element until it's mounted (React commit is async).
+  // Give up after ~600ms; fragment may simply not exist on this page.
+  // getElementById is preferred over querySelector — the id may contain
+  // CSS-unsafe characters (Cyrillic etc. — see Scenario 3d).
+  let attempts = 0;
+  const tryScroll = (): void => {
+    // eslint-disable-next-line unicorn/prefer-query-selector -- id may contain CSS-unsafe chars
+    const element = document.getElementById(id);
+
+    if (element) {
+      element.scrollIntoView();
+
+      return;
+    }
+
+    if (attempts < 20) {
+      attempts += 1;
+      setTimeout(tryScroll, 30);
+    }
+  };
+
+  setTimeout(tryScroll, 30);
+}
+
+function applyInitialF5Restore(router: RouterLike, mode: Mode): void {
+  if (mode !== "restore") {
+    // top: utility always scrolls to anchor-or-top regardless of nav state
+    // native: utility is fully disabled
+    return;
+  }
+
+  const navApi = (
+    globalThis as { navigation?: { activation?: { navigationType?: string } } }
+  ).navigation;
+
+  if (navApi?.activation?.navigationType !== "reload") {
+    return;
+  }
+
+  const route = router.getState();
+
+  if (!route) {
+    return;
+  }
+
+  const key = `${route.name}:${JSON.stringify(route.params)}`;
+  let store: Record<string, number | undefined>;
+
+  try {
+    const raw = globalThis.sessionStorage.getItem("real-router:scroll");
+
+    store = raw ? (JSON.parse(raw) as Record<string, number>) : {};
+  } catch {
+    return;
+  }
+
+  const pos = store[key];
+
+  if (typeof pos === "number" && pos > 0) {
+    // After React commits the route, scroll to the saved position.
+    setTimeout(() => {
+      globalThis.scrollTo(0, pos);
+    }, 50);
+  }
+}
+
+if ("navigation" in globalThis) {
+  const router = createRouter(routes, {
+    defaultRoute: "home",
+    allowNotFound: true,
+  });
+
+  router.usePlugin(navigationPluginFactory());
+
+  await router.start();
+
+  const mode = readMode();
+  const rootElement = document.querySelector("#root");
+
+  if (rootElement) {
+    // RouterProvider is mounted INSIDE App so that mode toggle can swap
+    // scrollRestoration options by remounting the provider (via React `key`).
+    // navigation-plugin intercepts `location.reload()` and converts it to a
+    // same-document SPA refresh — the React tree (and the already-mounted
+    // utility) survives, so reload-based mode swap doesn't actually work.
+    // Remounting the provider with a new `key` triggers utility destroy +
+    // recreate with the new mode.
+    const behavior = readBehavior();
+
+    createRoot(rootElement).render(
+      <App router={router} initialMode={mode} initialBehavior={behavior} />,
+    );
+
+    applyInitialAnchorScroll();
+    applyInitialF5Restore(router, mode);
+  }
+} else {
+  document.body.innerHTML = `
+    <div class="fallback">
+      <h1>Navigation API is required</h1>
+      <p>This example uses navigation-plugin which requires the Navigation API
+         (~88% global, Chrome 102+, Safari 26.2+, Firefox 147+).</p>
+      <p><a href="https://caniuse.com/mdn-api_navigation">caniuse.com/mdn-api_navigation</a></p>
+    </div>`;
+}

--- a/examples/web/react/scroll-restoration/src/pages/Article.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Article.tsx
@@ -1,0 +1,46 @@
+import { Link, useRoute } from "@real-router/react";
+
+import { ProgrammaticReloadDemo } from "../components/ProgrammaticReloadDemo";
+import { ReplaceDemo } from "../components/ReplaceDemo";
+
+import type { JSX } from "react";
+
+/**
+ * Article page — long body for scroll, plus ReplaceDemo (Scenario 4) and
+ * ProgrammaticReloadDemo (Scenario 7c) embedded near the top so e2e can
+ * scroll a known offset and click without hunting.
+ */
+
+const PARAGRAPH = `
+  This is article content. The body is long enough that scrollY of 1500-2500
+  is reachable without resizing the viewport. Replace navigation (button below)
+  preserves your scroll position; programmatic reload restores from the
+  sessionStorage scroll-restore store.
+`.trim();
+
+export function Article(): JSX.Element {
+  const { route } = useRoute<{ id: string }>();
+  const id = route.params.id;
+
+  return (
+    <div className="long-page">
+      <h1>Article #{id}</h1>
+      <p>
+        <Link routeName="articles" data-testid="back-to-list">
+          ← Back to list
+        </Link>
+      </p>
+
+      <div data-testid="article-actions">
+        <ReplaceDemo />
+        <ProgrammaticReloadDemo />
+      </div>
+
+      {Array.from({ length: 30 }, (_, i) => (
+        <p key={i}>
+          §{i + 1}. {PARAGRAPH}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/pages/Articles.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Articles.tsx
@@ -1,0 +1,67 @@
+import { Link } from "@real-router/react";
+
+import type { JSX } from "react";
+
+/**
+ * Long list of article cards — primary restore + save scene (Scenario 1, 7).
+ * 50 cards × ~120px = ~6000px page height, plenty of room to scroll past
+ * 3000px and verify back-restore lands at the captured position.
+ */
+
+const ARTICLE_TITLES = [
+  "Why we replaced Redux with router state",
+  "Hash routing without breaking tab UIs",
+  "Building a framework-agnostic router from scratch",
+  "Scroll restoration: the parts nobody talks about",
+  "Plugin architecture vs. monolithic routers",
+  "Cross-document navigation with the Navigation API",
+  "Type-safe URL parameters via TypeScript inference",
+  "Memory routing for terminal UIs",
+];
+
+const EXCERPTS = [
+  "Single source of truth for view state, deep linking comes for free.",
+  "Anchor scroll without sacrificing tabbed interfaces — yes, you can.",
+  "Six adapters, one core. Lessons from a year of decoupled routing.",
+  "Save on pagehide, restore on traverse, and never trust history.scrollRestoration.",
+  "Composable plugins beat hand-rolled middleware every time.",
+  "Reload, traverse, push, replace — and how to tell them apart.",
+  "Generics on hooks unlock auto-complete for params across the codebase.",
+  "Keyboard-driven navigation works the same as the web — once you have a router.",
+];
+
+const articles = Array.from({ length: 50 }, (_, i) => ({
+  id: String(i + 1),
+  title: `${
+    ARTICLE_TITLES[i % ARTICLE_TITLES.length]
+  } — part ${Math.floor(i / 10) + 1}`,
+  excerpt: `Article #${i + 1}. ${EXCERPTS[i % EXCERPTS.length]}`,
+}));
+
+export function Articles(): JSX.Element {
+  return (
+    <div>
+      <h1 style={{ padding: "24px 24px 0" }}>Articles</h1>
+      <p style={{ padding: "0 24px" }}>
+        Long list — scroll down, click any card, then press the browser Back
+        button. Position is restored (Scenario 1). F5 here saves the position
+        via <code>pagehide</code> and restores it on the next load (Scenario 7
+        after #531).
+      </p>
+      <div className="articles-list">
+        {articles.map((article) => (
+          <Link
+            key={article.id}
+            routeName="articles.article"
+            routeParams={{ id: article.id }}
+            data-testid={`article-card-${article.id}`}
+            className="article-card"
+          >
+            <h3>{article.title}</h3>
+            <p>{article.excerpt}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/pages/Documentation.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Documentation.tsx
@@ -1,0 +1,86 @@
+import { Link } from "@real-router/react";
+
+import type { JSX } from "react";
+
+/**
+ * Long page with anchor headings — exercises Scenario 3 (4 sub-tests):
+ * - 3a: page.goto('/docs#getting-started') initial entry with anchor
+ * - 3b: cross-path <Link hash> from / lands on /docs#installation
+ * - 3c: same-path <Link hash> on /docs#api → /docs#examples auto-force
+ * - 3d: cyrillic id /docs#секция-5 (percent-encoded in URL bar, decoded
+ *       by URL plugin into state.context.url.hash)
+ *
+ * After #531/#532 anchor scrolling works in both restore and top modes,
+ * across all four entry points. Each section is intentionally tall (~600px)
+ * so scroll position is unambiguous in e2e.
+ */
+
+const sections = [
+  { id: "getting-started", title: "Getting Started" },
+  { id: "installation", title: "Installation" },
+  { id: "configuration", title: "Configuration" },
+  { id: "api", title: "API Reference" },
+  { id: "examples", title: "Examples" },
+  { id: "troubleshooting", title: "Troubleshooting" },
+  { id: "section-5", title: "Section 5 (ASCII anchor)" },
+  { id: "секция-5", title: "Секция-5 (Cyrillic anchor)" },
+];
+
+const PARAGRAPH = `
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+  veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+  commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+  velit esse cillum dolore eu fugiat nulla pariatur.
+`.trim();
+
+export function Documentation(): JSX.Element {
+  return (
+    <div className="long-page">
+      <h1>Documentation</h1>
+      <p>
+        Long page with anchor sections. Anchor scroll works after #531/#532 in{" "}
+        <em>all</em> entry points: initial goto, cross-path{" "}
+        <code>&lt;Link hash&gt;</code>, same-path <code>&lt;Link hash&gt;</code>{" "}
+        (auto-force via <code>navigateWithHash</code>), and cyrillic ids
+        (decoded by URL plugin).
+      </p>
+
+      <nav className="docs-toc" aria-label="table of contents">
+        <h3>On this page</h3>
+        <ul>
+          {sections.map((section) => (
+            <li key={section.id}>
+              <Link
+                routeName="docs"
+                hash={section.id}
+                data-testid={`toc-${section.id}`}
+              >
+                {section.title}
+              </Link>
+            </li>
+          ))}
+          <li>
+            <Link
+              routeName="docs"
+              hash="no-such-section"
+              data-testid="toc-missing"
+            >
+              (broken anchor — no matching id)
+            </Link>
+          </li>
+        </ul>
+      </nav>
+
+      {sections.map((section) => (
+        <section key={section.id}>
+          <h2 id={section.id}>{section.title}</h2>
+          <p>{PARAGRAPH}</p>
+          <p>{PARAGRAPH}</p>
+          <p>{PARAGRAPH}</p>
+          <p>{PARAGRAPH}</p>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/pages/Gallery.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Gallery.tsx
@@ -1,0 +1,37 @@
+import type { JSX } from "react";
+
+/**
+ * Scenario 6 — custom scrollContainer. The <div id="virtual-scroller"> is
+ * styled overflow-y:auto + height:80vh; window does not scroll on this
+ * page, only the inner div. RouterProvider's scrollContainer getter
+ * returns this element when present, falls back to window otherwise
+ * (lazy resolve in readPos/writePos).
+ */
+
+const cells = Array.from({ length: 200 }, (_, i) => i + 1);
+
+export function Gallery(): JSX.Element {
+  return (
+    <div>
+      <h1 style={{ padding: "24px 24px 0" }}>Gallery</h1>
+      <p style={{ padding: "0 24px" }}>
+        Scroll inside the bordered container below. Position is captured against{" "}
+        <code>#virtual-scroller</code>, not <code>window</code>. Navigate away
+        and back to see restore.
+      </p>
+      <div id="virtual-scroller" data-testid="virtual-scroller">
+        <div className="gallery-grid">
+          {cells.map((cellNumber) => (
+            <div
+              className="gallery-cell"
+              key={cellNumber}
+              data-testid={`gallery-cell-${cellNumber}`}
+            >
+              #{cellNumber}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/pages/Home.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Home.tsx
@@ -1,0 +1,69 @@
+import { Link } from "@real-router/react";
+
+import type { JSX } from "react";
+
+/**
+ * Short landing page. Used as a starting point for forward navigation —
+ * any push from `/` lands on a long page with `scrollY === 0`. Hosts a
+ * cross-path `<Link hash>` for Scenario 3b.
+ */
+export function Home(): JSX.Element {
+  return (
+    <div className="long-page">
+      <h1>Scroll Restoration — feature demo</h1>
+      <p>
+        This example exercises every behavioral branch of{" "}
+        <code>createScrollRestoration</code> (#497). Navigate around to see how
+        scroll position is captured, restored, or reset depending on the
+        navigation type and the configured mode.
+      </p>
+      <p>
+        Watch the <strong>Scroll Meter</strong> in the bottom-right corner — it
+        shows live <code>scrollY</code>, the published{" "}
+        <code>state.context.navigation</code> direction / navigationType, and
+        the <code>sessionStorage</code> store keyed by{" "}
+        <code>{`name:canonicalJson(params)`}</code>.
+      </p>
+
+      <h2>Try these flows</h2>
+      <ul>
+        <li>
+          Open <Link routeName="articles">Articles</Link>, scroll down, click
+          any card, then Back — position is restored (Scenario 1).
+        </li>
+        <li>
+          From here, click{" "}
+          <Link
+            routeName="docs"
+            hash="installation"
+            data-testid="link-docs-installation"
+          >
+            Docs §Installation
+          </Link>{" "}
+          — cross-path push preserves the hash and scrolls to the anchor
+          (Scenario 3b, after #532).
+        </li>
+        <li>
+          Go to <Link routeName="settings">Settings</Link> to switch{" "}
+          <code>mode: restore | top | native</code> (Scenario 5).
+        </li>
+        <li>
+          Open <Link routeName="gallery">Gallery</Link> — a virtual scroller
+          inside a sized <code>&lt;div&gt;</code> (Scenario 6).
+        </li>
+        <li>
+          Edge case:{" "}
+          <Link
+            routeName="docs"
+            hash="no-such-section"
+            data-testid="link-docs-missing"
+          >
+            Docs §missing
+          </Link>{" "}
+          — hash with no matching <code>id</code>; utility falls through to{" "}
+          <code>writePos(0)</code> (Scenario 5i).
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/pages/Settings.tsx
+++ b/examples/web/react/scroll-restoration/src/pages/Settings.tsx
@@ -1,0 +1,86 @@
+import { BehaviorToggle } from "../components/BehaviorToggle";
+import { ModeToggle } from "../components/ModeToggle";
+
+import type { JSX } from "react";
+
+type Mode = "restore" | "top" | "native";
+
+interface SettingsProps {
+  readonly mode: Mode;
+  readonly onModeChange: (mode: Mode) => void;
+  readonly behavior: ScrollBehavior;
+  readonly onBehaviorChange: (behavior: ScrollBehavior) => void;
+}
+
+/**
+ * Settings page — ModeToggle (Scenario 5) and BehaviorToggle (Scenario 8).
+ * Both follow the same pattern: persist to localStorage + call the parent
+ * setter, which updates App state → RouterProvider remounts via `key` →
+ * scroll-restore utility is destroyed and recreated with new options.
+ *
+ * No full-document reload is used because navigation-plugin intercepts
+ * `location.reload()` and converts it to a same-document SPA refresh.
+ */
+export function Settings({
+  mode,
+  onModeChange,
+  behavior,
+  onBehaviorChange,
+}: SettingsProps): JSX.Element {
+  return (
+    <div className="long-page">
+      <h1>Settings</h1>
+
+      <h2>Scroll Restoration mode</h2>
+      <p>
+        Current: <strong>{mode}</strong>. Switching the mode remounts the
+        RouterProvider — the utility is destroyed (via React effect cleanup) and
+        re-created with the new mode. Mode is also persisted in{" "}
+        <code>localStorage["scroll-restoration-mode"]</code> so the next cold
+        load picks it up.
+      </p>
+
+      <ModeToggle mode={mode} onModeChange={onModeChange} />
+
+      <h2>Scroll behavior</h2>
+      <p>
+        Current: <strong>{behavior}</strong>. Forwarded to{" "}
+        <code>scrollTo({"{ behavior }"})</code> and{" "}
+        <code>scrollIntoView({"{ behavior }"})</code>. <code>smooth</code> is
+        best for <code>top</code> mode or anchor scroll; on <code>restore</code>{" "}
+        mode the animated re-position on Back can feel disorienting.
+      </p>
+
+      <BehaviorToggle behavior={behavior} onBehaviorChange={onBehaviorChange} />
+
+      <h2>What each mode does</h2>
+      <dl>
+        <dt>
+          <code>restore</code> (default)
+        </dt>
+        <dd>
+          Save on transition + pagehide; restore on back / traverse / reload.
+          Forward push scrolls to anchor or top.
+        </dd>
+        <dt>
+          <code>top</code>
+        </dt>
+        <dd>
+          Always scroll to top (or anchor when URL has fragment) regardless of
+          direction. Plugin-agnostic — works without
+          <code> state.context.navigation</code>.
+        </dd>
+        <dt>
+          <code>native</code>
+        </dt>
+        <dd>
+          Utility is fully disabled. <code>history.scrollRestoration</code>{" "}
+          stays at the browser default <code>"auto"</code> — the browser handles
+          restore natively. (Note: the utility's <code>"native"</code> is the
+          opposite of the DOM <code>"manual"</code> value: utility hands off to
+          the browser, browser uses its built-in restore.)
+        </dd>
+      </dl>
+    </div>
+  );
+}

--- a/examples/web/react/scroll-restoration/src/routes.ts
+++ b/examples/web/react/scroll-restoration/src/routes.ts
@@ -1,0 +1,13 @@
+import type { Route } from "@real-router/core";
+
+export const routes: Route[] = [
+  { name: "home", path: "/" },
+  { name: "docs", path: "/docs" },
+  {
+    name: "articles",
+    path: "/articles",
+    children: [{ name: "article", path: "/:id" }],
+  },
+  { name: "gallery", path: "/gallery" },
+  { name: "settings", path: "/settings" },
+];

--- a/examples/web/react/scroll-restoration/src/styles.css
+++ b/examples/web/react/scroll-restoration/src/styles.css
@@ -1,0 +1,217 @@
+/* Long pages give scroll something to do — base content height ~5000-6000px.
+ * Stable min-height on .content (the main container, present across all
+ * routes) gives the browser enough scroll room to satisfy `scrollTo(0, N)`
+ * called by the utility's rAF before React's mount commits the route's
+ * actual content. Without this, scrollY clamps to maxScroll of the
+ * partially-mounted page — Scenario 1's restore lands at e.g. 1707 instead
+ * of 3000. */
+
+main.content {
+  min-height: 7000px;
+}
+
+.long-page {
+  padding: 24px;
+  max-width: 800px;
+  min-height: 6500px;
+}
+
+.long-page h1 {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.long-page h2 {
+  margin-top: 48px;
+  scroll-margin-top: 80px; /* sticky header offset */
+}
+
+.long-page p {
+  line-height: 1.6;
+  margin: 12px 0;
+}
+
+.docs-toc {
+  position: sticky;
+  top: 80px;
+  float: right;
+  margin-left: 24px;
+  padding: 12px 16px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  font-size: 13px;
+  width: 220px;
+}
+
+.docs-toc h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  text-transform: uppercase;
+  color: #666;
+}
+
+.docs-toc ul {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.docs-toc li {
+  margin: 4px 0;
+}
+
+.articles-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  min-height: 6500px;
+}
+
+.article-card {
+  display: block;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+  text-decoration: none;
+  color: inherit;
+  min-height: 88px;
+}
+
+.article-card:hover {
+  border-color: #4a8fdf;
+  background: #f7faff;
+}
+
+.article-card h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+}
+
+.article-card p {
+  margin: 0;
+  font-size: 13px;
+  color: #666;
+}
+
+#virtual-scroller {
+  overflow-y: auto;
+  height: 80vh;
+  border: 1px solid #ddd;
+  margin: 24px;
+  padding: 0;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 8px;
+  padding: 8px;
+}
+
+.gallery-cell {
+  aspect-ratio: 4 / 3;
+  background: #ddd;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: #555;
+}
+
+.scroll-meter {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 280px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  font: 12px/1.4 ui-monospace, "SFMono-Regular", monospace;
+  z-index: 1000;
+}
+
+.scroll-meter h4 {
+  margin: 0 0 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #555;
+}
+
+.scroll-meter dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+  margin: 0;
+}
+
+.scroll-meter dt {
+  color: #999;
+}
+
+.scroll-meter dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.scroll-meter pre {
+  margin: 6px 0 0;
+  padding: 6px;
+  background: #f5f5f5;
+  border-radius: 3px;
+  font-size: 11px;
+  max-height: 100px;
+  overflow: auto;
+}
+
+.direction-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  margin: 0 8px;
+  font-size: 12px;
+  background: #eef;
+  border: 1px solid #99f;
+  border-radius: 12px;
+  color: #335;
+}
+
+.mode-toggle {
+  display: flex;
+  gap: 6px;
+  margin: 12px 0;
+}
+
+.mode-toggle button {
+  padding: 6px 14px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.mode-toggle button[data-active="true"] {
+  background: #4a8fdf;
+  color: #fff;
+  border-color: #4a8fdf;
+}
+
+.demo-button {
+  padding: 8px 14px;
+  margin: 4px 4px 4px 0;
+  font-size: 13px;
+  border: 1px solid #4a8fdf;
+  background: #fff;
+  color: #4a8fdf;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.demo-button:hover {
+  background: #4a8fdf;
+  color: #fff;
+}

--- a/examples/web/react/scroll-restoration/src/vite-env.d.ts
+++ b/examples/web/react/scroll-restoration/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/web/react/scroll-restoration/tsconfig.json
+++ b/examples/web/react/scroll-restoration/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "../shared"]
+}

--- a/examples/web/react/scroll-restoration/vite.config.ts
+++ b/examples/web/react/scroll-restoration/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    conditions: ["development"],
+  },
+});

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -414,7 +414,7 @@ interface RealRouterOptions {
 }
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. The utility is created by `provideEnvironmentInitializer` and torn down via `inject(DestroyRef)`. Options are a snapshot at bootstrap — not reactive to runtime changes. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. The utility is created by `provideEnvironmentInitializer` and torn down via `inject(DestroyRef)`. Options are a snapshot at bootstrap — not reactive to runtime changes. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/angular/src/dom-utils/scroll-restore.ts
+++ b/packages/angular/src/dom-utils/scroll-restore.ts
@@ -1,6 +1,6 @@
 import type { Router, State } from "@real-router/core";
 
-const STORAGE_KEY = "real-router:scroll";
+const DEFAULT_STORAGE_KEY = "real-router:scroll";
 
 const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
   destroy: () => {
@@ -8,12 +8,33 @@ const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
   },
 });
 
-export type ScrollRestorationMode = "restore" | "top" | "manual";
+export type ScrollRestorationMode = "restore" | "top" | "native";
 
 export interface ScrollRestorationOptions {
   mode?: ScrollRestorationMode | undefined;
   anchorScrolling?: boolean | undefined;
   scrollContainer?: (() => HTMLElement | null) | undefined;
+  /**
+   * Scroll behavior passed to `scrollTo({ behavior })` and
+   * `scrollIntoView({ behavior })`.
+   *
+   * - `"auto"` (default) — browser-defined, usually instant.
+   * - `"instant"` — explicit instant jump (no animation).
+   * - `"smooth"` — animated transition. Note: smooth restore on back/traverse
+   *   can feel disorienting if the user expects to land at the saved position
+   *   immediately. Recommended for `mode: "top"` or anchor scroll only.
+   *
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior).
+   */
+  behavior?: ScrollBehavior | undefined;
+  /**
+   * sessionStorage key used to persist saved scroll positions. Default:
+   * `"real-router:scroll"`. Override only when multiple independent
+   * `RouterProvider` instances share the same document and you need to
+   * isolate their scroll stores (e.g. micro-frontends, embedded widgets,
+   * or testing). For a single app with one provider the default is fine.
+   */
+  storageKey?: string | undefined;
 }
 
 interface NavigationContext {
@@ -31,15 +52,41 @@ export function createScrollRestoration(
 
   const mode = options?.mode ?? "restore";
 
-  // mode "manual" = utility does nothing. Don't flip history.scrollRestoration,
-  // don't subscribe, don't register pagehide — leave the browser's native
-  // auto-restore intact for the app to override if it wants to.
-  if (mode === "manual") {
+  // mode "native" = utility does nothing. Don't flip history.scrollRestoration,
+  // don't subscribe, don't register pagehide — `history.scrollRestoration`
+  // stays at the browser default ("auto") so the browser handles scroll
+  // restore natively. (Note: this is the OPPOSITE of `history.scrollRestoration
+  // === "manual"` — utility's "native" leaves the DOM property at "auto" so
+  // the browser is in charge.)
+  if (mode === "native") {
     return NOOP_INSTANCE;
   }
 
   const anchorEnabled = options?.anchorScrolling ?? true;
   const getContainer = options?.scrollContainer;
+  const behavior: ScrollBehavior = options?.behavior ?? "auto";
+  const storageKey = options?.storageKey ?? DEFAULT_STORAGE_KEY;
+
+  const loadStore = (): Record<string, number> => {
+    try {
+      const raw = sessionStorage.getItem(storageKey);
+
+      return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    } catch {
+      return {};
+    }
+  };
+
+  const putPos = (key: string, pos: number): void => {
+    try {
+      const store = loadStore();
+
+      store[key] = pos;
+      sessionStorage.setItem(storageKey, JSON.stringify(store));
+    } catch {
+      // Ignore quota / security errors.
+    }
+  };
 
   const prevScrollRestoration = history.scrollRestoration;
 
@@ -62,9 +109,9 @@ export function createScrollRestoration(
     const element = getContainer?.();
 
     if (element) {
-      element.scrollTop = top;
+      element.scrollTo({ top, left: 0, behavior });
     } else {
-      globalThis.scrollTo(0, top);
+      globalThis.scrollTo({ top, left: 0, behavior });
     }
   };
 
@@ -82,7 +129,7 @@ export function createScrollRestoration(
         const element = document.getElementById(ctxHash);
 
         if (element) {
-          element.scrollIntoView();
+          element.scrollIntoView({ behavior });
 
           return;
         }
@@ -112,7 +159,7 @@ export function createScrollRestoration(
       const element = document.getElementById(id);
 
       if (element) {
-        element.scrollIntoView();
+        element.scrollIntoView({ behavior });
 
         return;
       }
@@ -196,27 +243,6 @@ export function createScrollRestoration(
 
 function keyOf(state: State): string {
   return `${state.name}:${canonicalJson(state.params)}`;
-}
-
-function loadStore(): Record<string, number> {
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-
-    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
-  } catch {
-    return {};
-  }
-}
-
-function putPos(key: string, pos: number): void {
-  try {
-    const store = loadStore();
-
-    store[key] = pos;
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-  } catch {
-    // Ignore quota / security errors.
-  }
 }
 
 function canonicalJson(value: unknown): string {

--- a/packages/angular/tests/functional/scroll-restore.test.ts
+++ b/packages/angular/tests/functional/scroll-restore.test.ts
@@ -111,7 +111,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -132,7 +136,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
       makeState("about"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 420);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 420,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -228,7 +236,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
     );
 
     // ctxHash !== undefined branch entered, but ctxHash.length === 0 → top.
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -250,7 +262,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -298,7 +314,7 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
     sr.destroy();
   });
 
-  it("custom scrollContainer reads/writes .scrollTop", () => {
+  it("custom scrollContainer reads/writes via element.scrollTo", () => {
     const element = document.createElement("div");
 
     element.id = "scroller";
@@ -308,6 +324,9 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
       writable: true,
       configurable: true,
     });
+    const elementScrollToSpy = vi.fn();
+
+    element.scrollTo = elementScrollToSpy as unknown as typeof element.scrollTo;
 
     const fake = makeFakeRouter(makeState("home"));
     const sr = track(
@@ -324,7 +343,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
       makeState("home"),
     );
 
-    expect(element.scrollTop).toBe(200);
+    expect(elementScrollToSpy).toHaveBeenLastCalledWith({
+      top: 200,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -355,7 +378,11 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
     );
 
     expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
     globalThis.history.replaceState(null, "", "/");
@@ -396,10 +423,10 @@ describe("createScrollRestoration (Angular dom-utils copy)", () => {
     }).not.toThrow();
   });
 
-  it("mode 'manual' no-ops everything", () => {
+  it("mode 'native' no-ops everything", () => {
     const fake = makeFakeRouter(makeState("home"));
     const scrollSpy = vi.spyOn(globalThis, "scrollTo");
-    const sr = track(createScrollRestoration(fake.router, { mode: "manual" }));
+    const sr = track(createScrollRestoration(fake.router, { mode: "native" }));
 
     fake.emit(
       makeState("about", {}, { navigation: { navigationType: "push" } }),

--- a/packages/dom-utils/tests/functional/scroll-restore.test.ts
+++ b/packages/dom-utils/tests/functional/scroll-restore.test.ts
@@ -115,12 +115,12 @@ describe("createScrollRestoration", () => {
     expect(history.scrollRestoration).toBe("auto");
   });
 
-  it("mode 'manual' returns noop — no history flip, no subscribe, no pagehide", () => {
+  it("mode 'native' returns noop — no history flip, no subscribe, no pagehide", () => {
     history.scrollRestoration = "auto";
 
     const fake = makeFakeRouter(makeState("home"));
     const scrollSpy = vi.spyOn(globalThis, "scrollTo");
-    const sr = track(createScrollRestoration(fake.router, { mode: "manual" }));
+    const sr = track(createScrollRestoration(fake.router, { mode: "native" }));
 
     // No flip — browser's default auto-restore stays active.
     expect(history.scrollRestoration).toBe("auto");
@@ -144,7 +144,164 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
+
+    sr.destroy();
+  });
+
+  it("behavior option: 'smooth' is forwarded to scrollTo and scrollIntoView", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(
+      createScrollRestoration(fake.router, {
+        mode: "top",
+        behavior: "smooth",
+      }),
+    );
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "smooth",
+    });
+
+    sr.destroy();
+  });
+
+  it("behavior option: 'smooth' is forwarded to anchor scrollIntoView", () => {
+    const anchor = document.createElement("div");
+
+    anchor.id = "target";
+    document.body.append(anchor);
+    const scrollIntoViewSpy = vi.fn();
+
+    anchor.scrollIntoView = scrollIntoViewSpy;
+    globalThis.history.replaceState(null, "", "/#target");
+
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(
+      createScrollRestoration(fake.router, { behavior: "smooth" }),
+    );
+
+    fake.emit(
+      makeState(
+        "about",
+        {},
+        { navigation: { direction: "forward", navigationType: "push" } },
+      ),
+      makeState("home"),
+    );
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: "smooth" });
+
+    sr.destroy();
+    globalThis.history.replaceState(null, "", "/");
+  });
+
+  it("storageKey: custom key isolates store from default key", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(
+      createScrollRestoration(fake.router, { storageKey: "my-app:scroll" }),
+    );
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 250,
+      configurable: true,
+    });
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    // Custom key was written
+    expect(sessionStorage.getItem("my-app:scroll")).not.toBeNull();
+    // Default key untouched
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    sr.destroy();
+  });
+
+  it("storageKey: defaults to 'real-router:scroll' when omitted", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const sr = track(createScrollRestoration(fake.router));
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 100,
+      configurable: true,
+    });
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    expect(sessionStorage.getItem("real-router:scroll")).not.toBeNull();
+
+    sr.destroy();
+  });
+
+  it("storageKey: two utilities with different keys don't share state", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const srA = track(
+      createScrollRestoration(fake.router, { storageKey: "app-a:scroll" }),
+    );
+    const srB = track(
+      createScrollRestoration(fake.router, { storageKey: "app-b:scroll" }),
+    );
+
+    Object.defineProperty(globalThis, "scrollY", {
+      value: 333,
+      configurable: true,
+    });
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    // Both wrote (both are subscribed) but to different keys.
+    const storeA = JSON.parse(
+      sessionStorage.getItem("app-a:scroll") ?? "{}",
+    ) as Record<string, number>;
+    const storeB = JSON.parse(
+      sessionStorage.getItem("app-b:scroll") ?? "{}",
+    ) as Record<string, number>;
+
+    expect(storeA["home:{}"]).toBe(333);
+    expect(storeB["home:{}"]).toBe(333);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    srA.destroy();
+    srB.destroy();
+  });
+
+  it("behavior defaults to 'auto' when omitted", () => {
+    const fake = makeFakeRouter(makeState("home"));
+    const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+    const sr = track(createScrollRestoration(fake.router, { mode: "top" }));
+
+    fake.emit(
+      makeState("about", {}, { navigation: { navigationType: "push" } }),
+      makeState("home"),
+    );
+
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -165,7 +322,11 @@ describe("createScrollRestoration", () => {
       makeState("about"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 420);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 420,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -184,7 +345,11 @@ describe("createScrollRestoration", () => {
       makeState("about"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -203,7 +368,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -251,7 +420,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
     globalThis.history.replaceState(null, "", "/");
@@ -288,7 +461,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 77);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 77,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -305,7 +482,11 @@ describe("createScrollRestoration", () => {
       makeState("home", {}, { navigation: { navigationType: "reload" } }),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 200);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 200,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -317,7 +498,11 @@ describe("createScrollRestoration", () => {
 
     fake.emit(makeState("about"), makeState("home"));
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -385,7 +570,7 @@ describe("createScrollRestoration", () => {
     sr.destroy();
   });
 
-  it("custom scrollContainer reads/writes .scrollTop, not window", () => {
+  it("custom scrollContainer reads/writes via element.scrollTo, not window", () => {
     const element = document.createElement("div");
 
     element.id = "scroller";
@@ -395,6 +580,9 @@ describe("createScrollRestoration", () => {
       writable: true,
       configurable: true,
     });
+    const elementScrollToSpy = vi.fn();
+
+    element.scrollTo = elementScrollToSpy as unknown as typeof element.scrollTo;
 
     const fake = makeFakeRouter(makeState("home"));
     const windowScrollSpy = vi.spyOn(globalThis, "scrollTo");
@@ -414,7 +602,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(element.scrollTop).toBe(200);
+    expect(elementScrollToSpy).toHaveBeenLastCalledWith({
+      top: 200,
+      left: 0,
+      behavior: "auto",
+    });
     expect(windowScrollSpy).not.toHaveBeenCalled();
 
     sr.destroy();
@@ -441,6 +633,9 @@ describe("createScrollRestoration", () => {
       writable: true,
       configurable: true,
     });
+    const elementScrollToSpy = vi.fn();
+
+    element.scrollTo = elementScrollToSpy as unknown as typeof element.scrollTo;
 
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "about:{}": 150 }));
     fake.emit(
@@ -453,7 +648,11 @@ describe("createScrollRestoration", () => {
     );
 
     // Lazy resolve picked up the newly-mounted container.
-    expect(element.scrollTop).toBe(150);
+    expect(elementScrollToSpy).toHaveBeenLastCalledWith({
+      top: 150,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -476,7 +675,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -509,7 +712,11 @@ describe("createScrollRestoration", () => {
     );
 
     expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
     globalThis.history.replaceState(null, "", "/");
@@ -570,7 +777,11 @@ describe("createScrollRestoration", () => {
       makeState("about"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 77);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 77,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr2.destroy();
   });
@@ -729,7 +940,11 @@ describe("createScrollRestoration", () => {
     );
 
     // Corrupted JSON → store treated as empty → restores to 0.
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -767,7 +982,11 @@ describe("createScrollRestoration", () => {
     // Frame fires → scroll applied.
     pending.shift()?.(0);
 
-    expect(scrollSpy).toHaveBeenCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -817,7 +1036,11 @@ describe("createScrollRestoration", () => {
       makeState("home"),
     );
 
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
   });
@@ -869,7 +1092,11 @@ describe("createScrollRestoration", () => {
     }).not.toThrow();
 
     // No element matches the raw "foo%2" id either → scroll to top.
-    expect(scrollSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(scrollSpy).toHaveBeenLastCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
 
     sr.destroy();
     globalThis.history.replaceState(null, "", "/");

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -267,7 +267,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/preact/src/RouterProvider.tsx
+++ b/packages/preact/src/RouterProvider.tsx
@@ -47,6 +47,8 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
   // so we intentionally omit it from deps to keep inline getters stable.
   const srMode = scrollRestoration?.mode;
   const srAnchor = scrollRestoration?.anchorScrolling;
+  const srBehavior = scrollRestoration?.behavior;
+  const srStorageKey = scrollRestoration?.storageKey;
   const srEnabled = scrollRestoration !== undefined;
 
   useEffect(() => {
@@ -57,6 +59,8 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
     const sr = createScrollRestoration(router, {
       mode: srMode,
       anchorScrolling: srAnchor,
+      behavior: srBehavior,
+      storageKey: srStorageKey,
       // srEnabled check above guarantees scrollRestoration is defined.
       scrollContainer: scrollRestoration.scrollContainer,
     });
@@ -66,7 +70,7 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
     };
     // scrollRestoration (for scrollContainer) omitted — see comment above.
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [router, srEnabled, srMode, srAnchor]);
+  }, [router, srEnabled, srMode, srAnchor, srBehavior, srStorageKey]);
 
   useEffect(() => {
     if (!viewTransitions) {

--- a/packages/preact/tests/functional/RouterProvider.scroll.test.tsx
+++ b/packages/preact/tests/functional/RouterProvider.scroll.test.tsx
@@ -94,11 +94,11 @@ describe("RouterProvider — scrollRestoration", () => {
   // object thrash. If re-created on every render, prevScrollRestoration
   // captures "manual", and the final unmount fails to restore "auto".
   it("replacing the options ref with same fields — does NOT re-create the utility", async () => {
-    let setOpts!: (o: { mode: "restore" | "top" | "manual" }) => void;
+    let setOpts!: (o: { mode: "restore" | "top" | "native" }) => void;
 
     function Harness() {
       const [opts, update] = useState<{
-        mode: "restore" | "top" | "manual";
+        mode: "restore" | "top" | "native";
       }>({ mode: "restore" });
 
       setOpts = update;

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -329,7 +329,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/react/src/RouterProvider.tsx
+++ b/packages/react/src/RouterProvider.tsx
@@ -46,6 +46,8 @@ export const RouterProvider: FC<RouteProviderProps> = ({
   // so we intentionally omit it from deps to keep inline getters stable.
   const srMode = scrollRestoration?.mode;
   const srAnchor = scrollRestoration?.anchorScrolling;
+  const srBehavior = scrollRestoration?.behavior;
+  const srStorageKey = scrollRestoration?.storageKey;
   const srEnabled = scrollRestoration !== undefined;
 
   useEffect(() => {
@@ -56,6 +58,8 @@ export const RouterProvider: FC<RouteProviderProps> = ({
     const sr = createScrollRestoration(router, {
       mode: srMode,
       anchorScrolling: srAnchor,
+      behavior: srBehavior,
+      storageKey: srStorageKey,
       // srEnabled check above guarantees scrollRestoration is defined.
       scrollContainer: scrollRestoration.scrollContainer,
     });
@@ -65,7 +69,7 @@ export const RouterProvider: FC<RouteProviderProps> = ({
     };
     // scrollRestoration (for scrollContainer) omitted — see comment above.
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [router, srEnabled, srMode, srAnchor]);
+  }, [router, srEnabled, srMode, srAnchor, srBehavior, srStorageKey]);
 
   useEffect(() => {
     if (!viewTransitions) {

--- a/packages/react/tests/functional/RouterProvider.scroll.test.tsx
+++ b/packages/react/tests/functional/RouterProvider.scroll.test.tsx
@@ -93,11 +93,11 @@ describe("RouterProvider — scrollRestoration", () => {
   // object thrash. If re-created on every render, prevScrollRestoration
   // captures "manual", and the final unmount fails to restore "auto".
   it("replacing the options ref with same fields — does NOT re-create the utility", async () => {
-    let setOpts!: (o: { mode: "restore" | "top" | "manual" }) => void;
+    let setOpts!: (o: { mode: "restore" | "top" | "native" }) => void;
 
     const Harness: FC = () => {
       const [opts, update] = useState<{
-        mode: "restore" | "top" | "manual";
+        mode: "restore" | "top" | "native";
       }>({ mode: "restore" });
 
       setOpts = update;

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -372,7 +372,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Options are read once on mount — changing the prop at runtime does not reconfigure the utility (Solid `onMount` is non-reactive). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Options are read once on mount — changing the prop at runtime does not reconfigure the utility (Solid `onMount` is non-reactive). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -425,7 +425,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/svelte/src/RouterProvider.svelte
+++ b/packages/svelte/src/RouterProvider.svelte
@@ -42,16 +42,23 @@
   const srEnabled = $derived(scrollRestoration !== undefined);
   const srMode = $derived(scrollRestoration?.mode);
   const srAnchor = $derived(scrollRestoration?.anchorScrolling);
+  const srBehavior = $derived(scrollRestoration?.behavior);
+  const srStorageKey = $derived(scrollRestoration?.storageKey);
 
   $effect(() => {
     if (!srEnabled) return;
-    // scrollContainer is a function ref that naturally changes each render.
-    // Read it via `untrack` so this $effect does NOT depend on the parent
-    // `scrollRestoration` signal. Without this, a new inline options object
-    // would re-run the effect regardless of the primitive $derived memos.
+    // Read scrollRestoration object props via `untrack` for non-primitive
+    // refs that naturally change each render. Primitive $derived memos
+    // (mode/anchor/behavior/storageKey) drive re-runs.
+    void srMode;
+    void srAnchor;
+    void srBehavior;
+    void srStorageKey;
     const sr = createScrollRestoration(router, {
       mode: srMode,
       anchorScrolling: srAnchor,
+      behavior: srBehavior,
+      storageKey: srStorageKey,
       scrollContainer: untrack(() => scrollRestoration?.scrollContainer),
     });
     return () => sr.destroy();

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -527,7 +527,7 @@ h(
 );
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"manual"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Prop is reactive — toggling mode at runtime reconfigures the utility (watched by primitive fields, so inline objects with the same fields do not thrash). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Prop is reactive — toggling mode at runtime reconfigures the utility (watched by primitive fields, so inline objects with the same fields do not thrash). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
 
 ## View Transitions
 

--- a/packages/vue/src/RouterProvider.ts
+++ b/packages/vue/src/RouterProvider.ts
@@ -63,8 +63,14 @@ export const RouterProvider = defineComponent({
           props.scrollRestoration !== undefined,
           props.scrollRestoration?.mode,
           props.scrollRestoration?.anchorScrolling,
+          props.scrollRestoration?.behavior,
+          props.scrollRestoration?.storageKey,
         ] as const,
-      ([router, enabled, mode, anchorScrolling], _prev, onCleanup) => {
+      (
+        [router, enabled, mode, anchorScrolling, behavior, storageKey],
+        _prev,
+        onCleanup,
+      ) => {
         if (!enabled) {
           return;
         }
@@ -72,6 +78,8 @@ export const RouterProvider = defineComponent({
         const sr = createScrollRestoration(router, {
           mode,
           anchorScrolling,
+          behavior,
+          storageKey,
           scrollContainer: props.scrollRestoration?.scrollContainer,
         });
 

--- a/packages/vue/tests/functional/RouterProvider.scroll.test.ts
+++ b/packages/vue/tests/functional/RouterProvider.scroll.test.ts
@@ -154,8 +154,8 @@ describe("RouterProvider — scrollRestoration", () => {
 
       expect(history.scrollRestoration).toBe("manual");
 
-      // Switch to "manual" — utility returns noop; flip should be reverted.
-      opts.value = { mode: "manual" };
+      // Switch to "native" — utility returns noop; flip should be reverted.
+      opts.value = { mode: "native" };
       await wrapper.vm.$nextTick();
 
       expect(history.scrollRestoration).toBe("auto");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2641,6 +2641,43 @@ importers:
         specifier: 7.3.2
         version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/web/react/scroll-restoration:
+    dependencies:
+      '@real-router/core':
+        specifier: workspace:^
+        version: link:../../../../packages/core
+      '@real-router/navigation-plugin':
+        specifier: workspace:^
+        version: link:../../../../packages/navigation-plugin
+      '@real-router/react':
+        specifier: workspace:^
+        version: link:../../../../packages/react
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.58.2
+        version: 1.58.2
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 5.2.0
+        version: 5.2.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vite:
+        specifier: 7.3.2
+        version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3)
+
   examples/web/react/search-schema:
     dependencies:
       '@real-router/browser-plugin':

--- a/shared/dom-utils/scroll-restore.ts
+++ b/shared/dom-utils/scroll-restore.ts
@@ -1,6 +1,6 @@
 import type { Router, State } from "@real-router/core";
 
-const STORAGE_KEY = "real-router:scroll";
+const DEFAULT_STORAGE_KEY = "real-router:scroll";
 
 const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
   destroy: () => {
@@ -8,12 +8,33 @@ const NOOP_INSTANCE: { destroy: () => void } = Object.freeze({
   },
 });
 
-export type ScrollRestorationMode = "restore" | "top" | "manual";
+export type ScrollRestorationMode = "restore" | "top" | "native";
 
 export interface ScrollRestorationOptions {
   mode?: ScrollRestorationMode | undefined;
   anchorScrolling?: boolean | undefined;
   scrollContainer?: (() => HTMLElement | null) | undefined;
+  /**
+   * Scroll behavior passed to `scrollTo({ behavior })` and
+   * `scrollIntoView({ behavior })`.
+   *
+   * - `"auto"` (default) — browser-defined, usually instant.
+   * - `"instant"` — explicit instant jump (no animation).
+   * - `"smooth"` — animated transition. Note: smooth restore on back/traverse
+   *   can feel disorienting if the user expects to land at the saved position
+   *   immediately. Recommended for `mode: "top"` or anchor scroll only.
+   *
+   * See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior).
+   */
+  behavior?: ScrollBehavior | undefined;
+  /**
+   * sessionStorage key used to persist saved scroll positions. Default:
+   * `"real-router:scroll"`. Override only when multiple independent
+   * `RouterProvider` instances share the same document and you need to
+   * isolate their scroll stores (e.g. micro-frontends, embedded widgets,
+   * or testing). For a single app with one provider the default is fine.
+   */
+  storageKey?: string | undefined;
 }
 
 interface NavigationContext {
@@ -31,15 +52,41 @@ export function createScrollRestoration(
 
   const mode = options?.mode ?? "restore";
 
-  // mode "manual" = utility does nothing. Don't flip history.scrollRestoration,
-  // don't subscribe, don't register pagehide — leave the browser's native
-  // auto-restore intact for the app to override if it wants to.
-  if (mode === "manual") {
+  // mode "native" = utility does nothing. Don't flip history.scrollRestoration,
+  // don't subscribe, don't register pagehide — `history.scrollRestoration`
+  // stays at the browser default ("auto") so the browser handles scroll
+  // restore natively. (Note: this is the OPPOSITE of `history.scrollRestoration
+  // === "manual"` — utility's "native" leaves the DOM property at "auto" so
+  // the browser is in charge.)
+  if (mode === "native") {
     return NOOP_INSTANCE;
   }
 
   const anchorEnabled = options?.anchorScrolling ?? true;
   const getContainer = options?.scrollContainer;
+  const behavior: ScrollBehavior = options?.behavior ?? "auto";
+  const storageKey = options?.storageKey ?? DEFAULT_STORAGE_KEY;
+
+  const loadStore = (): Record<string, number> => {
+    try {
+      const raw = sessionStorage.getItem(storageKey);
+
+      return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    } catch {
+      return {};
+    }
+  };
+
+  const putPos = (key: string, pos: number): void => {
+    try {
+      const store = loadStore();
+
+      store[key] = pos;
+      sessionStorage.setItem(storageKey, JSON.stringify(store));
+    } catch {
+      // Ignore quota / security errors.
+    }
+  };
 
   const prevScrollRestoration = history.scrollRestoration;
 
@@ -62,9 +109,9 @@ export function createScrollRestoration(
     const element = getContainer?.();
 
     if (element) {
-      element.scrollTop = top;
+      element.scrollTo({ top, left: 0, behavior });
     } else {
-      globalThis.scrollTo(0, top);
+      globalThis.scrollTo({ top, left: 0, behavior });
     }
   };
 
@@ -82,7 +129,7 @@ export function createScrollRestoration(
         const element = document.getElementById(ctxHash);
 
         if (element) {
-          element.scrollIntoView();
+          element.scrollIntoView({ behavior });
 
           return;
         }
@@ -112,7 +159,7 @@ export function createScrollRestoration(
       const element = document.getElementById(id);
 
       if (element) {
-        element.scrollIntoView();
+        element.scrollIntoView({ behavior });
 
         return;
       }
@@ -196,27 +243,6 @@ export function createScrollRestoration(
 
 function keyOf(state: State): string {
   return `${state.name}:${canonicalJson(state.params)}`;
-}
-
-function loadStore(): Record<string, number> {
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-
-    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
-  } catch {
-    return {};
-  }
-}
-
-function putPos(key: string, pos: number): void {
-  try {
-    const store = loadStore();
-
-    store[key] = pos;
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-  } catch {
-    // Ignore quota / security errors.
-  }
 }
 
 function canonicalJson(value: unknown): string {


### PR DESCRIPTION
Closes #534. Two-commit PR built on `createScrollRestoration` (#497).

## What's new

- **`mode: "native"`** (renamed from `"manual"`) — utility returns `NOOP_INSTANCE`, leaves `history.scrollRestoration` at browser default `"auto"`. Browser handles restore natively.
- **`behavior?: ScrollBehavior`** — forwarded to `scrollTo({ behavior })` and `scrollIntoView({ behavior })`. Values: `"auto"` (default), `"instant"`, `"smooth"`. See [MDN ScrollToOptions.behavior](https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions/behavior).
- **`storageKey?: string`** — sessionStorage key for scroll-store, default `"real-router:scroll"`. Override for namespace-isolation between independent `RouterProvider` instances (micro-frontends, embedded widgets, testing setups).
- **React-only dogfood example** — `examples/web/react/scroll-restoration/` exercises every behavioral branch.

## Why rename `manual` → `native`

The old name had the **opposite** meaning of DOM `history.scrollRestoration === "manual"`:

| Term | DOM API | Utility (old) | Utility (new) |
| --- | --- | --- | --- |
| `"manual"` | Browser does nothing — app handles | Utility does nothing — browser handles | _removed_ |
| `"native"` | _N/A_ | _N/A_ | Utility does nothing — browser handles |
| `"auto"` | Browser handles natively | _N/A_ | _N/A_ |

API status remains `unstable` per `shared/dom-utils/CLAUDE.md` — pre-1.0 minor bump.

## Commits

- **`76654ebe`** — utility + adapters
  - `shared/dom-utils/scroll-restore.ts` — new options + closure-scoped `loadStore`/`putPos`
  - `packages/angular/src/dom-utils/scroll-restore.ts` — git-tracked sync (ng-packagr doesn't follow symlinks)
  - 4 adapter `RouterProvider` (react/preact/vue/svelte) — primitive deps + forward to `createScrollRestoration`. Solid + Angular pass through `props.scrollRestoration` whole — no provider changes
  - Unit tests: `scrollTo(0, N)` → `scrollTo({ top: N, left: 0, behavior: "auto" })` matchers; new tests for behavior `smooth` (scrollTo + scrollIntoView), default `auto`, storageKey isolation
  - 6 README updates (mode `"manual"` → `"native"` references)
  - **6 minor changesets** — `@real-router/{react,preact,solid,vue,svelte,angular}`. No core changes.

- **`8685b5f6`** — React example for #534
  - `examples/web/react/scroll-restoration/` — 25 files, 6 routes (home, docs, articles, articles.article, gallery, settings)
  - Components: `ScrollMeter` (live diagnostics), `ModeToggle`, `BehaviorToggle`, `DirectionBadge`, `ReplaceDemo`, `ProgrammaticReloadDemo`
  - Userland helpers in `main.tsx` — `applyInitialAnchorScroll` / `applyInitialF5Restore` bridge the race between `router.start()` first transition and utility subscribe
  - Mode + behavior toggles use React state + `key={`${mode}:${behavior}`}` on `RouterProvider` for utility destroy + recreate (navigation-plugin intercepts `location.reload()`, so reload-based mode swap doesn't actually work)
  - **24 Playwright tests** across 7 describe blocks:
    - `1` restore on Back, `2` top on forward push
    - `3` (4 sub-tests) anchor scrolling — initial goto, cross-path `<Link hash>`, same-path auto-force, cyrillic id (decoded from `state.context.url.hash`)
    - `4` replace no-op
    - `5` (12 sub-tests, a–l) mode + behavior toggle — covers 5h Chromium native restore, 5i/5j broken anchor, 5k smooth `scrollIntoView`, 5l SAME_STATES no-op
    - `6` (2 sub-tests) custom `scrollContainer` — virtual-scroller restore + null fallback to window across routes
    - `7` (3 sub-tests) F5 persistence — pagehide save, F5 restore via #531 priming, programmatic reload

## Documentation

- Wiki: [`Scroll-Restoration.md`](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) updated — props table, behavior matrix, mode rename + new options
- Example `README.md` includes behavior matrix + scenario list + plugin dependencies
- No CHANGELOG updates — generated by Changesets at release time

## Test plan

- [x] `pnpm build` (full graph: type-check → lint → test → bundle) — 279/279 tasks passed locally
- [x] All 6 adapter `RouterProvider.scroll.test` files updated to new `scrollTo({ top, left, behavior })` form
- [x] dom-utils unit tests: 132/132 passed (3 new for `behavior` + 3 new for `storageKey`)
- [x] Angular unit tests: 199/199 passed
- [x] Example `pnpm test:e2e` — **24/24 passing** locally (Chromium-gated 5h on `browserName === "chromium"`)
- [x] No `shouldPreserveHash` references outside historical doc context
- [x] No `mode: "manual"` references outside historical doc context (`history.scrollRestoration === "manual"` strings remain — that's the DOM API)
- [ ] CI green

## Backward compatibility

Default behavior unchanged:

- Default `mode: "restore"` works identically to before (just renamed peer mode)
- Default `behavior` is `"auto"` (browser default — instant in most cases) — matches previous unconditional `scrollTo(0, top)` behavior
- Default `storageKey: "real-router:scroll"` — existing sessionStorage entries continue to work after upgrade
- API surface remains `unstable` per dom-utils CLAUDE.md — minor bump

For users on `mode: "manual"`: rename to `mode: "native"`. No other migration needed.