### PR TITLE
refactor(core): architecture-review cleanups (#906 #908 #909 #910 #911)

### DIFF
--- a/.changeset/dead-validation-machinery-906-core.md
+++ b/.changeset/dead-validation-machinery-906-core.md
@@ -1,0 +1,13 @@
+---
+"@real-router/core": minor
+---
+
+Remove dead validation machinery (#906)
+
+Removes three never-used pieces of validation scaffolding surfaced by the architecture review (finding 2.1):
+
+- `RouteLifecycleNamespace.#registering` — a `Set` written (`.add`/`.delete`) but never read
+- `RouterValidator.lifecycle.validateNotRegistering` — interface member never called by core
+- `PluginsNamespace.validateNoDuplicatePlugins` static method — never called (the live duplicate check is the `RouterValidator.plugins.validateNoDuplicatePlugins` member, left untouched)
+
+**Breaking (type-only):** the `validateNotRegistering` member is removed from the exported `RouterValidator` interface. No runtime behavior changes — none of the removed code was on an execution path.

--- a/.changeset/dead-validation-machinery-906-validation-plugin.md
+++ b/.changeset/dead-validation-machinery-906-validation-plugin.md
@@ -1,0 +1,7 @@
+---
+"@real-router/validation-plugin": minor
+---
+
+Remove dead `validateNotRegistering` validator (#906)
+
+Drops the `validateNotRegistering` implementation (`validators/lifecycle.ts`) and its wiring in `validationPlugin.ts` — it implemented a `RouterValidator` member that core never invoked (dead on both ends). No change to `validationPlugin()` behavior.

--- a/.changeset/getroutesapi-cache-910-perf.md
+++ b/.changeset/getroutesapi-cache-910-perf.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Cache `getRoutesApi` per router (#910)
+
+`getRoutesApi(router)` now returns a stable, per-router cached instance (keyed by a `WeakMap`), mirroring `getPluginApi` / `getNavigator`. Avoids re-allocating the API closure bag on repeat calls and gives callers a stable object identity.

--- a/.changeset/review-s4-911-cleanup.md
+++ b/.changeset/review-s4-911-cleanup.md
@@ -1,0 +1,9 @@
+---
+"@real-router/core": minor
+---
+
+Remove dead `BuildStateResultWithSegments` type + internal cleanups (#911)
+
+- **Breaking (type-only):** removed the unused public `BuildStateResultWithSegments` type — it had zero consumers across the monorepo despite its `@internal` "used internally" note.
+- Renamed the internal logger-config guard `isLoggerConfig` → `assertLoggerConfig` with an `asserts config is LoggerConfig` signature: it validates-and-throws, so the `is`-predicate name was misleading.
+- Documented the intentional module-global `transitionPath` caches (shared across routers, bounded by route-name vocabulary, not per-router so not cleared on dispose).

--- a/.changeset/treeops-removal-909-refactor.md
+++ b/.changeset/treeops-removal-909-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Remove dead `store.treeOperations` indirection (#909)
+
+`getRoutesApi` now calls `commitTreeChanges` / `resetStore` / `nodeToDefinition` via direct static imports instead of a per-store `treeOperations` object. The indirection's stated rationale (avoid static `route-tree` import chains) no longer held — `route-tree` is always bundled into core. Internal only; no API or behavior change.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -2528,7 +2528,7 @@ export function getDependenciesApi(router: Router): DependenciesApi {
 
 **Extracted APIs:** `getRoutesApi`, `getDependenciesApi`, `getLifecycleApi`, `getPluginApi`, `cloneRouter`.
 
-**Tree operations injection:** `store.treeOperations` carries `commitTreeChanges` / `resetStore` (core helpers in `routesStore.ts`) and `nodeToDefinition` (from `route-tree`), set when the store is created. Injecting `nodeToDefinition` keeps `getRoutesApi` free of a static **runtime** `route-tree` import — it imports only route-tree _types_ (erased at compile) and reaches `nodeToDefinition` through the store. (`commitTreeChanges`/`resetStore` live in `routesStore`, which `getRoutesApi` already imports, so for those two the indirection no longer buys isolation.)
+**Tree operations injection (removed, #909):** `store.treeOperations` used to inject `commitTreeChanges` / `resetStore` / `nodeToDefinition` into the store so `getRoutesApi` could reach them without direct imports. The stated rationale (avoid static `route-tree` import chains) did not hold — `route-tree` is `alwaysBundle`d into core (a direct `nodeToDefinition` import adds no weight), and `commitTreeChanges`/`resetStore` already live in `routesStore`, which `getRoutesApi` imports anyway. Replaced with direct static imports; the per-store `treeOperations` object is gone.
 
 ### FSM Migration: dispose(), TransitionMeta, Event Flow
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -105,7 +105,7 @@ namespaces/DependenciesNamespace/
 └── index.ts               — exports
 ```
 
-**Store pattern:** `RoutesStore` and `DependenciesStore` are plain data interfaces (not classes). CRUD logic lives in the corresponding standalone API function (`getRoutesApi.ts`, `getDependenciesApi.ts`).
+**Store pattern:** `RoutesStore` and `DependenciesStore` are data-holder interfaces (not classes). Besides the tree/config/matcher data, `RoutesStore` deliberately carries internal cross-namespace references — `lifecycleNamespace` and `depsStore`, set after construction during wiring — so the standalone CRUD helpers can reach the lifecycle namespace (for `addCanActivate` / `clearDefinitionGuards` / `clearAll`) via `store.lifecycleNamespace` instead of threading a parameter through every helper. The store is the api/ layer's deliberate transport channel, not pure inert data. CRUD logic lives in the corresponding standalone API function (`getRoutesApi.ts`, `getDependenciesApi.ts`).
 
 ### Dependency Injection
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -33,7 +33,7 @@ import {
 import { CACHED_ALREADY_STARTED_ERROR } from "./namespaces/RouterLifecycleNamespace/constants";
 import { RouterError } from "./RouterError";
 import { getTransitionPath } from "./transitionPath";
-import { isLoggerConfig } from "./typeGuards";
+import { assertLoggerConfig } from "./typeGuards";
 import { RouterWiringBuilder, wireRouter } from "./wiring";
 
 import type { RouterInternals } from "./internals";
@@ -129,7 +129,8 @@ export class Router<
     // router options.
     const { logger: loggerConfig, ...routerOptions } = options;
 
-    if (loggerConfig && isLoggerConfig(loggerConfig)) {
+    if (loggerConfig) {
+      assertLoggerConfig(loggerConfig);
       logger.configure(loggerConfig);
     }
 
@@ -606,6 +607,10 @@ export class Router<
       this.#limits,
     );
     for (const plugin of filtered) {
+      // `getAll()` sits inside the optional-chain argument on purpose: with no
+      // validator installed (production default) the `?.` short-circuits and the
+      // array is never allocated. Hoisting it out would either allocate on the
+      // no-validator hot path or push the dev-only branch out of coverage.
       ctx.validator?.plugins.validateNoDuplicatePlugins(
         plugin,
         this.#plugins.getAll(),

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -1,4 +1,5 @@
 import { logger } from "@real-router/logger";
+import { nodeToDefinition } from "route-tree";
 
 import { throwIfDisposed } from "./helpers";
 import { guardRouteStructure } from "../guards";
@@ -17,7 +18,9 @@ import {
   assertAddable,
   buildAddArtifacts,
   buildReplaceArtifacts,
+  commitTreeChanges,
   refreshForwardMap,
+  resetStore,
 } from "../namespaces/RoutesNamespace/routesStore";
 
 import type { RoutesApi } from "./types";
@@ -501,7 +504,7 @@ function removeRoute<
     store.lifecycleNamespace!,
   );
 
-  store.treeOperations.commitTreeChanges(store);
+  commitTreeChanges(store);
 
   return true;
 }
@@ -643,7 +646,7 @@ function getRoute<
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- segments is non-empty (checked above)
   const targetNode = segments.at(-1)! as RouteTree;
-  const definition = store.treeOperations.nodeToDefinition(targetNode);
+  const definition = nodeToDefinition(targetNode);
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const factories = store.lifecycleNamespace!.getFactories();
 
@@ -654,9 +657,23 @@ function getRoute<
 // API factory
 // ============================================================================
 
+// Cache the assembled RoutesApi per router — mirrors getPluginApi()/getNavigator():
+// avoids re-allocating the 9-closure bag on each call (adapters/plugins poll it
+// from constructors) and gives spy/stub helpers a stable object identity. Closures
+// capture `ctx`/`store`, both stable for the router's lifetime, so caching is safe.
+// Single cast site: the value is stored as `unknown` (RoutesApi is invariant in
+// Dependencies, so one typed map can't hold every instantiation) and cast on read.
+const cache = new WeakMap<object, unknown>();
+
 export function getRoutesApi<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(router: Router<Dependencies>): RoutesApi<Dependencies> {
+  const cached = cache.get(router);
+
+  if (cached) {
+    return cached as RoutesApi<Dependencies>;
+  }
+
   const ctx = getInternals(router);
 
   const store = ctx.routeGetStore();
@@ -668,7 +685,7 @@ export function getRoutesApi<
     ctx.treeChanged.emit(event as TreeChangedEvent);
   };
 
-  return {
+  const api: RoutesApi<Dependencies> = {
     add: (routes, options) => {
       throwIfDisposed(ctx.isDisposed);
 
@@ -833,7 +850,7 @@ export function getRoutesApi<
           ? Object.freeze([...collectFlatRoutes(store, () => true).values()])
           : undefined;
 
-      store.treeOperations.resetStore(store);
+      resetStore(store);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed set after wiring
       store.lifecycleNamespace!.clearAll();
       ctx.clearState();
@@ -903,4 +920,8 @@ export function getRoutesApi<
 
     subscribeChanges: (handler) => ctx.treeChanged.subscribe(handler),
   };
+
+  cache.set(router, api);
+
+  return api;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,6 @@
 // Router-dependent types (re-exported from @real-router/types)
 
 export type {
-  BuildStateResultWithSegments,
   GuardFnFactory,
   PluginFactory,
   Route,

--- a/packages/core/src/namespaces/PluginsNamespace/PluginsNamespace.ts
+++ b/packages/core/src/namespaces/PluginsNamespace/PluginsNamespace.ts
@@ -40,20 +40,6 @@ export class PluginsNamespace<
     validatePlugin(plugin);
   }
 
-  static validateNoDuplicatePlugins<D extends DefaultDependencies>(
-    newFactories: PluginFactory<D>[],
-    hasPlugin: (factory: PluginFactory<D>) => boolean,
-  ): void {
-    for (const factory of newFactories) {
-      if (hasPlugin(factory)) {
-        throw new Error(
-          `[router.usePlugin] Plugin factory already registered. ` +
-            `To re-register, first unsubscribe the existing plugin.`,
-        );
-      }
-    }
-  }
-
   // =========================================================================
   // Dependency injection
   // =========================================================================

--- a/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
+++ b/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
@@ -76,8 +76,6 @@ export class RouteLifecycleNamespace<
     this.#canActivateFunctions,
   ];
 
-  readonly #registering = new Set<string>();
-
   #deps!: RouteLifecycleDependencies<Dependencies>;
   #limits: Limits = DEFAULT_LIMITS;
   #getValidator: (() => RouterValidator | null) | null = null;
@@ -433,9 +431,6 @@ export class RouteLifecycleNamespace<
 
     targetMap.set(name, factory);
 
-    // Mark route as being registered before calling user factory
-    this.#registering.add(name);
-
     try {
       const fn = this.#deps.compileFactory(factory);
 
@@ -459,8 +454,6 @@ export class RouteLifecycleNamespace<
       }
 
       throw error;
-    } finally {
-      this.#registering.delete(name);
     }
   }
 

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -1,7 +1,7 @@
 // packages/core/src/namespaces/RoutesNamespace/routesStore.ts
 
 import { logger } from "@real-router/logger";
-import { createMatcher, createRouteTree, nodeToDefinition } from "route-tree";
+import { createMatcher, createRouteTree } from "route-tree";
 
 import { DEFAULT_ROUTE_NAME, STANDARD_ROUTE_KEYS } from "./constants";
 import { resolveForwardChain } from "./forwardChain";
@@ -44,11 +44,6 @@ export interface RoutesStore<
   lifecycleNamespace: RouteLifecycleNamespace<Dependencies> | undefined;
   readonly pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>;
   readonly pendingCanDeactivate: Map<string, GuardFnFactory<Dependencies>>;
-  readonly treeOperations: {
-    readonly commitTreeChanges: (store: RoutesStore<Dependencies>) => void;
-    readonly resetStore: (store: RoutesStore<Dependencies>) => void;
-    readonly nodeToDefinition: (node: RouteTree) => RouteDefinition;
-  };
 }
 
 // =============================================================================
@@ -556,10 +551,5 @@ export function createRoutesStore<
     lifecycleNamespace: undefined,
     pendingCanActivate: artifacts.pendingCanActivate,
     pendingCanDeactivate: artifacts.pendingCanDeactivate,
-    treeOperations: {
-      commitTreeChanges,
-      resetStore,
-      nodeToDefinition,
-    },
   };
 }

--- a/packages/core/src/transitionPath.ts
+++ b/packages/core/src/transitionPath.ts
@@ -193,6 +193,10 @@ function pointOfDifference(
  * Validation significantly slows down nameToIDs execution.
  * The input should be validated by the function/method that calls nameToIDs.
  */
+// Module-global cache (shared across all router instances): bounded in practice by
+// the app's route-name vocabulary, which is stable across cloneRouter() requests, so
+// it does not grow per request. Intentionally NOT cleared on dispose() — it is not
+// per-router, so one router's teardown must not evict entries other routers rely on.
 const nameToIDsCache = new Map<string, string[]>();
 
 export function nameToIDs(name: string): string[] {
@@ -326,6 +330,7 @@ function computeNameToIDs(name: string): string[] {
 // Single-entry cache: shouldUpdateNode calls getTransitionPath N times per
 // navigation with the same state objects (once per subscribed node).
 // Cache by reference eliminates N-1 redundant computations.
+// Module-global (≤2 State refs); not cleared on dispose — negligible, not per-router.
 let cached1To: State | undefined;
 let cached1From: State | undefined;
 let cached1Result: TransitionPath | null = null;

--- a/packages/core/src/typeGuards.ts
+++ b/packages/core/src/typeGuards.ts
@@ -1,7 +1,7 @@
 // packages/core/src/typeGuards.ts
 
 /**
- * RealRouter-specific type guards for logger configuration
+ * RealRouter-specific assertion for logger configuration.
  */
 import type { LoggerConfig, LogLevelConfig } from "@real-router/logger";
 
@@ -28,7 +28,9 @@ function formatValue(value: unknown): string {
   return String(value);
 }
 
-export function isLoggerConfig(config: unknown): config is LoggerConfig {
+export function assertLoggerConfig(
+  config: unknown,
+): asserts config is LoggerConfig {
   if (typeof config !== "object" || config === null) {
     throw new TypeError("Logger config must be an object");
   }
@@ -74,6 +76,4 @@ export function isLoggerConfig(config: unknown): config is LoggerConfig {
       `Logger callbackIgnoresLevel must be a boolean, got ${typeof obj.callbackIgnoresLevel}`,
     );
   }
-
-  return true;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,9 +11,7 @@
 import type {
   LimitsConfig,
   NavigationOptions,
-  Params,
   RouterError as RouterErrorType,
-  RouteTreeState,
   State,
   TreeChangedEvent,
 } from "@real-router/types";
@@ -63,15 +61,3 @@ export type RouterEventMap = {
  * Immutable limits configuration type.
  */
 export type Limits = Readonly<LimitsConfig>;
-
-/**
- * Extended build result that includes segments for path building.
- * Used internally to avoid duplicate getSegmentsByName calls.
- *
- * @param segments - Route segments from getSegmentsByName (typed as unknown[] for cross-package compatibility)
- * @internal
- */
-export interface BuildStateResultWithSegments<P extends Params = Params> {
-  readonly state: RouteTreeState<P>;
-  readonly segments: readonly unknown[];
-}

--- a/packages/core/src/types/RouterValidator.ts
+++ b/packages/core/src/types/RouterValidator.ts
@@ -103,11 +103,6 @@ export interface RouterValidator {
    */
   lifecycle: {
     validateHandler: (handler: unknown, caller: string) => void;
-    validateNotRegistering: (
-      name: string,
-      guards: unknown,
-      caller: string,
-    ) => void;
     validateHandlerLimit: (
       count: number,
       limits: unknown,

--- a/packages/core/tests/functional/api/getRoutesApi/getRoutesApi.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/getRoutesApi.test.ts
@@ -29,10 +29,10 @@ describe("getRoutesApi()", () => {
     expect(typeof routesApi.get).toBe("function");
   });
 
-  it("should return a new object on each call", () => {
+  it("should return the same cached instance on repeat calls (#910)", () => {
     const routesApi2 = getRoutesApi(router);
 
-    expect(routesApi).not.toBe(routesApi2);
+    expect(routesApi).toBe(routesApi2);
   });
 
   it("has should check if route exists", () => {

--- a/packages/core/tests/functional/no-validation-plugin.test.ts
+++ b/packages/core/tests/functional/no-validation-plugin.test.ts
@@ -10,7 +10,6 @@ import {
 } from "@real-router/core/api";
 
 import { EventBusNamespace } from "../../src/namespaces/EventBusNamespace";
-import { PluginsNamespace } from "../../src/namespaces/PluginsNamespace";
 import { createTestRouter } from "../helpers";
 
 import type { Router } from "@real-router/core";
@@ -385,25 +384,6 @@ describe("core/without validation plugin", () => {
   });
 
   describe("internal validator static methods (coverage for validators still in core)", () => {
-    it("should throw when same factory registered twice (validateNoDuplicatePlugins)", () => {
-      const factory = () => ({});
-
-      expect(() => {
-        PluginsNamespace.validateNoDuplicatePlugins(
-          [factory],
-          (f) => f === factory,
-        );
-      }).toThrow();
-    });
-
-    it("should not throw when factory is not duplicate (validateNoDuplicatePlugins)", () => {
-      const factory = () => ({});
-
-      expect(() => {
-        PluginsNamespace.validateNoDuplicatePlugins([factory], () => false);
-      }).not.toThrow();
-    });
-
     it("should throw TypeError when subscribe listener is not a function (validateSubscribeListener)", () => {
       expect(() => {
         EventBusNamespace.validateSubscribeListener(null);

--- a/packages/core/tests/functional/typeGuards.test.ts
+++ b/packages/core/tests/functional/typeGuards.test.ts
@@ -1,138 +1,179 @@
 import { describe, it, expect } from "vitest";
 
-import { isLoggerConfig } from "../../src/typeGuards";
+import { assertLoggerConfig } from "../../src/typeGuards";
 
 describe("typeGuards", () => {
-  describe("isLoggerConfig", () => {
-    it("should return true for empty config object", () => {
-      expect(isLoggerConfig({})).toBe(true);
+  describe("assertLoggerConfig", () => {
+    it("does not throw for empty config object", () => {
+      expect(() => {
+        assertLoggerConfig({});
+      }).not.toThrow();
     });
 
-    it("should return true for valid level 'all'", () => {
-      expect(isLoggerConfig({ level: "all" })).toBe(true);
+    it("does not throw for valid level 'all'", () => {
+      expect(() => {
+        assertLoggerConfig({ level: "all" });
+      }).not.toThrow();
     });
 
-    it("should return true for valid level 'warn-error'", () => {
-      expect(isLoggerConfig({ level: "warn-error" })).toBe(true);
+    it("does not throw for valid level 'warn-error'", () => {
+      expect(() => {
+        assertLoggerConfig({ level: "warn-error" });
+      }).not.toThrow();
     });
 
-    it("should return true for valid level 'error-only'", () => {
-      expect(isLoggerConfig({ level: "error-only" })).toBe(true);
+    it("does not throw for valid level 'error-only'", () => {
+      expect(() => {
+        assertLoggerConfig({ level: "error-only" });
+      }).not.toThrow();
     });
 
-    it("should return true for valid callback function", () => {
-      expect(isLoggerConfig({ callback: () => {} })).toBe(true);
+    it("does not throw for valid callback function", () => {
+      expect(() => {
+        assertLoggerConfig({ callback: () => {} });
+      }).not.toThrow();
     });
 
-    it("should return true for valid config with both level and callback", () => {
-      expect(isLoggerConfig({ level: "all", callback: () => {} })).toBe(true);
+    it("does not throw for valid config with both level and callback", () => {
+      expect(() => {
+        assertLoggerConfig({ level: "all", callback: () => {} });
+      }).not.toThrow();
     });
 
-    it('should return true for valid level "none" (#789)', () => {
-      expect(isLoggerConfig({ level: "none" })).toBe(true);
+    it('does not throw for valid level "none" (#789)', () => {
+      expect(() => {
+        assertLoggerConfig({ level: "none" });
+      }).not.toThrow();
     });
 
-    it("should return true for callbackIgnoresLevel boolean (#789)", () => {
-      expect(isLoggerConfig({ callbackIgnoresLevel: true })).toBe(true);
-      expect(isLoggerConfig({ callbackIgnoresLevel: false })).toBe(true);
+    it("does not throw for callbackIgnoresLevel boolean (#789)", () => {
+      expect(() => {
+        assertLoggerConfig({ callbackIgnoresLevel: true });
+      }).not.toThrow();
+      expect(() => {
+        assertLoggerConfig({ callbackIgnoresLevel: false });
+      }).not.toThrow();
     });
 
-    it("should return true for the full LoggerConfig surface (#789)", () => {
-      expect(
-        isLoggerConfig({
+    it("does not throw for the full LoggerConfig surface (#789)", () => {
+      expect(() => {
+        assertLoggerConfig({
           level: "none",
           callback: () => {},
           callbackIgnoresLevel: true,
-        }),
-      ).toBe(true);
+        });
+      }).not.toThrow();
     });
 
-    it("should throw TypeError for non-object config (null)", () => {
-      expect(() => isLoggerConfig(null)).toThrow(TypeError);
-      expect(() => isLoggerConfig(null)).toThrow(
-        "Logger config must be an object",
-      );
+    it("throws TypeError for non-object config (null)", () => {
+      expect(() => {
+        assertLoggerConfig(null);
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig(null);
+      }).toThrow("Logger config must be an object");
     });
 
-    it("should throw TypeError for non-object config (primitive)", () => {
-      expect(() => isLoggerConfig("string")).toThrow(TypeError);
-      expect(() => isLoggerConfig(123)).toThrow(TypeError);
-      expect(() => isLoggerConfig(true)).toThrow(TypeError);
-      expect(() => isLoggerConfig(undefined)).toThrow(TypeError);
+    it("throws TypeError for non-object config (primitive)", () => {
+      expect(() => {
+        assertLoggerConfig("string");
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig(123);
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig(true);
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig(undefined);
+      }).toThrow(TypeError);
     });
 
-    it("should throw TypeError for unknown property", () => {
-      expect(() => isLoggerConfig({ unknown: "value" })).toThrow(TypeError);
-      expect(() => isLoggerConfig({ unknown: "value" })).toThrow(
-        'Unknown logger config property: "unknown"',
-      );
+    it("throws TypeError for unknown property", () => {
+      expect(() => {
+        assertLoggerConfig({ unknown: "value" });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ unknown: "value" });
+      }).toThrow('Unknown logger config property: "unknown"');
     });
 
-    it("should throw TypeError for invalid level - number", () => {
-      expect(() => isLoggerConfig({ level: 123 })).toThrow(TypeError);
-      expect(() => isLoggerConfig({ level: 123 })).toThrow(
-        "Invalid logger level",
-      );
+    it("throws TypeError for invalid level - number", () => {
+      expect(() => {
+        assertLoggerConfig({ level: 123 });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ level: 123 });
+      }).toThrow("Invalid logger level");
     });
 
-    it("should throw TypeError for invalid level - string not in set (line 60)", () => {
-      expect(() => isLoggerConfig({ level: "invalid" })).toThrow(TypeError);
-      expect(() => isLoggerConfig({ level: "invalid" })).toThrow(
-        "Invalid logger level",
-      );
+    it("throws TypeError for invalid level - string not in set", () => {
+      expect(() => {
+        assertLoggerConfig({ level: "invalid" });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ level: "invalid" });
+      }).toThrow("Invalid logger level");
     });
 
-    it("should throw TypeError for invalid level - object (formatValue branch line 36)", () => {
-      expect(() => isLoggerConfig({ level: { nested: true } })).toThrow(
-        TypeError,
-      );
-      expect(() => isLoggerConfig({ level: { nested: true } })).toThrow(
-        'Invalid logger level: {"nested":true}',
-      );
+    it("throws TypeError for invalid level - object (formatValue branch)", () => {
+      expect(() => {
+        assertLoggerConfig({ level: { nested: true } });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ level: { nested: true } });
+      }).toThrow('Invalid logger level: {"nested":true}');
     });
 
-    it("should throw TypeError for callback that is not a function", () => {
-      expect(() => isLoggerConfig({ callback: "not-a-function" })).toThrow(
-        TypeError,
-      );
-      expect(() => isLoggerConfig({ callback: "not-a-function" })).toThrow(
-        "Logger callback must be a function",
-      );
+    it("throws TypeError for callback that is not a function", () => {
+      expect(() => {
+        assertLoggerConfig({ callback: "not-a-function" });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ callback: "not-a-function" });
+      }).toThrow("Logger callback must be a function");
     });
 
-    it("should throw TypeError for callbackIgnoresLevel that is not a boolean (#789)", () => {
-      expect(() => isLoggerConfig({ callbackIgnoresLevel: "yes" })).toThrow(
-        TypeError,
-      );
-      expect(() => isLoggerConfig({ callbackIgnoresLevel: "yes" })).toThrow(
-        "Logger callbackIgnoresLevel must be a boolean",
-      );
+    it("throws TypeError for callbackIgnoresLevel that is not a boolean (#789)", () => {
+      expect(() => {
+        assertLoggerConfig({ callbackIgnoresLevel: "yes" });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ callbackIgnoresLevel: "yes" });
+      }).toThrow("Logger callbackIgnoresLevel must be a boolean");
     });
 
-    it('should list "none" in the invalid-level error message (#789)', () => {
-      expect(() => isLoggerConfig({ level: "invalid" })).toThrow(
-        '"all" | "warn-error" | "error-only" | "none"',
-      );
+    it('lists "none" in the invalid-level error message (#789)', () => {
+      expect(() => {
+        assertLoggerConfig({ level: "invalid" });
+      }).toThrow('"all" | "warn-error" | "error-only" | "none"');
     });
 
-    it("should accept undefined values for optional properties", () => {
-      expect(isLoggerConfig({ level: undefined })).toBe(true);
-      expect(isLoggerConfig({ callback: undefined })).toBe(true);
-      expect(isLoggerConfig({ callbackIgnoresLevel: undefined })).toBe(true);
-      expect(isLoggerConfig({ level: undefined, callback: undefined })).toBe(
-        true,
-      );
+    it("does not throw for undefined values on optional properties", () => {
+      expect(() => {
+        assertLoggerConfig({ level: undefined });
+      }).not.toThrow();
+      expect(() => {
+        assertLoggerConfig({ callback: undefined });
+      }).not.toThrow();
+      expect(() => {
+        assertLoggerConfig({ callbackIgnoresLevel: undefined });
+      }).not.toThrow();
+      expect(() => {
+        assertLoggerConfig({ level: undefined, callback: undefined });
+      }).not.toThrow();
     });
 
-    it("should format non-string, non-object values using String() (line 40)", () => {
-      // This tests the formatValue function's fallback branch
-      // Using Symbol which is neither string nor object
+    it("formats non-string, non-object values using String()", () => {
+      // Symbol is neither string nor object — exercises the formatValue fallback
       const symbolLevel = Symbol("test");
 
-      expect(() => isLoggerConfig({ level: symbolLevel })).toThrow(TypeError);
-      expect(() => isLoggerConfig({ level: symbolLevel })).toThrow(
-        "Invalid logger level: Symbol(test)",
-      );
+      expect(() => {
+        assertLoggerConfig({ level: symbolLevel });
+      }).toThrow(TypeError);
+      expect(() => {
+        assertLoggerConfig({ level: symbolLevel });
+      }).toThrow("Invalid logger level: Symbol(test)");
     });
   });
 });

--- a/packages/validation-plugin/CLAUDE.md
+++ b/packages/validation-plugin/CLAUDE.md
@@ -19,7 +19,7 @@ The `RouterValidator` interface is organized into 8 namespaces, matching core's 
 | `options`      | `validateLimitValue`, `validateLimits`, `validateOptions`, `validateResolvedDefaultRoute`                                                                                     |
 | `dependencies` | `validateDependencyName`, `validateSetDependencyArgs`, `validateDependenciesObject`, `validateDependencyExists`, `validateDependencyLimit`, `validateDependenciesStructure`, `validateCloneArgs` |
 | `plugins`      | `validatePluginLimit`, `validateNoDuplicatePlugins`, `validatePluginKeys` (validates hook names: `onStart`, `onStop`, `onTransitionStart`, `onTransitionLeaveApprove`, `onTransitionSuccess`, `onTransitionError`, `onTransitionCancel`, `teardown`), `validateCountThresholds`, `validateAddInterceptorArgs` |
-| `lifecycle`    | `validateHandler`, `validateNotRegistering`, `validateHandlerLimit`, `validateCountThresholds`                                                                                |
+| `lifecycle`    | `validateHandler`, `validateHandlerLimit`, `validateCountThresholds`                                                                                |
 | `navigation`   | `validateNavigateArgs`, `validateNavigateToDefaultArgs`, `validateNavigationOptions`, `validateParams`, `validateStartArgs`                                                   |
 | `state`        | `validateMakeStateArgs`, `validateAreStatesEqualArgs`                                                                                                                         |
 | `eventBus`     | `validateEventName`, `validateListenerArgs` — validates event names: `$start`, `$stop`, `$$start`, `$$leaveApprove`, `$$cancel`, `$$success`, `$$error`                      |

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -80,7 +80,15 @@ import {
 } from "./validators/routes";
 import { validateMakeStateArgs } from "./validators/state";
 
-import type { PluginFactory, RouterValidator } from "@real-router/core";
+import type { EventName, EventMethodMap } from "./validators/eventBus";
+import type {
+  PluginFactory,
+  RouterValidator,
+  Route,
+  RouteTree,
+  Plugin,
+  Options,
+} from "@real-router/core";
 import type { RouterInternals } from "@real-router/core/validation";
 
 function buildValidatorObject(ctx: RouterInternals): RouterValidator {
@@ -93,8 +101,7 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
       validateStateBuilderArgs,
 
       validateAddRouteArgs(routes) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        validateAddRouteArgs(routes as any);
+        validateAddRouteArgs(routes as readonly Route[]);
       },
 
       validateRoutes(routes, store) {
@@ -104,10 +111,8 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
         };
 
         validateRoutes(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-          routes as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-          typedStore.tree as any,
+          routes as Route[],
+          typedStore.tree as RouteTree | undefined,
           typedStore.config?.forwardMap,
         );
       },
@@ -169,8 +174,7 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
       },
 
       throwIfInternalRouteInArray(routes, caller) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        throwIfInternalRouteInArray(routes as any, caller);
+        throwIfInternalRouteInArray(routes as readonly Route[], caller);
       },
       validateExistingRoutes,
       validateForwardToConsistency,
@@ -180,8 +184,11 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
     },
     options: {
       validateLimitValue(name, value) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        validateLimitValue(name as any, value, "validate");
+        validateLimitValue(
+          name as keyof NonNullable<Options["limits"]>,
+          value,
+          "validate",
+        );
       },
       validateLimits(limits) {
         validateLimits(limits, "validate");
@@ -212,8 +219,11 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
     },
     plugins: {
       validatePluginLimit(count, limits) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-        validatePluginLimit(count, 1, (limits as any)?.maxPlugins);
+        validatePluginLimit(
+          count,
+          1,
+          (limits as { maxPlugins?: number } | undefined)?.maxPlugins,
+        );
       },
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       validateNoDuplicatePlugins(_factory, _factories) {},
@@ -234,8 +244,8 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
         validateHandlerLimit(
           count,
           caller,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-          (limits as any)?.maxLifecycleHandlers,
+          (limits as { maxLifecycleHandlers?: number } | undefined)
+            ?.maxLifecycleHandlers,
         );
       },
       validateCountThresholds(count, methodName) {
@@ -279,8 +289,10 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
       validateEventName,
 
       validateListenerArgs(name, cb) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        validateListenerArgs(name as any, cb as any);
+        validateListenerArgs<EventName>(
+          name as EventName,
+          cb as Plugin[EventMethodMap[EventName]],
+        );
       },
     },
   };

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -23,7 +23,6 @@ import {
 import { validateEventName, validateListenerArgs } from "./validators/eventBus";
 import {
   validateHandler,
-  validateNotRegistering,
   validateHandlerLimit,
   validateLifecycleCountThresholds,
   warnOverwrite as warnLifecycleOverwrite,
@@ -231,9 +230,6 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
     },
     lifecycle: {
       validateHandler,
-      validateNotRegistering(name, _guards, caller) {
-        validateNotRegistering(false, name, caller);
-      },
       validateHandlerLimit(count, limits, caller) {
         validateHandlerLimit(
           count,

--- a/packages/validation-plugin/src/validators/eventBus.ts
+++ b/packages/validation-plugin/src/validators/eventBus.ts
@@ -4,7 +4,7 @@ import type { Plugin } from "@real-router/core";
 
 // Local types — mirrors EventName and EventMethodMap from @real-router/types
 // (@real-router/types is not a direct dependency of this package)
-interface EventMethodMap {
+export interface EventMethodMap {
   $start: "onStart";
   $stop: "onStop";
   $$start: "onTransitionStart";
@@ -14,7 +14,7 @@ interface EventMethodMap {
   $$error: "onTransitionError";
 }
 
-type EventName = keyof EventMethodMap;
+export type EventName = keyof EventMethodMap;
 
 // Local set — mirrors validEventNames from @real-router/core/constants
 // (not exported from @real-router/core public API)

--- a/packages/validation-plugin/src/validators/lifecycle.ts
+++ b/packages/validation-plugin/src/validators/lifecycle.ts
@@ -21,18 +21,6 @@ export function validateHandler<D extends DefaultDependencies>(
   }
 }
 
-export function validateNotRegistering(
-  isRegistering: boolean,
-  name: string,
-  methodName: string,
-): void {
-  if (isRegistering) {
-    throw new Error(
-      `[router.${methodName}] Cannot modify route "${name}" during its own registration`,
-    );
-  }
-}
-
 export function validateHandlerLimit(
   currentCount: number,
   methodName: string,

--- a/packages/validation-plugin/tests/functional/integration/plugin-lifecycle.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/plugin-lifecycle.test.ts
@@ -166,20 +166,6 @@ describe("validationPlugin — lifecycle integration", () => {
     );
   });
 
-  it("validateNotRegistering wrapper — does not throw when not registering", () => {
-    router = createRouter([{ name: "home", path: "/home" }]);
-    router.usePlugin(validationPlugin());
-    const ctx = getInternals(router);
-
-    expect(() =>
-      ctx.validator?.lifecycle.validateNotRegistering(
-        "home",
-        [],
-        "canActivate",
-      ),
-    ).not.toThrow();
-  });
-
   it("validateDependencyExists — missing dependency throws ReferenceError", () => {
     router = createRouter([{ name: "home", path: "/home" }]);
     router.usePlugin(validationPlugin());

--- a/packages/validation-plugin/tests/functional/validators.test.ts
+++ b/packages/validation-plugin/tests/functional/validators.test.ts
@@ -16,7 +16,6 @@ import {
 } from "../../src/validators/eventBus";
 import {
   validateHandlerLimit,
-  validateNotRegistering,
   validateLifecycleCountThresholds,
   warnOverwrite as warnLifecycleOverwrite,
   warnAsyncGuardSync,
@@ -223,23 +222,6 @@ describe("lifecycle validators", () => {
       expect(() => {
         validateHandlerLimit(200, "test");
       }).toThrow(/limit exceeded.*200/i);
-    });
-  });
-
-  describe("validateNotRegistering", () => {
-    it("throws when isRegistering is true", () => {
-      expect(() => {
-        validateNotRegistering(true, "home", "canActivate");
-      }).toThrow(Error);
-      expect(() => {
-        validateNotRegistering(true, "home", "canActivate");
-      }).toThrow(/Cannot modify route "home" during its own registration/);
-    });
-
-    it("does not throw when isRegistering is false", () => {
-      expect(() => {
-        validateNotRegistering(false, "home", "canActivate");
-      }).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Core architecture-review cleanup batch (findings 2.1, 1.5, 2.2, 2.3, §4). Bundled on one branch per request.

## Changes

| Finding | Commit | Change | Bump |
|---|---|---|---|
| **2.1** | `23e001c7` | Remove dead validation machinery (`#registering`, static `validateNoDuplicatePlugins`, `validateNotRegistering`) — core + validation-plugin + dead tests | `minor` ×2 |
| — | `f0b8a28c` | follow-up: type validator-bridge casts to clear Sonar S4325 | — |
| **2.2** | `6a73ac44` | Remove `store.treeOperations` indirection — direct static imports instead (no test stubbed it; route-tree is always bundled) | `patch` |
| **2.3** | `6a73ac44` | Cache `getRoutesApi` per router via `WeakMap` (mirrors `getPluginApi`/`getNavigator`) | `patch` |
| **§4** | `2f0f36f9` | Remove dead public `BuildStateResultWithSegments`; `isLoggerConfig`→`assertLoggerConfig` (`asserts`); document `transitionPath` caches | `minor` |
| **1.5** | `56fb16f6` | Doc: `RoutesStore` carries `lifecycleNamespace`/`depsStore` by design (clarification, not refactor) | docs |

## Deliberately not changed
- **1.5 code move** — relocating `lifecycleNamespace` to `RouterInternals` would thread a param through ~6 `store`-taking CRUD helpers (they need the lifecycle *instance* for `clearDefinitionGuards`/`addCanActivate`/`clearAll`) for marginal purity. Resolved as a doc clarification — the review anticipated this.
- **§4 `getAll()`-in-loop** — the `?.` short-circuit already yields zero allocation on the no-validator (production) hot path; hoisting would either allocate there or push the dev-only branch out of core's 100% coverage. Optimal as-is (documented in-code).

## Verification
`pnpm build` green — **293/293 tasks** (type-check → lint → test → 100% coverage → bundle).

Closes #906
Closes #908
Closes #909
Closes #910
Closes #911