### PR TITLE
fix(core): accept full logger config surface + drop dead validation-plugin validator (#789)

### DIFF
--- a/.changeset/logger-config-789-fix.md
+++ b/.changeset/logger-config-789-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Accept the full `LoggerConfig` surface in `createRouter` options (#789)
+
+`isLoggerConfig` rejected `level: "none"` and the `callbackIgnoresLevel` key, so `createRouter(routes, { logger: { level: "none" } })` and `createRouter(routes, { logger: { callbackIgnoresLevel: true, callback } })` — both documented in the wiki and supported by `@real-router/logger` — threw a `TypeError` from the constructor. The guard now accepts the complete `LoggerConfig` surface (`"none"` level plus `callbackIgnoresLevel`, validated as a boolean), aligning core with the logger package, the validation plugin, and the wiki. Widens accepted input; not breaking.

--- a/.changeset/validation-logger-789-refactor.md
+++ b/.changeset/validation-logger-789-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+Remove dead `validateLoggerOption` (#789)
+
+The Router constructor consumes `options.logger` and strips the key before options are stored, so the retrospective pass always saw `logger: undefined` and `validateLoggerOption` never ran on the live path. Logger config is validated solely by core's `isLoggerConfig` guard at construction — the only place the input exists. Removes the unreachable validator, its `VALID_LOGGER_LEVELS` constant, and the now-unreachable `callbackIgnoresLevel`-without-`callback` diagnostic. Behavior-neutral on any reachable path.

--- a/packages/core/src/typeGuards.ts
+++ b/packages/core/src/typeGuards.ts
@@ -5,7 +5,12 @@
  */
 import type { LoggerConfig, LogLevelConfig } from "@real-router/logger";
 
-const VALID_LEVELS_SET = new Set<string>(["all", "warn-error", "error-only"]);
+const VALID_LEVELS_SET = new Set<string>([
+  "all",
+  "warn-error",
+  "error-only",
+  "none",
+]);
 
 function isValidLevel(value: unknown): value is LogLevelConfig {
   return typeof value === "string" && VALID_LEVELS_SET.has(value);
@@ -32,7 +37,11 @@ export function isLoggerConfig(config: unknown): config is LoggerConfig {
 
   // Check for unknown properties
   for (const key of Object.keys(obj)) {
-    if (key !== "level" && key !== "callback") {
+    if (
+      key !== "level" &&
+      key !== "callback" &&
+      key !== "callbackIgnoresLevel"
+    ) {
       throw new TypeError(`Unknown logger config property: "${key}"`);
     }
   }
@@ -40,7 +49,7 @@ export function isLoggerConfig(config: unknown): config is LoggerConfig {
   // Validate level if present
   if ("level" in obj && obj.level !== undefined && !isValidLevel(obj.level)) {
     throw new TypeError(
-      `Invalid logger level: ${formatValue(obj.level)}. Expected: "all" | "warn-error" | "error-only"`,
+      `Invalid logger level: ${formatValue(obj.level)}. Expected: "all" | "warn-error" | "error-only" | "none"`,
     );
   }
 
@@ -52,6 +61,17 @@ export function isLoggerConfig(config: unknown): config is LoggerConfig {
   ) {
     throw new TypeError(
       `Logger callback must be a function, got ${typeof obj.callback}`,
+    );
+  }
+
+  // Validate callbackIgnoresLevel if present (logger.configure does not type-check it)
+  if (
+    "callbackIgnoresLevel" in obj &&
+    obj.callbackIgnoresLevel !== undefined &&
+    typeof obj.callbackIgnoresLevel !== "boolean"
+  ) {
+    throw new TypeError(
+      `Logger callbackIgnoresLevel must be a boolean, got ${typeof obj.callbackIgnoresLevel}`,
     );
   }
 

--- a/packages/core/tests/functional/createRouter.test.ts
+++ b/packages/core/tests/functional/createRouter.test.ts
@@ -80,6 +80,24 @@ describe("createRouter", () => {
       ).not.toThrow();
     });
 
+    it('should accept level "none" (wiki-documented surface, #789)', () => {
+      expect(() =>
+        createRouter([], { logger: { level: "none" } }),
+      ).not.toThrow();
+    });
+
+    it("should accept callbackIgnoresLevel (wiki-documented surface, #789)", () => {
+      expect(() =>
+        createRouter([], {
+          logger: {
+            level: "all",
+            callback: () => {},
+            callbackIgnoresLevel: true,
+          },
+        }),
+      ).not.toThrow();
+    });
+
     it("should throw TypeError for invalid logger config", () => {
       expect(() =>
         createRouter([], { logger: { invalid: true } as any }),

--- a/packages/core/tests/functional/typeGuards.test.ts
+++ b/packages/core/tests/functional/typeGuards.test.ts
@@ -28,6 +28,25 @@ describe("typeGuards", () => {
       expect(isLoggerConfig({ level: "all", callback: () => {} })).toBe(true);
     });
 
+    it('should return true for valid level "none" (#789)', () => {
+      expect(isLoggerConfig({ level: "none" })).toBe(true);
+    });
+
+    it("should return true for callbackIgnoresLevel boolean (#789)", () => {
+      expect(isLoggerConfig({ callbackIgnoresLevel: true })).toBe(true);
+      expect(isLoggerConfig({ callbackIgnoresLevel: false })).toBe(true);
+    });
+
+    it("should return true for the full LoggerConfig surface (#789)", () => {
+      expect(
+        isLoggerConfig({
+          level: "none",
+          callback: () => {},
+          callbackIgnoresLevel: true,
+        }),
+      ).toBe(true);
+    });
+
     it("should throw TypeError for non-object config (null)", () => {
       expect(() => isLoggerConfig(null)).toThrow(TypeError);
       expect(() => isLoggerConfig(null)).toThrow(
@@ -81,9 +100,25 @@ describe("typeGuards", () => {
       );
     });
 
+    it("should throw TypeError for callbackIgnoresLevel that is not a boolean (#789)", () => {
+      expect(() => isLoggerConfig({ callbackIgnoresLevel: "yes" })).toThrow(
+        TypeError,
+      );
+      expect(() => isLoggerConfig({ callbackIgnoresLevel: "yes" })).toThrow(
+        "Logger callbackIgnoresLevel must be a boolean",
+      );
+    });
+
+    it('should list "none" in the invalid-level error message (#789)', () => {
+      expect(() => isLoggerConfig({ level: "invalid" })).toThrow(
+        '"all" | "warn-error" | "error-only" | "none"',
+      );
+    });
+
     it("should accept undefined values for optional properties", () => {
       expect(isLoggerConfig({ level: undefined })).toBe(true);
       expect(isLoggerConfig({ callback: undefined })).toBe(true);
+      expect(isLoggerConfig({ callbackIgnoresLevel: undefined })).toBe(true);
       expect(isLoggerConfig({ level: undefined, callback: undefined })).toBe(
         true,
       );

--- a/packages/validation-plugin/CLAUDE.md
+++ b/packages/validation-plugin/CLAUDE.md
@@ -49,11 +49,12 @@ Calling the unsubscribe function returned by `router.usePlugin(validationPlugin(
 | Combination                                                                 | Behavior                                   | Location                                      |
 | --------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------- |
 | `limits.warnListeners > limits.maxListeners` (and `maxListeners > 0`)       | `throw RangeError`                         | `validators/options.ts::validateLimits`       |
-| `logger.callbackIgnoresLevel: true` without `logger.callback`               | `logger.error("router.<method>", …)` (non-throwing — option would be ignored) | `validators/options.ts::validateLoggerOption` |
 | Static `defaultRoute: "<name>"` that does not exist in the route tree       | `throw Error` with `[validation-plugin]` prefix | Retrospective pass (`validationPlugin.ts`) |
 | `DefaultRouteCallback` returning a name that does not exist in the route tree | `throw Error` with `[validation-plugin]` prefix; propagates as `Promise.reject` via `navigateToDefault()` / `start()` fallback | Runtime hook `options.validateResolvedDefaultRoute` called from core's `resolveDefault()` when `defaultRoute` is a callback |
 
 Callbacks are intentionally **not** probed at registration time — their return value depends on dependencies that may not be set yet. The hook on `resolveDefault()` catches bad return values on the first actual use.
+
+**Logger config is not validated by this plugin.** The Router constructor consumes `options.logger` (applies it to the process-global logger singleton) and strips the key before options are stored (#724), so the retrospective pass — which reads the stored, logger-stripped options — never sees it. Logger config (`level` incl. `"none"`, `callback`, `callbackIgnoresLevel`) is therefore validated solely by core's `isLoggerConfig` guard at construction, the only place the input exists (#789). A prior `validateLoggerOption` here was dead on the live path and was removed.
 
 ### `navigateToDefault()` Promise contract
 

--- a/packages/validation-plugin/INVARIANTS.md
+++ b/packages/validation-plugin/INVARIANTS.md
@@ -21,7 +21,6 @@ Invariants verified by property-based tests (`tests/property/`). Each invariant 
 - `queryParams.arrayFormat`: `"none"` | `"brackets"` | `"index"` | `"comma"`
 - `queryParams.booleanFormat`: `"none"` | `"auto"` | `"empty-true"`
 - `queryParams.nullFormat`: `"default"` | `"hidden"`
-- `logger.level`: `"all"` | `"warn-error"` | `"error-only"` | `"none"`
 
 ### Limit bounds
 

--- a/packages/validation-plugin/src/validators/options.ts
+++ b/packages/validation-plugin/src/validators/options.ts
@@ -1,6 +1,5 @@
 // packages/validation-plugin/src/validators/options.ts
 
-import { logger } from "@real-router/logger";
 import { isObjKey } from "type-guards";
 
 const VALID_OPTION_VALUES = {
@@ -16,13 +15,13 @@ const VALID_QUERY_PARAMS = {
   numberFormat: ["none", "auto"] as const,
 } as const;
 
-const VALID_LOGGER_LEVELS = [
-  "all",
-  "warn-error",
-  "error-only",
-  "none",
-] as const;
-
+// `logger` is a valid option name, but its contents are NOT validated here.
+// The Router constructor consumes `options.logger` (applies it to the
+// process-global logger singleton via `logger.configure()`) and strips the key
+// before options are stored (#724). The retrospective pass reads the stored,
+// logger-stripped options, so any logger validation in this plugin is dead on
+// the live path. Logger config is therefore validated solely by core's
+// `isLoggerConfig` guard at construction — the only place the input exists (#789).
 const KNOWN_OPTIONS = new Set<string>([
   "defaultRoute",
   "defaultParams",
@@ -206,67 +205,6 @@ function validateQueryParamsOptions(
   }
 }
 
-function validateLoggerOption(loggerOpt: unknown, methodName: string): void {
-  if (loggerOpt === undefined) {
-    return;
-  }
-
-  if (!loggerOpt || typeof loggerOpt !== "object" || Array.isArray(loggerOpt)) {
-    throw new TypeError(
-      `[router.${methodName}] Invalid "logger": expected plain object`,
-    );
-  }
-
-  const loggerOptions = loggerOpt as Record<string, unknown>;
-
-  if (
-    loggerOptions.level !== undefined &&
-    !VALID_LOGGER_LEVELS.includes(
-      loggerOptions.level as (typeof VALID_LOGGER_LEVELS)[number],
-    )
-  ) {
-    const validLevelList = VALID_LOGGER_LEVELS.map((val) => `"${val}"`).join(
-      ", ",
-    );
-    const levelDisplay =
-      typeof loggerOptions.level === "string"
-        ? loggerOptions.level
-        : `(${typeof loggerOptions.level})`;
-
-    throw new TypeError(
-      `[router.${methodName}] Invalid "logger.level": "${levelDisplay}". Must be one of: ${validLevelList}`,
-    );
-  }
-
-  if (
-    loggerOptions.callback !== undefined &&
-    typeof loggerOptions.callback !== "function"
-  ) {
-    throw new TypeError(
-      `[router.${methodName}] Invalid "logger.callback": expected function`,
-    );
-  }
-
-  if (
-    loggerOptions.callbackIgnoresLevel !== undefined &&
-    typeof loggerOptions.callbackIgnoresLevel !== "boolean"
-  ) {
-    throw new TypeError(
-      `[router.${methodName}] Invalid "logger.callbackIgnoresLevel": expected boolean`,
-    );
-  }
-
-  if (
-    loggerOptions.callbackIgnoresLevel === true &&
-    loggerOptions.callback === undefined
-  ) {
-    logger.error(
-      `router.${methodName}`,
-      `"logger.callbackIgnoresLevel: true" has no effect without "logger.callback" — the option is ignored`,
-    );
-  }
-}
-
 export function validateOptions(options: unknown, methodName: string): void {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new TypeError(
@@ -322,7 +260,6 @@ export function validateOptions(options: unknown, methodName: string): void {
   }
 
   validateQueryParamsOptions(opts.queryParams, methodName);
-  validateLoggerOption(opts.logger, methodName);
 
   if (opts.limits !== undefined) {
     validateLimits(opts.limits, methodName);

--- a/packages/validation-plugin/tests/functional/validators.test.ts
+++ b/packages/validation-plugin/tests/functional/validators.test.ts
@@ -878,51 +878,6 @@ describe("Phase 2 options validators", () => {
       }).toThrow(TypeError);
     });
 
-    it("throws for invalid logger (non-object)", () => {
-      expect(() => {
-        validateOptions({ logger: "string" }, "test");
-      }).toThrow(TypeError);
-    });
-
-    it("throws for invalid logger (array)", () => {
-      expect(() => {
-        validateOptions({ logger: [] }, "test");
-      }).toThrow(TypeError);
-    });
-
-    it("throws for invalid logger.level (string value)", () => {
-      expect(() => {
-        validateOptions({ logger: { level: "bad" } }, "test");
-      }).toThrow(TypeError);
-      expect(() => {
-        validateOptions({ logger: { level: "bad" } }, "test");
-      }).toThrow("logger.level");
-    });
-
-    it("throws for invalid logger.level (non-string value)", () => {
-      expect(() => {
-        validateOptions({ logger: { level: 99 } }, "test");
-      }).toThrow(TypeError);
-    });
-
-    it("throws for invalid logger.callback (non-function)", () => {
-      expect(() => {
-        validateOptions({ logger: { callback: "not-fn" } }, "test");
-      }).toThrow(TypeError);
-      expect(() => {
-        validateOptions({ logger: { callback: "not-fn" } }, "test");
-      }).toThrow("logger.callback");
-    });
-
-    it("throws for invalid logger.callbackIgnoresLevel (non-boolean)", () => {
-      expect(() => {
-        validateOptions({ logger: { callbackIgnoresLevel: "yes" } }, "test");
-      }).toThrow(TypeError);
-      expect(() => {
-        validateOptions({ logger: { callbackIgnoresLevel: "yes" } }, "test");
-      }).toThrow("logger.callbackIgnoresLevel");
-    });
-
     it("accepts valid complete options", () => {
       expect(() => {
         validateOptions(
@@ -980,71 +935,6 @@ describe("Phase 2 options validators", () => {
       expect(() => {
         validateOptions({ limits: { maxPlugins: -1 } }, "test");
       }).toThrow(RangeError);
-    });
-
-    it("accepts undefined logger level (skips validation)", () => {
-      expect(() => {
-        validateOptions({ logger: {} }, "test");
-      }).not.toThrow();
-    });
-
-    it("accepts undefined logger callback (skips validation)", () => {
-      expect(() => {
-        validateOptions({ logger: { level: "all" } }, "test");
-      }).not.toThrow();
-    });
-
-    it("accepts undefined logger callbackIgnoresLevel (skips validation)", () => {
-      expect(() => {
-        validateOptions({ logger: { callback: () => {} } }, "test");
-      }).not.toThrow();
-    });
-
-    describe("callbackIgnoresLevel without callback (#471 case 4)", () => {
-      let errorSpy: ReturnType<typeof vi.spyOn>;
-
-      beforeEach(() => {
-        errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-      });
-
-      afterEach(() => {
-        errorSpy.mockRestore();
-      });
-
-      it("logs error when callbackIgnoresLevel is true and callback missing", () => {
-        validateOptions({ logger: { callbackIgnoresLevel: true } }, "test");
-
-        expect(errorSpy).toHaveBeenCalledWith(
-          "router.test",
-          expect.stringContaining("has no effect without"),
-        );
-      });
-
-      it("does not log error when callbackIgnoresLevel is false", () => {
-        validateOptions({ logger: { callbackIgnoresLevel: false } }, "test");
-
-        expect(errorSpy).not.toHaveBeenCalled();
-      });
-
-      it("does not log error when callback is provided alongside callbackIgnoresLevel", () => {
-        validateOptions(
-          {
-            logger: {
-              callbackIgnoresLevel: true,
-              callback: () => {},
-            },
-          },
-          "test",
-        );
-
-        expect(errorSpy).not.toHaveBeenCalled();
-      });
-
-      it("does not log error when callbackIgnoresLevel is undefined", () => {
-        validateOptions({ logger: { level: "all" } }, "test");
-
-        expect(errorSpy).not.toHaveBeenCalled();
-      });
     });
   });
 });

--- a/packages/validation-plugin/tests/property/helpers.ts
+++ b/packages/validation-plugin/tests/property/helpers.ts
@@ -106,13 +106,9 @@ const validLoggerArbitrary = fc
       }
     }
 
-    // Cross-field invariant (#471 case 4): callbackIgnoresLevel: true has no
-    // effect without callback. Drop the flag in that case so the generated
-    // options don't trigger the validator's noisy logger.error on every run.
-    if (result.callbackIgnoresLevel === true && result.callback === undefined) {
-      delete result.callbackIgnoresLevel;
-    }
-
+    // `logger` content is not validated by validateOptions — core's
+    // isLoggerConfig owns logger validation at construction (#789). Any
+    // well-typed logger object is accepted here, so no cross-field shaping.
     return result;
   });
 


### PR DESCRIPTION
## Summary

Resolves the `options.logger` surface desync across core, the validation plugin, and the wiki. A user copying a wiki logger example into `createRouter` no longer hits a constructor `TypeError`, and a validator that never ran is removed.

### #789 — `options.logger` surface desync

**core — accept the full `LoggerConfig` surface (`fix`, patch)**

- `createRouter(routes, { logger: { level: "none" } })` and `createRouter(routes, { logger: { callbackIgnoresLevel: true, callback } })` — both documented in the wiki and supported by `@real-router/logger` — threw a `TypeError` from the constructor.
- **Root cause:** `isLoggerConfig` validated a narrower surface (3 levels, only `level`/`callback`) than the `LoggerConfig` type it imports and than `logger.configure()` accepts — the single outlier among logger / validation-plugin / wiki. Expanded it to the full surface (`"none"` level + `callbackIgnoresLevel`, validated as a boolean, since `logger.configure()` does not type-check it). Existing structural checks (object-ness, unknown-key rejection, callback-is-function, invalid-level) are unchanged, so malformed configs still throw. Widens accepted input; not breaking.

**validation-plugin — remove dead `validateLoggerOption` (`refactor`, patch)**

- **Root cause:** the Router constructor consumes `options.logger` and strips the key before options are stored (#724), so the retrospective pass always read `logger: undefined` and `validateLoggerOption` never ran on the live path. Logger config is validated solely by core's `isLoggerConfig` at construction — the only place the input exists. Removed the unreachable validator, its `VALID_LOGGER_LEVELS` constant, and the dead `callbackIgnoresLevel`-without-`callback` diagnostic; documented the ownership in `CLAUDE.md` and synced `INVARIANTS.md`. Behavior-neutral on any reachable path.

> Wiki pages (`createRouter.md`, `RouterOptions.md`, `validation-plugin.md`) were updated in the `real-router.wiki` repo — the wide surface is now honest and the dead cross-field diagnostic is removed.

## Test plan

- [x] `core/tests/functional/createRouter.test.ts` › `should accept level "none"`, `should accept callbackIgnoresLevel` — fail before, pass after
- [x] `core/tests/functional/typeGuards.test.ts` › full-surface acceptance, `callbackIgnoresLevel` non-boolean throw, `"none"` listed in error message
- [x] `validation-plugin` functional + property suites updated; dead logger tests removed; `INVARIANTS.md` synced
- [x] `pnpm build` passes (292/292 tasks)
- [x] 100% coverage maintained

Closes #789
