### PR TITLE
fix(core): fire-and-forget safety — unhandled rejection + guard-block log fixes (#721)

### DIFF
--- a/.changeset/guard-block-suppression-721-fix.md
+++ b/.changeset/guard-block-suppression-721-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Suppress spurious "Unexpected navigation error" logs for guard-blocked fire-and-forget navigation (#721)
+
+Add `CANNOT_ACTIVATE` / `CANNOT_DEACTIVATE` to the fire-and-forget unhandled-rejection safety net's suppressed-error set. A guard returning `false` — or a plugin's guard-blocked `back()` / `forward()` routed through `navigateToState()` — is an expected navigation outcome, not an internal bug, yet such fire-and-forget calls previously emitted a misleading `logger.error("router.navigate", "Unexpected navigation error", …)`. Awaiting callers and `onTransitionError` plugins still receive the rejection.

--- a/.changeset/navigation-721-fix.md
+++ b/.changeset/navigation-721-fix.md
@@ -1,0 +1,12 @@
+---
+"@real-router/core": patch
+---
+
+Fix fire-and-forget unhandled rejection on `navigateToState()` and `navigateToDefault()` (#721)
+
+Restore the documented fire-and-forget safety invariant for two navigation entry points that leaked an `unhandledRejection` when the returned promise was not awaited:
+
+- `getPluginApi(router).navigateToState(state)` with a route no longer in the tree — the fresh `ROUTE_NOT_FOUND` rejection wrongly set the "skip suppression" flag reserved for pre-suppressed cached rejections, so the facade never attached its `.catch()`.
+- `router.navigateToDefault()` with no `defaultRoute`, called after `router.start()` — the method did not reset the sync-resolution flag on entry, so it read the stale `true` left by `start()` and took the "already resolved" branch, skipping suppression.
+
+Awaiting callers are unaffected: the rejection is still observable via `await`/`.catch()`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -432,7 +432,7 @@ These are deliberately designed constraints. Violating them will break the syste
 
 - **Concurrent navigation cancels previous** — the previous internal AbortController is aborted, promise rejects with `TRANSITION_CANCELLED`.
 - **Navigating FROM `UNKNOWN_ROUTE` auto-forces `replace: true`** — prevents browser history pollution with 404 entries.
-- **Fire-and-forget is safe** — `navigate()` internally suppresses unhandled rejections for expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
+- **Fire-and-forget is safe** — `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally suppress unhandled rejections for expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
 
 ### Packages
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -432,7 +432,7 @@ These are deliberately designed constraints. Violating them will break the syste
 
 - **Concurrent navigation cancels previous** — the previous internal AbortController is aborted, promise rejects with `TRANSITION_CANCELLED`.
 - **Navigating FROM `UNKNOWN_ROUTE` auto-forces `replace: true`** — prevents browser history pollution with 404 entries.
-- **Fire-and-forget is safe** — `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally suppress unhandled rejections for expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
+- **Fire-and-forget is safe** — `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally suppress unhandled rejections for expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`, `CANNOT_ACTIVATE`, `CANNOT_DEACTIVATE`). Guard blocks are an expected outcome, not an internal error — `await` the call (or use an `onTransitionError` plugin) to observe a guard rejection.
 
 ### Packages
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -322,7 +322,7 @@ router.dispose()  ───────────┘      ▼
                                AbortError auto-converted to TRANSITION_CANCELLED
 ```
 
-**Fire-and-forget safety:** `navigate()` internally attaches `.catch()` to suppress expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
+**Fire-and-forget safety:** `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally attach `.catch()` to suppress expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
 
 **Atomicity:** **State change is atomic** — `router.getState()` updates in one step via `completeTransition`. Either the full pipeline completes or nothing changes. However, the transition pipeline now has an observable intermediate phase: after deactivation guards pass and before activation guards run, the FSM enters `LEAVE_APPROVED`. This is the moment for safe side-effects — scroll preservation, fetch abort, analytics. Route state has not yet changed.
 

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -322,7 +322,7 @@ router.dispose()  ───────────┘      ▼
                                AbortError auto-converted to TRANSITION_CANCELLED
 ```
 
-**Fire-and-forget safety:** `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally attach `.catch()` to suppress expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`).
+**Fire-and-forget safety:** `navigate()`, `navigateToDefault()`, and the `navigateToState()` plugin primitive internally attach `.catch()` to suppress expected errors (`SAME_STATES`, `TRANSITION_CANCELLED`, `ROUTER_NOT_STARTED`, `ROUTE_NOT_FOUND`, `CANNOT_ACTIVATE`, `CANNOT_DEACTIVATE`). A guard block is an expected outcome, not an internal error — `await` the call (or subscribe via an `onTransitionError` plugin) to observe a guard rejection.
 
 **Atomicity:** **State change is atomic** — `router.getState()` updates in one step via `completeTransition`. Either the full pipeline completes or nothing changes. However, the transition pipeline now has an observable intermediate phase: after deactivation guards pass and before activation guards run, the FSM enters `LEAVE_APPROVED`. This is the moment for safe side-effects — scroll preservation, fetch abort, analytics. Route state has not yet changed.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,7 +53,7 @@ await router.navigate("users.profile", { id: "123" });
 | Method                              | Returns          | Description                               |
 | ----------------------------------- | ---------------- | ----------------------------------------- |
 | `navigate(name, params?, options?)` | `Promise<State>` | Navigate to a route. Fire-and-forget safe |
-| `navigateToDefault(options?)`       | `Promise<State>` | Navigate to the default route             |
+| `navigateToDefault(options?)`       | `Promise<State>` | Navigate to the default route. Fire-and-forget safe |
 | `navigateToNotFound(path?)`         | `State`          | Synchronously set UNKNOWN_ROUTE state     |
 | `canNavigateTo(name, params?)`      | `boolean`        | Check if guards allow navigation          |
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -55,11 +55,19 @@ import type { CreateMatcherOptions } from "route-tree";
 const EMPTY_OPTS: Readonly<NavigationOptions> = Object.freeze({});
 
 // Module-level so #onSuppressedError allocates nothing per navigate() call.
+// These are expected navigation outcomes owned by the caller, not internal
+// bugs — the safety net stays silent for them and lets awaiting callers see
+// the rejection. CANNOT_ACTIVATE / CANNOT_DEACTIVATE belong here: a guard
+// blocking (or a plugin's guard-blocked back()/forward()) is a normal result,
+// so a fire-and-forget call must not emit a spurious "Unexpected navigation
+// error" (#721).
 const SUPPRESSED_ERROR_CODES: ReadonlySet<string> = new Set([
   errorCodes.SAME_STATES,
   errorCodes.TRANSITION_CANCELLED,
   errorCodes.ROUTER_NOT_STARTED,
   errorCodes.ROUTE_NOT_FOUND,
+  errorCodes.CANNOT_ACTIVATE,
+  errorCodes.CANNOT_DEACTIVATE,
 ]);
 
 /**

--- a/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
@@ -159,8 +159,13 @@ export class NavigationNamespace {
       });
 
       deps.emitTransitionError(undefined, deps.getState(), err);
-      this.lastSyncRejected = true;
 
+      // This is a FRESH reject (carries `routeName`), not one of the
+      // pre-suppressed CACHED_*_REJECTION singletons. `lastSyncRejected`
+      // contractually means "I returned a pre-suppressed cached rejection —
+      // skip your .catch()", so leaving it unset lets the facade attach its
+      // own suppression. Setting it here leaked an unhandledRejection on
+      // fire-and-forget calls (#721).
       return Promise.reject(err);
     }
 
@@ -181,6 +186,13 @@ export class NavigationNamespace {
   }
 
   navigateToDefault(opts: NavigationOptions): Promise<State> {
+    // Reset the sync-resolution flag on entry, mirroring navigate() and
+    // navigateToState(). start() leaves `lastSyncResolved = true`, and the
+    // early reject paths below return before delegating to navigate(), so a
+    // stale `true` would make the facade take the "already resolved" branch
+    // and skip .catch() suppression — leaking an unhandledRejection on
+    // fire-and-forget calls (#721).
+    this.lastSyncResolved = false;
     const deps = this.#deps;
     const options = deps.getOptions();
 

--- a/packages/core/tests/functional/navigation/guard-block-suppression.test.ts
+++ b/packages/core/tests/functional/navigation/guard-block-suppression.test.ts
@@ -1,0 +1,78 @@
+import { logger } from "@real-router/logger";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { getLifecycleApi, getPluginApi } from "@real-router/core/api";
+
+import { createTestRouter } from "../../helpers";
+
+import type { Router } from "@real-router/core";
+import type { LifecycleApi } from "@real-router/core/api";
+
+/**
+ * A guard returning `false` (or a guard-blocked traversal from a plugin's
+ * `back()`/`forward()`) is an EXPECTED navigation outcome, not an internal
+ * bug. Fire-and-forget calls must not trip the unhandled-rejection safety
+ * net's `logger.error("router.navigate", "Unexpected navigation error", …)`
+ * for `CANNOT_ACTIVATE` / `CANNOT_DEACTIVATE` — that noise is what the
+ * memory-plugin `back()` audit surfaced under #721.
+ */
+const UNEXPECTED_ERROR_LOG = [
+  "router.navigate",
+  "Unexpected navigation error",
+] as const;
+
+let router: Router;
+let lifecycle: LifecycleApi;
+
+describe("fire-and-forget guard-block suppression (#721)", () => {
+  beforeEach(async () => {
+    router = createTestRouter();
+    await router.start("/home");
+    lifecycle = getLifecycleApi(router);
+  });
+
+  afterEach(() => {
+    router.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("does not log an unexpected-error when a canActivate guard blocks fire-and-forget navigate()", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    // `admin-protected` is defined with `canActivate: () => () => false`.
+    void router.navigate("admin-protected");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      ...UNEXPECTED_ERROR_LOG,
+      expect.anything(),
+    );
+  });
+
+  it("does not log an unexpected-error when a canDeactivate guard blocks fire-and-forget navigate()", async () => {
+    lifecycle.addDeactivateGuard("home", () => () => false);
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    void router.navigate("users");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      ...UNEXPECTED_ERROR_LOG,
+      expect.anything(),
+    );
+  });
+
+  it("does not log an unexpected-error when a guard blocks fire-and-forget navigateToState()", async () => {
+    lifecycle.addActivateGuard("users", () => () => false);
+    const matched = getPluginApi(router).matchPath("/users");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    void getPluginApi(router).navigateToState(matched!);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      ...UNEXPECTED_ERROR_LOG,
+      expect.anything(),
+    );
+  });
+});

--- a/packages/core/tests/functional/navigation/navigateToDefault.test.ts
+++ b/packages/core/tests/functional/navigation/navigateToDefault.test.ts
@@ -3,7 +3,7 @@ import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 import { errorCodes, events, RouterError } from "@real-router/core";
 import { getLifecycleApi, getPluginApi } from "@real-router/core/api";
 
-import { createTestRouter } from "../../helpers";
+import { captureUnhandledRejections, createTestRouter } from "../../helpers";
 
 import type { Params, Router } from "@real-router/core";
 import type { LifecycleApi } from "@real-router/core/api";
@@ -893,6 +893,22 @@ describe("navigateToDefault", () => {
       await expect(router.navigateToDefault()).rejects.toMatchObject({
         code: errorCodes.ROUTE_NOT_FOUND,
       });
+    });
+
+    it("does not leak an unhandledRejection when fire-and-forget after start() (#721)", async () => {
+      router.stop();
+      router = createTestRouter({ defaultRoute: "" });
+      // start() leaves the sync-resolution flag set; navigateToDefault() must
+      // reset it so its early ROUTE_NOT_FOUND rejection is still suppressed.
+      await router.start("/home");
+
+      const leaks = await captureUnhandledRejections(() => {
+        // Fire-and-forget: `void` only silences the lint rule; it attaches no
+        // handler, so the unhandled-rejection behaviour under test is intact.
+        void router.navigateToDefault();
+      });
+
+      expect(leaks).toHaveLength(0);
     });
   });
 

--- a/packages/core/tests/functional/navigation/navigateToState.test.ts
+++ b/packages/core/tests/functional/navigation/navigateToState.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@real-router/core";
 import { getLifecycleApi, getPluginApi } from "@real-router/core/api";
 
-import { createTestRouter } from "../../helpers";
+import { captureUnhandledRejections, createTestRouter } from "../../helpers";
 
 import type { Router, State } from "@real-router/core";
 import type { LifecycleApi } from "@real-router/core/api";
@@ -202,6 +202,30 @@ describe("navigateToState", () => {
         getPluginApi(router).navigateToState(matched!),
       ).rejects.toBeInstanceOf(RouterError);
       expect(router.getState()?.name).toBe("home");
+    });
+  });
+
+  describe("fire-and-forget safety (#721)", () => {
+    it("does not leak an unhandledRejection when a removed-route state is not awaited", async () => {
+      const ghost: State = {
+        name: "ghost.route",
+        params: {},
+        path: "/ghost",
+        transition: {
+          phase: "activating",
+          reason: "success",
+          segments: { deactivated: [], activated: [], intersection: "" },
+        },
+        context: {},
+      };
+
+      const leaks = await captureUnhandledRejections(() => {
+        // Fire-and-forget: `void` only silences the lint rule; it attaches no
+        // handler, so the unhandled-rejection behaviour under test is intact.
+        void getPluginApi(router).navigateToState(ghost);
+      });
+
+      expect(leaks).toHaveLength(0);
     });
   });
 

--- a/packages/core/tests/helpers/index.ts
+++ b/packages/core/tests/helpers/index.ts
@@ -36,3 +36,44 @@ export const makeState = (
 
   return state;
 };
+
+/**
+ * Runs `action` (a fire-and-forget navigation that returns a promise the
+ * caller intentionally does NOT await) and returns every process-level
+ * `unhandledRejection` it leaked.
+ *
+ * Ambient `unhandledRejection` listeners (e.g. vitest's, which would fail the
+ * whole run) are detached for the duration so a leak surfaces as a returned
+ * array entry, then restored. Used to assert the "fire-and-forget safety"
+ * invariant: navigation methods called without `await` must internally
+ * suppress expected rejections (#721).
+ */
+export async function captureUnhandledRejections(
+  action: () => void,
+): Promise<unknown[]> {
+  const captured: unknown[] = [];
+  const previous = process.listeners("unhandledRejection");
+
+  process.removeAllListeners("unhandledRejection");
+
+  const handler = (reason: unknown): void => {
+    captured.push(reason);
+  };
+
+  process.on("unhandledRejection", handler);
+
+  try {
+    action();
+    // `unhandledRejection` fires only after the microtask queue settles; one
+    // macrotask tick reliably flushes it before we read `captured`.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } finally {
+    process.off("unhandledRejection", handler);
+
+    for (const listener of previous) {
+      process.on("unhandledRejection", listener);
+    }
+  }
+
+  return captured;
+}


### PR DESCRIPTION
## Summary

Restores the documented **fire-and-forget safety** invariant for navigation — calling a navigation method without `await` must not emit an `unhandledRejection` warning or a spurious error log for expected outcomes. Two independent fixes (one commit each), both for #721:

- **`navigateToState()` / `navigateToDefault()` no longer leak an `unhandledRejection`** for expected `ROUTE_NOT_FOUND` rejections when fire-and-forget. `navigateToState()` flagged a *fresh* reject as "pre-suppressed", so the facade skipped its `.catch()`; `navigateToDefault()` never reset the sync-resolution flag on entry, so it read the stale `true` left by `start()` and took the "already resolved" branch.
- **Guard-blocked fire-and-forget navigation no longer logs a misleading `"Unexpected navigation error"`.** `CANNOT_ACTIVATE` / `CANNOT_DEACTIVATE` are now in the safety net's suppressed-error set — a guard returning `false` (or a plugin's guard-blocked `back()`/`forward()` routed through `navigateToState`) is an expected navigation outcome, not an internal bug. Surfaced by the memory-plugin audit recorded in the issue comments.

Awaiting callers and `onTransitionError` plugins still receive the rejection in every case — only the unhandled-rejection safety net changed.

Includes two `patch` changesets for `@real-router/core` and doc sync (root + package `ARCHITECTURE.md`; wiki `navigateToDefault` / `start` / `navigateToState` pages updated in the wiki repo).

## Test plan

- [x] `pnpm build` passes (type-check → lint → test → bundle, 291/291 tasks)
- [x] 100% test coverage maintained
- [x] New regression tests for both fire-and-forget rejection paths and all guard-block codes, validated mutationally (reverting either fix turns the new tests red)

Closes #721
