### PR TITLE
fix(core): persist custom route fields in routes.update (#797)

### DIFF
--- a/.changeset/update-custom-fields-core.md
+++ b/.changeset/update-custom-fields-core.md
@@ -1,0 +1,32 @@
+---
+"@real-router/core": patch
+---
+
+Fix `routes.update()` silently dropping plugin-defined custom route fields (#797)
+
+`getRoutesApi(router).update(name, patch)` previously applied only the
+structural/guard subset of the patch and silently discarded custom
+(plugin-defined) fields — lifecycle hooks, `preload`, `searchSchema`, etc. — so
+`getPluginApi(router).getRouteConfig(name)` kept returning stale values after an
+update. `update` now persists custom fields into the store, symmetric with
+`add`/`replace`.
+
+Semantics mirror the structural fields:
+
+- Shallow-merge by patch key — sibling custom fields are preserved.
+- `null` removes a single field; emptying the record drops it entirely
+  (`getRouteConfig` returns `undefined`, as after `add` with no custom fields).
+- `undefined` is a no-op (leaves the field untouched).
+
+Custom-field writes are applied **before** the structural config, so a throwing
+custom-field getter aborts the update before any store write (atomic), mirroring
+a throwing structural getter. Each merge writes a fresh record, so a previously
+cloned router stays isolated from later updates on the source. A custom-field-only
+patch emits no `TREE_CHANGED` event — consumers read custom fields lazily via
+`getRouteConfig`, so the next read observes the new value (the event stays
+structural-only by design).
+
+The public API surface is unchanged: `RouteConfigUpdate` stays a closed
+interface, and plugins opt into typed custom-field updates by augmenting it (see
+`@real-router/lifecycle-plugin`, `@real-router/preload-plugin`,
+`@real-router/search-schema-plugin`).

--- a/.changeset/update-custom-fields-lifecycle.md
+++ b/.changeset/update-custom-fields-lifecycle.md
@@ -1,0 +1,12 @@
+---
+"@real-router/lifecycle-plugin": minor
+---
+
+Support updating lifecycle hooks via `routes.update()` (#797)
+
+`RouteConfigUpdate` is now augmented with `onEnter` / `onStay` / `onLeave` /
+`onNavigate` (each `| null` to remove), symmetric with the existing `Route`
+augmentation. `getRoutesApi(router).update(name, { onNavigate })` hot-swaps a
+hook factory with precise typing; the plugin recompiles it lazily on the next
+navigation (the factory-reference change is detected automatically). Previously
+the hook patch was silently dropped by core and the old hook kept firing.

--- a/.changeset/update-custom-fields-preload.md
+++ b/.changeset/update-custom-fields-preload.md
@@ -1,0 +1,12 @@
+---
+"@real-router/preload-plugin": minor
+---
+
+Support updating `preload` via `routes.update()` (#797)
+
+`RouteConfigUpdate` is now augmented with `preload` (`| null` to remove),
+symmetric with the existing `Route` augmentation.
+`getRoutesApi(router).update(name, { preload })` hot-swaps the preload factory
+with precise typing; it is picked up lazily on the next hover/touch (the factory
+reference change invalidates the compiled cache). Previously the patch was
+silently dropped by core and the old factory stayed compiled.

--- a/.changeset/update-custom-fields-search-schema.md
+++ b/.changeset/update-custom-fields-search-schema.md
@@ -1,0 +1,12 @@
+---
+"@real-router/search-schema-plugin": minor
+---
+
+Support updating `searchSchema` via `routes.update()` (#797)
+
+`RouteConfigUpdate` is now augmented with `searchSchema` (`| null` to remove),
+symmetric with the existing `Route` augmentation.
+`getRoutesApi(router).update(name, { searchSchema })` swaps the schema with
+precise typing; the next navigation validates against it (the schema is read
+lazily per navigation). Previously the patch was silently dropped by core and
+navigation kept validating against the stale schema.

--- a/.changeset/update-custom-fields-types.md
+++ b/.changeset/update-custom-fields-types.md
@@ -1,0 +1,12 @@
+---
+"@real-router/types": patch
+---
+
+Document `RouteConfigUpdate` custom-field patch semantics and augmentability (#797)
+
+`RouteConfigUpdate` now documents that `routes.update()` patches plugin-defined
+custom fields (shallow-merge by key, `null` removes, `undefined` is a no-op) and
+that the interface is augmentable — a plugin declares its updatable field via
+declaration merging, mirroring its `Route` augmentation but with `| null` to
+allow removal. The interface stays closed (no index signature), so typos in
+structural field names remain compile errors.

--- a/packages/core-types/src/api.ts
+++ b/packages/core-types/src/api.ts
@@ -195,6 +195,16 @@ export interface RoutesApi<
 
   remove: (name: string) => void;
 
+  /**
+   * Patch an existing route's configuration in place (no tree rebuild).
+   *
+   * Applies the structural/guard fields and any plugin-defined custom fields
+   * (lifecycle hooks, `preload`, `searchSchema`, …) from the patch. Fields are
+   * shallow-merged by key; `null` removes a field, `undefined` is a no-op.
+   * `name`/`path`/`children` are immutable — use `remove` + `add` to
+   * restructure. See {@link RouteConfigUpdate} for the full semantics and the
+   * plugin augmentation pattern.
+   */
   update: (name: string, updates: RouteConfigUpdate<Dependencies>) => void;
 
   clear: () => void;

--- a/packages/core-types/src/router.ts
+++ b/packages/core-types/src/router.ts
@@ -375,8 +375,29 @@ export interface Route<
 }
 
 /**
- * Configuration update options for updateRoute().
- * All properties are optional. Set to null to remove the configuration.
+ * Configuration update options for `updateRoute()`.
+ *
+ * All properties are optional. For every field, `null` removes the
+ * configuration, `undefined` (or omission) leaves it untouched, and any other
+ * value sets it — values are shallow-merged into the route by patch key.
+ *
+ * Besides the structural and guard fields below, `update` also patches
+ * **plugin-defined custom fields** (lifecycle hooks, `preload`, `searchSchema`,
+ * …), symmetric with how `add`/`replace` register them. This interface is
+ * **augmentable**: a plugin declares its updatable field via declaration
+ * merging, mirroring its `Route` augmentation but with `| null` to allow removal:
+ *
+ * ```ts
+ * declare module "@real-router/core" {
+ *   interface RouteConfigUpdate<Dependencies extends DefaultDependencies> {
+ *     onNavigate?: LifecycleHookFactory<Dependencies> | null;
+ *   }
+ * }
+ * ```
+ *
+ * Note: `name` / `path` / `children` are route identity and are NOT patchable —
+ * use `remove` + `add` to restructure. The interface stays closed (no index
+ * signature) so typos in structural field names remain compile errors.
  */
 export interface RouteConfigUpdate<
   Dependencies extends DefaultDependencies = DefaultDependencies,

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -3,6 +3,7 @@ import { logger } from "@real-router/logger";
 import { throwIfDisposed } from "./helpers";
 import { guardRouteStructure } from "../guards";
 import { getInternals } from "../internals";
+import { STANDARD_ROUTE_KEYS } from "../namespaces/RoutesNamespace/constants";
 import {
   clearConfigEntries,
   removeFromDefinitions,
@@ -28,6 +29,7 @@ import type {
   DefaultDependencies,
   ForwardToCallback,
   Params,
+  RouteConfigUpdate,
   Router,
   TransitionMeta,
   TreeChangedEvent,
@@ -561,6 +563,70 @@ function updateRouteConfig<
 }
 
 /**
+ * Patches a route's plugin-defined **custom fields** — the `update` counterpart
+ * to how `add`/`replace` register them (`registerSingleRouteHandlers`). A custom
+ * field is any patch key not in {@link STANDARD_ROUTE_KEYS}.
+ *
+ * Semantics mirror the structural fields in {@link updateRouteConfig}:
+ * shallow-merge by patch key, `null` removes a single field, `undefined` is a
+ * no-op (leaves the field untouched). When the merge empties the record, the
+ * whole entry is dropped so `getRouteConfig` returns `undefined` — symmetric
+ * with `add`, which only stores a record when at least one custom field exists.
+ *
+ * The merged record is written as a **fresh object**, never mutated in place:
+ * `cloneRouter` shares per-route custom-field records by reference
+ * (`Object.assign`), so replacing the reference keeps a clone isolated from
+ * post-clone updates on the source.
+ */
+function updateRouteCustomFields<
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+>(
+  store: RoutesStore<Dependencies>,
+  name: string,
+  updates: RouteConfigUpdate<Dependencies>,
+): void {
+  let next: Record<string, unknown> | undefined;
+
+  // `Object.keys` (not `Object.entries`): a value is read only AFTER the
+  // standard-key guard, so structural-field getters — already read once by
+  // `update`'s destructuring — are not re-invoked. `Object.entries` would read
+  // every value eagerly, double-invoking a `defaultParams`/`forwardTo` getter
+  // and breaking the "user getter called once" invariant.
+  // eslint-disable-next-line unicorn/prefer-object-iterable-methods -- see above
+  for (const key of Object.keys(updates)) {
+    if (STANDARD_ROUTE_KEYS.has(key)) {
+      continue;
+    }
+
+    const value = (updates as Record<string, unknown>)[key];
+
+    // `undefined` mirrors the structural path: leave the field untouched.
+    if (value === undefined) {
+      continue;
+    }
+
+    // Clone-on-first-write — keeps clones (which alias this record) isolated.
+    next ??= { ...store.routeCustomFields[name] };
+
+    if (value === null) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+  }
+
+  if (next === undefined) {
+    return;
+  }
+
+  if (Object.keys(next).length > 0) {
+    store.routeCustomFields[name] = next;
+  } else {
+    delete store.routeCustomFields[name];
+  }
+}
+
+/**
  * Gets a route by name with all its configuration.
  */
 function getRoute<
@@ -696,6 +762,15 @@ export function getRoutesApi<
       }
 
       ctx.validator?.routes.validateUpdateRoute(name, updates, store);
+
+      // Custom (plugin-defined) fields — patched symmetrically with add/replace.
+      // Written before the structural config so a throwing custom-field getter
+      // aborts the update before any store write (atomic), mirroring how a
+      // throwing structural getter aborts at the destructuring above. Consumers
+      // read these lazily via getRouteConfig (lifecycle hooks, preload,
+      // searchSchema), so no TREE_CHANGED is needed — the next read sees the new
+      // value; the emit below stays structural-only by design (О-7).
+      updateRouteCustomFields(store, name, updates);
 
       updateRouteConfig(store, name, {
         forwardTo,

--- a/packages/core/src/namespaces/RoutesNamespace/constants.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/constants.ts
@@ -4,3 +4,25 @@
  * Default route name for the root node.
  */
 export const DEFAULT_ROUTE_NAME = "";
+
+/**
+ * Keys that belong to a route's structural/config surface — everything NOT in
+ * this set is a plugin-defined **custom field** (e.g. lifecycle hooks,
+ * `preload`, `searchSchema`), stored in `RoutesStore.routeCustomFields`.
+ *
+ * Single source of truth for the custom-field split, shared by route
+ * registration (`add`/`replace`) and `update` so both classify patch keys
+ * identically. `name`/`path`/`children` define route identity and are not
+ * patchable via `update`; the remaining six are the structural/guard config.
+ */
+export const STANDARD_ROUTE_KEYS: ReadonlySet<string> = new Set([
+  "name",
+  "path",
+  "children",
+  "canActivate",
+  "canDeactivate",
+  "forwardTo",
+  "encodeParams",
+  "decodeParams",
+  "defaultParams",
+]);

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -3,7 +3,7 @@
 import { logger } from "@real-router/logger";
 import { createMatcher, createRouteTree, nodeToDefinition } from "route-tree";
 
-import { DEFAULT_ROUTE_NAME } from "./constants";
+import { DEFAULT_ROUTE_NAME, STANDARD_ROUTE_KEYS } from "./constants";
 import { resolveForwardChain } from "./forwardChain";
 import { createEmptyConfig, sanitizeRoute } from "./helpers";
 
@@ -216,19 +216,8 @@ function registerSingleRouteHandlers<Dependencies extends DefaultDependencies>(
   pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>,
   pendingCanDeactivate: Map<string, GuardFnFactory<Dependencies>>,
 ): void {
-  const standardKeys = new Set([
-    "name",
-    "path",
-    "children",
-    "canActivate",
-    "canDeactivate",
-    "forwardTo",
-    "encodeParams",
-    "decodeParams",
-    "defaultParams",
-  ]);
   const customFields = Object.fromEntries(
-    Object.entries(route).filter(([key]) => !standardKeys.has(key)),
+    Object.entries(route).filter(([key]) => !STANDARD_ROUTE_KEYS.has(key)),
   );
 
   if (Object.keys(customFields).length > 0) {

--- a/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
@@ -2,13 +2,14 @@ import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
 import { errorCodes } from "@real-router/core";
 
-import { getPluginApi, getRoutesApi } from "../../../../src/api";
+import { cloneRouter, getPluginApi, getRoutesApi } from "../../../../src/api";
 import { createTestRouter } from "../../../helpers";
 
 import type {
   Router,
   GuardFnFactory,
   Params,
+  RouteConfigUpdate,
   RouterError,
 } from "@real-router/core";
 import type { RoutesApi } from "@real-router/types";
@@ -590,6 +591,198 @@ describe("core/routes/routeTree/updateRoute", () => {
 
       expect(guard2).toHaveBeenCalled();
       expect(guard1).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("custom fields", () => {
+    // RouteConfigUpdate is a closed interface; plugins augment it with their
+    // own custom fields (symmetric with how they augment Route). Core itself
+    // has no augmentation, so tests pass custom fields via a typed-local patch.
+    // `| undefined` is included so the fixture can express an explicit
+    // `undefined` value (a dynamic/untyped patch shape) and exercise core's
+    // defensive "undefined = no-op" branch under exactOptionalPropertyTypes.
+    type CustomPatch = RouteConfigUpdate & {
+      onView?: (() => () => void) | null | undefined;
+      label?: string | null | undefined;
+    };
+
+    const hook1 = (): (() => void) => (): void => {};
+    const hook2 = (): (() => void) => (): void => {};
+
+    it("should patch a custom field, swapping the stored value", () => {
+      routesApi.add({ name: "ur-cf-swap", path: "/ur-cf-swap", onView: hook1 });
+
+      const patch: CustomPatch = { onView: hook2 };
+
+      routesApi.update("ur-cf-swap", patch);
+
+      expect(getPluginApi(router).getRouteConfig("ur-cf-swap")).toStrictEqual({
+        onView: hook2,
+      });
+    });
+
+    it("should add a custom field to a route that had none", () => {
+      routesApi.add({ name: "ur-cf-new", path: "/ur-cf-new" });
+
+      expect(getPluginApi(router).getRouteConfig("ur-cf-new")).toBeUndefined();
+
+      const patch: CustomPatch = { onView: hook1 };
+
+      routesApi.update("ur-cf-new", patch);
+
+      expect(getPluginApi(router).getRouteConfig("ur-cf-new")).toStrictEqual({
+        onView: hook1,
+      });
+    });
+
+    it("should shallow-merge by patch key, preserving sibling custom fields", () => {
+      routesApi.add({
+        name: "ur-cf-merge",
+        path: "/ur-cf-merge",
+        onView: hook1,
+        label: "keep",
+      });
+
+      const patch: CustomPatch = { onView: hook2 };
+
+      routesApi.update("ur-cf-merge", patch);
+
+      // onView swapped; label untouched.
+      expect(getPluginApi(router).getRouteConfig("ur-cf-merge")).toStrictEqual({
+        onView: hook2,
+        label: "keep",
+      });
+    });
+
+    it("should remove a single custom field when set to null, keeping siblings", () => {
+      routesApi.add({
+        name: "ur-cf-rm-one",
+        path: "/ur-cf-rm-one",
+        onView: hook1,
+        label: "keep",
+      });
+
+      const patch: CustomPatch = { onView: null };
+
+      routesApi.update("ur-cf-rm-one", patch);
+
+      expect(getPluginApi(router).getRouteConfig("ur-cf-rm-one")).toStrictEqual(
+        {
+          label: "keep",
+        },
+      );
+    });
+
+    it("should drop the record entirely when the last custom field is removed", () => {
+      routesApi.add({
+        name: "ur-cf-rm-all",
+        path: "/ur-cf-rm-all",
+        onView: hook1,
+      });
+
+      const patch: CustomPatch = { onView: null };
+
+      routesApi.update("ur-cf-rm-all", patch);
+
+      // Empty record → no entry → getRouteConfig undefined (symmetric with add).
+      expect(
+        getPluginApi(router).getRouteConfig("ur-cf-rm-all"),
+      ).toBeUndefined();
+    });
+
+    it("should treat undefined as a no-op, leaving the custom field untouched", () => {
+      routesApi.add({
+        name: "ur-cf-undef",
+        path: "/ur-cf-undef",
+        onView: hook1,
+      });
+
+      const patch: CustomPatch = { onView: undefined };
+
+      routesApi.update("ur-cf-undef", patch);
+
+      expect(getPluginApi(router).getRouteConfig("ur-cf-undef")).toStrictEqual({
+        onView: hook1,
+      });
+    });
+
+    it("should patch structural and custom fields in the same update", () => {
+      routesApi.add({
+        name: "ur-cf-mixed",
+        path: "/ur-cf-mixed",
+        onView: hook1,
+      });
+
+      const patch: CustomPatch = {
+        defaultParams: { tab: "info" },
+        onView: hook2,
+      };
+
+      routesApi.update("ur-cf-mixed", patch);
+
+      // structural applied...
+      expect(routesApi.get("ur-cf-mixed")?.defaultParams).toStrictEqual({
+        tab: "info",
+      });
+      // ...custom applied, structural field not leaked into the custom record.
+      expect(getPluginApi(router).getRouteConfig("ur-cf-mixed")).toStrictEqual({
+        onView: hook2,
+      });
+    });
+
+    it("should not leak a custom-field update into a previously cloned router", () => {
+      routesApi.add({
+        name: "ur-cf-clone",
+        path: "/ur-cf-clone",
+        onView: hook1,
+      });
+
+      const clone = cloneRouter(router);
+
+      const patch: CustomPatch = { onView: hook2 };
+
+      routesApi.update("ur-cf-clone", patch);
+
+      // Source sees the new value; the clone (which aliases the pre-update
+      // record) keeps the original — fresh-object write preserves isolation.
+      expect(getPluginApi(router).getRouteConfig("ur-cf-clone")).toStrictEqual({
+        onView: hook2,
+      });
+      expect(getPluginApi(clone).getRouteConfig("ur-cf-clone")).toStrictEqual({
+        onView: hook1,
+      });
+
+      clone.dispose();
+    });
+
+    it("should leave config unchanged when a custom-field getter throws", () => {
+      routesApi.add({
+        name: "ur-cf-throw",
+        path: "/ur-cf-throw",
+        onView: hook1,
+        defaultParams: { page: 1 },
+      });
+
+      const throwingPatch: CustomPatch = {
+        defaultParams: { page: 2 },
+        get onView(): () => () => void {
+          throw new Error("custom getter explosion");
+        },
+      };
+
+      expect(() => {
+        routesApi.update("ur-cf-throw", throwingPatch);
+      }).toThrow(/custom getter explosion/);
+
+      // Atomic: neither the custom field nor the structural field was written —
+      // custom fields are applied before the structural config, so the throw
+      // aborts the update before any store write.
+      expect(getPluginApi(router).getRouteConfig("ur-cf-throw")).toStrictEqual({
+        onView: hook1,
+      });
+      expect(routesApi.get("ur-cf-throw")?.defaultParams).toStrictEqual({
+        page: 1,
+      });
     });
   });
 

--- a/packages/core/tests/functional/events/tree-changed.test.ts
+++ b/packages/core/tests/functional/events/tree-changed.test.ts
@@ -6,6 +6,7 @@ import { cloneRouter, getRoutesApi } from "@real-router/core/api";
 import type {
   Params,
   Route,
+  RouteConfigUpdate,
   Router,
   TreeChangedEvent,
 } from "@real-router/core";
@@ -333,29 +334,43 @@ describe("core/events/tree-changed", () => {
     expect(b).toHaveBeenCalledTimes(1);
   });
 
-  // Guard-only / empty updates are silent (О-7 + empty-patch rule).
-  it("does not emit for guard-only or empty update patches", () => {
+  // Guard-only / custom-field-only / empty updates are silent (О-7 +
+  // empty-patch rule). Custom fields (lifecycle hooks, preload, searchSchema)
+  // are read lazily by their consumers, so a custom-only patch needs no
+  // observation channel — same rationale as guards.
+  it("does not emit for guard-only, custom-field-only, or empty update patches", () => {
     const router = makeRouter([
       { name: "home", path: "/home" },
       { name: "other", path: "/other" },
     ]);
     const routesApi = getRoutesApi(router);
 
+    // Custom field is not on the closed RouteConfigUpdate; a plugin augments it.
+    type CustomPatch = RouteConfigUpdate & { onView?: (() => void) | null };
+
     const handler = vi.fn();
 
     routesApi.subscribeChanges(handler);
 
+    const setCustom: CustomPatch = { onView: () => {} };
+    const removeCustom: CustomPatch = { onView: null };
+    const mixed: CustomPatch = {
+      forwardTo: "other",
+      canActivate: () => () => true,
+      onView: () => {},
+    };
+
     routesApi.update("home", { canActivate: () => () => false });
     routesApi.update("home", { canActivate: null });
     routesApi.update("home", {});
+    routesApi.update("home", setCustom);
+    routesApi.update("home", removeCustom);
 
     expect(handler).not.toHaveBeenCalled();
 
-    // A structural field alongside a guard still emits — with guard filtered out.
-    routesApi.update("home", {
-      forwardTo: "other",
-      canActivate: () => () => true,
-    });
+    // A structural field alongside a guard AND a custom field still emits — with
+    // both the guard and the custom field filtered out of the structural patch.
+    routesApi.update("home", mixed);
 
     expect(handler).toHaveBeenCalledTimes(1);
 
@@ -363,6 +378,7 @@ describe("core/events/tree-changed", () => {
 
     expect(event.patch).toStrictEqual({ forwardTo: "other" });
     expect("canActivate" in event.patch).toBe(false);
+    expect("onView" in event.patch).toBe(false);
   });
 
   // Payloads carry route config; add-with-parent sets `parent`; update emits on

--- a/packages/lifecycle-plugin/CLAUDE.md
+++ b/packages/lifecycle-plugin/CLAUDE.md
@@ -17,7 +17,7 @@
 3. On `onTransitionLeaveApprove`: if route changed → calls `onLeave` on the leaving route
 4. On `onTransitionSuccess`: calls `onEnter` or `onStay` (depending on route name change) AND `onNavigate` — hooks are orthogonal, each fires independently based on its own condition
 
-Hook lookup: `api.getRouteConfig(routeName)?.[hookName]` — reads hook factory from route definition, compiles it lazily via `factory(router, getDependency)`, and caches the compiled hook per `hookName:routeName`. Same DI pattern as `GuardFnFactory`. Config changes are picked up lazily (recompiles when the `factory` reference differs); removed routes are evicted eagerly via a `getRoutesApi(router).subscribeChanges()` subscription (drops `hookName:routeName` entries on `remove`/`replace`, clears all on `clear`) so they don't linger as dead memory. The subscription is removed in `teardown`.
+Hook lookup: `api.getRouteConfig(routeName)?.[hookName]` — reads hook factory from route definition, compiles it lazily via `factory(router, getDependency)`, and caches the compiled hook per `hookName:routeName`. Same DI pattern as `GuardFnFactory`. Config changes — including hot-swapping a hook via `getRoutesApi(router).update(name, { onNavigate })` (#797), `replace`, or `remove`+`add` — are picked up lazily (recompiles when the `factory` reference differs); removed routes are evicted eagerly via a `getRoutesApi(router).subscribeChanges()` subscription (drops `hookName:routeName` entries on `remove`/`replace`, clears all on `clear`) so they don't linger as dead memory. The subscription is removed in `teardown`.
 
 ## Hook Semantics
 
@@ -60,7 +60,7 @@ The plugin has no options. Hook callbacks are the configuration — they live on
 
 ### Module augmentation
 
-`declare module "@real-router/core"` in `index.ts` extends the `Route` interface with typed `onEnter`, `onStay`, `onLeave`, `onNavigate` fields. Import the plugin package to get autocomplete.
+`declare module "@real-router/core"` in `index.ts` extends the `Route` interface with typed `onEnter`, `onStay`, `onLeave`, `onNavigate` fields, and the `RouteConfigUpdate` interface with the same fields (each `| null` to remove) so the hooks are patchable via `getRoutesApi(router).update(name, patch)` (#797). Import the plugin package to get autocomplete for both route definitions and update patches.
 
 ## See Also
 

--- a/packages/lifecycle-plugin/src/index.ts
+++ b/packages/lifecycle-plugin/src/index.ts
@@ -22,6 +22,16 @@ declare module "@real-router/core" {
      */
     onNavigate?: LifecycleHookFactory<Dependencies>;
   }
+
+  // Makes the hooks patchable via `getRoutesApi(router).update(name, patch)`
+  // (symmetric with the Route augmentation above). `null` removes a hook; the
+  // plugin recompiles lazily on the next navigation when the factory changes.
+  interface RouteConfigUpdate<Dependencies extends DefaultDependencies> {
+    onEnter?: LifecycleHookFactory<Dependencies> | null;
+    onStay?: LifecycleHookFactory<Dependencies> | null;
+    onLeave?: LifecycleHookFactory<Dependencies> | null;
+    onNavigate?: LifecycleHookFactory<Dependencies> | null;
+  }
 }
 
 export type { LifecycleHook, LifecycleHookFactory } from "./types";

--- a/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/lifecycle-plugin/tests/functional/lifecycle.test.ts
@@ -791,4 +791,68 @@ describe("@real-router/lifecycle-plugin", () => {
       }).not.toThrow();
     });
   });
+
+  describe("hot-swap hooks via routes.update (#797)", () => {
+    it("recompiles and fires the new onNavigate factory after update()", async () => {
+      const hook1 = vi.fn();
+      const hook2 = vi.fn();
+      const factory1: LifecycleHookFactory = () => hook1;
+      const factory2: LifecycleHookFactory = () => hook2;
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          { name: "target", path: "/target", onNavigate: factory1 },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+      const routesApi = getRoutesApi(router);
+
+      await router.start("/");
+      await router.navigate("target");
+
+      expect(hook1).toHaveBeenCalledTimes(1);
+      expect(hook2).not.toHaveBeenCalled();
+
+      // Hot-swap the hook factory — typed precisely via the RouteConfigUpdate
+      // augmentation. Before #797 this was silently dropped (factory2 calls: 0).
+      routesApi.update("target", { onNavigate: factory2 });
+
+      await router.navigate("home");
+      await router.navigate("target");
+
+      // New factory fires; old one is not re-invoked.
+      expect(hook2).toHaveBeenCalledTimes(1);
+      expect(hook1).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes the hook when update sets the factory to null", async () => {
+      const hook = vi.fn();
+      const factory: LifecycleHookFactory = () => hook;
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          { name: "target", path: "/target", onNavigate: factory },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(lifecyclePluginFactory());
+      const routesApi = getRoutesApi(router);
+
+      await router.start("/");
+      await router.navigate("target");
+
+      expect(hook).toHaveBeenCalledTimes(1);
+
+      routesApi.update("target", { onNavigate: null });
+
+      await router.navigate("home");
+      await router.navigate("target");
+
+      // Hook removed — no further calls.
+      expect(hook).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/preload-plugin/CLAUDE.md
+++ b/packages/preload-plugin/CLAUDE.md
@@ -77,7 +77,7 @@ The factory function checks `typeof document === "undefined"` before instantiati
 
 ### Module augmentation
 
-`Route.preload`, `Router.getPreloadSettings`, and `Router.getPreloadedState` are declared in `index.ts`. Import the package to get autocomplete for route definitions and both router methods. `getPreloadedState` is typed as optional — it is only present while the plugin is active.
+`Route.preload`, `RouteConfigUpdate.preload` (`| null`), `Router.getPreloadSettings`, and `Router.getPreloadedState` are declared in `index.ts`. The `RouteConfigUpdate` augmentation makes `preload` patchable via `getRoutesApi(router).update(name, { preload })` (#797) — picked up lazily on the next hover/touch. Import the package to get autocomplete for route definitions, update patches, and both router methods. `getPreloadedState` is typed as optional — it is only present while the plugin is active.
 
 ## See Also
 

--- a/packages/preload-plugin/src/index.ts
+++ b/packages/preload-plugin/src/index.ts
@@ -15,6 +15,13 @@ declare module "@real-router/core" {
     preload?: PreloadFnFactory<Dependencies>;
   }
 
+  // Makes `preload` patchable via `getRoutesApi(router).update(name, patch)`
+  // (symmetric with the Route augmentation). `null` removes it; the plugin
+  // recompiles lazily on the next hover/touch when the factory reference differs.
+  interface RouteConfigUpdate<Dependencies extends DefaultDependencies> {
+    preload?: PreloadFnFactory<Dependencies> | null;
+  }
+
   interface Router {
     getPreloadedState?: (href: string) => State | undefined;
     getPreloadSettings(): PreloadPluginOptions;

--- a/packages/preload-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/preload-plugin/tests/functional/lifecycle.test.ts
@@ -300,6 +300,47 @@ describe("preload-plugin — lifecycle", () => {
     router.stop();
   });
 
+  it("invalidates compiled preload cache after routes.update() swaps preload (#797)", async () => {
+    const preloadV1 = vi.fn().mockResolvedValue("v1");
+    const preloadV2 = vi.fn().mockResolvedValue("v2");
+
+    const { router } = createTestRouter([
+      { name: "home", path: "/", preload: () => preloadV1 },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    const anchor = createAnchor("/");
+
+    // First hover: V1 factory compiled and cached
+    fireMouseOver(anchor);
+    await waitForTimer(65);
+
+    expect(preloadV1).toHaveBeenCalledTimes(1);
+    expect(preloadV2).not.toHaveBeenCalled();
+
+    // Move away to reset currentAnchor
+    const div = document.createElement("div");
+
+    document.body.append(div);
+    fireMouseOver(div);
+
+    // Hot-swap the preload factory via update — typed precisely via the
+    // RouteConfigUpdate augmentation. Before #797 this was silently dropped.
+    getRoutesApi(router).update("home", { preload: () => preloadV2 });
+
+    // Re-hover: should use V2 (lazy revalidation on factory reference change)
+    fireMouseOver(anchor);
+    await waitForTimer(65);
+
+    expect(preloadV1).toHaveBeenCalledTimes(1);
+    expect(preloadV2).toHaveBeenCalledTimes(1);
+
+    router.stop();
+  });
+
   it("cleans compiled-preload entries on remove/replace/clear without breaking preload", async () => {
     const preloadFn = vi.fn().mockResolvedValue(undefined);
     const { router } = createTestRouter([

--- a/packages/search-schema-plugin/CLAUDE.md
+++ b/packages/search-schema-plugin/CLAUDE.md
@@ -22,12 +22,19 @@
 
 ## Module Augmentation
 
-Extends `Route` interface with `searchSchema` field:
+Extends the `Route` interface with `searchSchema`, and the `RouteConfigUpdate`
+interface with `searchSchema` (`| null`) so the schema is patchable via
+`getRoutesApi(router).update(name, { searchSchema })` (#797) — read lazily, so
+the next navigation validates against the new schema:
 
 ```typescript
 declare module "@real-router/core" {
   interface Route {
     searchSchema?: StandardSchemaV1;
+  }
+
+  interface RouteConfigUpdate {
+    searchSchema?: StandardSchemaV1 | null;
   }
 }
 ```

--- a/packages/search-schema-plugin/src/index.ts
+++ b/packages/search-schema-plugin/src/index.ts
@@ -6,6 +6,13 @@ declare module "@real-router/core" {
   interface Route {
     searchSchema?: StandardSchemaV1;
   }
+
+  // Makes `searchSchema` patchable via `getRoutesApi(router).update(name, patch)`
+  // (symmetric with the Route augmentation). `null` removes it; navigation reads
+  // the schema lazily, so the next navigation validates against the new schema.
+  interface RouteConfigUpdate {
+    searchSchema?: StandardSchemaV1 | null;
+  }
 }
 
 export type {

--- a/packages/search-schema-plugin/tests/functional/forwardState.test.ts
+++ b/packages/search-schema-plugin/tests/functional/forwardState.test.ts
@@ -1,4 +1,5 @@
 import { createRouter } from "@real-router/core";
+import { getRoutesApi } from "@real-router/core/api";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
 import { searchSchemaPlugin } from "@real-router/search-schema-plugin";
@@ -6,6 +7,7 @@ import { searchSchemaPlugin } from "@real-router/search-schema-plugin";
 import {
   createMockSchema,
   failingSchema,
+  passThroughSchema,
   searchSchema,
   schemaWithDefaults,
   asyncSchema,
@@ -830,6 +832,41 @@ describe("Search schema plugin", () => {
       const path = router.buildPath("search", { q: "  HELLO  " });
 
       expect(path).not.toContain("q=hello");
+    });
+  });
+
+  describe("hot-swap searchSchema via routes.update (#797)", () => {
+    it("validates against the new schema after update() swaps searchSchema", async () => {
+      // schema1 strips every param (strict mode uses validation.value verbatim).
+      const stripAll = createMockSchema({ validate: () => ({ value: {} }) });
+
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          { name: "search", path: "/search?q", searchSchema: stripAll },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(
+        searchSchemaPlugin({ mode: "development", strict: true }),
+      );
+      await router.start("/");
+
+      // Under schema1, `q` is stripped.
+      await router.navigate("search", { q: "hello" });
+
+      expect(router.getState()?.params).not.toHaveProperty("q");
+
+      // Hot-swap the schema via update — typed precisely via the augmentation.
+      // Before #797 this was silently dropped (the stale schema kept validating).
+      getRoutesApi(router).update("search", {
+        searchSchema: passThroughSchema(),
+      });
+
+      // Under schema2 (pass-through), `q` is now preserved.
+      await router.navigate("search", { q: "world" });
+
+      expect(router.getState()?.params).toMatchObject({ q: "world" });
     });
   });
 });

--- a/packages/validation-plugin/tests/functional/routes.validation.test.ts
+++ b/packages/validation-plugin/tests/functional/routes.validation.test.ts
@@ -334,6 +334,23 @@ describe("routes API validation — with validationPlugin", () => {
         raw.update("home", { encodeParams: transpiledEncoder });
       }).toThrow(/cannot be an async function/);
     });
+
+    it("should not reject custom (plugin-defined) fields in the patch (#797)", () => {
+      const raw = routes as unknown as {
+        update: (n: string, u: unknown) => void;
+      };
+
+      // The validator covers only the structural/guard surface; custom fields
+      // (lifecycle hooks, preload, searchSchema) are arbitrary and pass through.
+      // Locks the permissive contract that makes custom-field update work.
+      expect(() => {
+        raw.update("home", {
+          onView: () => () => {},
+          label: "x",
+          decodeParams: (p: unknown) => p,
+        });
+      }).not.toThrow();
+    });
   });
 
   describe("replaceRoutes validation", () => {


### PR DESCRIPTION
## Summary

`getRoutesApi(router).update(name, patch)` previously applied only the structural/guard subset of the patch and silently dropped plugin-defined custom fields (lifecycle hooks, `preload`, `searchSchema`), so `getPluginApi(router).getRouteConfig(name)` returned stale values after an update.

- `routes.update()` now patches custom route fields too — shallow-merge by patch key, `null` removes a field, `undefined` is a no-op — symmetric with `add`/`replace`.
- Lifecycle hooks (`onEnter`/`onStay`/`onLeave`/`onNavigate`), `preload`, and `searchSchema` can be hot-swapped at runtime with precise typing; consumers pick up the new value lazily on the next navigation/hover.
- `RouteConfigUpdate` stays a closed interface (structural-field typos remain compile errors); plugins opt in by augmenting it, symmetric with their `Route` augmentation.

**Root cause:** `update` destructured only the six known fields (`forwardTo`/`defaultParams`/`decodeParams`/`encodeParams`/`canActivate`/`canDeactivate`) and never read custom fields from the patch, so `routeCustomFields` was left untouched. The typed path was already a compile error (closed `RouteConfigUpdate`), so the runtime drop was reachable only via untyped JS. The fix persists custom fields in core and adds a typed update surface via per-plugin augmentation — an index signature was rejected because it would re-introduce silent-ignore of structural-field typos (the very failure mode this issue is about).

### Maintainability
- Extract `STANDARD_ROUTE_KEYS` as the single source of truth for the custom-field split, shared by `add`/`replace` registration and `update`.

## New API

```ts
// Hot-swap plugin config at runtime — typed via each plugin's RouteConfigUpdate augmentation
getRoutesApi(router).update("dashboard", { onNavigate: () => () => track() }); // lifecycle-plugin
getRoutesApi(router).update("users", { preload: () => (p) => fetchUsers(p) });  // preload-plugin
getRoutesApi(router).update("search", { searchSchema: nextSchema });            // search-schema-plugin
getRoutesApi(router).update("dashboard", { onNavigate: null });                 // null removes the field
```

## Test plan

- [x] `core/updateRoute.test.ts › custom fields` — swap, create, shallow-merge, null-removes-one, null-removes-last → undefined, undefined no-op, mixed structural+custom, clone isolation, throwing-getter atomicity (fails before / passes after)
- [x] `core/tree-changed.test.ts` — custom-field-only update emits no event; mixed patch emits structural-only
- [x] `lifecycle-plugin/lifecycle.test.ts` — hot-swap `onNavigate` via `update` (the original repro) + null removal
- [x] `preload-plugin/lifecycle.test.ts` / `search-schema-plugin/forwardState.test.ts` — `update` swaps `preload` / `searchSchema`, picked up lazily
- [x] `validation-plugin/routes.validation.test.ts` — `update` with custom fields does not throw
- [x] `pnpm build` passes (292/292 tasks)
- [x] 100% coverage maintained

Closes #797
