### PR TITLE
fix(browser-env): snapshot popstate location at fire time (#757) + test: lock factory-pool last-wins tracking (#758)

### DIFF
--- a/.changeset/popstate-deferred-location-757-browser-fix.md
+++ b/.changeset/popstate-deferred-location-757-browser-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix a deferred null-state popstate landing on the wrong route after a concurrent navigation (#757)
+
+When a back/forward event was deferred behind an in-flight async-guarded navigation and that event carried a `null`/invalid `history.state`, the popstate handler resolved its route via `matchPath(browser.getLocation())` at replay time — after the in-flight navigation's `onTransitionSuccess → replaceState` had already overwritten the live location. The router landed on the earlier target instead of the entry the user actually navigated to, and the visible URL desynced.
+
+The handler now snapshots the location the instant each popstate event fires and resolves the deferred event against that snapshot, so the last back/forward entry wins. The same snapshot also feeds the `navigateToNotFound` and strict-mode `ROUTE_NOT_FOUND` paths.

--- a/.changeset/popstate-deferred-location-757-hash-fix.md
+++ b/.changeset/popstate-deferred-location-757-hash-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Fix a deferred null-state popstate landing on the wrong route after a concurrent navigation (#757)
+
+When a back/forward event was deferred behind an in-flight async-guarded navigation and that event carried a `null`/invalid `history.state`, the shared popstate handler resolved its route via `matchPath(browser.getLocation())` at replay time — after the in-flight navigation's `onTransitionSuccess → replaceState` had already overwritten the live hash location. The router landed on the earlier target instead of the entry the user actually navigated to, and the visible URL desynced.
+
+The handler now snapshots the location the instant each popstate event fires and resolves the deferred event against that snapshot, so the last back/forward entry wins. The same snapshot also feeds the `navigateToNotFound` and strict-mode `ROUTE_NOT_FOUND` paths.

--- a/packages/browser-env/ARCHITECTURE.md
+++ b/packages/browser-env/ARCHITECTURE.md
@@ -46,11 +46,16 @@ interface Browser extends HistoryBrowser {
 
 `createPopstateHandler` + `createPopstateLifecycle` serialize popstate processing via a
 single-slot deferred-event queue. Only the **last** deferred event is kept — intermediate
-states are skipped. Critical errors (anything that isn't a `RouterError`) trigger a
-`replaceState` recovery that rolls the URL back to the router's current state.
+states are skipped. Each queued entry stores `{ evt, location }`: the route location is
+snapshotted the instant the event fires, because a deferred event is replayed only after
+the in-flight navigation's `onTransitionSuccess → replaceState` has already overwritten the
+live location — re-reading it at replay time would resolve the wrong target (#757). Critical
+errors (anything that isn't a `RouterError`) trigger a `replaceState` recovery that rolls
+the URL back to the router's current state.
 
-`getRouteFromEvent(evt, api, browser)` tries `isState(evt.state)` first; on failure it
-falls back to `api.matchPath(browser.getLocation())`. `updateBrowserState(state, url, replace, browser)`
+`getRouteFromEvent(evt, api, location)` tries `isState(evt.state)` first; on failure it
+falls back to `api.matchPath(location)`, where `location` is the snapshot the handler
+captured at event time. `updateBrowserState(state, url, replace, browser)`
 writes `{ name, params, path }` — nothing else — into `history.state`.
 
 ## Pure URL utilities

--- a/packages/browser-env/tests/property/browserEnv.properties.ts
+++ b/packages/browser-env/tests/property/browserEnv.properties.ts
@@ -338,7 +338,7 @@ describe("Browser-env Properties", () => {
         const api = createMockPluginApi(undefined);
         const browser = createSpyBrowser();
 
-        const result = getRouteFromEvent(evt, api, browser);
+        const result = getRouteFromEvent(evt, api, browser.getLocation());
 
         // Returns a State produced by api.makeState (#525). Source-of-truth
         // fields (name, params, path) come from history.state; the rest are
@@ -367,7 +367,7 @@ describe("Browser-env Properties", () => {
         const api = createMockPluginApi(matchResult);
         const browser = createSpyBrowser();
 
-        const result = getRouteFromEvent(evt, api, browser);
+        const result = getRouteFromEvent(evt, api, browser.getLocation());
 
         // matchPath's mock returns a full State; assert structural fields.
         expect(result).toMatchObject({ name, params, path: "/matched" });

--- a/packages/browser-env/tests/unit/popstate-handler.test.ts
+++ b/packages/browser-env/tests/unit/popstate-handler.test.ts
@@ -355,6 +355,61 @@ describe("popstate handler", () => {
         TRANSITION_OPTIONS,
       );
     });
+
+    it("resolves a deferred null-state event against the location captured at defer time, not the overwritten live location (#757)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      router.stop();
+      router = createRouter([
+        { name: "home", path: "/" },
+        { name: "users", path: "/users/:id" },
+      ]);
+      await router.start("/");
+
+      const deps = makeDeps({ allowNotFound: true });
+
+      // Mutable live location — mirrors how a real browser's getLocation()
+      // reflects the most recent history mutation.
+      let liveLocation = "/users/1";
+
+      deps.browser.getLocation = () => liveLocation;
+
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+
+      deps.api.navigateToState
+        .mockImplementationOnce(async () => {
+          await gate;
+
+          return router.getState()!;
+        })
+        .mockResolvedValue(router.getState()!);
+
+      const handler = createPopstateHandler(deps);
+
+      // Event #1: null state @ /users/1 → in-flight nav (gated).
+      handler(makePopStateEvent(null));
+      // Event #2: null state @ /users/2 arrives mid-transition → deferred.
+      liveLocation = "/users/2";
+      handler(makePopStateEvent(null));
+
+      // The in-flight nav's onTransitionSuccess → replaceState overwrites the
+      // live location back to /users/1 before the deferred event is processed.
+      liveLocation = "/users/1";
+      releaseFirst();
+      await flushAsync();
+
+      // The deferred event was captured @ /users/2 — it must resolve there,
+      // not against the overwritten /users/1 the completed nav left behind.
+      expect(deps.api.navigateToState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ name: "users", params: { id: "2" } }),
+        TRANSITION_OPTIONS,
+      );
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe("createPopstateLifecycle", () => {

--- a/packages/browser-env/tests/unit/popstate-utils.test.ts
+++ b/packages/browser-env/tests/unit/popstate-utils.test.ts
@@ -39,15 +39,15 @@ describe("getRouteFromEvent", () => {
       path: "/users",
     });
 
-    const matched = getRouteFromEvent(evt, api, makeFakeBrowser());
+    const matched = getRouteFromEvent(evt, api, "/");
 
     expect(matched).toMatchObject({ name: "users", path: "/users" });
   });
 
-  it("falls back to api.matchPath(getLocation) when history.state is not a router state", () => {
+  it("falls back to api.matchPath(location) when history.state is not a router state", () => {
     const evt = makePopStateEvent(null);
 
-    const matched = getRouteFromEvent(evt, api, makeFakeBrowser("/users"));
+    const matched = getRouteFromEvent(evt, api, "/users");
 
     expect(matched).toMatchObject({ name: "users" });
   });
@@ -55,9 +55,7 @@ describe("getRouteFromEvent", () => {
   it("returns undefined when neither history.state nor the location match", () => {
     const evt = makePopStateEvent(undefined);
 
-    expect(getRouteFromEvent(evt, api, makeFakeBrowser("/nope"))).toBe(
-      undefined,
-    );
+    expect(getRouteFromEvent(evt, api, "/nope")).toBe(undefined);
   });
 });
 

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -275,6 +275,8 @@ Each new plugin instance registers its own popstate listener in `onStart`. Witho
 
 `shared` is intentionally mutable. It's the only shared state between instances of the same factory.
 
+**Factory pool — last-wins (concurrent-live caveat, #758).** Because the single `removePopStateListener` slot is shared, each `onStart` removes the previous instance's listener before installing its own. The pattern is built for a pool where routers are created/destroyed **sequentially** (one live router at a time). If two routers from the same factory are live **at the same time** on one window, only the **last-started** one tracks `popstate` — the earlier one silently desyncs from the URL. There is a single `popstate` stream and a single URL, so this mutual exclusivity is inherent (who owns the URL with two live routers?). For genuinely concurrent routers, give each its own factory instance. Locked by `tests/stress/factory-instance-cleanup.stress.ts` (B7.5).
+
 ## Data Flow: Navigation
 
 ```

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -311,23 +311,25 @@ User clicks back or forward
         ▼
   browser.addPopstateListener → handler(evt)  (from createPopstateHandler)
         │
+        ├── location = browser.getLocation()   (snapshot at fire time, #757)
+        │
         ├── isTransitioning === true?
-        │     YES: deferredPopstateEvent = evt  (last-write-wins)
+        │     YES: deferred = { evt, location }  (last-write-wins)
         │          return
         │
         ├── isTransitioning = true
         │
-        ├── getRouteFromEvent(evt, api, browser)
+        ├── getRouteFromEvent(evt, api, location)
         │     │
         │     ├── isState(evt.state)?
         │     │     YES: { name: evt.state.name, params: evt.state.params }
         │     │
-        │     └── NO: api.matchPath(browser.getLocation())
+        │     └── NO: api.matchPath(location)
         │               └── URL matching as fallback
         │
         ├── route found?
         │     YES: await router.navigate(route.name, route.params, transitionOptions)
-        │     NO + allowNotFound: router.navigateToNotFound(browser.getLocation())
+        │     NO + allowNotFound: router.navigateToNotFound(location)
         │     NO + !allowNotFound: api.emitTransitionError(ROUTE_NOT_FOUND) + rollbackUrlToCurrentState()
         │                          (no silent navigateToDefault — see #483)
         │
@@ -346,8 +348,9 @@ User clicks back or forward
 Rapid back/forward clicks generate multiple popstate events in quick succession. Processing each one is pointless — only the final state matters.
 
 The `isTransitioning` flag blocks concurrent processing.
-New events are written to `deferredPopstateEvent` — each one overwrites the previous (last-write-wins).
-After the current transition completes, `processDeferredEvent()` processes the last deferred event.
+New events are written to the single-slot `deferred = { evt, location }` queue — each one overwrites the previous (last-write-wins).
+The `location` is snapshotted when the event fires, not when it is replayed: the in-flight navigation's `onTransitionSuccess → replaceState` overwrites the live location before `processDeferredEvent()` runs, so re-reading it then would resolve the wrong target (#757).
+After the current transition completes, `processDeferredEvent()` processes the last deferred event against its snapshotted location.
 
 ```
 Click 1 → onPopState → isTransitioning=true → navigate("page1")...

--- a/packages/browser-plugin/tests/functional/popstate.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate.test.ts
@@ -360,6 +360,53 @@ describe("Browser Plugin — Popstate", () => {
         name: "users.list",
       });
     });
+
+    it("resolves a deferred null-state event against the URL captured at defer time, not the in-flight nav's overwritten location (#757)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+
+      // Gate the in-flight nav (users.view) until we release it; the deferred
+      // target (users.list) is unguarded, so it settles in a single tick.
+      let releaseGuard!: () => void;
+      const guardGate = new Promise<boolean>((resolve) => {
+        releaseGuard = () => {
+          resolve(true);
+        };
+      });
+
+      getLifecycleApi(router).addActivateGuard(
+        "users.view",
+        () => () => guardGate,
+      );
+
+      // Event #1: typed-URL back entry (null history.state) to /users/view/1.
+      // Resolves via the matchPath fallback; nav goes in flight behind guard.
+      globalThis.history.replaceState({}, "", "/users/view/1");
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+
+      // Event #2: another null-state entry to /users/list arrives mid-
+      // transition → deferred. The browser now sits at /users/list.
+      globalThis.history.replaceState({}, "", "/users/list");
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+
+      // The second event must have been deferred behind the in-flight nav.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Transition in progress"),
+      );
+
+      // Release the in-flight nav. Its onTransitionSuccess → replaceState
+      // rewrites location back to /users/view/1 BEFORE the deferred event is
+      // processed — the exact overwrite that desynced the fallback.
+      releaseGuard();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // The deferred event targeted /users/list — it must win, not the
+      // /users/view/1 the completed in-flight nav left in location.
+      expect(router.getState()?.name).toBe("users.list");
+      expect(mockedBrowser.getLocation()).toBe("/users/list");
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe("Error Recovery", () => {

--- a/packages/browser-plugin/tests/stress/factory-instance-cleanup.stress.ts
+++ b/packages/browser-plugin/tests/stress/factory-instance-cleanup.stress.ts
@@ -11,7 +11,12 @@ import {
 
 import { browserPluginFactory } from "@real-router/browser-plugin";
 
-import { noop, routeConfig, expectedStressError } from "./helpers";
+import {
+  noop,
+  routeConfig,
+  expectedStressError,
+  waitForTransitions,
+} from "./helpers";
 import { createSafeBrowser } from "../../src/browser-env";
 
 import type { Browser } from "../../src/browser-env";
@@ -109,5 +114,92 @@ describe("B7.4 — factory pool: 100 routers, all disposed", () => {
       addSpy.mockRestore();
       removeSpy.mockRestore();
     }
+  });
+});
+
+/**
+ * B7.5 — Factory pool: concurrently-live routers (last-wins popstate)
+ *
+ * `SharedFactoryState` is allocated once per `browserPluginFactory(...)` call
+ * and shared across every router that consumes that factory. Each `onStart`
+ * removes the previous instance's popstate listener before installing its own
+ * — so when two routers from the same factory are live **at the same time**,
+ * only the LAST-started one tracks `popstate`; the earlier one silently
+ * desyncs from the URL.
+ *
+ * This is documented design (the factory-pool pattern assumes routers are
+ * created/destroyed sequentially). B7.4 above only asserts net-zero listeners
+ * — it never checks *which* router a popstate reaches. This test locks the
+ * last-wins contract so a regression where the expected (last) router stops
+ * tracking would be caught (#758).
+ */
+describe("B7.5 — factory pool: only the last concurrently-live router tracks popstate", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "warn").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+  });
+
+  beforeEach(() => {
+    globalThis.history.replaceState({}, "", "/");
+  });
+
+  afterAll(() => {
+    (console.warn as unknown as { mockRestore?: () => void }).mockRestore?.();
+    (console.error as unknown as { mockRestore?: () => void }).mockRestore?.();
+  });
+
+  it("routes a popstate to the last-started router; the earlier one does not react", async () => {
+    const safeBrowser = createSafeBrowser(
+      () => globalThis.location.pathname + globalThis.location.search,
+      "browser-plugin-pool",
+    );
+    const browser: Browser = {
+      ...safeBrowser,
+      pushState: (state: unknown, url: string) => {
+        safeBrowser.pushState(state, url);
+      },
+      replaceState: (state: unknown, url: string) => {
+        safeBrowser.replaceState(state, url);
+      },
+    };
+
+    const factory = browserPluginFactory({}, browser);
+
+    const r1 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const r2 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const unsub1 = r1.usePlugin(factory);
+    const unsub2 = r2.usePlugin(factory);
+
+    await r1.start();
+    // r2.start() removes r1's popstate listener and installs its own (last-wins).
+    await r2.start();
+
+    // Browser sits on a back/forward entry for /users/view/5.
+    const entry = {
+      name: "users.view",
+      params: { id: "5" },
+      path: "/users/view/5",
+    };
+
+    globalThis.history.replaceState(entry, "", "/users/view/5");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: entry }));
+
+    await waitForTransitions();
+
+    // Only the last-started router reacts; the earlier one silently desyncs.
+    expect(r2.getState()?.name).toBe("users.view");
+    expect(r2.getState()?.params).toMatchObject({ id: "5" });
+    expect(r1.getState()?.name).toBe("index");
+
+    unsub1();
+    r1.stop();
+    unsub2();
+    r2.stop();
   });
 });

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -284,6 +284,8 @@ Each new plugin instance registers its own popstate listener in `onStart`. Witho
 
 `shared` is intentionally mutable. It's the only shared state between instances of the same factory.
 
+**Factory pool — last-wins (concurrent-live caveat, #758).** Because the single `removePopStateListener` slot is shared, each `onStart` removes the previous instance's listener before installing its own. The pattern is built for a pool where routers are created/destroyed **sequentially** (one live router at a time). If two routers from the same factory are live **at the same time** on one window, only the **last-started** one tracks `popstate` — the earlier one silently desyncs from the URL. There is a single `popstate` stream and a single URL, so this mutual exclusivity is inherent. For genuinely concurrent routers, give each its own factory instance. Locked by `tests/stress/plugin-lifecycle-churn.stress.ts`.
+
 ## Data Flow: Navigation
 
 ```

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -319,23 +319,25 @@ User clicks back or forward
         ▼
   browser.addPopstateListener → handler(evt)  (from createPopstateHandler)
         │
+        ├── location = browser.getLocation()   (snapshot at fire time, #757)
+        │
         ├── isTransitioning === true?
-        │     YES: deferredPopstateEvent = evt  (last-write-wins)
+        │     YES: deferred = { evt, location }  (last-write-wins)
         │          return
         │
         ├── isTransitioning = true
         │
-        ├── getRouteFromEvent(evt, api, browser)
+        ├── getRouteFromEvent(evt, api, location)
         │     │
         │     ├── isState(evt.state)?
         │     │     YES: { name: evt.state.name, params: evt.state.params }
         │     │
-        │     └── NO: api.matchPath(browser.getLocation())
+        │     └── NO: api.matchPath(location)
         │               └── Hash URL matching as fallback
         │
         ├── route found?
         │     YES: await router.navigate(route.name, route.params, transitionOptions)
-        │     NO + allowNotFound: router.navigateToNotFound(browser.getLocation())
+        │     NO + allowNotFound: router.navigateToNotFound(location)
         │     NO + !allowNotFound: api.emitTransitionError(ROUTE_NOT_FOUND) + rollbackUrlToCurrentState()
         │                          (no silent navigateToDefault — see #483)
         │
@@ -354,8 +356,9 @@ User clicks back or forward
 Rapid back/forward clicks generate multiple popstate events in quick succession. Processing each one is pointless — only the final state matters.
 
 The `isTransitioning` flag blocks concurrent processing.
-New events are written to `deferredPopstateEvent` — each one overwrites the previous (last-write-wins).
-After the current transition completes, `processDeferredEvent()` processes the last deferred event.
+New events are written to the single-slot `deferred = { evt, location }` queue — each one overwrites the previous (last-write-wins).
+The `location` is snapshotted when the event fires, not when it is replayed: the in-flight navigation's `onTransitionSuccess → replaceState` overwrites the live hash location before `processDeferredEvent()` runs, so re-reading it then would resolve the wrong target (#757).
+After the current transition completes, `processDeferredEvent()` processes the last deferred event against its snapshotted location.
 
 See [browser-env/ARCHITECTURE.md](../browser-env/ARCHITECTURE.md) for implementation details.
 

--- a/packages/hash-plugin/tests/functional/popstate.test.ts
+++ b/packages/hash-plugin/tests/functional/popstate.test.ts
@@ -326,6 +326,53 @@ describe("Hash Plugin — Popstate & Error Recovery", async () => {
       // Last deferred event (state3 = users.list) must be the final transition.
       expect(names.at(-1)).toBe("users.list");
     });
+
+    it("resolves a deferred null-state event against the hash captured at defer time, not the in-flight nav's overwritten location (#757)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
+
+      // Gate the in-flight nav (users.view) until we release it; the deferred
+      // target (users.list) is unguarded, so it settles in a single tick.
+      let releaseGuard!: () => void;
+      const guardGate = new Promise<boolean>((resolve) => {
+        releaseGuard = () => {
+          resolve(true);
+        };
+      });
+
+      getLifecycleApi(router).addActivateGuard(
+        "users.view",
+        () => () => guardGate,
+      );
+
+      // Event #1: typed-URL back entry (null history.state) to #/users/view/1.
+      // Resolves via the matchPath fallback; nav goes in flight behind guard.
+      globalThis.history.replaceState({}, "", "/#/users/view/1");
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+
+      // Event #2: another null-state entry to #/users/list arrives mid-
+      // transition → deferred. The browser hash now reads /users/list.
+      globalThis.history.replaceState({}, "", "/#/users/list");
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+
+      // The second event must have been deferred behind the in-flight nav.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Transition in progress"),
+      );
+
+      // Release the in-flight nav. Its onTransitionSuccess → replaceState
+      // rewrites the hash back to /users/view/1 BEFORE the deferred event is
+      // processed — the exact overwrite that desynced the fallback.
+      releaseGuard();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // The deferred event targeted /users/list — it must win, not the
+      // /users/view/1 the completed in-flight nav left in the hash.
+      expect(router.getState()?.name).toBe("users.list");
+      expect(mockedBrowser.getLocation()).toBe("/users/list");
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe("Error Recovery", () => {

--- a/packages/hash-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
+++ b/packages/hash-plugin/tests/stress/plugin-lifecycle-churn.stress.ts
@@ -19,7 +19,11 @@ import {
   routeConfig,
 } from "./helpers";
 import { createSafeBrowser, safelyEncodePath } from "../../src/browser-env";
-import { createHashPrefixRegex, extractHashPath } from "../../src/hash-utils";
+import {
+  buildHashLocation,
+  createHashPrefixRegex,
+  extractHashPath,
+} from "../../src/hash-utils";
 
 import type { Router } from "@real-router/core";
 
@@ -158,5 +162,94 @@ describe("Hash Plugin Lifecycle Churn", () => {
 
     router.stop();
     unsubscribe();
+  });
+});
+
+/**
+ * Factory pool: concurrently-live routers (last-wins popstate) — #758.
+ *
+ * `SharedFactoryState` is allocated once per `hashPluginFactory(...)` call and
+ * shared across every router that consumes that factory. Each `onStart` removes
+ * the previous instance's popstate listener before installing its own, so when
+ * two routers from the same factory are live at the same time only the
+ * LAST-started one tracks `popstate`; the earlier one silently desyncs.
+ *
+ * This is documented design (the pool pattern assumes sequential router
+ * lifetimes). The leak tests above assert net-zero listeners but never check
+ * which router a popstate reaches — this locks the last-wins contract.
+ */
+describe("Hash factory pool: only the last concurrently-live router tracks popstate", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "warn").mockImplementation(noop);
+    vi.spyOn(console, "error").mockImplementation(noop);
+  });
+
+  beforeEach(() => {
+    globalThis.history.replaceState({}, "", "/");
+  });
+
+  afterAll(() => {
+    (console.warn as unknown as { mockRestore?: () => void }).mockRestore?.();
+    (console.error as unknown as { mockRestore?: () => void }).mockRestore?.();
+  });
+
+  it("routes a popstate to the last-started router; the earlier one does not react", async () => {
+    const prefixRegex = createHashPrefixRegex("");
+    const safeBrowser = createSafeBrowser(
+      () =>
+        buildHashLocation(
+          globalThis.location.hash,
+          globalThis.location.search,
+          prefixRegex,
+        ),
+      "hash-plugin-pool",
+    );
+    const browser = {
+      ...safeBrowser,
+      pushState: (state: unknown, url: string) => {
+        safeBrowser.pushState(state, url);
+      },
+      replaceState: (state: unknown, url: string) => {
+        safeBrowser.replaceState(state, url);
+      },
+    };
+
+    const factory = hashPluginFactory({}, browser);
+
+    const r1 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const r2 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const unsub1 = r1.usePlugin(factory);
+    const unsub2 = r2.usePlugin(factory);
+
+    await r1.start();
+    // r2.start() removes r1's popstate listener and installs its own (last-wins).
+    await r2.start();
+
+    const r1Before = r1.getState()?.name;
+
+    globalThis.history.replaceState({}, "", "/#/users/view/5");
+    globalThis.dispatchEvent(
+      new PopStateEvent("popstate", {
+        state: makePopstateState("users.view", { id: "5" }, "/users/view/5"),
+      }),
+    );
+
+    await waitForTransitions();
+
+    // Only the last-started router reacts; the earlier one silently desyncs.
+    expect(r2.getState()?.name).toBe("users.view");
+    expect(r2.getState()?.params).toMatchObject({ id: "5" });
+    expect(r1.getState()?.name).toBe(r1Before);
+
+    unsub1();
+    r1.stop();
+    unsub2();
+    r2.stop();
   });
 });

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -563,6 +563,8 @@ The factory may be called again — for example, during HMR or when reusing the 
 
 `shared` is intentionally mutable. It's the only shared state between instances of the same factory.
 
+**Factory pool — last-wins (concurrent-live caveat, #758).** Because the single `removeNavigateListener` slot is shared — and there is a single global `window.navigation` — each `onStart` removes the previous instance's navigate listener before installing its own. The pattern is built for a pool where routers are created/destroyed **sequentially** (one live router at a time). If two routers from the same factory are live **at the same time**, only the **last-started** one receives `navigate` events; the earlier one silently desyncs. This mutual exclusivity is inherent to the single global Navigation API. For genuinely concurrent routers, give each its own factory instance. Locked by `tests/stress/listener-leak.stress.ts` (N12.3).
+
 ## Plugin-event detection (PLUGIN_SYNC_INFO sentinel, #518 + #580)
 
 `navigation.navigate({ history: "replace" })` fires a navigate event — unlike `history.replaceState()` which does not fire popstate. The plugin must mark its own events so the handler short-circuits them, otherwise the event loops back through `router.navigate()`.

--- a/packages/navigation-plugin/src/types.ts
+++ b/packages/navigation-plugin/src/types.ts
@@ -45,7 +45,17 @@ export interface NavigationBrowser {
 
 /**
  * Shared mutable state across plugin instances created by the same factory.
- * Enables cleanup of a previous instance's navigate listener when the factory is reused.
+ * Enables cleanup of a previous instance's navigate listener when the factory
+ * is reused.
+ *
+ * Factory-pool caveat — last-wins (#758): because this slot is shared — and
+ * there is a single global `window.navigation` — each `onStart` removes the
+ * previous instance's navigate listener before installing its own. The pattern
+ * is built for a pool where routers are created/destroyed **sequentially**. If
+ * two routers from the same factory are live **at the same time**, only the
+ * LAST-started one receives `navigate` events; the earlier one silently
+ * desyncs. For multiple concurrently-live routers, give each its own factory
+ * instance.
  */
 export interface NavigationSharedState {
   removeNavigateListener: (() => void) | undefined;

--- a/packages/navigation-plugin/tests/stress/listener-leak.stress.ts
+++ b/packages/navigation-plugin/tests/stress/listener-leak.stress.ts
@@ -1,6 +1,16 @@
+import { createRouter } from "@real-router/core";
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 
-import { createStressRouter, noop } from "./helpers";
+import { navigationPluginFactory } from "@real-router/navigation-plugin";
+
+import {
+  createStressRouter,
+  noop,
+  routeConfig,
+  waitForTransitions,
+} from "./helpers";
+import { MockNavigation } from "../helpers/mockNavigation";
+import { createMockNavigationBrowser } from "../helpers/testUtils";
 
 describe("N12: Listener leak detection", () => {
   beforeAll(() => {
@@ -57,5 +67,55 @@ describe("N12: Listener leak detection", () => {
     expect(addListenerSpy).toHaveBeenCalledTimes(100);
 
     unsubscribe();
+  });
+
+  /**
+   * N12.3 — Factory pool: concurrently-live routers (last-wins navigate) — #758.
+   *
+   * `NavigationSharedState` is allocated once per `navigationPluginFactory(...)`
+   * call and shared across every router that consumes that factory. Each
+   * `onStart` removes the previous instance's navigate listener before
+   * installing its own (a single global `window.navigation`), so when two
+   * routers from the same factory are live at the same time only the
+   * LAST-started one receives `navigate` events; the earlier one silently
+   * desyncs. This is documented design (invariant E4). N12.1/N12.2 assert
+   * net-zero listeners but never check which router an event reaches — this
+   * locks the last-wins contract.
+   */
+  it("N12.3: factory pool — only the last concurrently-live router receives navigate events", async () => {
+    const mockNav = new MockNavigation("http://localhost/");
+    const browser = createMockNavigationBrowser(mockNav);
+    const factory = navigationPluginFactory({}, browser);
+
+    const r1 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const r2 = createRouter(routeConfig, {
+      defaultRoute: "home",
+      allowNotFound: true,
+    });
+    const unsub1 = r1.usePlugin(factory);
+    const unsub2 = r2.usePlugin(factory);
+
+    await r1.start();
+    // r2.start() removes r1's navigate listener and installs its own (last-wins).
+    await r2.start();
+
+    const r1Before = r1.getState()?.name;
+
+    // A user-initiated navigate (untagged — not PLUGIN_SYNC_INFO).
+    mockNav.navigate("http://localhost/users/view/5");
+    await waitForTransitions();
+
+    // Only the last-started router reacts; the earlier one silently desyncs.
+    expect(r2.getState()?.name).toBe("users.view");
+    expect(r2.getState()?.params).toMatchObject({ id: "5" });
+    expect(r1.getState()?.name).toBe(r1Before);
+
+    unsub1();
+    r1.stop();
+    unsub2();
+    r2.stop();
   });
 });

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -77,17 +77,21 @@ export function createPopstateHandler(
   deps: PopstateHandlerDeps,
 ): (evt: PopStateEvent) => void {
   let isTransitioning = false;
-  let deferredEvent: PopStateEvent | null = null;
+  // Snapshot the route location alongside the event: a deferred popstate is
+  // replayed only after the in-flight navigation's onTransitionSuccess →
+  // replaceState has overwritten the live location, so re-reading it at
+  // replay time would resolve the wrong target (#757).
+  let deferred: { evt: PopStateEvent; location: string } | null = null;
 
   function processDeferredEvent(): void {
-    if (deferredEvent) {
-      const evt = deferredEvent;
+    if (deferred) {
+      const { evt, location } = deferred;
 
-      deferredEvent = null;
+      deferred = null;
       console.warn(
         `[${deps.loggerContext}] Processing deferred popstate event`,
       );
-      void onPopState(evt);
+      void onPopState(evt, location);
     }
   }
 
@@ -129,12 +133,15 @@ export function createPopstateHandler(
     }
   }
 
-  async function onPopState(evt: PopStateEvent): Promise<void> {
+  async function onPopState(
+    evt: PopStateEvent,
+    location: string,
+  ): Promise<void> {
     if (isTransitioning) {
       console.warn(
         `[${deps.loggerContext}] Transition in progress, deferring popstate event`,
       );
-      deferredEvent = evt;
+      deferred = { evt, location };
 
       return;
     }
@@ -142,7 +149,7 @@ export function createPopstateHandler(
     isTransitioning = true;
 
     try {
-      const matched = getRouteFromEvent(evt, deps.api, deps.browser);
+      const matched = getRouteFromEvent(evt, deps.api, location);
 
       if (matched) {
         // api.navigateToState — plugin-only entry point. Preserves
@@ -154,12 +161,12 @@ export function createPopstateHandler(
           ...resolveHashOptions(deps, matched.path),
         });
       } else if (deps.allowNotFound) {
-        deps.router.navigateToNotFound(deps.browser.getLocation());
+        deps.router.navigateToNotFound(location);
       } else {
         // Strict mode — unmatched URL is an error. Emit $$error and sync URL
         // back to the current router state (no silent fallback to defaultRoute).
         const err = new RouterError(errorCodes.ROUTE_NOT_FOUND, {
-          path: deps.browser.getLocation(),
+          path: location,
         });
 
         deps.api.emitTransitionError(err);
@@ -184,7 +191,10 @@ export function createPopstateHandler(
     }
   }
 
-  return (evt: PopStateEvent) => void onPopState(evt);
+  // Snapshot the location the instant the event fires — before any in-flight
+  // navigation can overwrite it via replaceState (#757).
+  return (evt: PopStateEvent) =>
+    void onPopState(evt, deps.browser.getLocation());
 }
 
 export interface PopstateLifecycleDeps {

--- a/shared/browser-env/popstate-utils.ts
+++ b/shared/browser-env/popstate-utils.ts
@@ -13,13 +13,18 @@ import type { PluginApi } from "@real-router/core/api";
  *   `api.makeState`. The synthesized `transition`/`context` fields are
  *   placeholders; the navigation pipeline (`completeTransition` and plugin
  *   claim writes) replaces them.
- *   This branch is mandatory for hash-plugin: `browser.getLocation()`
- *   returns the History pathname, not the hash, so the matchPath fallback
- *   below cannot extract the hash route.
- * - Otherwise (e.g. manually entered URL with no recorded state), fall
- *   back to `api.matchPath(browser.getLocation())`. browser-plugin's
- *   `getLocation` returns the URL pathname — this works.
+ * - Otherwise (e.g. manually entered URL with no recorded state), fall back
+ *   to `api.matchPath(location)`. `location` is the route location the caller
+ *   captured when the popstate event fired — each plugin derives it from its
+ *   own `browser.getLocation()` (URL pathname for browser-plugin, hash-derived
+ *   path for hash-plugin), so the fallback works for both.
  * - `undefined` when neither path produces a match.
+ *
+ * The caller passes the location it snapshotted at event time rather than
+ * letting this function re-read `browser.getLocation()`: a deferred popstate
+ * is processed only after the in-flight navigation's `replaceState` has
+ * already overwritten the live location, so a late read would resolve the
+ * wrong target (#757).
  *
  * Replaces the previous `{ name, params }` shape so the caller can hand
  * the State directly to `router.navigateToState(state, opts)` and skip
@@ -29,13 +34,13 @@ import type { PluginApi } from "@real-router/core/api";
 export function getRouteFromEvent(
   evt: PopStateEvent,
   api: PluginApi,
-  browser: Browser,
+  location: string,
 ): State | undefined {
   if (isState(evt.state)) {
     return api.makeState(evt.state.name, evt.state.params, evt.state.path);
   }
 
-  return api.matchPath(browser.getLocation());
+  return api.matchPath(location);
 }
 
 /**

--- a/shared/browser-env/types.ts
+++ b/shared/browser-env/types.ts
@@ -11,7 +11,17 @@ export interface Browser extends HistoryBrowser {
 
 /**
  * Shared mutable state across plugin instances created by the same factory.
- * Enables cleanup of a previous instance's popstate listener when the factory is reused.
+ * Enables cleanup of a previous instance's popstate listener when the factory
+ * is reused.
+ *
+ * Factory-pool caveat — last-wins (#758): because this slot is shared, each
+ * `onStart` removes the previous instance's popstate listener before installing
+ * its own. The pattern is built for a pool where routers are created/destroyed
+ * **sequentially**. If two routers from the same factory are live **at the same
+ * time** on one window, only the LAST-started one tracks `popstate` — the
+ * earlier one silently desyncs from the URL (there is one `popstate` stream and
+ * one URL; who owns it is inherently ambiguous). For multiple concurrently-live
+ * routers, give each its own factory instance.
  */
 export interface SharedFactoryState {
   removePopStateListener: (() => void) | undefined;


### PR DESCRIPTION
## Summary

Two adjacent issues in the shared `browser-env` popstate / factory machinery consumed by `@real-router/browser-plugin` and `@real-router/hash-plugin` (and, for #758, `@real-router/navigation-plugin`).

### #757 — Deferred null-state popstate reads an overwritten location
- A back/forward entry deferred behind an in-flight async-guarded navigation, carrying a `null`/invalid `history.state`, now lands on the URL the user actually navigated to instead of the earlier in-flight target — the visible URL no longer desyncs.
- **Root cause:** the deferred-event queue stored only the event, so `getRouteFromEvent` re-read `browser.getLocation()` at replay time — after the in-flight navigation's `onTransitionSuccess → replaceState` had already overwritten the live location. The handler now snapshots the location the instant each popstate fires and resolves the deferred event against that snapshot (which also feeds `navigateToNotFound` and the strict-mode `ROUTE_NOT_FOUND` path). One fix in shared code resolves it for both plugins.

### #758 — Factory-pool last-wins: document the limitation, lock the contract
- Documents that a factory reused across multiple **concurrently-live** routers tracks `popstate`/`navigate` only in the **last-started** router; earlier routers silently desync. For genuinely concurrent routers, use one factory each.
- **Root cause / status:** documented design — a single `popstate`/`navigate` stream and one URL per window make the mutual exclusivity inherent. **No runtime change.** The gap was that the factory-pool stress tests asserted only net-zero listeners, never *which* router an event reached. That gap is now closed across browser, hash, and navigation plugins, and the caveat is documented on `SharedFactoryState` / `NavigationSharedState`, the plugins' `ARCHITECTURE.md`, and the wiki.

## Test plan

- [x] #757 — `packages/browser-env/tests/unit/popstate-handler.test.ts` (deferred null-state resolves against the captured location) + `packages/browser-plugin/tests/functional/popstate.test.ts` and `packages/hash-plugin/tests/functional/popstate.test.ts` (end-to-end last-wins via the real factory). Fail before / pass after.
- [x] #758 — `factory-instance-cleanup.stress.ts` (B7.5), `plugin-lifecycle-churn.stress.ts` (hash), `listener-leak.stress.ts` (N12.3) assert the last concurrently-live router tracks and earlier ones do not. Discriminating power mutation-validated (breaking the listener removal fails B7.5).
- [x] `pnpm build` passes (291/291 tasks)
- [x] 100% coverage maintained

Closes #757
Closes #758