### PR TITLE
fix(core): recover FSM from STARTING when start pipeline throws (#668)

### DIFF
--- a/.changeset/start-pipeline-recovery-668-fix.md
+++ b/.changeset/start-pipeline-recovery-668-fix.md
@@ -1,0 +1,17 @@
+---
+"@real-router/core": patch
+---
+
+Recover FSM from STARTING when start pipeline throws (#668)
+
+`Router.start()` advanced the FSM `IDLE → STARTING` before running the
+start-interceptor pipeline, but the `.catch` block only recovered from
+`READY`. A sync-throwing or async-rejecting start interceptor left the FSM
+stuck in `STARTING` with no FAIL emitted: subsequent `start()` calls rejected
+with `ROUTER_ALREADY_STARTED` forever, `stop()` was a no-op, and the only
+escape was `dispose()`.
+
+`start()` now wraps the interceptor pipeline so sync throws become
+rejections, and the `.catch` block also recovers from `STARTING` by emitting
+`sendFail()` to return the FSM to `IDLE`. A misbehaving start interceptor
+no longer bricks the router — the caller can drop the bad plugin and retry.

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -416,16 +416,28 @@ export class Router<
 
     this.#eventBus.sendStart();
 
-    const promiseState = getInternals(this)
-      .start(startPath)
-      .catch((error: unknown) => {
-        if (this.#eventBus.isReady()) {
-          this.#lifecycle.stop();
-          this.#eventBus.sendStop();
-        }
+    // Convert sync interceptor throws to rejections so the recovery branch in
+    // .catch is reachable; otherwise the throw escapes synchronously, FSM is
+    // left in STARTING, and the router is permanently bricked (#668).
+    let internalStart: Promise<State>;
 
-        throw error;
-      });
+    try {
+      internalStart = getInternals(this).start(startPath);
+    } catch (syncError: unknown) {
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- preserve original throw shape from user-provided start interceptor
+      internalStart = Promise.reject(syncError);
+    }
+
+    const promiseState = internalStart.catch((error: unknown) => {
+      if (this.#eventBus.isReady()) {
+        this.#lifecycle.stop();
+        this.#eventBus.sendStop();
+      } else if (this.#eventBus.isStarting()) {
+        this.#eventBus.sendFail(undefined, undefined, error);
+      }
+
+      throw error;
+    });
 
     Router.#suppressUnhandledRejection(promiseState);
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -192,6 +192,11 @@ export class Router<
     registerInternals(this, {
       makeState: (name, params, path, meta) =>
         this.#state.makeState(name, params, path, meta),
+      // `as unknown as` is required: createInterceptable2 returns a
+      // non-generic `(a: A, b: B) => R`, but RouterInternals["forwardState"]
+      // is declared with a generic parameter `<P extends Params = Params>`,
+      // which tsc will not infer from the non-generic source. Sonar S4325
+      // misclassifies this as a redundant cast.
       forwardState: createInterceptable2(
         "forwardState",
         (name: string, params: Params) =>

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -227,6 +227,10 @@ export class EventBusNamespace {
     return this.#fsm.getState() === routerStates.READY;
   }
 
+  isStarting(): boolean {
+    return this.#fsm.getState() === routerStates.STARTING;
+  }
+
   getCurrentToState(): State | undefined {
     return this.#currentToState;
   }

--- a/packages/core/tests/functional/routerLifecycle/dispose.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/dispose.test.ts
@@ -135,7 +135,13 @@ describe("dispose", () => {
       await navPromise;
     });
 
-    it("dispose() during stuck STARTING settles FSM at DISPOSED", async () => {
+    it("dispose() after a failed start settles FSM at DISPOSED", async () => {
+      // Historically this scenario left the FSM stuck in STARTING (no
+      // recovery in Router.start().catch — #668). #660 added a direct
+      // STARTING → DISPOSED transition as a safety net; #668 then made the
+      // recovery automatic so the FSM returns to IDLE on failure. Either
+      // arm should keep dispose() correct: after a failed start, dispose()
+      // must settle the FSM at DISPOSED.
       getPluginApi(router).addInterceptor("start", () => {
         throw new Error("sync interceptor throw");
       });
@@ -145,11 +151,6 @@ describe("dispose", () => {
       } catch {
         /* expected */
       }
-
-      // FSM is stuck in STARTING because the catch block in Router.start()
-      // only recovers when isReady(). Before the fix, the next sendDispose()
-      // was a no-op and isActive() remained true.
-      expect(router.isActive()).toBe(true);
 
       router.dispose();
 

--- a/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
@@ -514,4 +514,64 @@ describe("router.start() - error handling", () => {
       });
     });
   });
+
+  // #668: a misbehaving start interceptor must not brick the router. The
+  // catch block in Router.start() now recovers from STARTING by emitting
+  // sendFail() (FSM → IDLE), so a subsequent start() can succeed.
+  describe("start-pipeline recovery from stuck STARTING", () => {
+    it("recovers FSM after sync-throwing start interceptor — subsequent start() succeeds", async () => {
+      const localRouter = createTestRouter();
+
+      const removeInterceptor = getPluginApi(localRouter).addInterceptor(
+        "start",
+        () => {
+          throw new Error("sync interceptor throw");
+        },
+      );
+
+      await expect(localRouter.start("/home")).rejects.toThrow(
+        "sync interceptor throw",
+      );
+
+      expect(localRouter.isActive()).toBe(false);
+
+      // Drop the bad interceptor and retry — router must be usable
+      removeInterceptor();
+
+      const state = await localRouter.start("/home");
+
+      expect(state.name).toBe("home");
+      expect(localRouter.isActive()).toBe(true);
+
+      localRouter.stop();
+    });
+
+    it("recovers FSM after async-rejecting start interceptor — subsequent start() succeeds", async () => {
+      const localRouter = createTestRouter();
+
+      const removeInterceptor = getPluginApi(localRouter).addInterceptor(
+        "start",
+        async () => {
+          await Promise.resolve();
+
+          throw new Error("async interceptor reject");
+        },
+      );
+
+      await expect(localRouter.start("/home")).rejects.toThrow(
+        "async interceptor reject",
+      );
+
+      expect(localRouter.isActive()).toBe(false);
+
+      removeInterceptor();
+
+      const state = await localRouter.start("/home");
+
+      expect(state.name).toBe("home");
+      expect(localRouter.isActive()).toBe(true);
+
+      localRouter.stop();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #668. `Router.start()` advanced the FSM `IDLE → STARTING` via `sendStart()` before running the start-interceptor pipeline, but the `.catch` only recovered from `READY`. Two issues compounded:
  1. A **synchronous** interceptor throw escaped `.catch` entirely — the exception propagated out of `start()` synchronously even though the signature returns `Promise<State>`, leaving the FSM in `STARTING`.
  2. Even for async rejections that reached `.catch`, no FAIL was emitted, so the FSM stayed stuck and the router was unusable until `dispose()`.
- Wrap the sync call in `try/catch` so throws become rejections; add an `isStarting()` branch in `.catch` that emits `sendFail()` to return the FSM to `IDLE`. A misbehaving start interceptor no longer bricks the router — the caller can drop the bad plugin and retry.
- New `isStarting()` predicate on `EventBusNamespace` follows the existing `isReady/isTransitioning/isLeaveApproved` pattern.
- Orthogonal to #660 / PR #669. #660 fixes the post-dispose state-query leak; this PR fixes the upstream cause so the router doesn't need `dispose()` to recover from a faulty interceptor.

## Test plan

- [x] `pnpm build` — 286/286 tasks green, coverage stays at 100%/100%/100%/100% for core
- [x] New functional tests in `tests/functional/routerLifecycle/start/error-handling.test.ts`:
  - `recovers FSM after sync-throwing start interceptor — subsequent start() succeeds`
  - `recovers FSM after async-rejecting start interceptor — subsequent start() succeeds`
- [x] `probe-01-fsm-stuck-on-interceptor-throw.ts` — `router.isActive(): false` post-failure (was `true`)
- [x] `probe-02-fsm-stuck-on-async-interceptor-reject.ts` — `→ Bug REFUTED on async-reject path.`