### PR TITLE
refactor(core): split lifecycle factory storage by origin (#661)

### DIFF
--- a/.changeset/lifecycle-factory-origin-split-661.md
+++ b/.changeset/lifecycle-factory-origin-split-661.md
@@ -1,0 +1,37 @@
+---
+"@real-router/core": patch
+---
+
+Lift guard origin to a primary invariant in `RouteLifecycleNamespace` (#661)
+
+`RouteLifecycleNamespace` previously stored canActivate / canDeactivate
+factories in a single Map per kind and tracked "is this guard from a
+route definition vs added externally" via auxiliary `Set<string>`
+collections. Origin was a derived, Set-tracked property that the public
+API had to reconstruct, with a handful of subtle consequences for
+`removeActivateGuard`, `replace()`, and `cloneRouter`.
+
+Storage is now split per origin: `#definitionActivateFactories` /
+`#externalActivateFactories` (and symmetric pair for deactivate). The
+compiled-function view preserves the pre-refactor "last add wins"
+runtime semantic; on partial clear it falls back to whichever origin
+Map still holds the slot.
+
+Behavioural changes:
+
+- `clearCanActivate(name, origin?)` / `clearCanDeactivate(name, origin?)`
+  accept an optional `origin` filter (`"definition"` / `"external"`).
+  Default behaviour (no filter) is unchanged — both slots cleared.
+- `getFactoriesByOrigin()` added for `cloneRouter` consumption — returns
+  `{ definition: [deactivate, activate], external: [deactivate, activate] }`
+  so clones re-register guards with the original origin flag preserved.
+  `replace()` on the clone now correctly strips inherited definition
+  guards via `clearDefinitionGuards()`.
+- `getFactories()` retains its `[deactivate, activate]` flat shape with
+  external winning over definition for the same slot — backward compatible
+  with `getRoutesApi` and the route-removal cleanup path.
+
+Non-goals: this refactor does not address closure-sharing across
+clones (`base.deps` / `base.externalGuards` shared by reference — see
+#664 for the documented SSR usage rule: singletons → base, per-request
+→ clone via the override slot or `createRequestScope`).

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -3550,3 +3550,50 @@ The override is fresh per call and applied last in the merge — it wins over ba
 **Cross-request leaks require misuse, not the documented pattern.** They only occur when per-request mutable state is placed in `base.dependencies` instead of the override — an architectural error no clone strategy can correct without breaking singleton sharing.
 
 **Severity re-classification.** The audit's "CRITICAL CVE-class data leak / GHSA advisory" framing did not survive review (no remote vector, documented behaviour, broken proposed fix). Re-labelled LOW (documentation enhancement). Issue #664 was closed with doc-only changes; no `isolateDeps` flag, no auto-`structuredClone`, no DEV warning (mutable values in deps are normal — DB clients, EventEmitters, Maps).
+
+## `RouteLifecycleNamespace` factory storage split by origin (#661)
+
+### Problem
+
+Guard factories (`canActivate` / `canDeactivate`) had two possible origins:
+
+- **Definition** — declared on the route config: `{ name: "admin", canActivate: ... }`. Subject to `clearDefinitionGuards()` cleanup during `replace()`.
+- **External** — registered post-hoc via `getLifecycleApi().addActivateGuard(name, ...)`. Survives `replace()`.
+
+Storage was a single `Map<string, GuardFnFactory>` per kind plus an auxiliary `Set<string>` per kind tracking which slots came from definitions. Origin was a derived, Set-tracked property — every read had to consult both the Map and the Set to reconstruct it. That layout had three follow-on quirks: `removeActivateGuard` could not distinguish origins (the Set was for HMR cleanup, not for the public API), an external add over an existing definition cleared the Set entry without any signal that the original definition guard was being shadowed, and `cloneRouter`'s `getFactories()` returned a flat record so clones lost origin entirely (every guard re-registered as external).
+
+The original audit (`route-lifecycle-deep-2026-05-22.md` + `clone-router-deep-2026-05-22.md`) framed these as four CRITICAL bugs closing a "CVE-class data leak vector". After running every probe and tracing the call paths, none of the claims survived as CRITICAL — the closure-sharing claim in particular is a documented usage rule (#664-shaped: singletons on base, per-request on clone) that this refactor cannot address regardless of storage layout. Re-classified LOW (code-quality refactor); see issue #661 for the full re-evaluation table.
+
+### Solution
+
+Lift origin to a primary structural invariant by splitting storage into four factory Maps:
+
+```
+#definitionActivateFactories     #externalActivateFactories
+#definitionDeactivateFactories   #externalDeactivateFactories
+```
+
+Each `add*` call lands in exactly one of these Maps according to the `isFromDefinition` flag. The compiled-function view (`#canActivateFunctions` / `#canDeactivateFunctions`, one Map per kind) keeps the pre-refactor **last add wins** runtime semantic, preserving the `replaceRoutes: definition wins on replace` contract. On partial clear, the compiled function falls back to whichever origin Map still holds the slot.
+
+Public namespace surface (consumers inside core):
+
+- `clearCanActivate(name, origin?)` / `clearCanDeactivate(name, origin?)` — optional `"definition"` / `"external"` filter. Default (no filter) keeps the pre-refactor behaviour of clearing both slots.
+- `getFactoriesByOrigin(): { definition: [d, a]; external: [d, a] }` — used by `cloneRouter` to re-register each kind with the original `isFromDefinition` flag preserved. Subsequent `replace()` on the clone now correctly strips inherited definition guards.
+- `getFactories(): [d, a]` — backward-compatible flat shape (external wins on duplicate slot). Used by `getRoutesApi` consumers (`enrichRoute`, route-removal cleanup, the `auto-cleanup` test) without modification.
+- `clearDefinitionGuards()` — iterates `#definitionActivate*` keys; only deletes the compiled function for slots that lack a surviving external entry, otherwise the external function stays in place.
+
+`cloneRouter` was rewired to call `getFactoriesByOrigin()` instead of the flat `getLifecycleFactories()`: definition factories are registered via the namespace directly with `isFromDefinition=true`, external factories flow through the public `lifecycleApi.addActivateGuard` / `addDeactivateGuard` path. The public lifecycle API surface — `removeActivateGuard(name)` / `removeDeactivateGuard(name)` — is unchanged; wiki and JSDoc do not need updates.
+
+### Why
+
+**Origin becomes a property of where the factory lives, not a derived flag.** Set-tracked origin made every consumer (cloneRouter, replace, clearDefinitionGuards) reconstruct the intent from two data structures. With split Maps, "is this a definition guard?" is `definitionActivateFactories.has(name)` — one lookup, no reconstruction.
+
+**Clone semantics become predictable.** Before: `cloneRouter` lost origin, so a `replace()` on a clone couldn't strip inherited definition guards. After: clones round-trip origin and behave identically to the base under `replace()`.
+
+**Enables future API tightening without re-touching internals.** Once the team decides whether `removeActivateGuard` should default to "external only" (cleaner public contract — currently ambiguous in the wiki), the change is one line at the API site: `lifecycleNamespace.clearCanActivate(name, "external")`. Without this refactor, the same API change would require introducing origin-aware storage as part of the same PR.
+
+### Non-goals
+
+- **Closure-sharing across clones (audit Bug #2 / clone-router #2)** — not addressed and cannot be addressed by factory storage layout. A guard factory registered on the base with closure over per-request state is shared by reference with every clone regardless of how the factories are filed. The fix is documentation (singletons on base, per-request state on the clone via the override slot or `createRequestScope`), tracked under #664 for dependencies and applicable to guards verbatim.
+- **`removeActivateGuard` semantics** — unchanged. Default clear of both origin slots is preserved so this PR is a pure refactor at the public surface. Tightening to "external only" is a separate API-contract decision.
+

--- a/packages/core/src/api/cloneRouter.ts
+++ b/packages/core/src/api/cloneRouter.ts
@@ -95,8 +95,14 @@ export function cloneRouter<
 
   const options = ctx.cloneOptions();
   const sourceDeps = ctx.cloneDependencies();
-  const [canDeactivateFactories, canActivateFactories] =
-    ctx.getLifecycleFactories();
+  // Origin-aware factory snapshot — definition guards are re-registered with
+  // `isFromDefinition=true` on the clone so `replace()` can still strip them
+  // via `clearDefinitionGuards()`. External guards take the public lifecycle
+  // API path so they survive `replace()` symmetric with the base.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed set after wiring
+  const sourceLifecycleNamespace = sourceStore.lifecycleNamespace!;
+  const { definition: definitionFactories, external: externalFactories } =
+    sourceLifecycleNamespace.getFactoriesByOrigin();
   const pluginFactories = ctx.getPluginFactories();
 
   const mergedDeps = {
@@ -110,22 +116,35 @@ export function cloneRouter<
     mergedDeps,
   );
 
+  const newCtx = getInternals(newRouter);
+  const newStore = newCtx.routeGetStore();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed set after wiring
+  const newLifecycleNamespace = newStore.lifecycleNamespace!;
+
+  const [definitionDeactivate, definitionActivate] = definitionFactories;
+  const [externalDeactivate, externalActivate] = externalFactories;
+
+  for (const [name, handler] of Object.entries(definitionDeactivate)) {
+    newLifecycleNamespace.addCanDeactivate(name, handler, true);
+  }
+
+  for (const [name, handler] of Object.entries(definitionActivate)) {
+    newLifecycleNamespace.addCanActivate(name, handler, true);
+  }
+
   const lifecycle = getLifecycleApi(newRouter);
 
-  for (const [name, handler] of Object.entries(canDeactivateFactories)) {
+  for (const [name, handler] of Object.entries(externalDeactivate)) {
     lifecycle.addDeactivateGuard(name, handler);
   }
 
-  for (const [name, handler] of Object.entries(canActivateFactories)) {
+  for (const [name, handler] of Object.entries(externalActivate)) {
     lifecycle.addActivateGuard(name, handler);
   }
 
   if (pluginFactories.length > 0) {
     newRouter.usePlugin(...pluginFactories);
   }
-
-  const newCtx = getInternals(newRouter);
-  const newStore = newCtx.routeGetStore();
 
   // Apply cloned config directly to new store
   Object.assign(newStore.config.decoders, routeConfig.decoders);

--- a/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
+++ b/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
@@ -20,6 +20,23 @@ function booleanToFactory<Dependencies extends DefaultDependencies>(
 }
 
 /**
+ * Origin of a registered guard. `"definition"` — declared in route config and
+ * thus subject to `clearDefinitionGuards()` cleanup during `replace()`.
+ * `"external"` — registered post-hoc via `getLifecycleApi().add*Guard(...)`
+ * and survives `replace()`.
+ *
+ * Storage is split per origin (two Maps per kind, four Maps total) so origin
+ * is a primary invariant rather than a derived Set-tracked property. The
+ * compiled function (`#canActivateFunctions` / `#canDeactivateFunctions`)
+ * reflects the **last add wins** semantic for the slot (regardless of
+ * origin) — matching the pre-refactor behaviour and the
+ * `replaceRoutes.test.ts` "definition wins on replace" contract. On clear,
+ * the function falls back to whichever origin Map still holds an entry
+ * (external preferred if both remain after a partial clear).
+ */
+export type GuardOrigin = "definition" | "external";
+
+/**
  * Independent namespace for managing route lifecycle handlers.
  *
  * Static methods handle input validation (called by facade).
@@ -28,14 +45,29 @@ function booleanToFactory<Dependencies extends DefaultDependencies>(
 export class RouteLifecycleNamespace<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 > {
-  readonly #canDeactivateFactories = new Map<
+  // Storage split by origin: definition vs external. External wins at compile
+  // time for the same slot; clearDefinitionGuards / removeXGuard semantics are
+  // expressed in terms of these primary Maps.
+  readonly #definitionActivateFactories = new Map<
     string,
     GuardFnFactory<Dependencies>
   >();
-  readonly #canActivateFactories = new Map<
+  readonly #externalActivateFactories = new Map<
     string,
     GuardFnFactory<Dependencies>
   >();
+  readonly #definitionDeactivateFactories = new Map<
+    string,
+    GuardFnFactory<Dependencies>
+  >();
+  readonly #externalDeactivateFactories = new Map<
+    string,
+    GuardFnFactory<Dependencies>
+  >();
+  // Compiled-function view. Single Map per kind because navigation does not
+  // distinguish origin — it just runs the effective guard. Set on add (last
+  // add wins) and recompiled on clear from whichever origin Map still holds
+  // the slot.
   readonly #canDeactivateFunctions = new Map<string, GuardFn>();
   readonly #canActivateFunctions = new Map<string, GuardFn>();
   // Cached tuple — Maps never change reference, so this is stable
@@ -45,8 +77,6 @@ export class RouteLifecycleNamespace<
   ];
 
   readonly #registering = new Set<string>();
-  readonly #definitionActivateGuardNames = new Set<string>();
-  readonly #definitionDeactivateGuardNames = new Set<string>();
 
   #deps!: RouteLifecycleDependencies<Dependencies>;
   #limits: Limits = DEFAULT_LIMITS;
@@ -72,9 +102,30 @@ export class RouteLifecycleNamespace<
   }
 
   getHandlerCount(type: "activate" | "deactivate"): number {
-    return type === "activate"
-      ? this.#canActivateFactories.size
-      : this.#canDeactivateFactories.size;
+    const definitionMap =
+      type === "activate"
+        ? this.#definitionActivateFactories
+        : this.#definitionDeactivateFactories;
+    const externalMap =
+      type === "activate"
+        ? this.#externalActivateFactories
+        : this.#externalDeactivateFactories;
+
+    if (definitionMap.size === 0) {
+      return externalMap.size;
+    }
+
+    if (externalMap.size === 0) {
+      return definitionMap.size;
+    }
+
+    const names = new Set(definitionMap.keys());
+
+    for (const name of externalMap.keys()) {
+      names.add(name);
+    }
+
+    return names.size;
   }
 
   // =========================================================================
@@ -83,90 +134,95 @@ export class RouteLifecycleNamespace<
 
   /**
    * Adds a canActivate guard for a route.
-   * Handles overwrite detection and registration.
    *
    * @param name - Route name (input-validated by facade)
    * @param handler - Guard function or boolean (input-validated by facade)
-   * @param isFromDefinition - True when guard comes from route definition (tracked for HMR replace)
+   * @param isFromDefinition - True when guard comes from route definition
+   *   (lands in the definition Map; subject to `clearDefinitionGuards()`).
+   *   False (default) when added via `getLifecycleApi().addActivateGuard(...)`
+   *   (lands in the external Map; survives `replace()`).
+   *
+   * Last add wins at runtime: the compiled function reflects the factory
+   * passed to the most recent call, regardless of origin. Origin only
+   * determines which Map the factory is filed under (relevant for
+   * `clearDefinitionGuards()` and `cloneRouter` re-registration).
    */
   addCanActivate(
     name: string,
     handler: GuardFnFactory<Dependencies> | boolean,
     isFromDefinition = false,
   ): void {
-    if (isFromDefinition) {
-      this.#definitionActivateGuardNames.add(name);
-    } else {
-      this.#definitionActivateGuardNames.delete(name);
-    }
-
-    const isOverwrite = this.#canActivateFactories.has(name);
-
     this.#registerHandler(
       "activate",
       name,
       handler,
-      this.#canActivateFactories,
-      this.#canActivateFunctions,
+      isFromDefinition,
       "canActivate",
-      isOverwrite,
     );
   }
 
   /**
    * Adds a canDeactivate guard for a route.
-   * Handles overwrite detection and registration.
    *
-   * @param name - Route name (input-validated by facade)
-   * @param handler - Guard function or boolean (input-validated by facade)
-   * @param isFromDefinition - True when guard comes from route definition (tracked for HMR replace)
+   * Symmetric counterpart to {@link addCanActivate}.
    */
   addCanDeactivate(
     name: string,
     handler: GuardFnFactory<Dependencies> | boolean,
     isFromDefinition = false,
   ): void {
-    if (isFromDefinition) {
-      this.#definitionDeactivateGuardNames.add(name);
-    } else {
-      this.#definitionDeactivateGuardNames.delete(name);
-    }
-
-    const isOverwrite = this.#canDeactivateFactories.has(name);
-
     this.#registerHandler(
       "deactivate",
       name,
       handler,
-      this.#canDeactivateFactories,
-      this.#canDeactivateFunctions,
+      isFromDefinition,
       "canDeactivate",
-      isOverwrite,
     );
   }
 
   /**
    * Removes a canActivate guard for a route.
-   * Input already validated by facade (not registering).
    *
    * @param name - Route name (already validated by facade)
+   * @param origin - Optional origin filter. `"definition"` clears only the
+   *   definition slot; `"external"` clears only the external slot; omitted
+   *   (default) clears both — backward compatible with pre-refactor semantics.
    */
-  clearCanActivate(name: string): void {
-    this.#canActivateFactories.delete(name);
-    this.#canActivateFunctions.delete(name);
-    this.#definitionActivateGuardNames.delete(name);
+  clearCanActivate(name: string, origin?: GuardOrigin): void {
+    let cleared = false;
+
+    if (origin !== "external") {
+      cleared = this.#definitionActivateFactories.delete(name) || cleared;
+    }
+
+    if (origin !== "definition") {
+      cleared = this.#externalActivateFactories.delete(name) || cleared;
+    }
+
+    if (cleared) {
+      this.#recompileSlot("activate", name);
+    }
   }
 
   /**
    * Removes a canDeactivate guard for a route.
-   * Input already validated by facade (not registering).
    *
-   * @param name - Route name (already validated by facade)
+   * Symmetric counterpart to {@link clearCanActivate}.
    */
-  clearCanDeactivate(name: string): void {
-    this.#canDeactivateFactories.delete(name);
-    this.#canDeactivateFunctions.delete(name);
-    this.#definitionDeactivateGuardNames.delete(name);
+  clearCanDeactivate(name: string, origin?: GuardOrigin): void {
+    let cleared = false;
+
+    if (origin !== "external") {
+      cleared = this.#definitionDeactivateFactories.delete(name) || cleared;
+    }
+
+    if (origin !== "definition") {
+      cleared = this.#externalDeactivateFactories.delete(name) || cleared;
+    }
+
+    if (cleared) {
+      this.#recompileSlot("deactivate", name);
+    }
   }
 
   /**
@@ -174,36 +230,50 @@ export class RouteLifecycleNamespace<
    * Used by clearRoutes to reset all lifecycle state.
    */
   clearAll(): void {
-    this.#canActivateFactories.clear();
+    this.#definitionActivateFactories.clear();
+    this.#externalActivateFactories.clear();
+    this.#definitionDeactivateFactories.clear();
+    this.#externalDeactivateFactories.clear();
     this.#canActivateFunctions.clear();
-    this.#canDeactivateFactories.clear();
     this.#canDeactivateFunctions.clear();
-    this.#definitionActivateGuardNames.clear();
-    this.#definitionDeactivateGuardNames.clear();
   }
 
   /**
    * Clears only lifecycle handlers that were registered from route definitions.
-   * Used by HMR to remove definition-sourced guards without touching externally-added guards.
+   * Used by HMR `replace()` to remove definition-sourced guards without
+   * touching externally-added guards.
+   *
+   * For slots where both definition and external exist, the external factory
+   * stays and the compiled function is unchanged (external already won at
+   * registration time). For definition-only slots, the compiled function is
+   * dropped.
    */
   clearDefinitionGuards(): void {
-    for (const name of this.#definitionActivateGuardNames) {
-      this.#canActivateFactories.delete(name);
-      this.#canActivateFunctions.delete(name);
-    }
-    for (const name of this.#definitionDeactivateGuardNames) {
-      this.#canDeactivateFactories.delete(name);
-      this.#canDeactivateFunctions.delete(name);
+    for (const name of this.#definitionActivateFactories.keys()) {
+      if (!this.#externalActivateFactories.has(name)) {
+        this.#canActivateFunctions.delete(name);
+      }
     }
 
-    this.#definitionActivateGuardNames.clear();
-    this.#definitionDeactivateGuardNames.clear();
+    for (const name of this.#definitionDeactivateFactories.keys()) {
+      if (!this.#externalDeactivateFactories.has(name)) {
+        this.#canDeactivateFunctions.delete(name);
+      }
+    }
+
+    this.#definitionActivateFactories.clear();
+    this.#definitionDeactivateFactories.clear();
   }
 
   /**
-   * Returns lifecycle factories as records for cloning.
+   * Returns lifecycle factories as a flat `[deactivate, activate]` tuple of
+   * `Record<name, factory>` — the effective view where external wins over
+   * definition for the same slot. Used by `getRoutesApi` to enrich route
+   * objects with their current canActivate / canDeactivate factories and by
+   * the route-removal cleanup path.
    *
-   * @returns Tuple of [canDeactivateFactories, canActivateFactories]
+   * For cloneRouter (which needs to preserve origin on re-registration), use
+   * {@link getFactoriesByOrigin} instead.
    */
   getFactories(): [
     Record<string, GuardFnFactory<Dependencies>>,
@@ -212,15 +282,60 @@ export class RouteLifecycleNamespace<
     const deactivateRecord: Record<string, GuardFnFactory<Dependencies>> = {};
     const activateRecord: Record<string, GuardFnFactory<Dependencies>> = {};
 
-    for (const [name, factory] of this.#canDeactivateFactories) {
+    for (const [name, factory] of this.#definitionDeactivateFactories) {
+      deactivateRecord[name] = factory;
+    }
+    for (const [name, factory] of this.#externalDeactivateFactories) {
       deactivateRecord[name] = factory;
     }
 
-    for (const [name, factory] of this.#canActivateFactories) {
+    for (const [name, factory] of this.#definitionActivateFactories) {
+      activateRecord[name] = factory;
+    }
+    for (const [name, factory] of this.#externalActivateFactories) {
       activateRecord[name] = factory;
     }
 
     return [deactivateRecord, activateRecord];
+  }
+
+  /**
+   * Returns factories tagged by origin — definition and external as separate
+   * `[deactivate, activate]` tuples. Used by `cloneRouter` to re-register
+   * guards on the clone with their original origin flag preserved.
+   */
+  getFactoriesByOrigin(): {
+    definition: [
+      Record<string, GuardFnFactory<Dependencies>>,
+      Record<string, GuardFnFactory<Dependencies>>,
+    ];
+    external: [
+      Record<string, GuardFnFactory<Dependencies>>,
+      Record<string, GuardFnFactory<Dependencies>>,
+    ];
+  } {
+    const defDeact: Record<string, GuardFnFactory<Dependencies>> = {};
+    const defAct: Record<string, GuardFnFactory<Dependencies>> = {};
+    const extensionDeact: Record<string, GuardFnFactory<Dependencies>> = {};
+    const extensionAct: Record<string, GuardFnFactory<Dependencies>> = {};
+
+    for (const [name, factory] of this.#definitionDeactivateFactories) {
+      defDeact[name] = factory;
+    }
+    for (const [name, factory] of this.#definitionActivateFactories) {
+      defAct[name] = factory;
+    }
+    for (const [name, factory] of this.#externalDeactivateFactories) {
+      extensionDeact[name] = factory;
+    }
+    for (const [name, factory] of this.#externalActivateFactories) {
+      extensionAct[name] = factory;
+    }
+
+    return {
+      definition: [defDeact, defAct],
+      external: [extensionDeact, extensionAct],
+    };
   }
 
   /**
@@ -274,44 +389,49 @@ export class RouteLifecycleNamespace<
   // =========================================================================
 
   /**
-   * Registers a handler.
-   * Handles overwrite warning, count threshold warnings, and factory compilation.
-   *
-   * @param type - Guard type for log messages ("activate" or "deactivate")
-   * @param name - Route name to register the guard for
-   * @param handler - Guard factory function or boolean shorthand
-   * @param factories - Target factory map (canActivate or canDeactivate)
-   * @param functions - Target compiled functions map (canActivate or canDeactivate)
-   * @param methodName - Public API method name for error/warning messages
-   * @param isOverwrite - Whether this replaces an existing guard for the same route
+   * Routes a registration into the origin-specific factory Map and compiles
+   * the just-added factory (last add wins for the compiled function).
+   * Emits overwrite / threshold warnings symmetric with the pre-refactor
+   * single-Map behaviour: any prior entry for the slot — same origin or
+   * cross-origin — counts as an overwrite for the warning surface; only a
+   * brand-new slot (no entry in either Map) increments the threshold check.
    */
   #registerHandler(
     type: "activate" | "deactivate",
     name: string,
     handler: GuardFnFactory<Dependencies> | boolean,
-    factories: Map<string, GuardFnFactory<Dependencies>>,
-    functions: Map<string, GuardFn>,
+    isFromDefinition: boolean,
     methodName: string,
-    isOverwrite: boolean,
   ): void {
-    // Emit warnings
+    const factoryMaps = this.#getFactoryMaps(type);
+    const functions =
+      type === "activate"
+        ? this.#canActivateFunctions
+        : this.#canDeactivateFunctions;
+    const targetMap = isFromDefinition
+      ? factoryMaps.definition
+      : factoryMaps.external;
+    const otherMap = isFromDefinition
+      ? factoryMaps.external
+      : factoryMaps.definition;
+
+    const isOverwrite = targetMap.has(name) || otherMap.has(name);
+
     if (isOverwrite) {
       this.#getValidator?.()?.lifecycle.warnOverwrite(name, type, methodName);
     } else {
       this.#getValidator?.()?.lifecycle.validateCountThresholds(
-        factories.size + 1,
+        this.getHandlerCount(type) + 1,
         methodName,
       );
     }
 
-    // Convert boolean to factory if needed
     const factory =
       typeof handler === "boolean"
         ? booleanToFactory<Dependencies>(handler)
         : handler;
 
-    // Store factory
-    factories.set(name, factory);
+    targetMap.set(name, factory);
 
     // Mark route as being registered before calling user factory
     this.#registering.add(name);
@@ -327,13 +447,74 @@ export class RouteLifecycleNamespace<
 
       functions.set(name, fn);
     } catch (error) {
-      // Rollback on failure to maintain consistency
-      factories.delete(name);
+      // Rollback the slot we just touched to keep storage consistent. If a
+      // cross-origin entry exists for the same name, its compiled function
+      // remains in place — recompile so navigation still sees a valid guard.
+      targetMap.delete(name);
+
+      if (otherMap.has(name)) {
+        this.#recompileSlot(type, name);
+      } else {
+        functions.delete(name);
+      }
 
       throw error;
     } finally {
       this.#registering.delete(name);
     }
+  }
+
+  /**
+   * Recompiles the compiled-function slot from whichever origin Map still has
+   * an entry for `name` after a clear. External wins over definition; if
+   * neither has an entry, the compiled function is deleted.
+   */
+  #recompileSlot(type: "activate" | "deactivate", name: string): void {
+    const factoryMaps = this.#getFactoryMaps(type);
+    const functions =
+      type === "activate"
+        ? this.#canActivateFunctions
+        : this.#canDeactivateFunctions;
+
+    const effective =
+      factoryMaps.external.get(name) ?? factoryMaps.definition.get(name);
+
+    if (!effective) {
+      functions.delete(name);
+
+      return;
+    }
+
+    try {
+      const fn = this.#deps.compileFactory(effective);
+
+      /* v8 ignore next 4 -- @preserve: stored factories were validated at add time, compileFactory should yield a function on second call too */
+      if (typeof fn !== "function") {
+        functions.delete(name);
+
+        return;
+      }
+
+      functions.set(name, fn);
+    } catch {
+      /* v8 ignore next 2 -- @preserve: defensive — a user-provided factory could theoretically throw on re-compile (state changed since add time); deleting the function blocks navigation on that slot */
+      functions.delete(name);
+    }
+  }
+
+  #getFactoryMaps(type: "activate" | "deactivate"): {
+    definition: Map<string, GuardFnFactory<Dependencies>>;
+    external: Map<string, GuardFnFactory<Dependencies>>;
+  } {
+    return type === "activate"
+      ? {
+          definition: this.#definitionActivateFactories,
+          external: this.#externalActivateFactories,
+        }
+      : {
+          definition: this.#definitionDeactivateFactories,
+          external: this.#externalDeactivateFactories,
+        };
   }
 
   /**

--- a/packages/core/tests/functional/routeLifecycle/RouteLifecycleNamespace.unit.test.ts
+++ b/packages/core/tests/functional/routeLifecycle/RouteLifecycleNamespace.unit.test.ts
@@ -1,0 +1,335 @@
+// packages/core/tests/functional/routeLifecycle/RouteLifecycleNamespace.unit.test.ts
+//
+// Direct-namespace unit tests for the origin-aware split storage introduced
+// by issue #661. These exercise behaviour that the public lifecycle API does
+// not currently surface — most notably the optional `origin` filter on
+// `clearCanActivate` / `clearCanDeactivate` and `getFactoriesByOrigin()` —
+// so they need to drive the namespace methods directly instead of going
+// through `getLifecycleApi`.
+
+import { describe, it, expect, vi } from "vitest";
+
+import { RouteLifecycleNamespace } from "../../../src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace";
+
+import type { GuardFn, State } from "@real-router/types";
+
+const TO_STATE: State = {
+  name: "users",
+  path: "/users",
+  params: {},
+  context: {},
+  transition: {
+    phase: "activating",
+    reason: "success",
+    segments: { deactivated: [], activated: [], intersection: "" },
+  },
+};
+const FROM_STATE: State = {
+  name: "home",
+  path: "/home",
+  params: {},
+  context: {},
+  transition: {
+    phase: "activating",
+    reason: "success",
+    segments: { deactivated: [], activated: [], intersection: "" },
+  },
+};
+
+function createNamespace(
+  compileFactory?: (factory: unknown) => GuardFn,
+): RouteLifecycleNamespace {
+  const ns = new RouteLifecycleNamespace();
+
+  ns.setDependencies({
+    compileFactory:
+      (compileFactory as never) ??
+      (((factory: () => GuardFn) => factory()) as never),
+  });
+  ns.setValidatorGetter(() => null);
+
+  return ns;
+}
+
+describe("RouteLifecycleNamespace — origin-aware split storage (#661)", () => {
+  describe("addCanActivate stores per origin", () => {
+    it("definition add lands in definition Map, external add lands in external Map", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("home", () => () => true, true);
+      ns.addCanActivate("admin", () => () => true, false);
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("home" in definition[1]).toBe(true);
+      expect("home" in external[1]).toBe(false);
+
+      expect("admin" in external[1]).toBe(true);
+      expect("admin" in definition[1]).toBe(false);
+    });
+
+    it("cross-origin same-slot stores both factories; last add wins for compiled function", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("contested", () => () => true, false); // external = allow
+      ns.addCanActivate("contested", () => () => false, true); // definition added last
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("contested" in definition[1]).toBe(true);
+      expect("contested" in external[1]).toBe(true);
+
+      const [, activate] = ns.getFunctions();
+      const guardFn = activate.get("contested");
+
+      expect(guardFn).toBeDefined();
+      // Last add (definition = block) wins
+      expect(guardFn?.(TO_STATE, FROM_STATE)).toBe(false);
+    });
+  });
+
+  describe("clearCanActivate honours origin filter", () => {
+    it("origin='external' removes only external slot; definition remains and recompiles", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("contested", () => () => false, true); // definition = block
+      ns.addCanActivate("contested", () => () => true, false); // external = allow
+
+      const [, activateBefore] = ns.getFunctions();
+
+      expect(activateBefore.get("contested")?.(TO_STATE, FROM_STATE)).toBe(
+        true,
+      );
+
+      ns.clearCanActivate("contested", "external");
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("contested" in definition[1]).toBe(true);
+      expect("contested" in external[1]).toBe(false);
+
+      const [, activateAfter] = ns.getFunctions();
+
+      // Function recompiled from remaining definition slot — block
+      expect(activateAfter.get("contested")?.(TO_STATE, FROM_STATE)).toBe(
+        false,
+      );
+    });
+
+    it("origin='definition' removes only definition slot; external remains and recompiles", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("contested", () => () => true, true); // definition = allow
+      ns.addCanActivate("contested", () => () => false, false); // external = block
+
+      ns.clearCanActivate("contested", "definition");
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("contested" in definition[1]).toBe(false);
+      expect("contested" in external[1]).toBe(true);
+
+      const [, activate] = ns.getFunctions();
+
+      // Function reflects the surviving external slot — block
+      expect(activate.get("contested")?.(TO_STATE, FROM_STATE)).toBe(false);
+    });
+
+    it("default (no origin) clears both slots; function deleted", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("contested", () => () => true, true);
+      ns.addCanActivate("contested", () => () => false, false);
+
+      ns.clearCanActivate("contested");
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("contested" in definition[1]).toBe(false);
+      expect("contested" in external[1]).toBe(false);
+
+      const [, activate] = ns.getFunctions();
+
+      expect(activate.get("contested")).toBeUndefined();
+    });
+
+    it("no-op when slot does not exist on either origin Map", () => {
+      const ns = createNamespace();
+
+      expect(() => {
+        ns.clearCanActivate("ghost");
+      }).not.toThrow();
+      expect(() => {
+        ns.clearCanActivate("ghost", "external");
+      }).not.toThrow();
+    });
+  });
+
+  describe("clearCanDeactivate honours origin filter (symmetric)", () => {
+    it("origin='external' falls back to definition slot", () => {
+      const ns = createNamespace();
+
+      ns.addCanDeactivate("home", () => () => true, true);
+      ns.addCanDeactivate("home", () => () => false, false);
+
+      ns.clearCanDeactivate("home", "external");
+
+      const [deactivate] = ns.getFunctions();
+
+      // Recompiled from remaining definition slot — allow
+      expect(deactivate.get("home")?.(TO_STATE, FROM_STATE)).toBe(true);
+    });
+
+    it("origin='definition' falls back to external slot", () => {
+      const ns = createNamespace();
+
+      ns.addCanDeactivate("home", () => () => true, true);
+      ns.addCanDeactivate("home", () => () => false, false);
+
+      ns.clearCanDeactivate("home", "definition");
+
+      const [deactivate] = ns.getFunctions();
+
+      // Recompiled from remaining external slot — block
+      expect(deactivate.get("home")?.(TO_STATE, FROM_STATE)).toBe(false);
+    });
+
+    it("default clears both slots and deletes the function", () => {
+      const ns = createNamespace();
+
+      ns.addCanDeactivate("home", () => () => true, true);
+      ns.addCanDeactivate("home", () => () => true, false);
+
+      ns.clearCanDeactivate("home");
+
+      const [deactivate] = ns.getFunctions();
+
+      expect(deactivate.get("home")).toBeUndefined();
+    });
+  });
+
+  describe("getHandlerCount counts distinct slots across origins", () => {
+    it("counts each (name, type) once even when both origins hold the slot", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("a", () => () => true, true);
+      ns.addCanActivate("a", () => () => true, false);
+      ns.addCanActivate("b", () => () => true, false);
+
+      expect(ns.getHandlerCount("activate")).toBe(2);
+      expect(ns.getHandlerCount("deactivate")).toBe(0);
+    });
+
+    it("returns the active Map size when one origin is empty", () => {
+      const ns = createNamespace();
+
+      ns.addCanDeactivate("x", () => () => true, true);
+      ns.addCanDeactivate("y", () => () => true, true);
+
+      expect(ns.getHandlerCount("deactivate")).toBe(2);
+    });
+  });
+
+  describe("clearDefinitionGuards preserves external slots and their functions", () => {
+    it("definition-only slot — function deleted", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("def-only", () => () => false, true);
+      ns.clearDefinitionGuards();
+
+      const [, activate] = ns.getFunctions();
+
+      expect(activate.get("def-only")).toBeUndefined();
+    });
+
+    it("definition-and-external slot — definition cleared, external function survives", () => {
+      const ns = createNamespace();
+
+      ns.addCanActivate("both", () => () => true, true);
+      ns.addCanActivate("both", () => () => false, false);
+
+      ns.clearDefinitionGuards();
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("both" in definition[1]).toBe(false);
+      expect("both" in external[1]).toBe(true);
+
+      const [, activate] = ns.getFunctions();
+
+      expect(activate.get("both")?.(TO_STATE, FROM_STATE)).toBe(false);
+    });
+
+    it("symmetric deactivate path — definition-and-external slot preserves external function", () => {
+      const ns = createNamespace();
+
+      ns.addCanDeactivate("both-deact", () => () => true, true);
+      ns.addCanDeactivate("both-deact", () => () => false, false);
+
+      ns.clearDefinitionGuards();
+
+      const { definition, external } = ns.getFactoriesByOrigin();
+
+      expect("both-deact" in definition[0]).toBe(false);
+      expect("both-deact" in external[0]).toBe(true);
+
+      const [deactivate] = ns.getFunctions();
+
+      expect(deactivate.get("both-deact")?.(TO_STATE, FROM_STATE)).toBe(false);
+    });
+  });
+
+  describe("#registerHandler rollback preserves cross-origin slot", () => {
+    it("when external add throws on compile, surviving definition slot stays valid", () => {
+      const compileFactory = vi.fn((factory: unknown) => {
+        const fn = (factory as () => GuardFn)();
+
+        if (typeof fn !== "function") {
+          throw new TypeError("bad factory");
+        }
+
+        return fn;
+      });
+
+      const ns = createNamespace(compileFactory);
+
+      ns.addCanActivate("contested", () => () => true, true); // definition
+
+      expect(() => {
+        // External add with a bad factory that returns non-function
+        ns.addCanActivate(
+          "contested",
+
+          (() => null) as any,
+          false,
+        );
+      }).toThrow();
+
+      // External rolled back; definition still in place; function recompiled
+      const { external, definition } = ns.getFactoriesByOrigin();
+
+      expect("contested" in external[1]).toBe(false);
+      expect("contested" in definition[1]).toBe(true);
+
+      const [, activate] = ns.getFunctions();
+
+      expect(activate.get("contested")?.(TO_STATE, FROM_STATE)).toBe(true);
+    });
+  });
+
+  describe("getFactories — backward-compatible flat shape", () => {
+    it("merges definition + external; external wins on duplicate name", () => {
+      const ns = createNamespace();
+
+      const defFactory = (): GuardFn => () => true;
+      const extensionFactory = (): GuardFn => () => false;
+
+      ns.addCanActivate("dup", defFactory, true);
+      ns.addCanActivate("dup", extensionFactory, false);
+
+      const [, activate] = ns.getFactories();
+
+      expect(activate.dup).toBe(extensionFactory);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #661 (re-classified to MEDIUM/refactor after issue body update).
- `RouteLifecycleNamespace` previously stored canActivate / canDeactivate factories in a single Map per kind with auxiliary `Set<string>` collections tracking which slots came from route definitions vs were added externally. Origin was a derived property that the public API had to reconstruct.
- Lift origin to a primary structural invariant: two factory Maps per kind (`#definitionActivateFactories` / `#externalActivateFactories` + symmetric deactivate). Compiled-function view preserves the pre-refactor "last add wins" semantic so the `replaceRoutes: definition wins on replace` contract stays green; on partial clear the function falls back to whichever origin Map still holds the slot.
- `cloneRouter` now uses `getFactoriesByOrigin()` and re-registers definition guards via the namespace with `isFromDefinition=true`, so a subsequent `replace()` on the clone strips inherited definition guards correctly. External guards still flow through the public `lifecycleApi` path and survive `replace()`.

## Public surface

- `clearCanActivate(name, origin?)` / `clearCanDeactivate(name, origin?)` accept an optional `"definition"` / `"external"` filter. Default (no filter) keeps pre-refactor behaviour.
- New `getFactoriesByOrigin(): { definition: [d, a], external: [d, a] }` for clone consumption.
- `getFactories(): [d, a]` retains its flat shape (external wins on duplicate slot) for `getRoutesApi` consumers — `enrichRoute`, route-removal cleanup, the `auto-cleanup` test continue to work unchanged.

## Non-goals (explicit per the issue body)

- `removeActivateGuard` semantics are NOT tightened — that's a follow-up after the refactor lands.
- closure-sharing across clones is a documented SSR usage rule per #664 (singletons → base, per-request → clone), not a code defect this PR addresses.

## Test plan

- [x] `pnpm build` — 286/286 tasks green
- [x] `pnpm -F @real-router/core test` — 2256 passed, coverage **100%/100%/100%/100%**
- [x] New `tests/functional/routeLifecycle/RouteLifecycleNamespace.unit.test.ts` (15 cases) covers:
  - `addCan*Activate` stores per origin; cross-origin same-slot stores both factories
  - "last add wins" for compiled function (preserves `replaceRoutes: definition wins on replace`)
  - `clearCan*Activate(name, "external")` / `clearCan*Activate(name, "definition")` fallback recompile
  - default `clear*` clears both slots and deletes the compiled function
  - `getHandlerCount` counts distinct slots across origins
  - `clearDefinitionGuards` preserves external slots and their compiled functions (both activate and deactivate)
  - cross-origin rollback when external add over existing definition throws on compile
  - `getFactories` flat shape: external wins on duplicate
- [x] Existing `replaceRoutes.test.ts`, `auto-cleanup.test.ts`, `getLifecycleApi/addActivateGuard.test.ts` all green