### PR TITLE
docs: clarify resolve:dependabot also fixes lint:dedupe-only PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,10 @@ pnpm lint:deps          # Check dependency versions (syncpack)
 pnpm lint:dedupe        # Check for duplicate deps
 pnpm lint:e2e           # Verify e2e directories have spec files
 pnpm lint:unused        # Check for unused code (knip)
-pnpm resolve:dependabot <PR#>  # Rebase+squash-resolve a CONFLICTING Dependabot PR (keeps master linear)
+pnpm resolve:dependabot <PR#>  # Rebase+dedupe a Dependabot PR — conflicting OR lint:dedupe-failing (keeps master linear)
 ```
 
-**Conflicting Dependabot PRs:** resolve with `pnpm resolve:dependabot <PR#>` (rebase onto master → semver-union resolve → squash-merge). Never resolve them with a merge commit — `master` is protected with "Merge commits are not allowed". See IMPLEMENTATION_NOTES "Squash-resolve for CONFLICTING Dependabot PRs".
+**Dependabot PRs needing `resolve:dependabot`:** resolve with `pnpm resolve:dependabot <PR#>` (rebase onto master → semver-union resolve → regenerate + dedupe lockfile → squash-merge). Use it in **two** cases: (1) the PR **conflicts** with master, or (2) the PR's only failure is the **`lint:dedupe`** gate (`ERR_PNPM_DEDUPE_CHECK_ISSUES`) — Dependabot never runs `pnpm dedupe`, so grouped bumps leave duplicate versions in the lockfile (e.g. `semver` 7.8.1 **and** 7.8.2). The script's lockfile-reconcile step (`pnpm install` → `pnpm dedupe` → amend) runs even on a clean rebase, so it fixes the dedupe-only case too. Never resolve with a merge commit — `master` is protected with "Merge commits are not allowed". See IMPLEMENTATION_NOTES "Squash-resolve for CONFLICTING Dependabot PRs". (A lint failure from a linter-plugin **bump itself** — e.g. new `eslint-plugin-unicorn` rules — is a code/config fix, not something `resolve:dependabot` handles.)
 
 ## Non-Obvious Conventions
 

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -472,6 +472,27 @@ grouped Dependabot bumps conflict (adjacent version lines). Stop-for-review is t
 default because the heuristic is a heuristic — a human eyeballs the resolved
 versions before any force-push.
 
+**Also the fix for `lint:dedupe`-only failures (not just conflicts).** Dependabot
+never runs `pnpm dedupe`, so a grouped bump frequently leaves duplicate versions in
+`pnpm-lock.yaml` (e.g. `semver@7.8.1` **and** `7.8.2`, `lru-cache`, `undici`,
+`tinyexec`). CI's `lint:dedupe` step (`pnpm dedupe --check`) then fails with
+`ERR_PNPM_DEDUPE_CHECK_ISSUES` even though the PR merges cleanly. The same script
+fixes this: its lockfile-reconcile tail (`pnpm install` → `pnpm dedupe` → amend)
+runs **unconditionally**, including after a clean rebase with zero conflicts, so the
+deduped lockfile is folded into the single dep-bump commit. (For a one-off you can
+also just `pnpm dedupe` on the PR branch and commit the lockfile — that is exactly
+what the script's tail does — but `resolve:dependabot` is the blessed path because it
+also brings the branch up to date with `master`, which the protected branch requires
+before merge.)
+
+**Not a fix for a linter-plugin bump that adds rules.** When the eslint group bumps a
+plugin to a version with new recommended rules (e.g. `eslint-plugin-unicorn` 64 → 65
+added `no-array-from-fill`, `prefer-includes-over-repeated-comparisons`,
+`no-this-outside-of-class`, …), the failure is in `lint`, not `lint:dedupe`. That is a
+code/config decision — fix the flagged sites, or opt out of the new rules in
+`eslint.config.mjs` and track re-enabling (e.g. #712) — and is out of scope for
+`resolve:dependabot`.
+
 ### Danger JS
 
 `.github/workflows/danger.yml` runs automated PR review checks via `dangerfile.ts`:


### PR DESCRIPTION
Dependabot never runs `pnpm dedupe`, so grouped bumps leave duplicate versions in `pnpm-lock.yaml` and fail the `lint:dedupe` gate (`ERR_PNPM_DEDUPE_CHECK_ISSUES`) even without a merge conflict. The `resolve:dependabot` script already fixes this — its lockfile-reconcile tail (`pnpm install → pnpm dedupe → amend`) runs on a clean rebase too — but the docs only described the CONFLICTING case.

- **CLAUDE.md** — `resolve:dependabot` now documented for both conflicting **and** `lint:dedupe`-failing PRs; note that a lint failure from a linter-plugin **bump itself** (new rules) is out of scope.
- **IMPLEMENTATION_NOTES.md** — two paragraphs added to the existing section (dedupe-only case + the linter-bump caveat). Section heading kept stable (CLAUDE.md cross-references it by title).

Context: encountered while fixing the failing Dependabot PRs #705, #708, #711 (dedupe) and #706 (eslint group bump → new unicorn v65 rules, tracked in #712).