### PR TITLE
fix(core): add DISPOSE transitions from STARTING / READY / TRANSITION_STARTED / LEAVE_APPROVED (#660)

### DIFF
--- a/.changeset/fsm-dispose-transitions-660-fix.md
+++ b/.changeset/fsm-dispose-transitions-660-fix.md
@@ -1,0 +1,18 @@
+---
+"@real-router/core": patch
+---
+
+Settle FSM at DISPOSED regardless of pre-dispose state (#660)
+
+`routerFSM` only declared `DISPOSE → DISPOSED` from `IDLE`. If the FSM was
+stuck in `STARTING` (e.g. the start pipeline threw between `sendStart()` and
+`sendStarted()/sendFail()` — typically a misbehaving start interceptor),
+the subsequent `sendDispose()` was a no-op and `isActive()` / `isDisposed()`
+returned stale truth after `router.dispose()`. Mutating methods were already
+guarded by `#markDisposed()`, but the state-query API leaked the stuck-FSM
+state.
+
+`DISPOSE → DISPOSED` is now wired from `STARTING`, `READY`,
+`TRANSITION_STARTED`, and `LEAVE_APPROVED` so `dispose()` always settles the
+FSM at `DISPOSED`. Healthy flows are unaffected — the facade still routes
+through `IDLE` via `stop()`/`sendCancelIfPossible()`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -255,23 +255,29 @@ stateDiagram-v2
 
     STARTING --> READY : STARTED
     STARTING --> IDLE : FAIL
+    STARTING --> DISPOSED : DISPOSE
 
     READY --> TRANSITION_STARTED : NAVIGATE
     READY --> READY : FAIL
     READY --> IDLE : STOP
+    READY --> DISPOSED : DISPOSE
 
     TRANSITION_STARTED --> TRANSITION_STARTED : NAVIGATE
     TRANSITION_STARTED --> LEAVE_APPROVED : LEAVE_APPROVE
     TRANSITION_STARTED --> READY : CANCEL
     TRANSITION_STARTED --> READY : FAIL
+    TRANSITION_STARTED --> DISPOSED : DISPOSE
 
     LEAVE_APPROVED --> READY : COMPLETE
     LEAVE_APPROVED --> READY : CANCEL
     LEAVE_APPROVED --> READY : FAIL
     LEAVE_APPROVED --> TRANSITION_STARTED : NAVIGATE
+    LEAVE_APPROVED --> DISPOSED : DISPOSE
 
     DISPOSED --> [*]
 ```
+
+`DISPOSE` is wired from every non-DISPOSED state so `router.dispose()` always settles the FSM at `DISPOSED`. For healthy flows the facade still orchestrates cleanup through `IDLE` (`STOP` → `IDLE` → `DISPOSE`); the direct transitions are a safety net for cases where the FSM cannot be returned to `IDLE` first (e.g. `dispose()` mid-`STARTING` after a start-pipeline throw).
 
 | State                | Description                                           |
 | -------------------- | ----------------------------------------------------- |

--- a/packages/core/src/fsm/routerFSM.ts
+++ b/packages/core/src/fsm/routerFSM.ts
@@ -64,11 +64,17 @@ export interface RouterPayloads {}
  *
  * Transitions:
  * - IDLE → STARTING (START), DISPOSED (DISPOSE)
- * - STARTING → READY (STARTED), IDLE (FAIL)
- * - READY → TRANSITION_STARTED (NAVIGATE), READY (FAIL, self-loop for early validation errors), IDLE (STOP)
- * - TRANSITION_STARTED → LEAVE_APPROVED (LEAVE_APPROVE), TRANSITION_STARTED (NAVIGATE, self-loop), READY (CANCEL, FAIL)
- * - LEAVE_APPROVED → READY (COMPLETE, CANCEL, FAIL), TRANSITION_STARTED (NAVIGATE)
+ * - STARTING → READY (STARTED), IDLE (FAIL), DISPOSED (DISPOSE)
+ * - READY → TRANSITION_STARTED (NAVIGATE), READY (FAIL, self-loop for early validation errors), IDLE (STOP), DISPOSED (DISPOSE)
+ * - TRANSITION_STARTED → LEAVE_APPROVED (LEAVE_APPROVE), TRANSITION_STARTED (NAVIGATE, self-loop), READY (CANCEL, FAIL), DISPOSED (DISPOSE)
+ * - LEAVE_APPROVED → READY (COMPLETE, CANCEL, FAIL), TRANSITION_STARTED (NAVIGATE), DISPOSED (DISPOSE)
  * - DISPOSED → (no transitions)
+ *
+ * DISPOSE is wired from every non-DISPOSED state so `router.dispose()` always
+ * settles the FSM at DISPOSED. The facade orchestrates cleanup through IDLE
+ * for healthy flows; the direct transitions guarantee the FSM is not left
+ * stuck if cleanup is skipped (e.g. dispose mid-STARTING when the start
+ * pipeline threw before STARTED/FAIL).
  */
 const routerFSMConfig: FSMConfig<RouterState, RouterEvent, null> = {
   initial: routerStates.IDLE,
@@ -81,23 +87,27 @@ const routerFSMConfig: FSMConfig<RouterState, RouterEvent, null> = {
     [routerStates.STARTING]: {
       [routerEvents.STARTED]: routerStates.READY,
       [routerEvents.FAIL]: routerStates.IDLE,
+      [routerEvents.DISPOSE]: routerStates.DISPOSED,
     },
     [routerStates.READY]: {
       [routerEvents.NAVIGATE]: routerStates.TRANSITION_STARTED,
       [routerEvents.FAIL]: routerStates.READY,
       [routerEvents.STOP]: routerStates.IDLE,
+      [routerEvents.DISPOSE]: routerStates.DISPOSED,
     },
     [routerStates.TRANSITION_STARTED]: {
       [routerEvents.NAVIGATE]: routerStates.TRANSITION_STARTED,
       [routerEvents.LEAVE_APPROVE]: routerStates.LEAVE_APPROVED,
       [routerEvents.CANCEL]: routerStates.READY,
       [routerEvents.FAIL]: routerStates.READY,
+      [routerEvents.DISPOSE]: routerStates.DISPOSED,
     },
     [routerStates.LEAVE_APPROVED]: {
       [routerEvents.NAVIGATE]: routerStates.TRANSITION_STARTED,
       [routerEvents.COMPLETE]: routerStates.READY,
       [routerEvents.CANCEL]: routerStates.READY,
       [routerEvents.FAIL]: routerStates.READY,
+      [routerEvents.DISPOSE]: routerStates.DISPOSED,
     },
     [routerStates.DISPOSED]: {},
   },

--- a/packages/core/tests/functional/routerLifecycle/dispose.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/dispose.test.ts
@@ -103,6 +103,59 @@ describe("dispose", () => {
 
       expect(stopListener).not.toHaveBeenCalled();
     });
+
+    it("dispose() during LEAVE_APPROVED settles FSM at DISPOSED", async () => {
+      await router.start("/home");
+
+      const lifecycle = getLifecycleApi(router);
+      let resolveActivation: ((v: boolean) => void) | undefined;
+
+      lifecycle.addActivateGuard(
+        "users.list",
+        () => () =>
+          new Promise<boolean>((resolve) => {
+            resolveActivation = resolve;
+          }),
+      );
+
+      const navPromise = router.navigate("users.list").catch(() => {});
+
+      // wait for LEAVE_APPROVED to be reached (deactivation guards have all
+      // run; we are blocked on the activation-side async guard)
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(router.isLeaveApproved()).toBe(true);
+
+      router.dispose();
+
+      expect(router.isActive()).toBe(false);
+      expect(router.getState()).toBeUndefined();
+
+      resolveActivation?.(true);
+      await navPromise;
+    });
+
+    it("dispose() during stuck STARTING settles FSM at DISPOSED", async () => {
+      getPluginApi(router).addInterceptor("start", () => {
+        throw new Error("sync interceptor throw");
+      });
+
+      try {
+        await router.start("/home");
+      } catch {
+        /* expected */
+      }
+
+      // FSM is stuck in STARTING because the catch block in Router.start()
+      // only recovers when isReady(). Before the fix, the next sendDispose()
+      // was a no-op and isActive() remained true.
+      expect(router.isActive()).toBe(true);
+
+      router.dispose();
+
+      expect(router.isActive()).toBe(false);
+      expect(router.getState()).toBeUndefined();
+    });
   });
 
   describe("dispose() clears resources", () => {


### PR DESCRIPTION
## Summary

- Fixes #660. `routerFSM` only declared `DISPOSE → DISPOSED` from `IDLE`. Every other state had no `DISPOSE` transition, so a `sendDispose()` from a stuck FSM (most plausibly mid-`STARTING` after a start-pipeline throw) was a no-op. `#markDisposed()` still patched mutating methods, but `isActive()` / `isDisposed()` returned stale truth permanently.
- Wire `DISPOSE → DISPOSED` from `STARTING`, `READY`, `TRANSITION_STARTED`, `LEAVE_APPROVED`. Healthy flows are unchanged — the facade still orchestrates cleanup through `IDLE`; the direct transitions are a safety net for stuck-FSM cases.
- Doc commit updates the mermaid FSM diagram in root `ARCHITECTURE.md` to reflect the new transitions, with a note on the orchestrated-vs-direct distinction. Wiki diagram updated separately in `real-router.wiki/core-concepts.md` (already pushed).
- Does NOT close #668 — that's a different root cause in `Router.start().catch()` and is filed as a sibling PR.

## Test plan

- [x] `pnpm build` — 286/286 tasks green, coverage stays at 100%/100%/100%/100% for core
- [x] New functional tests in `tests/functional/routerLifecycle/dispose.test.ts`:
  - `dispose() during LEAVE_APPROVED settles FSM at DISPOSED` (via async activate-guard)
  - `dispose() during stuck STARTING settles FSM at DISPOSED` (via sync-throw start-interceptor — actual bug repro)
- [x] `probe-03-dispose-mid-starting.ts` — `isActive: false` post-dispose
- [x] `probe-04-dispose-leaves-fsm-starting.ts` — `→ FSM properly reached DISPOSED`