### PR TITLE
fix(logger): guard against re-entrant callbacks calling logger.* (#791)

### DIFF
--- a/.changeset/logger-callback-reentrancy-fix.md
+++ b/.changeset/logger-callback-reentrancy-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/logger": patch
+---
+
+Guard against re-entrant logger callbacks (#791)
+
+A `callback` that itself calls `logger.*` on the happy path used to recurse through `#invokeCallback` until a swallowed `RangeError` (~5.9k self-calls and `console.error` per single log). A `#inCallback` re-entrancy guard now skips the nested callback invocation, turning the pattern into a safe no-op. Console output is unaffected: the nested message is still written once.

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -38,6 +38,7 @@ src/
 
 - **Singleton** -- `logger` is a module-level instance; all imports share the same config state
 - **Callback errors are swallowed** -- if `callback` throws, the error is caught and reported via `console.error` directly (avoids recursive logger calls)
+- **Re-entrant callbacks are a safe no-op** -- if `callback` calls `logger.*`, an `#inCallback` re-entrancy guard skips the nested callback invocation (the nested message still reaches the console once). Without it the call would recurse ~5.9k deep to a swallowed `RangeError` (#791)
 - **`callbackIgnoresLevel`** -- when true, callback receives ALL messages even if console output is filtered; when false (default), callback follows the same threshold as console
 - **Level `"none"` early exit** -- when level is `"none"` and `callbackIgnoresLevel` is false, `#writeLog` returns immediately without any processing
 - **Console safety** -- `#writeToConsole` checks `typeof console !== "undefined"` and `typeof console[level] === "function"` before calling

--- a/packages/logger/INVARIANTS.md
+++ b/packages/logger/INVARIANTS.md
@@ -44,6 +44,7 @@
 | 6   | Callback and console are consistent when callbackIgnoresLevel is false | The number of times the callback is called equals the number of times the corresponding console method is called. They are never out of sync.                   |
 | 7   | Callback invocation is deterministic                                   | The same `(configLevel, messageLevel, callbackIgnoresLevel)` combination always produces the same callback invocation count.                                    |
 | 8   | Changing callbackIgnoresLevel takes effect immediately                 | Switching `callbackIgnoresLevel` from `false` to `true` causes the very next log call to invoke the callback, even if the message would otherwise be filtered.  |
+| 9   | Re-entrant callback does not recurse                                   | A callback that calls `logger.*` is invoked at most once per top-level log call. The nested re-entry is skipped by the `#inCallback` guard (safe no-op), instead of recursing to a swallowed `RangeError`. Console output for the nested message still happens once. |
 
 ## Test Files
 
@@ -51,4 +52,4 @@
 | --------------------------------------- | ---------- | --------------- |
 | `tests/property/config.properties.ts`   | 10         | Configuration   |
 | `tests/property/level.properties.ts`    | 10         | Level Filtering |
-| `tests/property/callback.properties.ts` | 8          | Callback        |
+| `tests/property/callback.properties.ts` | 9          | Callback        |

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -64,6 +64,8 @@ logger.configure({
 | `callback` | `LogCallback` | — | Custom handler for log messages |
 | `callbackIgnoresLevel` | `boolean` | `false` | When `true`, callback receives all messages regardless of level |
 
+> **Note:** The `callback` may safely call `logger.*`. A re-entrancy guard turns the nested call into a no-op (the message is still written to the console once), so it never recurses.
+
 ### `callbackIgnoresLevel`
 
 Decouples console output from callback — useful for error tracking, metrics, or external logging:

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -52,6 +52,14 @@ class Logger {
   #currentThreshold = 0;
 
   /**
+   * Re-entrancy guard: true while a user callback is executing. Prevents a
+   * callback that itself calls `logger.*` from recursing back through
+   * `#invokeCallback` (which would otherwise spin ~5.9k deep until a swallowed
+   * RangeError, see #791). Console output is unaffected.
+   */
+  #inCallback = false;
+
+  /**
    * Configures the logger with new settings.
    *
    * @param config - Partial configuration to merge with existing config
@@ -287,8 +295,17 @@ class Logger {
       return;
     }
 
+    // Re-entrancy guard: a callback calling logger.* re-enters here via
+    // #writeLog → #invokeCallback. Skip the nested invocation so the pattern is
+    // a safe no-op (console output already happened in #writeLog) instead of
+    // recursing to a swallowed RangeError (#791).
+    if (this.#inCallback) {
+      return;
+    }
+
     // Wrap callback invocation in try-catch to prevent user code errors
     // from breaking the logger or causing cascading failures
+    this.#inCallback = true;
     try {
       this.#config.callback(level, context, message, ...args);
     } catch (error) {
@@ -300,6 +317,8 @@ class Logger {
       ) {
         console.error("[Logger] Error in callback:", error);
       }
+    } finally {
+      this.#inCallback = false;
     }
   }
 }

--- a/packages/logger/tests/functional/logger.test.ts
+++ b/packages/logger/tests/functional/logger.test.ts
@@ -802,25 +802,37 @@ describe("Logger", () => {
     });
   });
 
-  describe("recursive callback", () => {
-    it("should not infinite loop when logger.log is called inside callback", () => {
+  describe("re-entrant callback (issue #791)", () => {
+    it("should invoke the callback only once when it re-enters the logger", () => {
       let callCount = 0;
 
-      const recursiveCallback: LogCallback = () => {
+      // A callback that re-enters the logger on the happy path (no self-bound).
+      // Without a re-entrancy guard this recurses ~5.9k deep until a swallowed
+      // RangeError, invoking the callback thousands of times.
+      const reentrantCallback: LogCallback = () => {
         callCount++;
-        if (callCount <= 3) {
-          // This will call the callback again, but eventually stops
-          // because each nested call increments callCount
-          logger.log("Inner", "recursive");
-        }
+        logger.error("Inner", "from callback");
       };
 
-      logger.configure({ callback: recursiveCallback });
-      logger.log("Outer", "start");
+      logger.configure({ callback: reentrantCallback });
+      logger.error("Outer", "kick");
 
-      // Should terminate — callback calls logger.log which calls callback again,
-      // but callCount guard prevents infinite recursion
-      expect(callCount).toBe(4); // initial + 3 recursive calls
+      // The nested logger.error must NOT re-invoke the callback (safe no-op).
+      expect(callCount).toBe(1);
+    });
+
+    it("should preserve nested console output without flooding it", () => {
+      const reentrantCallback: LogCallback = () => {
+        logger.error("Inner", "from callback");
+      };
+
+      logger.configure({ callback: reentrantCallback });
+      logger.error("Outer", "kick");
+
+      // Outer message + the single nested message — not ~5.9k console.error.
+      expect(console.error).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenNthCalledWith(1, "[Outer] kick");
+      expect(console.error).toHaveBeenNthCalledWith(2, "[Inner] from callback");
     });
   });
 

--- a/packages/logger/tests/property/callback.properties.ts
+++ b/packages/logger/tests/property/callback.properties.ts
@@ -15,6 +15,8 @@ import {
   throwingCallbackArbitrary,
 } from "./helpers";
 
+import type { LogCallback } from "@real-router/logger";
+
 const noop = () => {};
 
 describe("Logger Callback Properties", () => {
@@ -313,6 +315,32 @@ describe("Logger Callback Properties", () => {
 
         // Result should be the same
         expect(callCount1).toBe(callCount2);
+      },
+    );
+  });
+
+  describe("Re-entrancy guard", () => {
+    test.prop([logLevelArbitrary, contextArbitrary, messageArbitrary], {
+      numRuns: 500,
+    })(
+      "re-entrant callback is invoked exactly once per top-level call",
+      (messageLevel, context, message) => {
+        vi.clearAllMocks();
+
+        let callCount = 0;
+        // A callback that re-enters the logger on the happy path. Without the
+        // #inCallback guard this recurses until a swallowed RangeError (#791).
+        const reentrantCallback: LogCallback = () => {
+          callCount++;
+          logger.error("Inner", "nested");
+        };
+
+        logger.configure({ level: "all", callback: reentrantCallback });
+
+        logger[messageLevel](context, message);
+
+        // The nested logger.error must not re-invoke the callback.
+        expect(callCount).toBe(1);
       },
     );
   });


### PR DESCRIPTION
## Summary

- A logger `callback` that calls `logger.*` is now a safe no-op on re-entry instead of recursing thousands of levels deep and flooding the console.
- Console delivery is unchanged: the nested message is still written once.

### #791 — re-entrant callback recurses ~5.9k → 5888 console.error per log
- A callback that calls `logger.*` on the happy path used to recurse `logger.error → #writeLog → #invokeCallback → callback → logger.error → …` until a swallowed `RangeError`, emitting ~5888 `console.error` per single log call.
- **Root cause:** the anti-recursion logic only guarded the *catch* branch (a throwing callback is reported via `console.error` directly); a callback re-entering the logger on the happy path was unguarded. Fixed with an `#inCallback` re-entrancy guard that skips the nested `#invokeCallback` (set before the call, reset in `finally`). Existing throw-handling, level filtering, and `callbackIgnoresLevel` semantics are untouched.

### Maintainability
- Documented the new behavior: Callback invariant #9 in `INVARIANTS.md` (mapped 1:1 to the new property test), a CLAUDE gotcha, and a README note that a callback may safely call `logger.*`.

## Test plan

- [x] `tests/functional/logger.test.ts` → `re-entrant callback (issue #791)`: callback fires exactly once; nested console output preserved at ≤ 2 `console.error` (RED before fix: `callCount = 5888`)
- [x] `tests/property/callback.properties.ts` → `re-entrant callback is invoked exactly once per top-level call` (500 runs)
- [x] `pnpm build` passes (292/292)
- [x] 100% coverage maintained

Closes #791
