### PR TITLE
docs(core): clarify cloneRouter shallow-merge dependency semantics (#664)

### DIFF
--- a/.changeset/clonerouter-ssr-docs-664.md
+++ b/.changeset/clonerouter-ssr-docs-664.md
@@ -1,0 +1,13 @@
+---
+"@real-router/core": patch
+---
+
+Document `cloneRouter` shallow-merge dependency semantics for SSR multi-tenancy (#664)
+
+Clarifies in JSDoc and `IMPLEMENTATION_NOTES.md` that
+`base.dependencies` values are shared by reference between the base
+router and every clone (singleton services like DB clients depend on
+this). Per-request mutable state — `currentUser`, `traceId`,
+`sessionId` — must flow through the `cloneRouter` override parameter
+or `createRequestScope`, never `base.dependencies`. No behaviour
+change.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -3494,3 +3494,59 @@ Under `@real-router/navigation-plugin` there is **no behaviour change** — ever
 - `packages/core/tests/functional/navigation/navigate/navigation-options.test.ts` — the "transition meta flags" suite gains six new cases covering `replace: true`, `replace: false`, default `undefined`, `navigateToNotFound`, `forceReplaceFromUnknown` auto-force, and the override of an explicit `replace: false` from `UNKNOWN_ROUTE` (the `!opts.replace` condition matches both `undefined` and `false`), plus a timing-parity case mirroring the existing reload guard test.
 - `packages/dom-utils/tests/functional/scroll-restore.test.ts` — a new describe block adds six cases under a browser-plugin-like environment (no `state.context.navigation`) plus a regression test that simulates navigation-plugin's #531 priming (`nav.navigationType === "reload"` with `transition.reload === undefined`) and verifies that the F5 restore path still fires.
 - `packages/angular/src/dom-utils/scroll-restore.ts` is regenerated from `shared/dom-utils/scroll-restore.ts` by the existing `prebundle` script (`pnpm -F @real-router/angular bundle`) — ng-packagr cannot follow the symlinks the other adapters use, so the file is git-tracked and must be kept in sync.
+
+## `cloneRouter` keeps dependency values shared by reference, on purpose (#664)
+
+### Problem
+
+`cloneRouter(base, deps?)` merges `base.dependencies` and the override via shallow spread:
+
+```typescript
+const mergedDeps = { ...sourceDeps, ...dependencies };
+```
+
+Top-level keys are new; values (`Map`, `Set`, class instances, functions, nested plain objects) are shared by reference between `base` and every clone. An audit (`packages/core/.claude/audit/clone-router-deep-2026-05-22.md` Bug #1) reported this as a CRITICAL SSR data-leak vector and proposed an `isolateDeps: true` flag wired to `structuredClone(sourceDeps)`.
+
+### Solution
+
+**Keep the shallow merge. Document the contract loudly.** Three doc surfaces:
+
+1. JSDoc on `packages/core/src/api/cloneRouter.ts` with the singletons-vs-per-request rule and an `@example` showing the correct shape.
+2. `real-router.wiki/clone.md` — dedicated **SSR multi-tenancy** section with a lifecycle table (singletons → base; per-request → override / `createRequestScope`).
+3. `real-router.wiki/ssr.md` — SSR-safety callout next to the introductory `cloneRouter` example, linking back to (2).
+
+No code changes in `cloneRouter.ts`. `createRequestScope` already routes per-request state through the override slot (`{ ...deps, abortSignal: signal }`) by construction.
+
+### Why
+
+**`structuredClone` of dependency values breaks the common case.** Verified locally:
+
+- Class instances (`new DbClient()`) lose their prototype on clone — methods become `undefined`.
+- Functions (`logger: () => "log"`) throw `DataCloneError`.
+- Singleton pools (DB connection pool, LRU cache) fragment into N un-pooled copies, destroying pool semantics.
+- Circular references throw.
+
+`guardDependencies` in `packages/core/src/guards.ts:6` already constrains the top-level `dependencies` argument to a plain object, but values inside are intentionally unconstrained because most useful deps are class instances or services. Any auto-clone strategy is a regression for those shapes.
+
+**The override slot already solves per-request isolation.** The documented SSR pattern is:
+
+```typescript
+const base = createRouter(routes, options, {
+  db: new DbClient(dbUrl),       // singleton — shared (correct)
+  logger,
+});
+
+// Per request
+const clone = cloneRouter(base, {
+  currentUser,                   // unique per request
+  traceId,
+});
+// or, for Node/Web request lifecycles:
+const scope = createRequestScope(req, base, { currentUser, traceId });
+```
+
+The override is fresh per call and applied last in the merge — it wins over base keys. `createRequestScope` additionally injects a fresh `AbortController().signal` as `abortSignal` per request, so the documented SSR pattern is already isolation-correct by construction.
+
+**Cross-request leaks require misuse, not the documented pattern.** They only occur when per-request mutable state is placed in `base.dependencies` instead of the override — an architectural error no clone strategy can correct without breaking singleton sharing.
+
+**Severity re-classification.** The audit's "CRITICAL CVE-class data leak / GHSA advisory" framing did not survive review (no remote vector, documented behaviour, broken proposed fix). Re-labelled LOW (documentation enhancement). Issue #664 was closed with doc-only changes; no `isolateDeps` flag, no auto-`structuredClone`, no DEV warning (mutable values in deps are normal — DB clients, EventEmitters, Maps).

--- a/packages/core/src/api/cloneRouter.ts
+++ b/packages/core/src/api/cloneRouter.ts
@@ -9,6 +9,69 @@ import { getLifecycleApi } from "./getLifecycleApi";
 import type { Route } from "../types";
 import type { DefaultDependencies, Router } from "@real-router/types";
 
+/**
+ * Build an independent router instance that shares the route tree, options,
+ * lifecycle guards, and plugin factories of `router`. The primary use case
+ * is **SSR multi-tenancy** — one base router per process, one clone per
+ * request.
+ *
+ * @param router - Source router (must not be disposed).
+ * @param dependencies - Optional per-clone overrides merged on top of the
+ *   base router's dependencies. Always **fresh per call** in the documented
+ *   SSR pattern: pass per-request state here, never store it in the base.
+ *
+ * @remarks
+ *
+ * **Dependency merge — shallow by design.** `base.dependencies` are spread
+ * into the clone via `{ ...sourceDeps, ...dependencies }`. Top-level keys
+ * are new objects, but **values are shared by reference**: a `Map`, `Set`,
+ * class instance, function, or nested plain object stored in
+ * `base.dependencies` is the **same instance** in every clone. Mutations
+ * in one clone are visible in the base and in every sibling clone.
+ *
+ * This is intentional. `structuredClone` of dep values is **not** applied
+ * because it would:
+ * - strip class prototypes (`new DbClient()` → plain object, methods lost)
+ * - reject functions and symbols (`DataCloneError`)
+ * - fragment singleton pools (one connection pool per request — pool
+ *   semantics destroyed)
+ * - reject circular references
+ *
+ * **SSR rule of thumb.** Place values in `base.dependencies` according to
+ * their lifecycle:
+ *
+ * - **Singletons / shared services** → `base.dependencies`. Examples: DB
+ *   client, connection pool, logger, config, feature-flag client. Process-
+ *   wide pooling depends on sharing these by reference.
+ * - **Per-request state** → the `dependencies` override parameter (or
+ *   `createRequestScope`'s `deps` argument). Examples: `currentUser`,
+ *   `traceId`, `sessionId`, `abortSignal`. The override is applied last,
+ *   so it wins over base keys; pass a fresh object per call.
+ *
+ * Cross-request data leaks are **only possible** when per-request mutable
+ * state is incorrectly placed in `base.dependencies`. The override slot is
+ * the safe channel.
+ *
+ * @example
+ * ```typescript
+ * // Server boot — singletons only
+ * const base = createRouter(routes, options, {
+ *   db: new DbClient(dbUrl),
+ *   logger,
+ * });
+ *
+ * // Per request — fresh override per call
+ * const clone = cloneRouter(base, {
+ *   currentUser,
+ *   traceId,
+ * });
+ * // clone.deps.db === base.deps.db  ✓ shared pool (intentional)
+ * // clone.deps.currentUser          ✓ unique per request
+ * ```
+ *
+ * @see createRequestScope — `@real-router/core/utils` SSR helper that
+ *   wraps this function and injects `abortSignal` automatically.
+ */
 export function cloneRouter<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(


### PR DESCRIPTION
## Summary

- Closes #664 (re-classified as **LOW / documentation** after analysis).
- Audit `clone-router-deep-2026-05-22.md` Bug #1 flagged the shallow `{ ...sourceDeps, ...dependencies }` merge as a CRITICAL SSR data-leak vector and proposed `isolateDeps: true` wired to `structuredClone(sourceDeps)`. Closer review showed:
  - `structuredClone` strips class prototypes (DbClient, EventEmitter — methods become undefined), throws `DataCloneError` on functions, fragments singleton pools, rejects circular refs. The proposed fix is a regression for the common dep shapes.
  - The override slot already solves per-request isolation: `cloneRouter(base, perRequestDeps)` and `createRequestScope(req, base, deps)` both pass fresh per-request state through the override, which is applied last in the merge.
  - Cross-request leaks require placing per-request mutable state in `base.deps` instead of the override — an architectural error no clone strategy can correct without breaking singleton sharing.
  - `wiki/clone.md` already said "Shallow copy" — the gap is prominence, not behaviour.
- **No code changes.** Three doc surfaces touched:
  - `packages/core/src/api/cloneRouter.ts` — full `@remarks` JSDoc with the singletons-vs-per-request lifecycle rule, `@example`, and an explicit note that `structuredClone` is not applied (and why).
  - `IMPLEMENTATION_NOTES.md` — Problem → Solution → Why entry recording the design rationale and severity re-classification.
  - Wiki: `clone.md` gets a new **SSR multi-tenancy — dependency reference sharing** section; `ssr.md` gets a safety callout linking to it. Committed in the wiki repo at `103c4a3`.

## Test plan

- [x] `pnpm build` — 286/286 tasks green, coverage 100%
- [x] `pnpm -F @real-router/core lint` — clean
- [x] `pnpm -F @real-router/core type-check` — clean
- [x] Manual: rendered JSDoc in IDE shows the `@remarks`, lifecycle rule, and `@example` correctly
- [x] Wiki rendering: `clone.md` SSR section and `ssr.md` callout render with working cross-links