### PR TITLE
feat(core): lift replace to TransitionMeta for portable push/replace discrimination (#657)

### DIFF
--- a/.changeset/transition-replace-angular.md
+++ b/.changeset/transition-replace-angular.md
@@ -1,0 +1,17 @@
+---
+"@real-router/angular": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `provideRealRouter({ scrollRestoration })`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`realLink` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-angular.md
+++ b/.changeset/transition-replace-angular.md
@@ -2,7 +2,7 @@
 "@real-router/angular": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `provideRealRouter({ scrollRestoration })`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/.changeset/transition-replace-core.md
+++ b/.changeset/transition-replace-core.md
@@ -2,7 +2,7 @@
 "@real-router/core": minor
 ---
 
-Add `state.transition.replace` for portable push/replace discrimination across URL plugins
+Add `state.transition.replace` for portable push/replace discrimination across URL plugins (#658)
 
 `TransitionMeta` gains an optional `replace?: boolean` field, written in three places — symmetric with the existing `reload` / `redirected` flags:
 

--- a/.changeset/transition-replace-core.md
+++ b/.changeset/transition-replace-core.md
@@ -1,0 +1,24 @@
+---
+"@real-router/core": minor
+---
+
+Add `state.transition.replace` for portable push/replace discrimination across URL plugins
+
+`TransitionMeta` gains an optional `replace?: boolean` field, written in three places — symmetric with the existing `reload` / `redirected` flags:
+
+- `completeTransition()` lifts `opts.replace` from `NavigationOptions` (including the result of `forceReplaceFromUnknown()`, Invariant 12)
+- `navigateToNotFound()` writes `replace: true` inline, mirroring the `FROZEN_REPLACE_OPTS` plugins already see via `onTransitionSuccess`'s 3rd argument (Invariant 7)
+- `DEFAULT_TRANSITION` is unchanged
+
+Subscribers can now portably discriminate replace transitions under any URL plugin (browser, hash, navigation, memory, or no plugin):
+
+```ts
+router.subscribe(({ route }) => {
+  if (route.transition.replace) return; // skip programmatic redirects / corrections / auto-replace from UNKNOWN_ROUTE
+  analytics.pageView(route.path);
+});
+```
+
+Existing usage of `state.context.navigation.navigationType === "replace"` (navigation-plugin only) continues to work — the two signals complement each other. See `packages/core/CLAUDE.md` → "Core vs plugin signals" for the side-by-side comparison.
+
+The new field is additive, optional, and zero API-breaking on the core type level. It is stripped from `serializeRouterState` along with the rest of `transition` (per-navigation meta is meaningless after hydration).

--- a/.changeset/transition-replace-preact.md
+++ b/.changeset/transition-replace-preact.md
@@ -2,7 +2,7 @@
 "@real-router/preact": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/.changeset/transition-replace-preact.md
+++ b/.changeset/transition-replace-preact.md
@@ -1,0 +1,17 @@
+---
+"@real-router/preact": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`<Link>` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-react.md
+++ b/.changeset/transition-replace-react.md
@@ -2,7 +2,7 @@
 "@real-router/react": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/.changeset/transition-replace-react.md
+++ b/.changeset/transition-replace-react.md
@@ -1,0 +1,17 @@
+---
+"@real-router/react": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`<Link>` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-solid.md
+++ b/.changeset/transition-replace-solid.md
@@ -2,7 +2,7 @@
 "@real-router/solid": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/.changeset/transition-replace-solid.md
+++ b/.changeset/transition-replace-solid.md
@@ -1,0 +1,17 @@
+---
+"@real-router/solid": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`<Link>` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-svelte.md
+++ b/.changeset/transition-replace-svelte.md
@@ -1,0 +1,17 @@
+---
+"@real-router/svelte": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`<Link>` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-svelte.md
+++ b/.changeset/transition-replace-svelte.md
@@ -2,7 +2,7 @@
 "@real-router/svelte": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/.changeset/transition-replace-vue.md
+++ b/.changeset/transition-replace-vue.md
@@ -1,0 +1,17 @@
+---
+"@real-router/vue": minor
+---
+
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+
+`createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
+
+- Programmatic replace (`navigate(..., { replace: true })`, OAuth callbacks, params canonicalization, `navigateToNotFound()`, auto-force-from-`UNKNOWN_ROUTE`) → **skip** (scroll position preserved)
+- Programmatic reload (`navigate(..., { reload: true })`) → **restore** from `sessionStorage`
+- Forward push (`<Link>` without `replace`), browser back/forward (popstate), F5 cross-document → `scrollToHashOrTop` (unchanged)
+
+Under `@real-router/navigation-plugin` there is no behaviour change — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active.
+
+Opt-out for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+This release also bundles the updated `transition.replace` core field; existing code reading `state.context.navigation.navigationType` is unaffected.

--- a/.changeset/transition-replace-vue.md
+++ b/.changeset/transition-replace-vue.md
@@ -2,7 +2,7 @@
 "@real-router/vue": minor
 ---
 
-**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin`
+**BREAKING CHANGE (behaviour):** scroll-restoration disambiguation under `browser-plugin` (#658)
 
 `createScrollRestoration` (used by `<RouterProvider scrollRestoration>`) now disambiguates push, replace, and reload transitions under `@real-router/browser-plugin` using the portable `state.transition.replace` / `state.transition.reload` flags introduced in `@real-router/core`. Before this release the utility had no portable way to read `replace` under browser-plugin, so it called `scrollToHashOrTop` on **every** transition. After this release:
 

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -3438,3 +3438,59 @@ Fix: split each navigation into two `act` blocks using manually-resolved `addAct
 
 - `@testing-library/preact@3.2.4` (current pin) does not yet ship a Preact 11 compatible release. Matrix-testing the adapter against Preact 11 is blocked on the testing library — the issue carries the `upstream` label for this reason.
 - Once `@testing-library/preact` ships an 11-compatible version, run the unit suite against both majors (manual matrix or pnpm-overrides per CI job) before publishing the 1.0 of the adapter.
+
+## Replace Flag Propagation in `TransitionMeta` (#XXX)
+
+### Problem
+
+Three of the four "primary" `NavigationOptions` fields — `reload`, `redirected`, and (until now) `replace` — were treated asymmetrically by the transition pipeline. `reload` and `redirected` were lifted into `state.transition.{reload, redirected}` in `completeTransition.ts`, so subscribers could portably discriminate them across any URL plugin (browser, hash, navigation, memory, none). `replace` was not: a subscriber that wanted to know "was this transition a replace?" had to read `state.context.navigation.navigationType === "replace"`, which is set **only** by `@real-router/navigation-plugin`. Under `@real-router/browser-plugin`, `@real-router/hash-plugin`, or no URL plugin at all, the signal was simply unavailable.
+
+The visible damage was in `shared/dom-utils/scroll-restore.ts`. Under navigation-plugin the utility correctly skipped scroll capture on a replace (OAuth callback, params canonicalization, `navigateToNotFound`, auto-force-from-`UNKNOWN_ROUTE`). Under browser-plugin the `state.context.navigation` namespace was undefined, the `!nav` early-return fired, and **every** transition — replace or not — snapped the viewport via `scrollToHashOrTop`. The same asymmetry blocked any subscriber-level "skip programmatic replaces" idiom from being written portably (analytics, view-transitions, route-announcer — none could rely on a plugin-specific namespace).
+
+Internally `replace` is a **core-level decision**: it originates in `router.navigate(name, params, { replace })` and is auto-forced by `forceReplaceFromUnknown()` and `navigateToNotFound()` (Invariants 7 and 12 in `packages/core/INVARIANTS.md`). Subscribers were the one audience that could not see it.
+
+### Solution
+
+`TransitionMeta` gains an optional `replace?: boolean` field, written in three places (symmetric with `reload`):
+
+- `completeTransition.ts` — `if (opts.replace !== undefined) meta.replace = opts.replace;` lifts user-supplied and auto-forced opts (including the result of `forceReplaceFromUnknown`).
+- `NavigationNamespace.navigateToNotFound()` — inline meta gets `replace: true` directly, mirroring the `FROZEN_REPLACE_OPTS = { replace: true }` that plugins already see via `onTransitionSuccess`'s 3rd argument.
+- `DEFAULT_TRANSITION` — unchanged (pre-navigation fallback, no opts to lift).
+
+`shared/dom-utils/scroll-restore.ts` is refactored to consume the portable flag. Under any URL plugin the disambiguation now reads:
+
+- `route.transition.replace || nav?.navigationType === "replace"` → skip restore.
+- `route.transition.reload || nav?.navigationType === "reload"` → restore from `sessionStorage`.
+- `nav?.direction === "back" || nav?.navigationType === "traverse"` → restore.
+- otherwise → `scrollToHashOrTop`.
+
+Both arms in the `replace` and `reload` checks are intentional. The plugin arm preserves F5/cross-document scroll restoration under navigation-plugin (`getActivationType()` #531 priming sets `nav.navigationType === "reload"` while leaving `opts.reload` undefined on the initial transition). Dropping the plugin arm would silently regress F5 under navigation-plugin.
+
+### Why
+
+**Symmetry with the existing precedent.** `reload` and `redirected` proved the pattern; `replace` was the last hold-out. The added field is additive, optional, and zero API-breaking on the core type level.
+
+**Closes a real gap, not a theoretical one.** The verified consumer is `scroll-restore.ts`. Under browser-plugin every replace transition (e.g. an OAuth callback `router.navigate("dashboard", {}, { replace: true })`) used to snap the viewport. Now it preserves position. The same change unblocks `scroll-spy` (#575) under browser-plugin and lets analytics / loaders use a `if (route.transition.replace) return` idiom portably.
+
+**Subscriber/plugin visibility parity.** Plugins received `opts.replace` via `onTransitionSuccess(toState, fromState, opts)` since forever. After this change subscribers see it via `state.transition.replace` — closes the asymmetry between the two audiences that Invariant 7 had documented but not exposed.
+
+### Before / After — scroll-restore behaviour under `browser-plugin` (`scrollRestoration={{ mode: "restore" }}`)
+
+| Transition type                                                                                | Before                                              | After                                                          |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| Forward push (`<Link>` without `replace`)                                                      | `scrollToHashOrTop` (snap to top / anchor)          | `scrollToHashOrTop` (unchanged)                                |
+| Replace (`navigate(..., { replace: true })`, OAuth callback, params canonicalization)          | `scrollToHashOrTop` (undesired snap)                | **skip** (preserve scroll position)                            |
+| Programmatic reload (`navigate(..., { reload: true })`)                                        | `scrollToHashOrTop` (snap, lose pre-reload position) | **restore** from `sessionStorage` (via `subscribe`'s `previousRoute` capture; `pagehide` does not fire on same-document programmatic nav) |
+| F5 cross-document (browser-driven reload)                                                      | `scrollToHashOrTop`                                 | `scrollToHashOrTop` (**unchanged** — `opts.reload` is undefined on the initial transition and browser-plugin has no Navigation API `getActivationType` analogue; closing this requires a core-level F5 priming, out of scope) |
+| Browser back/forward (popstate)                                                                | `scrollToHashOrTop` (snap)                          | `scrollToHashOrTop` (unchanged — `direction`/`traverse` disambiguation requires navigation-plugin) |
+| `navigateToNotFound()`                                                                         | `scrollToHashOrTop`                                 | **skip** (driven by inline `transition.replace = true`)        |
+
+Opt-out for users who relied on the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: "top" }}`.
+
+Under `@real-router/navigation-plugin` there is **no behaviour change** — every existing branch (`replace` / `reload` / `traverse` / `direction === "back"`) remains active. The new `transition.replace` / `transition.reload` checks short-circuit the same paths slightly earlier with identical observable results.
+
+### Tests
+
+- `packages/core/tests/functional/navigation/navigate/navigation-options.test.ts` — the "transition meta flags" suite gains six new cases covering `replace: true`, `replace: false`, default `undefined`, `navigateToNotFound`, `forceReplaceFromUnknown` auto-force, and the override of an explicit `replace: false` from `UNKNOWN_ROUTE` (the `!opts.replace` condition matches both `undefined` and `false`), plus a timing-parity case mirroring the existing reload guard test.
+- `packages/dom-utils/tests/functional/scroll-restore.test.ts` — a new describe block adds six cases under a browser-plugin-like environment (no `state.context.navigation`) plus a regression test that simulates navigation-plugin's #531 priming (`nav.navigationType === "reload"` with `transition.reload === undefined`) and verifies that the F5 restore path still fires.
+- `packages/angular/src/dom-utils/scroll-restore.ts` is regenerated from `shared/dom-utils/scroll-restore.ts` by the existing `prebundle` script (`pnpm -F @real-router/angular bundle`) — ng-packagr cannot follow the symlinks the other adapters use, so the file is git-tracked and must be kept in sync.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -532,7 +532,7 @@ interface RealRouterOptions {
 }
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. The utility is created by `provideEnvironmentInitializer` and torn down via `inject(DestroyRef)`. Options are a snapshot at bootstrap — not reactive to runtime changes. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. The utility is created by `provideEnvironmentInitializer` and torn down via `inject(DestroyRef)`. Options are a snapshot at bootstrap — not reactive to runtime changes. Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## Server-Side Rendering
 

--- a/packages/angular/src/dom-utils/scroll-restore.ts
+++ b/packages/angular/src/dom-utils/scroll-restore.ts
@@ -229,28 +229,36 @@ export function createScrollRestoration(
       }
     }
 
-    // Single rAF so DOM is committed before we read anchors / write scroll.
-    // Guard against destroy() racing with the callback.
     requestAnimationFrame(() => {
       if (destroyed) {
         return;
       }
 
-      if (mode === "top" || !nav) {
+      if (mode === "top") {
         scrollToHashOrTop(route);
 
         return;
       }
 
-      if (nav.navigationType === "replace") {
+      if (route.transition.replace || nav?.navigationType === "replace") {
         return;
       }
 
-      if (
-        nav.direction === "back" ||
-        nav.navigationType === "traverse" ||
-        nav.navigationType === "reload"
-      ) {
+      // Both arms are required: `transition.reload` only fires for programmatic
+      // `router.navigate({reload:true})`. F5 under navigation-plugin primes
+      // `nav.navigationType === "reload"` via #531 getActivationType but leaves
+      // opts.reload undefined, so dropping the plugin arm would regress F5
+      // scroll-restore. Same belt-and-suspenders pattern is used for replace
+      // above. Browser-plugin's F5 is not covered (no priming, out of scope).
+      if (route.transition.reload || nav?.navigationType === "reload") {
+        const key = safeKeyOf(route);
+
+        writePos(key === null ? 0 : (loadStore()[key] ?? 0));
+
+        return;
+      }
+
+      if (nav?.direction === "back" || nav?.navigationType === "traverse") {
         const key = safeKeyOf(route);
 
         writePos(key === null ? 0 : (loadStore()[key] ?? 0));

--- a/packages/core-types/src/base.ts
+++ b/packages/core-types/src/base.ts
@@ -26,6 +26,7 @@ export interface TransitionMeta {
   phase: TransitionPhase;
   reason: TransitionReason;
   reload?: boolean;
+  replace?: boolean;
   redirected?: boolean;
   from?: string;
   blocker?: string;

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -257,7 +257,7 @@ fsm.on("TRANSITION_STARTED", "CANCEL", (p) =>
            │
            ▼
 ┌──────────────────────┐
-│  Build TransitionMeta│  { reload?, redirected?, phase, from, reason, segments }
+│  Build TransitionMeta│  { reload?, replace?, redirected?, phase, from, reason, segments }
 │  + deep freeze       │
 └──────────┬───────────┘
            │

--- a/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
@@ -235,6 +235,7 @@ export class NavigationNamespace {
       phase: "activating",
       ...(fromState && { from: fromState.name }),
       reason: "success",
+      replace: true,
       segments,
     };
 

--- a/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
@@ -42,6 +42,10 @@ function buildTransitionMeta(
     meta.reload = opts.reload;
   }
 
+  if (opts.replace !== undefined) {
+    meta.replace = opts.replace;
+  }
+
   if (opts.redirected !== undefined) {
     meta.redirected = opts.redirected;
   }

--- a/packages/core/tests/functional/navigation/navigate/navigation-options.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/navigation-options.test.ts
@@ -162,7 +162,7 @@ describe("router.navigate() - navigation meta and options", () => {
     });
   });
 
-  describe("transition meta flags (transition.reload and transition.redirected)", () => {
+  describe("transition meta flags (reload, replace, redirected)", () => {
     it("sets transition.reload to true when navigating with reload option", async () => {
       const state = await router.navigate("profile", {}, { reload: true });
 
@@ -209,6 +209,82 @@ describe("router.navigate() - navigation meta and options", () => {
       expect(reloadInGuard).toBeUndefined();
       // After success, transition.reload is available
       expect(freshRouter.getState()?.transition?.reload).toBe(true);
+
+      freshRouter.stop();
+    });
+
+    it("sets transition.replace to true when navigating with replace option", async () => {
+      const state = await router.navigate("profile", {}, { replace: true });
+
+      expect(state.transition?.replace).toBe(true);
+    });
+
+    it("does not set transition.replace for normal navigation (undefined)", async () => {
+      const state = await router.navigate("profile", {}, {});
+
+      expect(state.transition?.replace).toBeUndefined();
+    });
+
+    it("sets transition.replace to false when explicitly passed replace: false", async () => {
+      const state = await router.navigate("profile", {}, { replace: false });
+
+      expect(state.transition?.replace).toBe(false);
+    });
+
+    it("navigateToNotFound sets transition.replace = true (symmetric with plugin visibility via FROZEN_REPLACE_OPTS)", () => {
+      const state = router.navigateToNotFound("/bogus");
+
+      expect(state.transition?.replace).toBe(true);
+    });
+
+    it("auto-forces transition.replace = true when navigating FROM UNKNOWN_ROUTE state", async () => {
+      const freshRouter = createTestRouter();
+
+      await freshRouter.start("/home");
+      freshRouter.navigateToNotFound("/unknown");
+
+      const state = await freshRouter.navigate("users", {}, {});
+
+      expect(state.transition?.replace).toBe(true);
+
+      freshRouter.stop();
+    });
+
+    it("auto-forces transition.replace = true even when explicit replace: false is passed FROM UNKNOWN_ROUTE state", async () => {
+      // forceReplaceFromUnknown's `!opts.replace` condition matches BOTH
+      // undefined AND false — intentional: navigation FROM UNKNOWN_ROUTE
+      // always replaces to prevent history pollution (Invariant 12).
+      const freshRouter = createTestRouter();
+
+      await freshRouter.start("/home");
+      freshRouter.navigateToNotFound("/unknown");
+
+      const state = await freshRouter.navigate("users", {}, { replace: false });
+
+      expect(state.transition?.replace).toBe(true);
+
+      freshRouter.stop();
+    });
+
+    it("transition.replace is not available during guard execution (only after success)", async () => {
+      const freshRouter = createTestRouter();
+      let replaceInGuard: boolean | undefined;
+
+      await freshRouter.start("/home");
+
+      getLifecycleApi(freshRouter).addActivateGuard(
+        "profile",
+        () => (toState) => {
+          replaceInGuard = toState.transition?.replace;
+
+          return true;
+        },
+      );
+
+      await freshRouter.navigate("profile", {}, { replace: true });
+
+      expect(replaceInGuard).toBeUndefined();
+      expect(freshRouter.getState()?.transition?.replace).toBe(true);
 
       freshRouter.stop();
     });

--- a/packages/dom-utils/tests/functional/scroll-restore.test.ts
+++ b/packages/dom-utils/tests/functional/scroll-restore.test.ts
@@ -17,13 +17,14 @@ function makeState(
   name: string,
   params: Record<string, unknown> = {},
   context: Record<string, unknown> = {},
+  transition: Partial<State["transition"]> = {},
 ): State {
   return {
     name,
     params: params as State["params"],
     path: "/",
     context: context,
-    transition: {} as State["transition"],
+    transition: transition as State["transition"],
   };
 }
 
@@ -1274,6 +1275,125 @@ describe("createScrollRestoration", () => {
 
       sr.destroy();
       consoleError.mockRestore();
+    });
+  });
+
+  describe("portable disambiguation via transition.replace / transition.reload (RFC)", () => {
+    it("browser-plugin like (no context.navigation) + transition.replace=true → skip restore (no scrollTo)", () => {
+      const fake = makeFakeRouter(makeState("home"));
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      fake.emit(
+        makeState("about", {}, {}, { replace: true }),
+        makeState("home"),
+      );
+
+      expect(scrollSpy).not.toHaveBeenCalled();
+
+      sr.destroy();
+    });
+
+    it("browser-plugin like (no context.navigation) + transition.reload=true → restore from sessionStorage", () => {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 333 }));
+
+      const fake = makeFakeRouter(makeState("about"));
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      fake.emit(
+        makeState("home", {}, {}, { reload: true }),
+        makeState("about"),
+      );
+
+      expect(scrollSpy).toHaveBeenLastCalledWith({
+        top: 333,
+        left: 0,
+        behavior: "auto",
+      });
+
+      sr.destroy();
+    });
+
+    it("browser-plugin like (no context.navigation) + plain push (no replace/reload) → scrollToHashOrTop", () => {
+      const fake = makeFakeRouter(makeState("home"));
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      fake.emit(makeState("about"), makeState("home"));
+
+      expect(scrollSpy).toHaveBeenLastCalledWith({
+        top: 0,
+        left: 0,
+        behavior: "auto",
+      });
+
+      sr.destroy();
+    });
+
+    it("browser-plugin like (no context.navigation) + navigateToNotFound-shaped state (transition.replace=true) → skip restore", () => {
+      const fake = makeFakeRouter(makeState("home"));
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      // navigateToNotFound builds state with transition.replace=true inline;
+      // browser-plugin doesn't write state.context.navigation. The portable
+      // transition.replace flag is what drives the skip path now.
+      fake.emit(
+        makeState("@@router/UNKNOWN_ROUTE", {}, {}, { replace: true }),
+        makeState("home"),
+      );
+
+      expect(scrollSpy).not.toHaveBeenCalled();
+
+      sr.destroy();
+    });
+
+    it("browser-plugin F5 regression: no context.navigation AND no transition.reload → scrollToHashOrTop (browser-plugin can't disambiguate F5; out of scope)", () => {
+      // F5 under browser-plugin: opts.reload is undefined on initial
+      // transition, and there's no Navigation API getActivationType analogue
+      // to prime nav.navigationType — neither signal fires. The behaviour
+      // intentionally stays at the legacy "scroll to top / hash" — closing
+      // this gap requires core-level F5 priming, out of scope for this RFC.
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 999 }));
+
+      const fake = makeFakeRouter();
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      fake.emit(makeState("home"));
+
+      expect(scrollSpy).toHaveBeenLastCalledWith({
+        top: 0,
+        left: 0,
+        behavior: "auto",
+      });
+
+      sr.destroy();
+    });
+
+    it("navigation-plugin F5 regression: context.navigation.navigationType='reload' + transition.reload=undefined (simulates #531 priming) → restore from sessionStorage", () => {
+      // The plugin arm in the OR-condition is what preserves F5 scroll
+      // restoration under navigation-plugin: getActivationType() primes
+      // nav.navigationType="reload" but opts.reload stays undefined on the
+      // initial transition, so transition.reload alone wouldn't trigger.
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ "home:{}": 555 }));
+
+      const fake = makeFakeRouter();
+      const scrollSpy = vi.spyOn(globalThis, "scrollTo");
+      const sr = track(createScrollRestoration(fake.router));
+
+      fake.emit(
+        makeState("home", {}, { navigation: { navigationType: "reload" } }),
+      );
+
+      expect(scrollSpy).toHaveBeenLastCalledWith({
+        top: 555,
+        left: 0,
+        behavior: "auto",
+      });
+
+      sr.destroy();
     });
   });
 });

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -385,7 +385,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Override the `sessionStorage` key via `storageKey` (default `"real-router:scroll"`) when isolating multiple routers on one origin. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Override the `sessionStorage` key via `storageKey` (default `"real-router:scroll"`) when isolating multiple routers on one origin. Lifecycle tied to the provider — created on mount, destroyed on unmount. Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## View Transitions
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -449,7 +449,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## View Transitions
 

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -524,7 +524,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Options are read once on mount — changing the prop at runtime does not reconfigure the utility (Solid `onMount` is non-reactive). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Options are read once on mount — changing the prop at runtime does not reconfigure the utility (Solid `onMount` is non-reactive). Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## View Transitions
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -473,7 +473,7 @@ Opt-in preservation of scroll position across navigations:
 </RouterProvider>
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Lifecycle tied to the provider — created on mount, destroyed on unmount. Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## View Transitions
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -607,7 +607,7 @@ h(
 );
 ```
 
-Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Prop is reactive — toggling mode at runtime reconfigures the utility (watched by primitive fields, so inline objects with the same fields do not thrash). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for details.
+Restores scroll on back/forward, scrolls to top (or `#hash`) on push. Three modes: `"restore"` (default), `"top"`, `"native"`. Custom containers via `scrollContainer: () => HTMLElement | null`. Prop is reactive — toggling mode at runtime reconfigures the utility (watched by primitive fields, so inline objects with the same fields do not thrash). Under `@real-router/browser-plugin`, replace transitions now preserve scroll position and programmatic reloads restore from `sessionStorage` (portable via `state.transition.replace` / `state.transition.reload`). See [Scroll Restoration guide](https://github.com/greydragon888/real-router/wiki/Scroll-Restoration) for the full behaviour matrix.
 
 ## View Transitions
 

--- a/shared/dom-utils/scroll-restore.ts
+++ b/shared/dom-utils/scroll-restore.ts
@@ -229,28 +229,36 @@ export function createScrollRestoration(
       }
     }
 
-    // Single rAF so DOM is committed before we read anchors / write scroll.
-    // Guard against destroy() racing with the callback.
     requestAnimationFrame(() => {
       if (destroyed) {
         return;
       }
 
-      if (mode === "top" || !nav) {
+      if (mode === "top") {
         scrollToHashOrTop(route);
 
         return;
       }
 
-      if (nav.navigationType === "replace") {
+      if (route.transition.replace || nav?.navigationType === "replace") {
         return;
       }
 
-      if (
-        nav.direction === "back" ||
-        nav.navigationType === "traverse" ||
-        nav.navigationType === "reload"
-      ) {
+      // Both arms are required: `transition.reload` only fires for programmatic
+      // `router.navigate({reload:true})`. F5 under navigation-plugin primes
+      // `nav.navigationType === "reload"` via #531 getActivationType but leaves
+      // opts.reload undefined, so dropping the plugin arm would regress F5
+      // scroll-restore. Same belt-and-suspenders pattern is used for replace
+      // above. Browser-plugin's F5 is not covered (no priming, out of scope).
+      if (route.transition.reload || nav?.navigationType === "reload") {
+        const key = safeKeyOf(route);
+
+        writePos(key === null ? 0 : (loadStore()[key] ?? 0));
+
+        return;
+      }
+
+      if (nav?.direction === "back" || nav?.navigationType === "traverse") {
         const key = safeKeyOf(route);
 
         writePos(key === null ? 0 : (loadStore()[key] ?? 0));


### PR DESCRIPTION
## Summary

- Adds `replace?: boolean` to `TransitionMeta`, symmetric with the existing `reload` / `redirected` flags. Closes the asymmetry where `replace` was only readable via `state.context.navigation.navigationType` under `@real-router/navigation-plugin` — subscribers under browser-plugin, hash-plugin, memory-plugin, or no plugin had no portable way to discriminate replace transitions.
- Refactors `shared/dom-utils/scroll-restore.ts` to portable disambiguation through `route.transition.replace` + `route.transition.reload`. Under browser-plugin, replace transitions now preserve scroll position (skip) and programmatic reloads restore from `sessionStorage`. The plugin arm of the OR-conditions is **kept** to preserve F5 cross-document scroll restore under navigation-plugin via the existing #531 priming (otherwise F5 under navigation-plugin would regress — `opts.reload` is `undefined` on the priming-driven initial transition).
- Bonus: `navigateToNotFound()` writes `replace: true` inline, giving subscribers the same visibility plugins already had via `FROZEN_REPLACE_OPTS` (Invariant 7). The auto-force-from-`UNKNOWN_ROUTE` path (Invariant 12) is automatically lifted through `completeTransition()` without a separate edit.
- Documentation refreshed across the monorepo (`IMPLEMENTATION_NOTES.md` entry with Before/After matrix, `packages/core/CLAUDE.md`, `packages/navigation-plugin/CLAUDE.md`, `shared/dom-utils/CLAUDE.md`, `packages/core/ARCHITECTURE.md`, all 6 adapter READMEs) and on the wiki (`State.md`, `NavigationOptions.md`, `navigateToNotFound.md`, `Scroll-Restoration.md` — wiki commit lives in [real-router.wiki](https://github.com/greydragon888/real-router.wiki)).

## New API

```typescript
interface TransitionMeta {
  phase: TransitionPhase;
  reason: TransitionReason;
  reload?: boolean;
  replace?: boolean;     // ← NEW (additive, optional)
  redirected?: boolean;
  from?: string;
  blocker?: string;
  segments: { deactivated, activated, intersection };
}
```

Portable consumer idiom (works under any URL plugin or none):

```typescript
router.subscribe(({ route }) => {
  if (route.transition.replace) return;  // skip OAuth callbacks / canonicalization / navigateToNotFound / auto-force from UNKNOWN_ROUTE
  analytics.pageView(route.path);
});
```

`replace === true` covers all three sources: user-passed `opts.replace`, `forceReplaceFromUnknown()` auto-force, and `navigateToNotFound()` inline meta.

## Breaking changes

**Observable behaviour change** under `@real-router/browser-plugin` with `scrollRestoration={{ mode: \"restore\" }}`:

| Transition type                                                                           | Before                                              | After                                                          |
| ----------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
| Forward push (`<Link>` without `replace`)                                                 | `scrollToHashOrTop` (snap to top / anchor)          | `scrollToHashOrTop` (unchanged)                                |
| Replace (`navigate(..., { replace: true })`, OAuth callback, params canonicalization)     | `scrollToHashOrTop` (undesired snap)                | **skip** (preserve scroll position)                            |
| Programmatic reload (`navigate(..., { reload: true })`)                                   | `scrollToHashOrTop` (snap, lose pre-reload position) | **restore** from `sessionStorage`                              |
| F5 cross-document (browser-driven reload)                                                 | `scrollToHashOrTop`                                 | `scrollToHashOrTop` (**unchanged** — no `getActivationType` analogue under browser-plugin; closing this requires a core-level priming, out of scope) |
| Browser back/forward (popstate)                                                           | `scrollToHashOrTop` (snap)                          | `scrollToHashOrTop` (unchanged — `direction`/`traverse` disambiguation requires navigation-plugin) |
| `navigateToNotFound()`                                                                    | `scrollToHashOrTop`                                 | **skip** (via inline `transition.replace = true`)              |

**Opt-out** for the legacy snap-on-every-transition behaviour: `scrollRestoration={{ mode: \"top\" }}`.

Under `@real-router/navigation-plugin` there is **no behaviour change** — every existing branch (`replace` / `reload` / `traverse` / `direction === \"back\"`) remains active.

7 changesets cover the behaviour notice: `@real-router/core` (minor — adds `transition.replace`) + `@real-router/{react,preact,solid,vue,svelte,angular}` × 6 (minor — same BREAKING CHANGE (behaviour) notice across all 6).

## Test plan

- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes
- [x] 100% test coverage maintained
- [x] `packages/core` — 7 new cases in `navigation-options.test.ts` covering positive / negative / `replace: false` / `navigateToNotFound` / auto-force from `UNKNOWN_ROUTE` / explicit-`false`-override (the `!opts.replace` condition matches both `undefined` and `false`) / timing parity — **2234 pass**
- [x] `packages/dom-utils` — 6 new cases in `scroll-restore.test.ts` covering browser-plugin-like environment (no `context.navigation`) and F5 regression under both URL plugins — **147 pass**
- [x] Existing navigation-plugin scroll-restore tests — backward compatible (every existing branch still triggers, `transition.X` checks short-circuit slightly earlier with identical observable results)
- [x] Angular sync copy regenerated via `prebundle` script (`diff -q shared/dom-utils/scroll-restore.ts packages/angular/src/dom-utils/scroll-restore.ts` clean)
- [x] Full graph build: **286/286 successful, 0 failures, ~2m40s**
- [x] `pnpm changeset status` — 7 changesets valid, expected minor bumps for `core` + 6 adapters

## RFC

Full design, audit findings, edge cases, and acceptance criteria are documented in `.claude/rfc-transition-meta-discrimination.md` on the branch.

Closes #657