### PR TITLE
fix(rx): release source on takeUntil source-error (#877) + docs(rx): correct events$ count & TC39-style wording (#878)

### DIFF
--- a/.changeset/takeuntil-source-error-877-fix.md
+++ b/.changeset/takeuntil-source-error-877-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/rx": patch
+---
+
+Release the source subscription when the source errors under `takeUntil` (#877)
+
+`takeUntil` sets `completed = true` on a source `error()` and never forwards another source value, but it previously left the now-inert source subscription open — asymmetric with the notifier-emit, notifier-error, and source-complete branches, which all release the source eagerly. The source-error branch now unsubscribes the source as well, so its resource (e.g. a `state$` router listener reached through a throwing upstream operator) is released immediately instead of dangling until the consumer's `unsubscribe()`. A post-subscribe guard also covers a source that errors synchronously during subscribe.

--- a/packages/rx/ARCHITECTURE.md
+++ b/packages/rx/ARCHITECTURE.md
@@ -247,11 +247,13 @@ createStatefulOperator(subscribeFn) — Stateful operators (distinctUntilChanged
 | Notifier emits   | Complete + unsubscribe both  |
 | Notifier errors  | Error + unsubscribe both     |
 | Source emits     | Forward to observer          |
-| Source errors    | Error + unsubscribe notifier |
+| Source errors    | Error + unsubscribe both     |
 | Source completes | Complete + unsubscribe both  |
 | Unsubscribe      | Unsubscribe both             |
 
-**Subscription order:** Notifier subscribes first (handles synchronous emission), then source. Early return if notifier completes/errors synchronously before source subscription — the now-assigned notifier subscription is unsubscribed on that early return so it never dangles (#773).
+**Subscription order:** Notifier subscribes first (handles synchronous emission), then source. Early return if notifier completes/errors synchronously before source subscription — the now-assigned notifier subscription is unsubscribed on that early return so it never dangles (#773). Symmetrically, a source that completes/errors **synchronously** is released by a post-subscribe `if (completed)` check, since its handler ran before `sourceSubscription` was assigned (#877).
+
+**Terminal cleanup symmetry (#877):** every branch that sets `completed` releases **both** subscriptions. Because `error` is non-terminal at the `RxObservable` layer, a source `error()` does not close the source on its own — but `takeUntil` is permanently inert after it (`completed = true` drops all later values), so it unsubscribes the source rather than holding a subscription it will never use again.
 
 ## Error Isolation
 

--- a/packages/rx/ARCHITECTURE.md
+++ b/packages/rx/ARCHITECTURE.md
@@ -48,7 +48,7 @@ graph LR
 | Consumer         | What it uses                                | Purpose                           |
 | ---------------- | ------------------------------------------- | --------------------------------- |
 | **state$()**     | `getPluginApi`, `events.TRANSITION_SUCCESS` | Subscribe to state changes        |
-| **events$()**    | `getPluginApi`, all 6 event constants       | Subscribe to all lifecycle events |
+| **events$()**    | `getPluginApi`, all 7 event constants       | Subscribe to all lifecycle events |
 | **observable()** | `state$()`                                  | TC39 Observable interop wrapper   |
 
 ## Core Design
@@ -195,17 +195,18 @@ events$(router)
   new RxObservable(observer => {
     │
     ├── api = getPluginApi(router)
-    ├── Register 6 listeners (with partial-registration safety):
-    │   ├── ROUTER_START      → { type: "ROUTER_START" }
-    │   ├── ROUTER_STOP       → { type: "ROUTER_STOP" }
-    │   ├── TRANSITION_START  → { type, toState, fromState }
-    │   ├── TRANSITION_SUCCESS → { type, toState, fromState, options }
-    │   ├── TRANSITION_ERROR  → { type, toState, fromState, error }
-    │   └── TRANSITION_CANCEL → { type, toState, fromState }
+    ├── Register 7 listeners (with partial-registration safety):
+    │   ├── ROUTER_START             → { type: "ROUTER_START" }
+    │   ├── ROUTER_STOP              → { type: "ROUTER_STOP" }
+    │   ├── TRANSITION_START         → { type, toState, fromState }
+    │   ├── TRANSITION_LEAVE_APPROVE → { type, toState, fromState }
+    │   ├── TRANSITION_SUCCESS       → { type, toState, fromState, options }
+    │   ├── TRANSITION_ERROR         → { type, toState, fromState, error }
+    │   └── TRANSITION_CANCEL        → { type, toState, fromState }
     │
     ├── catch: Unsubscribe all registered listeners, re-throw error
     │
-    └── return () => { unsubscribe all 6 }   // teardown
+    └── return () => { unsubscribe all 7 }   // teardown
   })
 ```
 

--- a/packages/rx/CLAUDE.md
+++ b/packages/rx/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | Export                   | Kind     | Description                                                       |
 | ------------------------ | -------- | ----------------------------------------------------------------- |
-| `RxObservable`           | class    | TC39-compatible Observable with `subscribe()`, `pipe()`, `[Symbol.asyncIterator]()` |
+| `RxObservable`           | class    | TC39-style Observable with `subscribe()`, `pipe()`, `[Symbol.asyncIterator]()` |
 | `state$`                 | function | Creates `RxObservable<SubscribeState>` from router state changes  |
 | `events$`                | function | Creates `RxObservable<RouterEvent>` from all router events        |
 | `observable`             | function | Semantic wrapper over `state$()` for RxJS `from()` interop       |

--- a/packages/rx/src/operators/takeUntil.ts
+++ b/packages/rx/src/operators/takeUntil.ts
@@ -90,6 +90,14 @@ export function takeUntil<T>(notifier: RxObservable<unknown>): Operator<T, T> {
 
           completed = true;
 
+          // takeUntil is now inert (completed=true drops every later source value),
+          // so release the source — exactly as the notifier-emit / notifier-error
+          // branches do. sourceSubscription is undefined only when the source errors
+          // synchronously; the post-subscribe block below releases it in that case.
+          if (sourceSubscription) {
+            sourceSubscription.unsubscribe();
+          }
+
           // notifierSubscription is always defined here (notifier subscribes before source)
           notifierSubscription.unsubscribe();
 
@@ -100,9 +108,18 @@ export function takeUntil<T>(notifier: RxObservable<unknown>): Operator<T, T> {
         },
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive
+      if (completed) {
+        // The source completed/errored synchronously inside its own subscribe, so the
+        // handler ran before `sourceSubscription` was assigned and could not release it.
+        // complete() already closed the source (no-op here), but a non-terminal error
+        // leaves it open — release the now-assigned subscription so it does not dangle (#877).
+        sourceSubscription.unsubscribe();
+      }
+
       return () => {
-        // Both guaranteed defined: notifier subscribes first (line 37),
-        // early return on line 60 if sync complete/error, source subscribes after (line 64)
+        // Both guaranteed defined: notifier subscribes first, early return above on
+        // sync notifier complete/error, source subscribes after.
         sourceSubscription.unsubscribe();
         notifierSubscription.unsubscribe();
       };

--- a/packages/rx/tests/stress/lifecycle-leak.stress.ts
+++ b/packages/rx/tests/stress/lifecycle-leak.stress.ts
@@ -70,6 +70,31 @@ describe("RX9: Lifecycle / resource-leak under repetition", () => {
     expect(notifierTeardowns).toBe(1000);
   });
 
+  it("9.5: 1000 takeUntil() with an erroring source → the source subscription is released every time", () => {
+    let sourceTeardowns = 0;
+    let fail: (() => void) | undefined;
+
+    const notifier = new RxObservable<void>(() => () => {});
+    const source = new RxObservable<number>((observer) => {
+      fail = () => observer.error?.(new Error("boom"));
+
+      return () => {
+        sourceTeardowns += 1;
+      };
+    });
+
+    for (let i = 0; i < 1000; i++) {
+      source.pipe(takeUntil(notifier)).subscribe({ error: () => {} });
+      fail?.();
+    }
+
+    // The source-error branch must unsubscribe the now-inert source (completed=true
+    // drops every later value); otherwise every takeUntil leaves a live source
+    // subscription dangling — symmetric to the 9.2 notifier-error leak. Healthy:
+    // 1000. Leak (#877): 0.
+    expect(sourceTeardowns).toBe(1000);
+  });
+
   it("9.3: 2000 cycles of mixed complete/unsubscribe terminals → teardown runs exactly once each", () => {
     let teardowns = 0;
     let complete: (() => void) | undefined;

--- a/packages/rx/tests/unit/operators/takeUntil.test.ts
+++ b/packages/rx/tests/unit/operators/takeUntil.test.ts
@@ -458,4 +458,48 @@ describe("takeUntil()", () => {
 
     expect(notifierCleanups).toStrictEqual([1]);
   });
+
+  it("should release the source subscription when the source errors", () => {
+    const sourceCleanups: number[] = [];
+    let sourceErrorFn: ((error: Error) => void) | undefined;
+
+    const notifier = new RxObservable<void>(() => {
+      return () => {};
+    });
+
+    const source = new RxObservable<number>((observer) => {
+      sourceErrorFn = (error) => observer.error?.(error);
+
+      return () => sourceCleanups.push(1);
+    });
+
+    source.pipe(takeUntil(notifier)).subscribe({ error: () => {} });
+
+    sourceErrorFn?.(new Error("source error"));
+
+    // takeUntil sets completed=true on a source error and will never forward
+    // another source value — so the now-inert source subscription must be
+    // released, exactly as the notifier-emit / notifier-error branches do.
+    expect(sourceCleanups).toStrictEqual([1]);
+  });
+
+  it("should release the source subscription when the source errors synchronously", () => {
+    const sourceCleanups: number[] = [];
+
+    const notifier = new RxObservable<void>(() => {
+      return () => {};
+    });
+
+    // Source errors synchronously inside its own subscribe — sourceSubscription is
+    // still unassigned in the error handler, so the post-subscribe block must release it.
+    const source = new RxObservable<number>((observer) => {
+      observer.error?.(new Error("sync source error"));
+
+      return () => sourceCleanups.push(1);
+    });
+
+    source.pipe(takeUntil(notifier)).subscribe({ error: () => {} });
+
+    expect(sourceCleanups).toStrictEqual([1]);
+  });
 });


### PR DESCRIPTION
## Summary

Two independent rx changes on one branch (one PR, separate commits per the project convention).

### #877 — takeUntil source-error leaves the source subscription dangling
- `takeUntil` now releases the **source** subscription when the source errors, matching the notifier-emit, notifier-error, and source-complete branches (all release both subscriptions).
- **Root cause:** the source-error branch unsubscribed only the notifier. Because `error` is non-terminal at the `RxObservable` layer, the source stayed open; and since `takeUntil` sets `completed = true` on a source error (every later value is dropped), the source subscription was held with no purpose until the consumer's `unsubscribe()`. A throwing operator over `state$` could thus leak a router listener. A post-subscribe guard also covers a source that errors synchronously during subscribe.

### #878 — rx doc-drift
- `ARCHITECTURE.md`: `events$` registers **7** listeners, not 6 — corrected the count references and added the missing `TRANSITION_LEAVE_APPROVE` to the registration diagram.
- `CLAUDE.md`: the `RxObservable` row now reads "TC39-style" instead of "TC39-compatible", consistent with the rest of the docs and the non-terminal-error divergence (#775).
- The takeUntil-table item from #878 (it assumed a terminal-error model) was corrected by the #877 commit: `Source errors → unsubscribe both`.

## Test plan

- [x] `tests/unit/operators/takeUntil.test.ts` — "should release the source subscription when the source errors" (async) and "...synchronously" (sync): fail before, pass after
- [x] `tests/stress/lifecycle-leak.stress.ts` — RX9.5: 1000× erroring source releases the source every time (mutationally validated — reverting the fix turns it red)
- [x] `pnpm build` passes (291/291 tasks)
- [x] 100% coverage maintained (230/230 statements, 83/83 branches)

Closes #877
Closes #878
