### PR TITLE
fix(core): keep committed start state when interceptor rejects post-commit (#763)

### DIFF
--- a/.changeset/start-phantom-success-763-fix.md
+++ b/.changeset/start-phantom-success-763-fix.md
@@ -1,0 +1,12 @@
+---
+"@real-router/core": minor
+---
+
+Keep the committed state when a `start` interceptor rejects after commit ([#763](https://github.com/greydragon888/real-router/issues/763))
+
+A `start` interceptor that throws *after* `next(path)` already committed the state and emitted `TRANSITION_SUCCESS` — the window where the SSR/RSC loader plugins run their loader — no longer rolls the router back to IDLE. Subscribers had already observed the success, so retracting it left a "phantom success": the event fired, then `getState()` went back to `undefined`.
+
+- Post-commit interceptor rejection: the committed state stands, `isActive()` stays `true`, and the loader error surfaces only through the rejected `start()` promise (the "Loader errors propagate" contract is preserved).
+- Pre-commit failures (route not found, a blocked activation guard, a sync interceptor throw before `next()`) are unchanged — the half-started FSM still unwinds to IDLE (two-phase start).
+
+Breaking for code that relied on a rejected `start()` always leaving the router un-started: after a post-commit interceptor failure the router is now started, so a retry must `stop()` first (a second `start()` rejects with `ROUTER_ALREADY_STARTED`).

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -449,7 +449,16 @@ export class Router<
     }
 
     const promiseState = internalStart.catch((error: unknown) => {
-      if (this.#eventBus.isReady()) {
+      // Unwind a READY FSM back to IDLE only when nothing was committed —
+      // e.g. an activation guard blocked the start navigation, so no
+      // TRANSITION_SUCCESS was emitted (`getState()` is undefined). If a
+      // start interceptor instead threw AFTER navigateToState committed and
+      // emitted TRANSITION_SUCCESS (the SSR/RSC loader window), `getState()`
+      // is defined: subscribers already observed the success, so rolling back
+      // would retract it (phantom success, #763). Keep the committed state —
+      // the error still surfaces via the rejection below. A throw before
+      // `next()` never reached READY and unwinds via the STARTING branch.
+      if (this.#eventBus.isReady() && this.#state.get() === undefined) {
         this.#lifecycle.stop();
         this.#eventBus.sendStop();
       } else if (this.#eventBus.isStarting()) {

--- a/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/start/error-handling.test.ts
@@ -574,4 +574,44 @@ describe("router.start() - error handling", () => {
       localRouter.stop();
     });
   });
+
+  // #763: a start interceptor that throws AFTER calling next() fails post-commit
+  // — navigateToState already committed the state and emitted TRANSITION_SUCCESS
+  // to subscribers (the SSR/RSC loader plugins run their loader in exactly this
+  // window). Rolling the start back to IDLE retracts a success subscribers
+  // already observed ("phantom success"). The committed navigation must stand;
+  // the loader error surfaces only through the rejected start() promise.
+  describe("#763: post-commit start-interceptor failure keeps observed success", () => {
+    it("does not retract the committed state when an interceptor throws after next()", async () => {
+      const localRouter = createTestRouter();
+      const observed: string[] = [];
+
+      localRouter.subscribe(({ route }) => observed.push(route.name));
+
+      const removeInterceptor = getPluginApi(localRouter).addInterceptor(
+        "start",
+        async (next, path) => {
+          await next(path); // commits state + emits TRANSITION_SUCCESS("home")
+
+          throw new Error("loader failed after commit");
+        },
+      );
+
+      // The loader error still propagates — "Loader errors propagate" contract.
+      await expect(localRouter.start("/home")).rejects.toThrow(
+        "loader failed after commit",
+      );
+
+      // The subscriber observed TRANSITION_SUCCESS("home")...
+      expect(observed).toStrictEqual(["home"]);
+
+      // ...so the router must NOT have rolled the start back: the committed
+      // state stands and the router stays started (no phantom success).
+      expect(localRouter.getState()?.name).toBe("home");
+      expect(localRouter.isActive()).toBe(true);
+
+      removeInterceptor();
+      localRouter.stop();
+    });
+  });
 });

--- a/packages/ssr-data-plugin/CLAUDE.md
+++ b/packages/ssr-data-plugin/CLAUDE.md
@@ -334,6 +334,8 @@ In practice this only matters for in-memory hydration paths — JSON-roundtrip s
 
 If a loader throws, the error propagates through the `start()` promise. The caller's `try/catch` handles it — same as any async guard failure.
 
+On the `start()` path the loader runs **after** `await next(path)` committed the state and emitted `TRANSITION_SUCCESS`. When that loader rejects, core does **not** roll the start back (#763): the committed state stands and `router.isActive()` stays `true` — only the `start()` promise rejects. On SSR the per-request router is discarded so this is moot; on the client the router stays consistent with the success subscribers already observed. (The CSR `invalidate(...)` path runs the loader in the awaited LEAVE_APPROVE phase, *before* `TRANSITION_SUCCESS`, so a rejection there fails the `navigate()` before any commit.)
+
 ## Composition with `rsc-server-plugin`
 
 `@real-router/ssr-data-plugin` and `@real-router/rsc-server-plugin` follow the **same factory pattern** (claim-based namespace + `start()` interceptor) and are designed to run **side-by-side** on the same router. Their namespaces are distinct:

--- a/packages/ssr-data-plugin/tests/functional/data-loader.test.ts
+++ b/packages/ssr-data-plugin/tests/functional/data-loader.test.ts
@@ -720,10 +720,11 @@ describe("@real-router/ssr-data-plugin", () => {
       );
 
       expect(loader).not.toHaveBeenCalled();
-      // `?.` is intentional here: a rejected `start()` leaves the FSM in a
-      // pre-init state, so `getState()` returns `undefined`. The assertion
-      // remains meaningful — "no state at all" passes "data is undefined"
-      // just like "state with data: undefined" would.
+      // `resolveMode` throws AFTER `next()` committed, so post-#763 the
+      // router stays started and `getState()` returns the committed state
+      // (no rollback — the observed success is not retracted). The loader
+      // never ran and `modeClaim.write` never reached, so both context
+      // fields stay undefined; the `?.` is now defensive, not load-bearing.
       expect(router.getState()?.context.data).toBeUndefined();
       expect(router.getState()?.context.ssrDataMode).toBeUndefined();
     });


### PR DESCRIPTION
## Summary

- A `start` interceptor that throws **after** `next(path)` committed the state — the window where the SSR/RSC loader plugins run their loader — no longer rolls the router back to IDLE. Subscribers had already observed `TRANSITION_SUCCESS`, so the rollback produced a **phantom success**: the event fired, then `getState()` went back to `undefined`.
- `Router.start()`'s `.catch` now distinguishes failure shapes by whether a state was committed (`this.#state.get()`): a **post-commit** interceptor rejection keeps the router started and surfaces the loader error only through the rejected `start()` promise; **pre-commit** failures (route not found, blocked activation guard, sync throw before `next()`) still unwind to IDLE (two-phase start).
- The "Loader errors propagate" contract is preserved — plugins still must not swallow the error; core owns the state-consistency half by keeping the commit.

## Breaking changes

After a **post-commit** start-interceptor failure the router is now **started** (was: rolled back to un-started).

```js
import { getPluginApi } from "@real-router/core/api";

// A start interceptor that fails after the commit (models an SSR/RSC loader throwing)
getPluginApi(router).addInterceptor("start", async (next, path) => {
  const state = await next(path); // commits + emits TRANSITION_SUCCESS("home")
  throw new Error("loader failed after commit");
});

// Before #763
await router.start("/home").catch(() => {});
router.isActive();        // false       ← phantom success: subscribers saw success first
router.getState();        // undefined

// After #763
await router.start("/home").catch(() => {});
router.isActive();        // true        ← committed state stands, observed success not retracted
router.getState()?.name;  // "home"
```

A retry after a post-commit failure must `stop()` first — a second `start()` rejects with `ROUTER_ALREADY_STARTED`.

## Test plan

- [x] `pnpm build` passes (type-check → lint → test → bundle, 291/291 tasks)
- [x] 100% test coverage maintained (core: 2284 tests, 990/990 branches)
- [x] New functional test — `routerLifecycle/start/error-handling.test.ts › #763: post-commit start-interceptor failure keeps observed success`
- [x] SSR loader plugins green, no regression (ssr-data 204, rsc-server 144)
- [x] Pre-commit/pre-existing guards unchanged: two-phase start (guard block) + #668 stuck-STARTING recovery still pass

Closes #763
