### PR TITLE
fix(memory-plugin): same-tick navigate-after-back() (#807) + short-circuit no-emission contract (#808)

### DIFF
--- a/.changeset/memory-sync-back-navigate-807-fix.md
+++ b/.changeset/memory-sync-back-navigate-807-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/memory-plugin": patch
+---
+
+Fix a synchronous `navigate()` fired in the same tick as `back()` / `forward()` / `go()` corrupting the in-memory history stack ([#807](https://github.com/greydragon888/real-router/issues/807))
+
+`back()` / `forward()` / `go()` set an internal `navigatingFromHistory` flag and reset it only in a `.then` microtask, but core commits the history-restore navigation **synchronously**. A `navigate()` issued in the same tick therefore observed the stale flag and was swallowed as a phantom history-restore: the new route was never pushed, `state.context.memory` kept the back/forward `direction` and the old `historyIndex`, and a phantom forward leg survived (`canGoForward()` stayed `true`, `forward()` jumped to a route that no longer matched the router state).
+
+The flag is now consumed when the restore commit is observed (`onTransitionSuccess`), not in the later microtask, so a same-tick `navigate()` is recorded as a normal push. The fire-and-forget contract and `back()`/`forward()`/`go()` semantics are unchanged; the generation guard still reverts the optimistic index on a guard-blocked or superseded history navigation.

--- a/packages/memory-plugin/ARCHITECTURE.md
+++ b/packages/memory-plugin/ARCHITECTURE.md
@@ -31,12 +31,13 @@ graph LR
 
     subgraph plugin [Plugin Instance]
         OTS["onTransitionSuccess"] --> PUSH[push / replace entry]
+        OTS --> CONSUME["consume #navigatingFromHistory on commit (history replay)"]
         OS["onStop"] --> CLEAR[clear entries]
         TD["teardown"] --> RM[removeExtensions + clear]
         GO["#go(delta)"] --> IDXSYNC["#index = targetIndex (optimistic)"]
         IDXSYNC --> NAV["router.navigate()"]
-        NAV --> CATCH[".catch() → revert #index if generation matches"]
-        NAV --> FIN[".finally() → reset flag if generation matches"]
+        NAV -->|commit| OTS
+        NAV --> CATCH[".catch() → revert #index + reset flag if generation matches"]
     end
 ```
 
@@ -55,7 +56,8 @@ Forward navigation: navigate("users", { id: "1" })
     onTransitionSuccess(toState, fromState, opts)
     │
     ├── #navigatingFromHistory === true?
-    │   └── YES → return (skip recording — this is a back/forward replay)
+    │   └── YES → #navigatingFromHistory = false (consume on commit),
+    │             rewrite context, return (skip recording — back/forward replay)
     │
     ├── opts.replace === true AND #index >= 0?
     │   └── YES → #entries[#index] = entry  (overwrite current)
@@ -89,11 +91,12 @@ back() / forward() / go(delta)
         ├── #index = targetIndex  (optimistic sync update)
         │
         └── router.navigate(entry.name, entry.params, { replace: true })
-            ├── .catch()   → if (generation === #goGeneration) #index = previousIndex
-            └── .finally() → if (generation === #goGeneration) #navigatingFromHistory = false
+            ├── SUCCESS → onTransitionSuccess consumes #navigatingFromHistory on commit
+            └── .catch()  → if (generation === #goGeneration)
+                               #index = previousIndex; #navigatingFromHistory = false
 ```
 
-The `navigatingFromHistory` flag prevents `onTransitionSuccess` from recording the replayed navigation as a new history entry. The `#goGeneration` guard ensures that only the latest in-flight `#go` call can revert the index or clear the flag — older superseded calls no-op on settle.
+The `navigatingFromHistory` flag prevents `onTransitionSuccess` from recording the replayed navigation as a new history entry. It is consumed the moment the restore commit is observed inside `onTransitionSuccess` — **not** in a later microtask — so a `navigate()` issued in the same tick as `back()`/`forward()`/`go()` is still recorded as a fresh push ([#807](https://github.com/greydragon888/real-router/issues/807)). A guard-blocked or rejected replay never reaches `onTransitionSuccess`, so the `.catch()` handler clears the flag and reverts the optimistic index instead; the `#goGeneration` guard ensures only the latest in-flight `#go` call can do so — older superseded calls no-op on settle.
 
 ## Data Flow
 
@@ -124,9 +127,9 @@ router.back()
     │
     router.navigate(entry.name, entry.params, { replace: true })
     │
-    ├── SUCCESS → .finally() → if (generation === #goGeneration) #navigatingFromHistory = false
-    └── BLOCKED → .catch()   → if (generation === #goGeneration) #index = previousIndex
-                  .finally() → if (generation === #goGeneration) #navigatingFromHistory = false
+    ├── SUCCESS → onTransitionSuccess → #navigatingFromHistory = false (consume on commit)
+    └── BLOCKED → .catch() → if (generation === #goGeneration)
+                                #index = previousIndex; #navigatingFromHistory = false
 ```
 
 ### Guard blocks back navigation
@@ -141,8 +144,8 @@ router.back()
     │
     CANNOT_ACTIVATE (guard returns false)
     │
-    .catch()   → #index = previousIndex (revert)
-    .finally() → #navigatingFromHistory = false
+    .catch() → #index = previousIndex (revert), #navigatingFromHistory = false
+    (onTransitionSuccess never fired, so the flag is cleared here)
 
 canGoBack() reflects the reverted position
 ```

--- a/packages/memory-plugin/src/plugin.ts
+++ b/packages/memory-plugin/src/plugin.ts
@@ -66,6 +66,13 @@ export class MemoryPlugin {
         opts: NavigationOptions,
       ) => {
         if (this.#navigatingFromHistory) {
+          // Consume the flag on observing the commit, not in a later microtask.
+          // Core commits navigateToState synchronously (optimistic-sync), so a
+          // navigate() fired in the SAME tick as back()/forward()/go() would
+          // otherwise still see the flag set — the .then reset is a microtask
+          // that has not run yet — and be swallowed as a phantom history-restore
+          // (no push, stale direction/historyIndex, orphan forward leg) (#807).
+          this.#navigatingFromHistory = false;
           this.#writeMemoryContext(toState, this.#pendingDirection);
 
           return;
@@ -157,19 +164,19 @@ export class MemoryPlugin {
     // forwardState + buildPath re-resolution and their interceptors; route
     // mutations between record and replay do not retroactively change what
     // back/forward commits (#561).
-    void this.#api.navigateToState(entry, { replace: true }).then(
-      () => {
-        if (this.#goGeneration === generation) {
-          this.#navigatingFromHistory = false;
-        }
-      },
-      () => {
-        if (this.#goGeneration === generation) {
-          this.#index = previousIndex;
-          this.#navigatingFromHistory = false;
-        }
-      },
-    );
+    void this.#api.navigateToState(entry, { replace: true }).catch(() => {
+      // Reject only: guard block, ROUTE_NOT_FOUND, or cancellation by a newer
+      // navigation. onTransitionSuccess never fired, so the flag was not
+      // consumed there — revert the optimistic index and clear the flag here. A
+      // successful navigateToState always emits onTransitionSuccess (which now
+      // resets the flag), so no resolve handler is needed. The generation guard
+      // skips a superseded #go whose optimistic target a newer #go has already
+      // overtaken — it must not revert the newer call's index or flag (#505).
+      if (this.#goGeneration === generation) {
+        this.#index = previousIndex;
+        this.#navigatingFromHistory = false;
+      }
+    });
   }
 
   #clear(): void {

--- a/packages/memory-plugin/src/plugin.ts
+++ b/packages/memory-plugin/src/plugin.ts
@@ -164,7 +164,7 @@ export class MemoryPlugin {
     // forwardState + buildPath re-resolution and their interceptors; route
     // mutations between record and replay do not retroactively change what
     // back/forward commits (#561).
-    void this.#api.navigateToState(entry, { replace: true }).catch(() => {
+    this.#api.navigateToState(entry, { replace: true }).catch(() => {
       // Reject only: guard block, ROUTE_NOT_FOUND, or cancellation by a newer
       // navigation. onTransitionSuccess never fired, so the flag was not
       // consumed there — revert the optimistic index and clear the flag here. A

--- a/packages/memory-plugin/tests/functional/plugin.test.ts
+++ b/packages/memory-plugin/tests/functional/plugin.test.ts
@@ -536,6 +536,41 @@ describe("Memory plugin", () => {
       expect(router.getState()?.name).toBe("users");
     });
 
+    it("should record a synchronous navigate() fired in the same tick as back() as a fresh push (#807)", async () => {
+      router.usePlugin(memoryPluginFactory());
+      await router.start("/");
+
+      await router.navigate("users");
+      await router.navigate("settings");
+
+      // History: [home, users, settings], index=2.
+      // back() commits synchronously (optimistic-sync) and only resets the
+      // #navigatingFromHistory flag in a later microtask. A navigate() fired
+      // in the SAME tick must still be recorded as a fresh push — it must not
+      // be swallowed by the stale history-restore flag.
+      router.back(); // → users (index 1), flag set true
+      await router.navigate("user", { id: "1" }); // same tick: must push, not restore
+
+      // The push landed and truncated the forward leg: history is
+      // [home, users, user] at index 2, recorded as a normal "navigate".
+      expect(router.getState()?.name).toBe("user");
+      expect(router.getState()?.context.memory).toStrictEqual({
+        direction: "navigate",
+        historyIndex: 2,
+      });
+      // No phantom forward entry left over from the cancelled back().
+      expect(router.canGoForward()).toBe(false);
+      expect(router.canGoBack()).toBe(true);
+
+      // Entry ↔ state consistency: back() from the recorded push lands on
+      // "users" (the truncated forward "settings" is gone).
+      await waitForHistoryNavigation(router, () => {
+        router.back();
+      });
+
+      expect(router.getState()?.name).toBe("users");
+    });
+
     it("should handle replace as first navigation after start", async () => {
       router.usePlugin(memoryPluginFactory());
       await router.start("/");

--- a/packages/memory-plugin/tests/functional/plugin.test.ts
+++ b/packages/memory-plugin/tests/functional/plugin.test.ts
@@ -430,6 +430,56 @@ describe("Memory plugin", () => {
     expect(stateBefore.context.memory?.historyIndex).toBe(1);
   });
 
+  it("does not emit a transition on a same-path short-circuit back() — subscribers are not notified, only context.memory is rewritten (#808)", async () => {
+    router.usePlugin(memoryPluginFactory());
+    await router.start("/");
+
+    await router.navigate("users");
+    await router.navigate("home", {}, { replace: true });
+
+    // History: [home, home], index=1. Both entries have path "/".
+    const stateBefore = router.getState()!;
+
+    let notifications = 0;
+    const unsub = router.subscribe(() => {
+      notifications++;
+    });
+
+    router.back(); // short-circuit: index 1 → 0, no navigateToState, no emission
+
+    // A short-circuit move is metadata-only (the visible route is unchanged), so
+    // it emits no transition: router.subscribe listeners — and adapters keyed on
+    // TRANSITION_SUCCESS — are NOT notified.
+    expect(notifications).toBe(0);
+    // ...but context.memory is still rewritten in place, so a synchronous read
+    // reflects the new direction/historyIndex (the real value of #508).
+    expect(router.getState()).toBe(stateBefore);
+    expect(stateBefore.context.memory).toStrictEqual({
+      direction: "back",
+      historyIndex: 0,
+    });
+
+    unsub();
+
+    // Discriminating control: a back() to a DIFFERENT path is a full transition
+    // and DOES notify exactly once.
+    await router.navigate("users"); // [home, users], index=1
+    await router.navigate("home"); //  [home, users, home], index=2
+
+    let fullNavNotifications = 0;
+    const unsubFull = router.subscribe(() => {
+      fullNavNotifications++;
+    });
+
+    router.back(); // → users (path "/users" ≠ "/") → full transition
+    await settle();
+
+    expect(fullNavNotifications).toBe(1);
+    expect(router.getState()?.name).toBe("users");
+
+    unsubFull();
+  });
+
   it("should navigate back normally when target entry has a different path", async () => {
     router.usePlugin(memoryPluginFactory());
     await router.start("/");

--- a/packages/memory-plugin/tests/stress/back-then-navigate-race.stress.ts
+++ b/packages/memory-plugin/tests/stress/back-then-navigate-race.stress.ts
@@ -39,6 +39,25 @@ describe("S11: back() in flight + immediate navigate() race", () => {
       expect(router.getState()?.name).toBe("profile");
       expect(router.canGoBack()).toBe(true);
 
+      // The push must be recorded as a fresh "navigate", NOT swallowed as a
+      // history-restore. Before the #807 fix the flag was still true when
+      // profile committed, so the entry was never pushed: direction stuck at
+      // "back", historyIndex stuck at 1, and a phantom forward leg ("settings")
+      // survived. These four assertions fail on the corrupt stack — name and
+      // canGoBack alone do not discriminate it.
+      expect(router.getState()?.context.memory).toStrictEqual({
+        direction: "navigate",
+        historyIndex: 2,
+      });
+      expect(router.canGoForward()).toBe(false);
+
+      // Entry ↔ router-state consistency: forward() from the freshly pushed
+      // profile must go nowhere (no phantom "settings" forward entry).
+      router.forward();
+      await settle();
+
+      expect(router.getState()?.name).toBe("profile");
+
       // Verify follow-up navigation also records normally (flag not stuck).
       await router.navigate("users");
 


### PR DESCRIPTION
## Summary

Two related `memory-plugin` history-stack fixes, as independent commits.

### #807 — a same-tick `navigate()` after `back()`/`forward()`/`go()` corrupted the stack
- A `navigate()` fired in the **same tick** as `back()`/`forward()`/`go()` — the cancel-and-redirect pattern, e.g. `router.back(); router.navigate("login")` — is now recorded as a fresh forward push instead of being silently swallowed. Previously the new route was never pushed: `state.context.memory` kept the back/forward `direction` and the stale `historyIndex`, and a phantom forward leg survived (`canGoForward()` stuck `true`, `forward()` jumping to a route that no longer matched the router state).
- **Root cause:** `#go()` set the internal `navigatingFromHistory` flag synchronously but reset it only in a later `.then` microtask, while core commits `navigateToState` **synchronously** (optimistic-sync). The flag is now consumed the moment the restore commit is observed in `onTransitionSuccess` — not in the microtask — closing the window. Fire-and-forget semantics, `back()`/`forward()`/`go()` behavior, and the `#goGeneration` guard are unchanged.

### #808 — short-circuit (same-path back/forward) emits no transition; docs overstated it
- A same-path short-circuit rewrites `state.context.memory` in place (so a **synchronous** `getState().context.memory` read reflects the move — the real value of #508) but emits **no `TRANSITION_SUCCESS`**: `router.subscribe` listeners and `TRANSITION_SUCCESS`-keyed adapters are not notified. The CLAUDE.md/#508 gotcha claimed the opposite ("subscribers receive the same signal").
- **Resolution = docs, not behavior.** Emitting on a same-path move would be a phantom event (the route genuinely does not change) with no clean plugin-layer implementation — it would mean breaking the `TRANSITION_SUCCESS = real transition` contract (the same class just reinforced in #763). The code behavior is correct; the docs were wrong. This PR **locks the real contract with a regression test**; the doc correction lands in the wiki (`memory-plugin.md`) + local `CLAUDE.md`.

### Maintainability
- Dropped a redundant `void` operator on the fire-and-forget `.catch()` (SonarCloud `S3735`): `@typescript-eslint/no-floating-promises` is disabled repo-wide and `.catch()` already handles the rejection, matching the existing `Router.ts` / `preload-plugin` convention. Behavior unchanged.

## Test plan

- [x] **#807** — new functional test (same-tick push) fails before / passes after; strengthened stress **S11.1** asserts `direction` / `historyIndex` / `canGoForward()` / entry↔state consistency; async-stress regression (`generation-guard-async`, `concurrent-back-forward`) green
- [x] **#808** — new functional regression test: short-circuit `back()` emits **0** events, `context.memory` still rewritten, state identity preserved; different-path control emits exactly **1**
- [x] `pnpm build` passes (291/291 tasks)
- [x] 100% coverage maintained (memory-plugin: 49 functional, 25 stress, 21 property)

Closes #807
Closes #808