### PR TITLE
fix(core): make getRoutesApi add/replace/update atomic (#698)

### DIFF
--- a/.changeset/route-crud-atomicity-698-fix.md
+++ b/.changeset/route-crud-atomicity-698-fix.md
@@ -1,0 +1,20 @@
+---
+"@real-router/core": minor
+---
+
+Make `getRoutesApi` route mutations atomic (#698)
+
+`add`, `replace`, and `update` previously mutated the route store before running
+steps that can throw (circular/async `forwardTo`, invalid path constraint) and had
+no rollback, so without `@real-router/validation-plugin` a failed call left a torn
+store: a duplicate name silently overwrote a live route, a failed `replace` lost the
+whole tree, and a cycle-creating `update({ forwardTo })` poisoned the forward map so a
+later unrelated `add` threw.
+
+`add` and `replace` now build the new tree, config, and forward map into local
+structures and only swap them into the store once the build has fully succeeded — so
+a rejected call throws and leaves the existing routes untouched. `update({ forwardTo })`
+resolves the forward chain on a candidate map before committing, so a cycle no longer
+corrupts state. Adding a route whose name already exists, or under a missing `parent`,
+now throws a clear error instead of silently overwriting a live route or crashing with
+a `TypeError`, regardless of whether the validation plugin is installed.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -13,29 +13,29 @@ export default [
   {
     name: "@real-router/core/api (ESM)",
     path: "packages/core/dist/esm/api.mjs",
-    limit: "20 kB",
+    limit: "20.5 kB",
     ignore: ignoreCore,
   },
 
   // ── UI Bindings ───────────────────────────────────────────────────
-  esm("react", "8 kB", ["react", "react-dom", ...ignoreCore]),
-  esm("preact", "8 kB", [
+  esm("react", "10 kB", ["react", "react-dom", ...ignoreCore]),
+  esm("preact", "10 kB", [
     "preact",
     "preact/hooks",
     "preact/compat",
     ...ignoreCore,
   ]),
-  esm("solid", "8 kB", [
+  esm("solid", "10 kB", [
     "solid-js",
     "solid-js/store",
     "solid-js/web",
     ...ignoreCore,
   ]),
-  esm("vue", "8 kB", ["vue", ...ignoreCore]),
+  esm("vue", "10 kB", ["vue", ...ignoreCore]),
   {
     name: "@real-router/angular (FESM2022)",
     path: "packages/angular/dist/fesm2022/real-router-angular.mjs",
-    limit: "8 kB",
+    limit: "10 kB",
     ignore: [
       "@angular/core",
       "@angular/common",

--- a/benchmarks/core/audit-probes/route-crud-atomicity-2026-06-04/probe-01-unified-torn-state.ts
+++ b/benchmarks/core/audit-probes/route-crud-atomicity-2026-06-04/probe-01-unified-torn-state.ts
@@ -1,0 +1,64 @@
+/**
+ * Unified ROOT-CAUSE probe: "mutate-then-validate without rollback" across the
+ * three mutating route-CRUD ops, WITHOUT validation-plugin (production default,
+ * since CLAUDE.md wires `__DEV__ && validationPlugin()`).
+ *
+ * Single regression anchor for the proposed prepare-then-commit fix. After the
+ * fix, every "VIOLATED" line below must flip to clean (op throws BEFORE mutating
+ * the store, leaving prior routes intact).
+ *
+ * Per-method detail probes:
+ *   add-route-2026-06-04/probe-05,06   replace-2026-06-04/probe-01,02
+ *   update-route-2026-06-04/probe-01,02
+ */
+
+import { createRouter } from "@real-router/core";
+import { getPluginApi, getRoutesApi } from "@real-router/core/api";
+
+function freshRouter() {
+  const router = createRouter([
+    { name: "home", path: "/home" },
+    { name: "about", path: "/about" },
+  ]);
+  return { router, routesApi: getRoutesApi(router), api: getPluginApi(router) };
+}
+
+console.log("=== ROOT CAUSE: route-CRUD mutate-then-validate w/o rollback (no plugin) ===\n");
+
+// 1) add: duplicate existing name must NOT overwrite the live route
+{
+  const { router, routesApi, api } = freshRouter();
+  try {
+    routesApi.add({ name: "home", path: "/home-2" }); // dup name → must throw now
+  } catch { /* expected throw after fix */ }
+  const homeMatches = api.matchPath("/home")?.name ?? "undefined";
+  console.log("add: dup name");
+  console.log("  /home still matches 'home' :", homeMatches === "home", homeMatches === "home" ? "" : `<-- VIOLATED (now ${homeMatches}; buildPath=${router.buildPath("home")})`);
+}
+
+// 2) replace: core-level error (circular forwardTo) wipes the whole old tree
+{
+  const { routesApi, api } = freshRouter();
+  try {
+    routesApi.replace([
+      { name: "a", path: "/a", forwardTo: "b" },
+      { name: "b", path: "/b", forwardTo: "a" },
+    ]);
+  } catch { /* expected throw */ }
+  const homeAlive = api.matchPath("/home")?.name === "home";
+  console.log("replace: circular forwardTo in new set");
+  console.log("  old /home survives failed replace :", homeAlive, homeAlive ? "" : "<-- VIOLATED (entire tree lost on failed replace)");
+}
+
+// 3) update: failed cycle poisons config.forwardMap → unrelated future add throws
+{
+  const { routesApi } = freshRouter();
+  routesApi.add({ name: "a", path: "/a" });
+  routesApi.add({ name: "b", path: "/b" });
+  routesApi.update("a", { forwardTo: "b" });
+  try { routesApi.update("b", { forwardTo: "a" }); } catch { /* expected */ }
+  let unrelatedAddThrew = false;
+  try { routesApi.add({ name: "z", path: "/z" }); } catch { unrelatedAddThrew = true; }
+  console.log("update: failed cycle then unrelated add");
+  console.log("  later add('z') stays clean        :", !unrelatedAddThrew, unrelatedAddThrew ? "<-- VIOLATED (poisoned forwardMap surfaces in unrelated op)" : "");
+}

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -6,16 +6,17 @@ import { createInterceptable, getInternals } from "../internals";
 import {
   clearConfigEntries,
   removeFromDefinitions,
-  sanitizeRoute,
 } from "../namespaces/RoutesNamespace/helpers";
 import {
   validateClearRoutes,
   validateRemoveRoute,
 } from "../namespaces/RoutesNamespace/routeGuards";
 import {
-  clearRouteData,
+  adoptRouteArtifacts,
+  assertAddable,
+  buildAddArtifacts,
+  buildReplaceArtifacts,
   refreshForwardMap,
-  registerAllRouteHandlers,
 } from "../namespaces/RoutesNamespace/routesStore";
 
 import type { RoutesApi } from "./types";
@@ -35,32 +36,6 @@ import type { RouteDefinition, RouteTree } from "route-tree";
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/**
- * Recursively finds a route definition by its full dotted name.
- */
-function findDefinition(
-  definitions: RouteDefinition[],
-  fullName: string,
-  parentPrefix = "",
-): RouteDefinition | undefined {
-  for (const def of definitions) {
-    const currentFullName = parentPrefix
-      ? `${parentPrefix}.${def.name}`
-      : def.name;
-
-    if (currentFullName === fullName) {
-      return def;
-    }
-
-    if (def.children && fullName.startsWith(`${currentFullName}.`)) {
-      return findDefinition(def.children, fullName, currentFullName);
-    }
-  }
-
-  /* v8 ignore next -- @preserve: defensive return, callers validate route exists before calling */
-  return undefined;
-}
 
 /**
  * Clears all config entries and lifecycle handlers for a removed route
@@ -116,20 +91,36 @@ function updateForwardTo<
   name: string,
   forwardTo: string | ForwardToCallback<Dependencies> | null,
   config: RouteConfig,
-  refreshForwardMapFn: (config: RouteConfig) => Record<string, string>,
 ): Record<string, string> {
+  // Prepare-then-commit (issue #698): apply the change to CLONES of the forward
+  // maps, resolve the chain (a cycle throws here), and only then swap the clones
+  // in — so a rejected update never leaves config.forwardMap poisoned.
+  const forwardMap = Object.assign(
+    Object.create(null) as RouteConfig["forwardMap"],
+    config.forwardMap,
+  );
+  const forwardFnMap = Object.assign(
+    Object.create(null) as RouteConfig["forwardFnMap"],
+    config.forwardFnMap,
+  );
+
   if (forwardTo === null) {
-    delete config.forwardMap[name];
-    delete config.forwardFnMap[name];
+    delete forwardMap[name];
+    delete forwardFnMap[name];
   } else if (typeof forwardTo === "string") {
-    delete config.forwardFnMap[name];
-    config.forwardMap[name] = forwardTo;
+    delete forwardFnMap[name];
+    forwardMap[name] = forwardTo;
   } else {
-    delete config.forwardMap[name];
-    config.forwardFnMap[name] = forwardTo;
+    delete forwardMap[name];
+    forwardFnMap[name] = forwardTo;
   }
 
-  return refreshForwardMapFn(config);
+  const resolved = refreshForwardMap({ ...config, forwardMap });
+
+  config.forwardMap = forwardMap;
+  config.forwardFnMap = forwardFnMap;
+
+  return resolved;
 }
 
 /**
@@ -212,37 +203,19 @@ function addRoutes<
   routes: Route<Dependencies>[],
   parentName?: string,
 ): void {
-  if (parentName) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const parentDef = findDefinition(store.definitions, parentName)!;
-
-    parentDef.children ??= [];
-
-    for (const route of routes) {
-      parentDef.children.push(sanitizeRoute(route));
-    }
-  } else {
-    for (const route of routes) {
-      store.definitions.push(sanitizeRoute(route));
-    }
-  }
-
-  registerAllRouteHandlers(
-    routes,
-    store.config,
-    store.routeCustomFields,
-    store.pendingCanActivate,
-    store.pendingCanDeactivate,
-    store.depsStore,
-    parentName ?? "",
-  );
-
-  store.treeOperations.commitTreeChanges(store);
+  // Prepare-then-commit (issue #698): reject the silent-corruption cases
+  // up front (dup name vs existing, missing parent), build the merged tree /
+  // config into locals (async/circular forwardTo + invalid constraint throw
+  // here), then swap atomically. A rejected add leaves the store untouched.
+  assertAddable(store, routes, parentName);
+  adoptRouteArtifacts(store, buildAddArtifacts(store, routes, parentName));
 }
 
 /**
- * Atomically replaces all routes with a new set.
- * Follows RFC 6-step semantics for HMR support.
+ * Atomically replaces all routes with a new set (HMR / code-splitting).
+ * Prepare-then-commit (issue #698): the new set is fully built into locals
+ * first — a circular/async forwardTo or invalid path throws here, leaving the
+ * existing tree intact — then committed.
  */
 function replaceRoutes<
   Dependencies extends DefaultDependencies = DefaultDependencies,
@@ -253,32 +226,19 @@ function replaceRoutes<
   currentPath: string | undefined,
   previousTransition: TransitionMeta | undefined,
 ): void {
-  // Step 2: Clear route data (WITHOUT tree rebuild)
-  clearRouteData(store);
-
-  // Step 3: Clear definition lifecycle handlers (preserve external guards)
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed set after wiring
-  store.lifecycleNamespace!.clearDefinitionGuards();
-
-  // Step 4: Register new routes
-  for (const route of routes) {
-    store.definitions.push(sanitizeRoute(route));
-  }
-
-  registerAllRouteHandlers(
+  // Build the whole new set BEFORE touching the store.
+  const artifacts = buildReplaceArtifacts(
     routes,
-    store.config,
-    store.routeCustomFields,
-    store.pendingCanActivate,
-    store.pendingCanDeactivate,
-    store.depsStore,
-    "",
+    store.rootPath,
+    store.matcherOptions,
   );
 
-  // Step 5: One tree rebuild
-  store.treeOperations.commitTreeChanges(store);
+  // Clear definition lifecycle handlers (preserve external guards), then swap.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed set after wiring
+  store.lifecycleNamespace!.clearDefinitionGuards();
+  adoptRouteArtifacts(store, artifacts);
 
-  // Step 6: Revalidate state (preserve transition from previous state)
+  // Revalidate state (preserve transition from previous state)
   if (currentPath !== undefined) {
     const revalidated = ctx.matchPath(currentPath, ctx.getOptions());
 
@@ -341,7 +301,6 @@ function updateRouteConfig<
       name,
       updates.forwardTo,
       store.config,
-      (config) => refreshForwardMap(config),
     );
   }
 

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -132,6 +132,32 @@ export function refreshForwardMap(config: RouteConfig): Record<string, string> {
 // Route handler registration
 // =============================================================================
 
+/**
+ * Throws if `forwardTo` is an async function (native or transpiled). Async
+ * forwardTo callbacks break the synchronous matchPath/buildPath contract.
+ * Runs inside `registerForwardTo`, which the prepare-phase build invokes via
+ * `registerAllRouteHandlers` — so the check fires before any store mutation.
+ */
+function assertForwardToNotAsync(forwardTo: unknown, fullName: string): void {
+  if (typeof forwardTo !== "function") {
+    return;
+  }
+
+  const isNativeAsync =
+    (forwardTo as { constructor: { name: string } }).constructor.name ===
+    "AsyncFunction";
+  const isTranspiledAsync = (forwardTo as { toString: () => string })
+    .toString()
+    .includes("__awaiter");
+
+  if (isNativeAsync || isTranspiledAsync) {
+    throw new TypeError(
+      `forwardTo callback cannot be async for route "${fullName}". ` +
+        `Async functions break matchPath/buildPath.`,
+    );
+  }
+}
+
 function registerForwardTo<Dependencies extends DefaultDependencies>(
   route: Route<Dependencies>,
   fullName: string,
@@ -163,19 +189,7 @@ function registerForwardTo<Dependencies extends DefaultDependencies>(
     );
   }
 
-  if (typeof route.forwardTo === "function") {
-    const isNativeAsync =
-      (route.forwardTo as { constructor: { name: string } }).constructor
-        .name === "AsyncFunction";
-    const isTranspiledAsync = route.forwardTo.toString().includes("__awaiter");
-
-    if (isNativeAsync || isTranspiledAsync) {
-      throw new TypeError(
-        `forwardTo callback cannot be async for route "${fullName}". ` +
-          `Async functions break matchPath/buildPath.`,
-      );
-    }
-  }
+  assertForwardToNotAsync(route.forwardTo, fullName);
 
   // forwardTo is guaranteed to exist at this point
   if (typeof route.forwardTo === "string") {
@@ -193,7 +207,6 @@ function registerSingleRouteHandlers<Dependencies extends DefaultDependencies>(
   routeCustomFields: Record<string, Record<string, unknown>>,
   pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>,
   pendingCanDeactivate: Map<string, GuardFnFactory<Dependencies>>,
-  depsStore: RoutesDependencies<Dependencies> | undefined,
 ): void {
   const standardKeys = new Set([
     "name",
@@ -214,20 +227,15 @@ function registerSingleRouteHandlers<Dependencies extends DefaultDependencies>(
     routeCustomFields[fullName] = customFields;
   }
 
+  // Guards are collected here and registered into the lifecycle later — by
+  // `adoptRouteArtifacts` (add/replace) or `setDependencies` (initial routes) —
+  // so the build stays a pure, side-effect-free preparation step.
   if (route.canActivate) {
-    if (depsStore) {
-      depsStore.addActivateGuard(fullName, route.canActivate);
-    } else {
-      pendingCanActivate.set(fullName, route.canActivate);
-    }
+    pendingCanActivate.set(fullName, route.canActivate);
   }
 
   if (route.canDeactivate) {
-    if (depsStore) {
-      depsStore.addDeactivateGuard(fullName, route.canDeactivate);
-    } else {
-      pendingCanDeactivate.set(fullName, route.canDeactivate);
-    }
+    pendingCanDeactivate.set(fullName, route.canDeactivate);
   }
 
   if (route.forwardTo) {
@@ -249,15 +257,12 @@ function registerSingleRouteHandlers<Dependencies extends DefaultDependencies>(
   }
 }
 
-export function registerAllRouteHandlers<
-  Dependencies extends DefaultDependencies,
->(
+function registerAllRouteHandlers<Dependencies extends DefaultDependencies>(
   routes: readonly Route<Dependencies>[],
   config: RouteConfig,
   routeCustomFields: Record<string, Record<string, unknown>>,
   pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>,
   pendingCanDeactivate: Map<string, GuardFnFactory<Dependencies>>,
-  depsStore: RoutesDependencies<Dependencies> | undefined,
   parentName = "",
 ): void {
   for (const route of routes) {
@@ -270,7 +275,6 @@ export function registerAllRouteHandlers<
       routeCustomFields,
       pendingCanActivate,
       pendingCanDeactivate,
-      depsStore,
     );
 
     if (route.children) {
@@ -280,10 +284,248 @@ export function registerAllRouteHandlers<
         routeCustomFields,
         pendingCanActivate,
         pendingCanDeactivate,
-        depsStore,
         fullName,
       );
     }
+  }
+}
+
+// =============================================================================
+// Prepare-then-commit (issue #698)
+//
+// add()/replace() build the complete new store state into LOCAL structures, and
+// only swap it into the store once every core-level error has surfaced from the
+// build itself (async/circular forwardTo throw in registerAllRouteHandlers /
+// refreshForwardMap; invalid path constraint throws in rebuildTree). The store
+// is mutated only by `adoptRouteArtifacts`, which cannot throw — so a rejected
+// build leaves the existing routes untouched. The two silent-corruption cases
+// route-tree never throws on (duplicate name vs an existing route, missing
+// parent) are caught up front by `assertAddable`.
+// =============================================================================
+
+/**
+ * The fully-built, ready-to-swap result of preparing a route mutation. Holds
+ * everything `adoptRouteArtifacts` assigns into the store.
+ */
+interface RouteArtifacts<
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+> {
+  readonly definitions: RouteDefinition[];
+  readonly config: RouteConfig;
+  readonly routeCustomFields: Record<string, Record<string, unknown>>;
+  readonly pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>;
+  readonly pendingCanDeactivate: Map<string, GuardFnFactory<Dependencies>>;
+  readonly tree: RouteTree;
+  readonly matcher: Matcher;
+  readonly resolvedForwardMap: Record<string, string>;
+}
+
+/** Null-proto shallow clone of a RouteConfig (preserves the 5 maps' contents). */
+function cloneConfig(config: RouteConfig): RouteConfig {
+  const clone = createEmptyConfig();
+
+  Object.assign(clone.decoders, config.decoders);
+  Object.assign(clone.encoders, config.encoders);
+  Object.assign(clone.defaultParams, config.defaultParams);
+  Object.assign(clone.forwardMap, config.forwardMap);
+  Object.assign(clone.forwardFnMap, config.forwardFnMap);
+
+  return clone;
+}
+
+/**
+ * Returns a new definitions array with `added` inserted, without mutating the
+ * input. For a top-level add the existing definitions are shallow-copied and
+ * `added` appended. For a parented add the spine down to the parent is cloned
+ * (siblings/other branches are shared by reference) and `added` appended to the
+ * parent's children. Caller guarantees the parent path exists (see assertAddable).
+ */
+function insertAddedDefinitions(
+  definitions: readonly RouteDefinition[],
+  added: RouteDefinition[],
+  parentSegments: readonly string[],
+): RouteDefinition[] {
+  if (parentSegments.length === 0) {
+    return [...definitions, ...added];
+  }
+
+  const [head, ...rest] = parentSegments;
+
+  return definitions.map((def) => {
+    if (def.name !== head) {
+      return def;
+    }
+
+    const children = def.children ?? [];
+
+    return {
+      ...def,
+      children:
+        rest.length === 0
+          ? [...children, ...added]
+          : insertAddedDefinitions(children, added, rest),
+    };
+  });
+}
+
+/** Depth-first walk yielding each route's full dotted name (no side effects). */
+function walkRouteNames<Dependencies extends DefaultDependencies>(
+  routes: readonly Route<Dependencies>[],
+  parentName: string,
+  onName: (fullName: string) => void,
+): void {
+  for (const route of routes) {
+    const fullName = parentName ? `${parentName}.${route.name}` : route.name;
+
+    onName(fullName);
+
+    if (route.children) {
+      walkRouteNames(route.children, fullName, onName);
+    }
+  }
+}
+
+/**
+ * Up-front guard for `add` against the two corruptions route-tree stays silent
+ * on: a missing `parent`, and a name that collides with an EXISTING route
+ * (which would otherwise be silently overwritten). Throws before any build.
+ */
+export function assertAddable<Dependencies extends DefaultDependencies>(
+  store: RoutesStore<Dependencies>,
+  routes: readonly Route<Dependencies>[],
+  parentName: string | undefined,
+): void {
+  if (parentName !== undefined && !store.matcher.hasRoute(parentName)) {
+    throw new Error(
+      `[router.addRoute] Parent route "${parentName}" does not exist`,
+    );
+  }
+
+  walkRouteNames(routes, parentName ?? "", (fullName) => {
+    if (store.matcher.hasRoute(fullName)) {
+      throw new Error(`[router.addRoute] Route "${fullName}" already exists`);
+    }
+  });
+}
+
+/**
+ * Builds RouteArtifacts from a final definitions array and the routes whose
+ * handlers (config + guards) populate `config`/`routeCustomFields`. Guards are
+ * collected into the returned pending maps (depsStore is intentionally omitted
+ * so nothing compiles or touches the lifecycle here). THROWS on async/circular
+ * forwardTo and invalid path constraint — before the caller mutates the store.
+ */
+function buildArtifacts<Dependencies extends DefaultDependencies>(
+  definitions: RouteDefinition[],
+  routesForHandlers: readonly Route<Dependencies>[],
+  config: RouteConfig,
+  routeCustomFields: Record<string, Record<string, unknown>>,
+  handlerParentName: string,
+  rootPath: string,
+  matcherOptions: CreateMatcherOptions | undefined,
+): RouteArtifacts<Dependencies> {
+  const pendingCanActivate = new Map<string, GuardFnFactory<Dependencies>>();
+  const pendingCanDeactivate = new Map<string, GuardFnFactory<Dependencies>>();
+
+  registerAllRouteHandlers(
+    routesForHandlers,
+    config,
+    routeCustomFields,
+    pendingCanActivate,
+    pendingCanDeactivate,
+    handlerParentName,
+  );
+
+  const resolvedForwardMap = refreshForwardMap(config);
+  const { tree, matcher } = rebuildTree(definitions, rootPath, matcherOptions);
+
+  return {
+    definitions,
+    config,
+    routeCustomFields,
+    pendingCanActivate,
+    pendingCanDeactivate,
+    tree,
+    matcher,
+    resolvedForwardMap,
+  };
+}
+
+/** Builds the merged artifacts for an incremental `add` (existing ∪ new). */
+export function buildAddArtifacts<Dependencies extends DefaultDependencies>(
+  store: RoutesStore<Dependencies>,
+  routes: readonly Route<Dependencies>[],
+  parentName: string | undefined,
+): RouteArtifacts<Dependencies> {
+  const definitions = insertAddedDefinitions(
+    store.definitions,
+    routes.map((route) => sanitizeRoute(route)),
+    parentName === undefined ? [] : parentName.split("."),
+  );
+
+  return buildArtifacts(
+    definitions,
+    routes,
+    cloneConfig(store.config),
+    Object.assign(
+      Object.create(null) as Record<string, Record<string, unknown>>,
+      store.routeCustomFields,
+    ),
+    parentName ?? "",
+    store.rootPath,
+    store.matcherOptions,
+  );
+}
+
+/** Builds the fresh artifacts for a full `replace` (standalone new set). */
+export function buildReplaceArtifacts<Dependencies extends DefaultDependencies>(
+  routes: readonly Route<Dependencies>[],
+  rootPath: string,
+  matcherOptions: CreateMatcherOptions | undefined,
+): RouteArtifacts<Dependencies> {
+  return buildArtifacts(
+    routes.map((route) => sanitizeRoute(route)),
+    routes,
+    createEmptyConfig(),
+    Object.create(null) as Record<string, Record<string, unknown>>,
+    "",
+    rootPath,
+    matcherOptions,
+  );
+}
+
+/**
+ * Commits prepared artifacts into the store in place. Pure assignment — never
+ * throws — so it is the single atomic swap point of the prepare-then-commit
+ * pipeline. Guard registration is deferred to here (the build collected guards
+ * without compiling); `depsStore` is always set on a wired router, which is the
+ * only path that reaches `add`/`replace`.
+ */
+export function adoptRouteArtifacts<Dependencies extends DefaultDependencies>(
+  store: RoutesStore<Dependencies>,
+  artifacts: RouteArtifacts<Dependencies>,
+): void {
+  store.definitions.length = 0;
+
+  for (const def of artifacts.definitions) {
+    store.definitions.push(def);
+  }
+
+  Object.assign(store.config, artifacts.config);
+  store.routeCustomFields = artifacts.routeCustomFields;
+  store.tree = artifacts.tree;
+  store.matcher = artifacts.matcher;
+  store.resolvedForwardMap = artifacts.resolvedForwardMap;
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depsStore is set once the router is wired; add/replace only run on a wired router (constructor-time registration uses createRoutesStore)
+  const deps = store.depsStore!;
+
+  for (const [name, handler] of artifacts.pendingCanActivate) {
+    deps.addActivateGuard(name, handler);
+  }
+
+  for (const [name, handler] of artifacts.pendingCanDeactivate) {
+    deps.addDeactivateGuard(name, handler);
   }
 }
 
@@ -297,46 +539,24 @@ export function createRoutesStore<
   routes: Route<Dependencies>[],
   matcherOptions?: CreateMatcherOptions,
 ): RoutesStore<Dependencies> {
-  const definitions: RouteDefinition[] = [];
-  const config: RouteConfig = createEmptyConfig();
-  const routeCustomFields: Record<
-    string,
-    Record<string, unknown>
-  > = Object.create(null) as Record<string, Record<string, unknown>>;
-  const pendingCanActivate = new Map<string, GuardFnFactory<Dependencies>>();
-  const pendingCanDeactivate = new Map<string, GuardFnFactory<Dependencies>>();
-
-  for (const route of routes) {
-    definitions.push(sanitizeRoute(route));
-  }
-
-  const { tree, matcher } = rebuildTree(definitions, "", matcherOptions);
-
-  registerAllRouteHandlers(
-    routes,
-    config,
-    routeCustomFields,
-    pendingCanActivate,
-    pendingCanDeactivate,
-    undefined,
-    "",
-  );
-
-  const resolvedForwardMap = refreshForwardMap(config);
+  // Initial routes are a standalone set at rootPath "" — same build the
+  // prepare-then-commit `replace` path uses. Guards land in the pending maps
+  // (depsStore is wired later via setDependencies, which flushes them).
+  const artifacts = buildReplaceArtifacts(routes, "", matcherOptions);
 
   return {
-    definitions,
-    config,
-    tree,
-    matcher,
-    resolvedForwardMap,
-    routeCustomFields,
+    definitions: artifacts.definitions,
+    config: artifacts.config,
+    tree: artifacts.tree,
+    matcher: artifacts.matcher,
+    resolvedForwardMap: artifacts.resolvedForwardMap,
+    routeCustomFields: artifacts.routeCustomFields,
     rootPath: "",
     matcherOptions,
     depsStore: undefined,
     lifecycleNamespace: undefined,
-    pendingCanActivate,
-    pendingCanDeactivate,
+    pendingCanActivate: artifacts.pendingCanActivate,
+    pendingCanDeactivate: artifacts.pendingCanDeactivate,
     treeOperations: {
       commitTreeChanges,
       resetStore,

--- a/packages/core/tests/functional/api/getRoutesApi/addRoute.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/addRoute.test.ts
@@ -1431,4 +1431,57 @@ describe("core/routes/addRoute", () => {
       warnSpy.mockRestore();
     });
   });
+
+  // Prepare-then-commit atomicity (issue #698): without validation-plugin, a
+  // failing add must throw BEFORE mutating the store — never leave a torn tree.
+  describe("atomicity (issue #698)", () => {
+    it("duplicate name vs existing route → throws, existing route unchanged", () => {
+      expect(() => {
+        routesApi.add({ name: "home", path: "/home-2" });
+      }).toThrow(/already exists/);
+
+      // The live "home" route is untouched (not silently overwritten).
+      expect(router.buildPath("home")).toBe("/home");
+      expect(getPluginApi(router).matchPath("/home")?.name).toBe("home");
+      expect(getPluginApi(router).matchPath("/home-2")).toBeUndefined();
+    });
+
+    it("missing parent → clean error (not a TypeError), nothing added", () => {
+      expect(() => {
+        routesApi.add({ name: "orphan", path: "/orphan" }, { parent: "nope" });
+      }).toThrow(/Parent route "nope" does not exist/);
+
+      expect(routesApi.has("orphan")).toBe(false);
+      // Existing tree intact.
+      expect(router.buildPath("home")).toBe("/home");
+    });
+
+    it("circular forwardTo batch → throws, no route from the batch is added", () => {
+      expect(() => {
+        routesApi.add([
+          { name: "cycA", path: "/cyc-a", forwardTo: "cycB" },
+          { name: "cycB", path: "/cyc-b", forwardTo: "cycA" },
+        ]);
+      }).toThrow(/Circular forwardTo/);
+
+      expect(routesApi.has("cycA")).toBe(false);
+      expect(routesApi.has("cycB")).toBe(false);
+      // Existing routes still usable.
+      expect(router.buildPath("home")).toBe("/home");
+    });
+
+    it("invalid constraint → throws, store not dirtied (subsequent add works)", () => {
+      expect(() => {
+        routesApi.add({ name: "bad", path: "/:id<[>" });
+      }).toThrow();
+
+      expect(routesApi.has("bad")).toBe(false);
+      // definitions were not left in a torn state — a later valid add succeeds.
+      expect(() => {
+        routesApi.add({ name: "good-after-bad", path: "/good-after-bad" });
+      }).not.toThrow();
+      expect(routesApi.has("good-after-bad")).toBe(true);
+      expect(router.buildPath("home")).toBe("/home");
+    });
+  });
 });

--- a/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
@@ -748,4 +748,40 @@ describe("core/routes/replaceRoutes", () => {
       expect(routesApi.has("extra")).toBe(true);
     });
   });
+
+  // Prepare-then-commit atomicity (issue #698): a failing replace must throw
+  // BEFORE the destructive clearRouteData — the old tree must survive intact.
+  describe("atomicity (issue #698)", () => {
+    it("circular forwardTo in new set → throws, old tree intact", () => {
+      expect(() => {
+        routesApi.replace([
+          { name: "a", path: "/a", forwardTo: "b" },
+          { name: "b", path: "/b", forwardTo: "a" },
+        ]);
+      }).toThrow(/Circular forwardTo/);
+
+      // Old routes survive the failed replace.
+      expect(routesApi.has("home")).toBe(true);
+      expect(routesApi.has("users")).toBe(true);
+      expect(getPluginApi(router).matchPath("/home")?.name).toBe("home");
+      expect(routesApi.has("a")).toBe(false);
+    });
+
+    it("async forwardTo in new set → throws, old tree intact", () => {
+      expect(() => {
+        routesApi.replace([
+          {
+            name: "x",
+            path: "/x",
+            forwardTo: (async () => "y") as unknown as string,
+          },
+          { name: "y", path: "/y" },
+        ]);
+      }).toThrow(/cannot be async/);
+
+      expect(routesApi.has("home")).toBe(true);
+      expect(getPluginApi(router).matchPath("/home")?.name).toBe("home");
+      expect(routesApi.has("x")).toBe(false);
+    });
+  });
 });

--- a/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
@@ -978,6 +978,24 @@ describe("core/routes/routeTree/updateRoute", () => {
           routesApi.update("ur-self", { forwardTo: "ur-self" });
         }).toThrow(/Circular forwardTo/);
       });
+
+      // Prepare-then-commit atomicity (issue #698): a cycle-creating update must
+      // not poison config.forwardMap, so a later unrelated add must not throw.
+      it("cycle-creating update does not poison forwardMap (subsequent add is clean)", () => {
+        routesApi.add({ name: "ur-poison-a", path: "/ur-poison-a" });
+        routesApi.add({ name: "ur-poison-b", path: "/ur-poison-b" });
+        routesApi.update("ur-poison-a", { forwardTo: "ur-poison-b" });
+
+        expect(() => {
+          routesApi.update("ur-poison-b", { forwardTo: "ur-poison-a" });
+        }).toThrow(/Circular forwardTo/);
+
+        // forwardMap was not corrupted — an unrelated add does not re-throw the cycle.
+        expect(() => {
+          routesApi.add({ name: "ur-poison-c", path: "/ur-poison-c" });
+        }).not.toThrow();
+        expect(routesApi.has("ur-poison-c")).toBe(true);
+      });
     });
 
     describe("sequential updates", () => {

--- a/packages/core/tests/property/routeManagement.properties.ts
+++ b/packages/core/tests/property/routeManagement.properties.ts
@@ -75,6 +75,10 @@ describe("Route Management (getRoutesApi) Properties", () => {
         { name: "cycB", path: "/cyc-b", forwardTo: "cycA" },
       ]);
     }).toThrow();
+
+    // Atomicity (issue #698): a rejected cyclic batch leaves nothing behind.
+    expect(routesApi.has("cycA")).toBe(false);
+    expect(routesApi.has("cycB")).toBe(false);
   });
 
   it("replace atomicity: old routes gone, new routes present", () => {


### PR DESCRIPTION
Closes #698.

## Problem

`getRoutesApi(router)`'s `add`, `replace`, and `update` mutated the shared route store **before** running steps that can throw at the core level (circular/async `forwardTo`, invalid path constraint) and had no rollback. The only pre-screen is the opt-in `@real-router/validation-plugin` (dev-only by convention), so production builds hit a torn store:

- `add({ name: <existing> })` silently overwrote a live route (`matchPath('/home')` → `undefined`).
- a failed `replace` (circular `forwardTo` in the new set) wiped the whole tree.
- a cycle-creating `update({ forwardTo })` poisoned `config.forwardMap`, so a later unrelated `add` threw with an unrelated stack trace.

## Fix — build-then-swap

`add` and `replace` now build the new tree, config, and forward map into **local** structures; the throwing core-level errors surface from that build, and a non-throwing `adoptRouteArtifacts` swaps the result into the store only on success — so a rejected call leaves existing routes untouched. `update({ forwardTo })` resolves the chain on a candidate map before committing, so a cycle can no longer corrupt state.

route-tree stays silent on duplicate names, so the two silent-corruption cases it can't surface — a duplicate name vs an **existing** route, and a missing `parent` — are rejected up front by `assertAddable` with a clear error, instead of silently overwriting a live route or crashing with a `TypeError`. All of this is independent of whether the validation plugin is installed.

## What changed

- `packages/core/src/namespaces/RoutesNamespace/routesStore.ts` — `assertAddable`, `buildAddArtifacts` / `buildReplaceArtifacts` (build into locals, throw before mutating), `adoptRouteArtifacts` (atomic, non-throwing swap). `registerAllRouteHandlers` no longer registers guards inline (collects them; applied at adopt / `setDependencies`).
- `packages/core/src/api/getRoutesApi.ts` — `addRoutes`/`replaceRoutes` rewired to build-then-swap; `updateForwardTo` does clone-and-swap; dead `findDefinition` removed.
- Regression tests in `addRoute`/`replaceRoutes`/`updateRoute` (`describe("atomicity (issue #698)")`) + a property-test assertion, all run **without** the validation plugin.
- Regression anchor probe: `benchmarks/core/audit-probes/route-crud-atomicity-2026-06-04/probe-01-unified-torn-state.ts`.

No public API change. Internal-only; framework adapters and plugins unaffected.

## Verification

- `probe-01-unified-torn-state.ts` prints `true` on all three lines (was `false` × 3).
- `@real-router/core`: 100% coverage (statements / branches / functions / lines), full suite green.
- `pnpm build` across the graph: 287/287 tasks successful.
