### PR TITLE
fix(event-emitter): snapshot invariant in depth-tracking path when size=1 (#659)

### DIFF
--- a/.changeset/eventemitter-snapshot-659-fix.md
+++ b/.changeset/eventemitter-snapshot-659-fix.md
@@ -1,0 +1,12 @@
+---
+"@real-router/core": patch
+---
+
+Fix EventEmitter snapshot invariant when depth tracking is enabled and only one listener exists (#659)
+
+`#emitWithDepthTracking` skipped the snapshot copy for listener sets of size 1
+and iterated the live `Set` directly, so a listener registered reentrantly
+inside the lone listener fired in the current emit cycle instead of waiting
+for the next one. Since core uses `maxEventDepth: 5`, this affected every
+reentrant `router.subscribe(...)` call made while only one subscriber was
+registered for the same event.

--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
       "devalue": ">=5.8.1",
       "fast-uri": ">=3.1.2",
       "hono": ">=4.12.18",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "js-cookie": ">=3.0.7"
     }
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/packages/event-emitter/src/EventEmitter.ts
+++ b/packages/event-emitter/src/EventEmitter.ts
@@ -267,7 +267,7 @@ export class EventEmitter<TEventMap extends Record<string, unknown[]>> {
     try {
       depthMap.set(eventName, depth + 1);
 
-      const listeners = set.size === 1 ? set : [...set];
+      const listeners = [...set];
 
       for (const cb of listeners) {
         try {

--- a/packages/event-emitter/tests/functional/event-emitter.test.ts
+++ b/packages/event-emitter/tests/functional/event-emitter.test.ts
@@ -522,6 +522,21 @@ describe("EventEmitter", () => {
       expect(cb2).toHaveBeenCalledWith(1, 2);
     });
 
+    it("should use snapshot iteration with depth tracking — size=1 listener added during emit NOT called", () => {
+      const emitter = createEmitter({
+        limits: { maxListeners: 0, warnListeners: 0, maxEventDepth: 5 },
+      });
+      const laterCb = vi.fn();
+
+      emitter.on("reset", () => {
+        emitter.on("reset", laterCb);
+      });
+
+      emitter.emit("reset");
+
+      expect(laterCb).not.toHaveBeenCalled();
+    });
+
     it("should call listener with 4+ args when depth tracking is on", () => {
       const emitter = createEmitter({
         limits: { maxListeners: 0, warnListeners: 0, maxEventDepth: 5 },

--- a/packages/event-emitter/tests/property/eventEmitter.properties.ts
+++ b/packages/event-emitter/tests/property/eventEmitter.properties.ts
@@ -242,19 +242,34 @@ describe("EventEmitter Property-Based Tests", () => {
   });
 
   describe("snapshot — listener added during emit is not called", () => {
-    test.prop([arbEventName, arbData], {
-      numRuns: NUM_RUNS.lifecycle,
-    })(
+    // Covers both #emitFast (maxEventDepth=0) and #emitWithDepthTracking (>0).
+    // Initial existing-listener count is varied so size=1 (the historic bug)
+    // and size>=2 paths in both branches are exercised symmetrically.
+    test.prop(
+      [
+        arbEventName,
+        arbData,
+        fc.constantFrom(0, 5),
+        fc.integer({ min: 0, max: 4 }),
+      ],
+      { numRuns: NUM_RUNS.lifecycle },
+    )(
       "listener added inside emit handler is not invoked in the current emit",
-      (eventName, data) => {
-        const emitter = createTestEmitter();
+      (eventName, data, maxEventDepth, extraListenerCount) => {
+        const emitter = createTestEmitter(maxEventDepth);
         const [laterListener] = createUniqueListeners(1);
+        const existingListeners = createUniqueListeners(extraListenerCount);
 
         const firstFn = (_data: number) => {
           emitter.on(eventName, laterListener.fn);
         };
 
         emitter.on(eventName, firstFn);
+
+        for (const { fn } of existingListeners) {
+          emitter.on(eventName, fn);
+        }
+
         emitter.emit(eventName, data);
 
         expect(laterListener.getCallCount()).toBe(0);
@@ -264,6 +279,10 @@ describe("EventEmitter Property-Based Tests", () => {
         expect(laterListener.getCallCount()).toBe(1);
 
         emitter.off(eventName, firstFn);
+
+        for (const { fn } of existingListeners) {
+          emitter.off(eventName, fn);
+        }
       },
     );
   });

--- a/packages/event-emitter/tests/property/helpers.ts
+++ b/packages/event-emitter/tests/property/helpers.ts
@@ -46,9 +46,15 @@ export const arbNonFunction: fc.Arbitrary<unknown> = fc.oneof(
   fc.constant(Symbol("test")),
 );
 
-export function createTestEmitter(): EventEmitter<TestEventMap> {
+export function createTestEmitter(
+  maxEventDepth = 0,
+): EventEmitter<TestEventMap> {
   // eslint-disable-next-line unicorn/prefer-event-target -- custom EventEmitter, not Node.js EventEmitter
-  return new EventEmitter<TestEventMap>();
+  return new EventEmitter<TestEventMap>(
+    maxEventDepth === 0
+      ? undefined
+      : { limits: { maxListeners: 0, warnListeners: 0, maxEventDepth } },
+  );
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ overrides:
   fast-uri: '>=3.1.2'
   hono: '>=4.12.18'
   ip-address: '>=10.1.1'
+  js-cookie: '>=3.0.7'
 
 importers:
 
@@ -12745,9 +12746,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
@@ -21966,10 +21967,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.7
       glob: 10.5.0
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-md4@0.3.2: {}
 


### PR DESCRIPTION
## Summary

- Fixes #659. `EventEmitter.#emitWithDepthTracking` used `set.size === 1 ? set : [...set]` as the iteration source — when there was exactly one listener the live `Set` was iterated, so a reentrant `on()` inside that listener fired in the same emit cycle. `@real-router/core` runs with `maxEventDepth: 5`, so this was the path actually used in production.
- Always snapshot via `[...set]`. `#emitFast` was not the bug source: `const [cb] = set` captures once and closes the iterator (verified in isolation). Issue text and severity have been updated on the issue itself.
- Added a depth-tracking + size=1 reentrant-subscribe functional test and parameterised the snapshot property test by `maxEventDepth ∈ {0, 5}` and initial listener count `[0..4]` so both branches of `#emit` are covered symmetrically.
- Second commit bumps the transitive devDep `js-cookie` 3.0.5 → 3.0.7 via `pnpm.overrides` to clear GHSA-qjx8-664m-686j surfaced by the pre-push osv-scanner.

## Test plan

- [x] `pnpm build` — 286/286 tasks green (type-check → lint → test → bundle)
- [x] `benchmarks/core/audit-probes/event-bus-2026-05-22/probe-01-snapshot-invariant.mjs` post-fix output:
      `[A:size=1] calls: ["outer"]` / `[B:size=2] calls: ["first","second"]`
- [x] New functional test `should use snapshot iteration with depth tracking — size=1 listener added during emit NOT called` passes
- [x] Parameterised property test runs for all `(maxEventDepth, extraListenerCount)` combinations
- [x] osv-scanner clean after `js-cookie` override