### PR TITLE
feat(preact): Preact 11 forward-compat; widen peer dep range (#592)

### DIFF
--- a/.changeset/preact-11-compat.md
+++ b/.changeset/preact-11-compat.md
@@ -1,0 +1,11 @@
+---
+"@real-router/preact": minor
+---
+
+Add Preact 11 support; widen peer dependency range (#592)
+
+The adapter now compiles against both Preact 10 (≥ 10.28) and Preact 11 by importing `HTMLAttributes` / `TargetedMouseEvent` from the top-level `preact` namespace instead of the `JSX` namespace. Preact 11 restructures `JSX.*` and only keeps `Element` / `IntrinsicElements`; everything else moves to `preact`. The top-level exports landed in Preact 10.28, so the peer-dep floor moves up to that version.
+
+**Migration:** if you use the adapter you only need to upgrade Preact to 10.28 or newer. No source-code changes are required in consumer apps.
+
+**Peer dependency:** `"preact": ">=10.28.0 || ^11.0.0-0"`. The `-0` suffix lets `npm`/`pnpm` accept Preact 11 pre-release tags during the beta window.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -3339,3 +3339,31 @@ Six `ssr-mixed/` examples (React, Preact, Vue, Solid, Svelte, Angular) — each 
 4. **Function form** — same route with `?format=html` ↔ `?format=pdf` toggles the mode; assertion via `response.text()` body length and presence of `<script>__SSR_STATE__</script>`.
 
 Angular `ssr-mixed/` is uniquely structured: `AngularNodeAppEngine` takes control of the request immediately after invocation, so per-route mode branching happens in **Express middleware before Angular** (`server.ts` performs `cloneRouter` + `ssrDataPluginFactory` + `await router.start(url)` BEFORE `angularApp.handle(req)`, reads `getSsrDataMode(state)`, branches: `next()` → AngularNodeAppEngine for `"full"` mode, or `res.send(shell)` for shell modes). The TransferState bridge applies automatically only in the `"full"` mode path; the shell modes use `<script>__SSR_STATE__</script>` directly (no Angular bootstrap, so no `TransferState` involvement). Documented in `packages/angular/CLAUDE.md` SSR section.
+
+## Preact 11 forward-compat & peer-dep floor bump (#592)
+
+### Problem
+
+Preact 11 (currently in beta) restructures the `JSX` namespace: only `JSX.Element` and `JSX.IntrinsicElements` remain inside it; everything else (`HTMLAttributes`, `TargetedMouseEvent`, …) moves to the top-level `preact` namespace. Our `@real-router/preact` adapter referenced `JSX.HTMLAttributes` and `JSX.TargetedMouseEvent` in two source files (`src/types.ts`, `src/components/Link.tsx`), so the bundle would not type-check against v11. Peer dep `>=10.0.0` also had no way to opt into Preact 11 betas.
+
+### Solution
+
+- Source imports switched to the top-level form: `import type { HTMLAttributes, TargetedMouseEvent } from "preact"`. This compiles against Preact 10.28+ AND Preact 11 — Preact 10.28 introduced `src/dom.d.ts` and re-exported these types from the package root while keeping the legacy `JSXInternal` namespace as a backward-compat shim; Preact 11 retains the top-level exports and drops the namespace shim.
+- `peerDependencies.preact` widened to `">=10.28.0 || ^11.0.0-0"`. The `-0` suffix lets `npm`/`pnpm` accept Preact 11 pre-release tags during the beta window. The floor moves from 10.0 → 10.28 because the new import path does not exist in earlier 10.x typings.
+- `syncpack.config.mjs` adds an "Ignore preact peer dependency range" version group. The `sameRange` consistency policy panics on compound `||` ranges, and this peer dep is structurally a one-off.
+- `packages/preact/devDependencies.preact` bumped from `10.25.4` → `10.29.2` so the adapter's own type-check exercises the new import path.
+
+### Why this bumps the floor
+
+We deliberately do **not** keep `JSX.HTMLAttributes` in the source even though it still works on Preact 10.28+. The whole point of the migration is to write code that compiles on Preact 11 without conditional types — keeping the namespace import would defer the change and leave a v11 footgun. The 10.0–10.27 user is a year+ behind on patches; the cost of asking them to bump is lower than carrying a back-compat shim through every adapter source.
+
+### Stress-test regression — `combined-spa.stress.tsx` 8.2
+
+Bumping the dev floor surfaced a latent stress-test issue: Preact 10.28 backported the v11 cascading-render fix (preactjs/preact#4966 + #4967), which now correctly coalesces same-microtask `setState` pairs whose final value equals the previous one. The transition stress test relied on **un**-batched rendering: it counted `useRouterTransition` renders across 100 fully-synchronous navigations, and because `IDLE_SNAPSHOT` is a frozen singleton, the polyfill's `Object.is(prev, next)` bail-out now collapses `IDLE → transitioning → IDLE` round trips to zero renders.
+
+Fix: split each navigation into two `act` blocks using manually-resolved `addActivateGuard` promises so `TRANSITION_START` commits before `TRANSITION_SUCCESS` is fired. This mirrors how real apps interleave a microtask (guards, lazy loads, fetches) between start and end, which is what makes the transitioning state observable. The 100-render lower bound stays — the test is back to exercising both edges of the transition lifecycle, not whatever Preact's batcher chose to drop on that particular release.
+
+### Forward direction
+
+- `@testing-library/preact@3.2.4` (current pin) does not yet ship a Preact 11 compatible release. Matrix-testing the adapter against Preact 11 is blocked on the testing library — the issue carries the `upstream` label for this reason.
+- Once `@testing-library/preact` ships an 11-compatible version, run the unit suite against both majors (manual matrix or pnpm-overrides per CI job) before publishing the 1.0 of the adapter.

--- a/examples/web/preact/animation-examples/motion-animations/package.json
+++ b/examples/web/preact/animation-examples/motion-animations/package.json
@@ -15,7 +15,7 @@
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
     "motion": "12.37.0",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/animation-examples/page-animations/package.json
+++ b/examples/web/preact/animation-examples/page-animations/package.json
@@ -14,7 +14,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/animation-examples/route-animations/package.json
+++ b/examples/web/preact/animation-examples/route-animations/package.json
@@ -14,7 +14,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/animation-examples/view-transitions/package.json
+++ b/examples/web/preact/animation-examples/view-transitions/package.json
@@ -14,7 +14,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/async-guards/package.json
+++ b/examples/web/preact/async-guards/package.json
@@ -15,7 +15,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/auth-guards/package.json
+++ b/examples/web/preact/auth-guards/package.json
@@ -15,7 +15,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/basic/package.json
+++ b/examples/web/preact/basic/package.json
@@ -13,7 +13,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",

--- a/examples/web/preact/combined/package.json
+++ b/examples/web/preact/combined/package.json
@@ -20,7 +20,7 @@
     "@real-router/persistent-params-plugin": "workspace:^",
     "@real-router/search-schema-plugin": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2",
+    "preact": "10.29.2",
     "zod": "3.24.4"
   },
   "devDependencies": {

--- a/examples/web/preact/data-loading/package.json
+++ b/examples/web/preact/data-loading/package.json
@@ -16,7 +16,7 @@
     "@real-router/lifecycle-plugin": "workspace:^",
     "@real-router/preload-plugin": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/dynamic-routes/package.json
+++ b/examples/web/preact/dynamic-routes/package.json
@@ -15,7 +15,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/error-handling/package.json
+++ b/examples/web/preact/error-handling/package.json
@@ -15,7 +15,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/hash-routing/package.json
+++ b/examples/web/preact/hash-routing/package.json
@@ -14,7 +14,7 @@
     "@real-router/core": "workspace:^",
     "@real-router/hash-plugin": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/lazy-loading/package.json
+++ b/examples/web/preact/lazy-loading/package.json
@@ -13,7 +13,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",

--- a/examples/web/preact/nested-routes/package.json
+++ b/examples/web/preact/nested-routes/package.json
@@ -15,7 +15,7 @@
     "@real-router/browser-plugin": "workspace:^",
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/package.json
+++ b/examples/web/preact/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "dependencies": {
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   }
 }

--- a/examples/web/preact/persistent-params/package.json
+++ b/examples/web/preact/persistent-params/package.json
@@ -14,7 +14,7 @@
     "@real-router/core": "workspace:^",
     "@real-router/persistent-params-plugin": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2"
+    "preact": "10.29.2"
   },
   "devDependencies": {
     "@preact/preset-vite": "2.10.5",

--- a/examples/web/preact/search-schema/package.json
+++ b/examples/web/preact/search-schema/package.json
@@ -15,7 +15,7 @@
     "@real-router/core": "workspace:^",
     "@real-router/search-schema-plugin": "workspace:^",
     "@real-router/preact": "workspace:^",
-    "preact": "10.28.2",
+    "preact": "10.29.2",
     "zod": "3.24.4"
   },
   "devDependencies": {

--- a/examples/web/preact/ssr-examples/ssg/package.json
+++ b/examples/web/preact/ssr-examples/ssg/package.json
@@ -15,8 +15,8 @@
     "@real-router/core": "workspace:^",
     "@real-router/preact": "workspace:^",
     "@real-router/ssr-data-plugin": "workspace:^",
-    "preact": "10.28.2",
-    "preact-render-to-string": "6.6.7"
+    "preact": "10.29.2",
+    "preact-render-to-string": "6.7.0"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/ssr-examples/ssr-mixed/package.json
+++ b/examples/web/preact/ssr-examples/ssr-mixed/package.json
@@ -16,8 +16,8 @@
     "@real-router/preact": "workspace:^",
     "@real-router/ssr-data-plugin": "workspace:^",
     "express": "5.1.0",
-    "preact": "10.28.2",
-    "preact-render-to-string": "6.6.7"
+    "preact": "10.29.2",
+    "preact-render-to-string": "6.7.0"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/ssr-examples/ssr-streaming/package.json
+++ b/examples/web/preact/ssr-examples/ssr-streaming/package.json
@@ -15,8 +15,8 @@
     "@real-router/preact": "workspace:^",
     "@real-router/ssr-data-plugin": "workspace:^",
     "express": "5.1.0",
-    "preact": "10.28.2",
-    "preact-render-to-string": "6.6.7"
+    "preact": "10.29.2",
+    "preact-render-to-string": "6.7.0"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/examples/web/preact/ssr-examples/ssr/package.json
+++ b/examples/web/preact/ssr-examples/ssr/package.json
@@ -16,8 +16,8 @@
     "@real-router/preact": "workspace:^",
     "@real-router/ssr-data-plugin": "workspace:^",
     "express": "5.1.0",
-    "preact": "10.28.2",
-    "preact-render-to-string": "6.6.7"
+    "preact": "10.29.2",
+    "preact-render-to-string": "6.7.0"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -17,7 +17,7 @@ Add `@real-router/browser-plugin` (or `hash-plugin` / `navigation-plugin` /
 `memory-plugin`) when you need History API integration — the Quick Start below
 uses it.
 
-**Peer dependency:** `preact` >= 10.0.0
+**Peer dependency:** `preact` >= 10.28.0 (Preact 10) or ^11.0.0-0 (Preact 11 beta and later). The adapter imports DOM types (`HTMLAttributes`, `TargetedMouseEvent`) from the top-level `preact` namespace introduced in 10.28; Preact 11's JSX-namespace restructure preserves the same imports.
 
 ## Quick Start
 

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -84,10 +84,10 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/preact": "3.2.4",
     "@testing-library/user-event": "14.6.1",
-    "preact": "10.25.4",
-    "preact-render-to-string": "6.6.7"
+    "preact": "10.29.2",
+    "preact-render-to-string": "6.7.0"
   },
   "peerDependencies": {
-    "preact": ">=10.0.0"
+    "preact": ">=10.28.0 || ^11.0.0-0"
   }
 }

--- a/packages/preact/src/components/Link.tsx
+++ b/packages/preact/src/components/Link.tsx
@@ -12,7 +12,7 @@ import { useIsActiveRoute } from "../hooks/useIsActiveRoute";
 import { useRouter } from "../hooks/useRouter";
 
 import type { LinkProps } from "../types";
-import type { FunctionComponent, JSX } from "preact";
+import type { FunctionComponent, TargetedMouseEvent } from "preact";
 
 /**
  * Custom comparator for `Link`'s `memo()` wrapper.
@@ -95,9 +95,7 @@ export const Link: FunctionComponent<LinkProps> = memo(
       hash === undefined ? undefined : { hash },
     );
 
-    const handleClick = (
-      evt: JSX.TargetedMouseEvent<HTMLAnchorElement>,
-    ): void => {
+    const handleClick = (evt: TargetedMouseEvent<HTMLAnchorElement>): void => {
       if (onClick) {
         onClick(evt);
 

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -4,7 +4,7 @@ import type {
   Navigator,
   State,
 } from "@real-router/core";
-import type { JSX } from "preact";
+import type { HTMLAttributes } from "preact";
 
 export interface RouteState<P extends Params = Params> {
   route: State<P> | undefined;
@@ -16,7 +16,7 @@ export type RouteContext<P extends Params = Params> = {
 } & RouteState<P>;
 
 export interface LinkProps<P extends Params = Params> extends Omit<
-  JSX.HTMLAttributes<HTMLAnchorElement>,
+  HTMLAttributes<HTMLAnchorElement>,
   "className"
 > {
   routeName: string;

--- a/packages/preact/tests/stress/combined-spa.stress.tsx
+++ b/packages/preact/tests/stress/combined-spa.stress.tsx
@@ -1,4 +1,5 @@
 import { createRouter } from "@real-router/core";
+import { getLifecycleApi } from "@real-router/core/api";
 import { render, act, cleanup } from "@testing-library/preact";
 import { describe, it, expect, afterEach } from "vitest";
 
@@ -93,7 +94,34 @@ describe("R8 — combined SPA simulation", () => {
     }));
     const router = createRouter(routes, { defaultRoute: "item0" });
 
-    await router.start("/item0");
+    // Manually-resolved activate guards split each navigation into two
+    // observable phases. Without this split, Preact 10.28+ batches the
+    // TRANSITION_START and TRANSITION_SUCCESS setState calls into a single
+    // commit; since IDLE_SNAPSHOT is a frozen singleton, the polyfill's
+    // `Object.is(prev, next)` bail-out collapses the round trip to zero
+    // renders. Real apps always interleave a microtask (guards, lazy
+    // loads, data fetching) between start and success — we model that
+    // explicitly so the stress test continues to exercise both edges of
+    // the transition.
+    const lifecycle = getLifecycleApi(router);
+    const pendingResolvers: ((value: boolean) => void)[] = [];
+
+    for (const route of routes) {
+      lifecycle.addActivateGuard(
+        route.name,
+        () => () =>
+          new Promise<boolean>((resolve) => {
+            pendingResolvers.push(resolve);
+          }),
+      );
+    }
+
+    // Bypass guards for the initial mount.
+    pendingResolvers.length = 0;
+    const startPromise = router.start("/item0");
+
+    pendingResolvers.shift()?.(true);
+    await startPromise;
 
     let progressRenders = 0;
 
@@ -121,7 +149,14 @@ describe("R8 — combined SPA simulation", () => {
 
     for (let nav = 0; nav < 100; nav++) {
       await act(async () => {
-        await router.navigate(`item${(nav % 49) + 1}`);
+        void router.navigate(`item${(nav % 49) + 1}`);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        pendingResolvers.shift()?.(true);
+        await Promise.resolve();
+        await Promise.resolve();
       });
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1497,8 +1497,8 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
 
   examples/web/preact/animation-examples/motion-animations:
     dependencies:
@@ -1515,15 +1515,15 @@ importers:
         specifier: 12.37.0
         version: 12.37.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1543,15 +1543,15 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1571,15 +1571,15 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1599,15 +1599,15 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1627,21 +1627,21 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1670,21 +1670,21 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1713,12 +1713,12 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1753,8 +1753,8 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/search-schema-plugin
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       zod:
         specifier: 3.24.4
         version: 3.24.4
@@ -1764,13 +1764,13 @@ importers:
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1805,15 +1805,15 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preload-plugin
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1833,21 +1833,21 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1876,21 +1876,21 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -1919,15 +1919,15 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1947,12 +1947,12 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1972,21 +1972,21 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.28.2)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -2018,12 +2018,12 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/preact
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
     devDependencies:
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2046,8 +2046,8 @@ importers:
         specifier: workspace:^
         version: link:../../../../packages/search-schema-plugin
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       zod:
         specifier: 3.24.4
         version: 3.24.4
@@ -2057,7 +2057,7 @@ importers:
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2080,18 +2080,18 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/ssr-data-plugin
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       preact-render-to-string:
-        specifier: 6.6.7
-        version: 6.6.7(preact@10.28.2)
+        specifier: 6.7.0
+        version: 6.7.0(preact@10.29.2)
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/node':
         specifier: 25.8.0
         version: 25.8.0
@@ -2123,18 +2123,18 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       preact-render-to-string:
-        specifier: 6.6.7
-        version: 6.6.7(preact@10.28.2)
+        specifier: 6.7.0
+        version: 6.7.0(preact@10.29.2)
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6
@@ -2169,18 +2169,18 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       preact-render-to-string:
-        specifier: 6.6.7
-        version: 6.6.7(preact@10.28.2)
+        specifier: 6.7.0
+        version: 6.7.0(preact@10.29.2)
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6
@@ -2212,18 +2212,18 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       preact:
-        specifier: 10.28.2
-        version: 10.28.2
+        specifier: 10.29.2
+        version: 10.29.2
       preact-render-to-string:
-        specifier: 6.6.7
-        version: 6.6.7(preact@10.28.2)
+        specifier: 6.7.0
+        version: 6.7.0(preact@10.29.2)
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
       '@preact/preset-vite':
         specifier: 2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6
@@ -6198,16 +6198,16 @@ importers:
         version: 6.9.1
       '@testing-library/preact':
         specifier: 3.2.4
-        version: 3.2.4(preact@10.25.4)
+        version: 3.2.4(preact@10.29.2)
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       preact:
-        specifier: 10.25.4
-        version: 10.25.4
+        specifier: 10.29.2
+        version: 10.29.2
       preact-render-to-string:
-        specifier: 6.6.7
-        version: 6.6.7(preact@10.25.4)
+        specifier: 6.7.0
+        version: 6.7.0(preact@10.29.2)
 
   packages/preload-plugin:
     dependencies:
@@ -13748,16 +13748,13 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  preact-render-to-string@6.6.7:
-    resolution: {integrity: sha512-3XdbsX3+vn9dQW+jJI/FsI9rlkgl6dbeUpqLsChak6jp3j3auFqBCkno7VChbMFs5Q8ylBj6DrUkKRwtVN3nvw==}
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
 
-  preact@10.25.4:
-    resolution: {integrity: sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==}
-
-  preact@10.28.2:
-    resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -17875,12 +17872,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.28.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(rollup@4.60.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.28.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
@@ -17896,20 +17893,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.3': {}
 
-  '@prefresh/core@1.5.9(preact@10.28.2)':
+  '@prefresh/core@1.5.9(preact@10.29.2)':
     dependencies:
-      preact: 10.28.2
+      preact: 10.29.2
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.28.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
-      '@prefresh/core': 1.5.9(preact@10.28.2)
+      '@prefresh/core': 1.5.9(preact@10.29.2)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 10.28.2
+      preact: 10.29.2
       vite: 7.3.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
@@ -18623,15 +18620,10 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/preact@3.2.4(preact@10.25.4)':
+  '@testing-library/preact@3.2.4(preact@10.29.2)':
     dependencies:
       '@testing-library/dom': 8.20.1
-      preact: 10.25.4
-
-  '@testing-library/preact@3.2.4(preact@10.28.2)':
-    dependencies:
-      '@testing-library/dom': 8.20.1
-      preact: 10.28.2
+      preact: 10.29.2
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -23024,17 +23016,11 @@ snapshots:
       commander: 9.5.0
     optional: true
 
-  preact-render-to-string@6.6.7(preact@10.25.4):
+  preact-render-to-string@6.7.0(preact@10.29.2):
     dependencies:
-      preact: 10.25.4
+      preact: 10.29.2
 
-  preact-render-to-string@6.6.7(preact@10.28.2):
-    dependencies:
-      preact: 10.28.2
-
-  preact@10.25.4: {}
-
-  preact@10.28.2: {}
+  preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
 

--- a/syncpack.config.mjs
+++ b/syncpack.config.mjs
@@ -70,6 +70,16 @@ export default {
       isIgnored: true,
     },
     {
+      // Preact adapter spans Preact 10.28+ and Preact 11 beta — the
+      // compound peer range `>=10.28.0 || ^11.0.0-0` can't be compared
+      // with `sameRange` policy against the pinned example versions.
+      label: "Ignore preact peer dependency range",
+      packages: ["@real-router/preact"],
+      dependencies: ["preact"],
+      dependencyTypes: ["peer"],
+      isIgnored: true,
+    },
+    {
       label: "Workspace packages use workspace:^ protocol",
       dependencies: [
         "@real-router/*",


### PR DESCRIPTION
Closes #592.

## Summary

- Replace `JSX.HTMLAttributes` / `JSX.TargetedMouseEvent` with the top-level `preact` exports so the adapter compiles against both Preact 10.28+ and Preact 11 (which restructures the `JSX` namespace down to `Element` / `IntrinsicElements` only).
- Widen `peerDependencies.preact` to `">=10.28.0 || ^11.0.0-0"`. Floor moves to 10.28 because that's where the top-level type exports (`src/dom.d.ts`) appeared. `^11.0.0-0` admits Preact 11 beta tags.
- Bump devDep `preact@10.25.4 → 10.29.2` and `preact-render-to-string@6.6.7 → 6.7.0`; mirror the same versions across all 21 Preact examples.
- Rework `combined-spa.stress.tsx 8.2` to survive Preact 10.28's same-microtask `setState` coalescing (Preact backported v11's cascading-render fix — preactjs/preact#4966 + #4967). The previous test relied on un-batched intermediate renders; the new version splits each navigation into observable start/end phases via manually-resolved `addActivateGuard` promises.
- `syncpack.config.mjs` carries an "Ignore preact peer dependency range" version group — `sameRange` policy panics on compound `||` ranges, and this peer dep is structurally a one-off.
- `IMPLEMENTATION_NOTES.md` Problem → Solution → Why entry; `packages/preact/README.md` peer-dep note; changeset (minor bump for `@real-router/preact`).

## Open / upstream

- Matrix-testing the adapter against Preact 11 is blocked on `@testing-library/preact@3.2.4` (no Preact-11-compatible release yet). Carried as `upstream` label on the issue; flipping the default peer expectation waits on that release.
- Examples sit at `preact@10.29.2`; bumping them to a Preact 11 beta requires the same upstream unblock.

## Test plan

- [x] `pnpm -F @real-router/preact build` — type-check, lint, 358 unit + 104 stress + property tests
- [x] `pnpm turbo run build` — full graph, 286/286 tasks green
- [x] `pnpm lint:deps` — syncpack clean after compound-range ignore rule
- [x] `pnpm -F @real-router/preact lint:package` / `lint:types` — publint + attw 🟢
- [ ] Verify against `@testing-library/preact` once it ships a Preact 11 compatible release