### PR TITLE
fix(core): race abort signal in subscribe-leave settle, unblock pipeline (#663)

### DIFF
--- a/.changeset/subscribe-leave-signal-race-663-fix.md
+++ b/.changeset/subscribe-leave-signal-race-663-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/core": patch
+---
+
+Unblock navigation pipeline when a `subscribeLeave` listener ignores its abort signal (#663)
+
+`EventBusNamespace.awaitLeaveListeners` awaited leave-listener promises via
+`Promise.allSettled` without observing the abort signal. A
+`subscribeLeave(() => new Promise(() => {}))` (or any listener that ignores
+`payload.signal`) hung the pipeline forever — concurrent `router.navigate`
+calls aborted the controller but `allSettled` kept waiting, so no
+navigation could complete.
+
+`settleLeavePromises` now races `Promise.allSettled` against the abort
+signal: when the signal aborts, the returned Promise rejects with
+`signal.reason` and the navigation pipeline unwinds via the normal
+`TRANSITION_CANCELLED` path. The abort event listener is cleaned up on
+natural completion to avoid leaking handlers.
+
+**Semantic note for plugin authors:** listeners that have not settled by
+abort time are **abandoned** — their Promises may still resolve in the
+background and hold references via closure until they do. Long-running
+leave listeners must respect `payload.signal` for cooperative cleanup. The
+router cannot synchronously force a hung Promise to resolve.

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -28,19 +28,48 @@ function ensureError(value: unknown): Error {
 function settleLeavePromises(
   promises: Promise<void>[],
   firstSyncError: unknown,
+  signal: AbortSignal,
 ): Promise<void> {
-  return Promise.allSettled(promises).then((results) => {
-    if (firstSyncError !== undefined) {
-      throw ensureError(firstSyncError);
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(ensureError(signal.reason));
+    };
+
+    if (signal.aborted) {
+      onAbort();
+
+      return;
     }
 
-    const rejected = results.find(
-      (result): result is PromiseRejectedResult => result.status === "rejected",
-    );
+    signal.addEventListener("abort", onAbort, { once: true });
 
-    if (rejected !== undefined) {
-      throw ensureError(rejected.reason);
-    }
+    void Promise.allSettled(promises).then((results) => {
+      signal.removeEventListener("abort", onAbort);
+
+      if (signal.aborted) {
+        // Race lost to abort — the abort handler already rejected; do nothing
+        return;
+      }
+
+      if (firstSyncError !== undefined) {
+        reject(ensureError(firstSyncError));
+
+        return;
+      }
+
+      const rejected = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+
+      if (rejected !== undefined) {
+        reject(ensureError(rejected.reason));
+
+        return;
+      }
+
+      resolve();
+    });
   });
 }
 
@@ -311,7 +340,7 @@ export class EventBusNamespace {
       return undefined;
     }
 
-    return settleLeavePromises(promises, firstSyncError);
+    return settleLeavePromises(promises, firstSyncError, signal);
   }
 
   clearAll(): void {

--- a/packages/core/src/namespaces/NavigationNamespace/transition/guardPhase.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/guardPhase.ts
@@ -202,6 +202,9 @@ async function finishAfterAsyncLeave(
 ): Promise<void> {
   await leaveCompletion;
 
+  /* v8 ignore next 3 -- @preserve: unreachable after #663 — signal abort
+     mid-leave rejects via settleLeavePromises, so `await leaveCompletion`
+     throws directly instead of completing with a stale isActive() */
   if (!isActive()) {
     throw new RouterError(errorCodes.TRANSITION_CANCELLED);
   }

--- a/packages/core/tests/functional/observable/subscribe-leave.test.ts
+++ b/packages/core/tests/functional/observable/subscribe-leave.test.ts
@@ -238,6 +238,103 @@ describe("core/observable/subscribeLeave", () => {
     });
   });
 
+  // #663 — pipeline must not block on a listener that ignores its abort
+  // signal. The race rejects the awaitLeaveListeners promise with
+  // signal.reason as soon as the controller aborts; the hung listener
+  // promise is abandoned (may still complete in background).
+  describe("awaitLeaveListeners — signal race", () => {
+    it("rejects with signal.reason when controller aborts mid-await", async () => {
+      const controller = new AbortController();
+      const abortReason = new RouterError("CANCELLED");
+
+      bus.subscribeLeave(() => new Promise<void>(() => {}));
+
+      const result = bus.awaitLeaveListeners(
+        TO_STATE,
+        FROM_STATE,
+        controller.signal,
+      );
+
+      controller.abort(abortReason);
+
+      await expect(result).rejects.toBe(abortReason);
+    });
+
+    it("rejects immediately when signal is already aborted on entry", async () => {
+      const controller = new AbortController();
+      const abortReason = new RouterError("CANCELLED");
+
+      controller.abort(abortReason);
+
+      bus.subscribeLeave(() => new Promise<void>(() => {}));
+
+      const result = bus.awaitLeaveListeners(
+        TO_STATE,
+        FROM_STATE,
+        controller.signal,
+      );
+
+      await expect(result).rejects.toBe(abortReason);
+    });
+
+    it("resolves normally when listeners settle before abort fires", async () => {
+      const controller = new AbortController();
+      let called = false;
+
+      bus.subscribeLeave(async () => {
+        called = true;
+      });
+
+      const result = bus.awaitLeaveListeners(
+        TO_STATE,
+        FROM_STATE,
+        controller.signal,
+      );
+
+      await result;
+
+      expect(called).toBe(true);
+
+      // Abort after natural completion must not affect the resolved promise
+      controller.abort(new RouterError("CANCELLED"));
+    });
+
+    it("cooperatively-cancelling listener still propagates its own rejection", async () => {
+      const controller = new AbortController();
+      const listenerReason = new Error("listener cooperative cancel");
+
+      bus.subscribeLeave(
+        ({ signal: sig }) =>
+          new Promise<void>((_, reject) => {
+            sig.addEventListener(
+              "abort",
+              () => {
+                reject(listenerReason);
+              },
+              {
+                once: true,
+              },
+            );
+          }),
+      );
+
+      const result = bus.awaitLeaveListeners(
+        TO_STATE,
+        FROM_STATE,
+        controller.signal,
+      );
+
+      const abortReason = new RouterError("CANCELLED");
+
+      controller.abort(abortReason);
+
+      // Race winner is the signal arm — abortReason wins over listenerReason.
+      // listenerReason still bubbles via the listener's promise but is
+      // discarded by the pipeline (the navigation is already cancelling).
+      await expect(result).rejects.toBe(abortReason);
+    });
+  });
+
   describe("clearAll", () => {
     it("clears leave listeners", () => {
       const listener = vi.fn();


### PR DESCRIPTION
## Summary

- Fixes #663. `EventBusNamespace.awaitLeaveListeners` used `Promise.allSettled` without observing the abort signal. A `subscribeLeave(() => new Promise(() => {}))` (or any listener that ignored `payload.signal`) hung the navigation pipeline forever: concurrent `router.navigate` aborted the controller but allSettled kept waiting.
- `settleLeavePromises` now races allSettled against the abort signal inside a manually-controlled Promise so the abort handler is removed on natural completion (no leaked listener). On abort, the returned Promise rejects with `signal.reason` and the navigation pipeline unwinds via the standard `TRANSITION_CANCELLED` path.
- **Abandoned-listener semantics** (documented in changeset): listeners that have not settled by abort time may still resolve in the background and hold closure references until they do. Long-running leave listeners must respect `payload.signal`; the router cannot synchronously force a hung Promise to resolve.
- Side effect: `guardPhase.finishAfterAsyncLeave` line 205–207 (`if (!isActive()) throw TRANSITION_CANCELLED`) is now unreachable after this PR — signal abort mid-await rejects via `settleLeavePromises` instead of letting `await leaveCompletion` complete with a stale `isActive()`. Annotated with `v8 ignore`.
- Scope: Part A from issue #663 only. Part B (`#cleanupController` reason propagation) is **not a bug** — see issue body. No changes to `NavigationNamespace`.

## Test plan

- [x] `pnpm build` — 286/286 tasks green
- [x] `pnpm -F @real-router/core test` — 2242 passed, coverage 100%/100%/100%/100%
- [x] New `awaitLeaveListeners — signal race` describe in `tests/functional/observable/subscribe-leave.test.ts`:
  - `rejects with signal.reason when controller aborts mid-await`
  - `rejects immediately when signal is already aborted on entry`
  - `resolves normally when listeners settle before abort fires`
  - `cooperatively-cancelling listener still propagates its own rejection` (signal arm wins, listener rejection preempted)
- [x] Local probe: hung listener + concurrent `navigate` → navA rejected `CANCELLED`, navB completed successfully (pipeline unblocked)