### PR TITLE
fix(validation-plugin): implement duplicate-plugin detection (#726)

### DIFF
--- a/.changeset/dup-plugin-detection-726-fix.md
+++ b/.changeset/dup-plugin-detection-726-fix.md
@@ -1,0 +1,9 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+Implement duplicate-plugin detection (#726)
+
+`validateNoDuplicatePlugins` was an inert no-op, so re-registering the same plugin factory under the validation plugin (`usePlugin(f); usePlugin(f)` without `unsubscribe()` in between) was silently accepted — registering double interceptors. It now throws `[router.usePlugin] Plugin factory already registered.`.
+
+Plugins that claim a context namespace (e.g. `persistent-params`) already failed on double-init via core's `claimContextNamespace` collision guard; this closes the gap for plugins that **don't** claim a namespace, where core had no backstop. The check only runs when `@real-router/validation-plugin` is registered; distinct factories are unaffected.

--- a/packages/persistent-params-plugin/CLAUDE.md
+++ b/packages/persistent-params-plugin/CLAUDE.md
@@ -100,7 +100,7 @@ After updating the snapshot, `onTransitionSuccess` publishes it to `state.contex
 
 ### Double initialization throws
 
-`usePlugin` is called once per router. Calling it twice with the same factory (without `unsubscribe()` in between) throws from core. The plugin itself doesn't guard against this.
+`usePlugin` is called once per router. Calling it twice with the same factory (without `unsubscribe()` in between) throws from core: the second instance's `claimContextNamespace("persistentParams")` hits the already-claimed namespace (`CONTEXT_NAMESPACE_ALREADY_CLAIMED`). The plugin itself adds no explicit guard — the core namespace-claim collision is the backstop. (With `@real-router/validation-plugin`, the duplicate **factory** is rejected even earlier, before the factory runs — #726.)
 
 ## Module Structure
 

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -43,6 +43,7 @@ import {
 } from "./validators/options";
 import {
   validatePluginLimit,
+  validateNoDuplicatePlugins,
   validatePluginKeys,
   validateCountThresholds as validatePluginCountThresholds,
   warnBatchDuplicates,
@@ -225,8 +226,7 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
           (limits as { maxPlugins?: number } | undefined)?.maxPlugins,
         );
       },
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      validateNoDuplicatePlugins(_factory, _factories) {},
+      validateNoDuplicatePlugins,
       validatePluginKeys,
       validateCountThresholds(count) {
         const maxPlugins = ctx.getOptions().limits?.maxPlugins ?? 50;

--- a/packages/validation-plugin/src/validators/plugins.ts
+++ b/packages/validation-plugin/src/validators/plugins.ts
@@ -38,6 +38,18 @@ export function validatePluginLimit(
   }
 }
 
+export function validateNoDuplicatePlugins(
+  factory: unknown,
+  factories: unknown[],
+): void {
+  if (factories.includes(factory)) {
+    throw new Error(
+      `[router.usePlugin] Plugin factory already registered. ` +
+        `To re-register, first unsubscribe the existing plugin.`,
+    );
+  }
+}
+
 export function validateCountThresholds(
   count: number,
   maxPlugins: number,

--- a/packages/validation-plugin/tests/functional/integration/plugin-lifecycle.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/plugin-lifecycle.test.ts
@@ -193,4 +193,31 @@ describe("validationPlugin — lifecycle integration", () => {
     expect(() => router.areStatesEqual(state, state, false)).not.toThrow();
     expect(() => router.areStatesEqual(state, state, true)).not.toThrow();
   });
+
+  describe("duplicate plugin detection (#726)", () => {
+    it("usePlugin throws when the same factory is registered twice", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: "home",
+      });
+      router.usePlugin(validationPlugin());
+
+      const myPlugin = () => ({});
+
+      router.usePlugin(myPlugin);
+
+      expect(() => router.usePlugin(myPlugin)).toThrow(/already registered/i);
+    });
+
+    it("usePlugin does not throw for distinct factories", () => {
+      router = createRouter([{ name: "home", path: "/home" }], {
+        defaultRoute: "home",
+      });
+      router.usePlugin(validationPlugin());
+
+      expect(() => {
+        router.usePlugin(() => ({}));
+        router.usePlugin(() => ({}));
+      }).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Closes the remaining open item of #726 (**item 3** — items 1/2/4/5 shipped in #907).

## Root

`@real-router/validation-plugin`'s `validateNoDuplicatePlugins` was an inert no-op (`(_factory, _factories) {}`). `Router.ts` calls it via `ctx.validator?.plugins.validateNoDuplicatePlugins(plugin, this.#plugins.getAll())`, so under the validation plugin, re-registering the **same factory** (`usePlugin(f); usePlugin(f)` without `unsubscribe()`) was silently accepted → double interceptors, no diagnostic.

## Fix

Implemented the identity check in `validators/plugins.ts` (the `(factory, factories)` args were already threaded), wired as a shorthand. It now throws `[router.usePlugin] Plugin factory already registered.` Distinct factories are unaffected; the check only runs when the validation plugin is registered.

## Scope correction (vs the issue's item-3 probe)

The #726 comment claimed the `persistent-params` "double init throws" doc was a lie. That probe used a **generic** factory (`() => ({})`) which claims no context namespace. Verified empirically that `persistent-params` **does** throw on double-init — via core's always-active `claimContextNamespace("persistentParams")` collision (`CONTEXT_NAMESPACE_ALREADY_CLAIMED`). So the real gap was only for plugins that **don't** claim a namespace (no core backstop), which this fix closes. The persistent-params doc is **corrected to name the actual mechanism**, not removed.

## Tests
`duplicate plugin detection (#726)` in `plugin-lifecycle.test.ts` — same-factory twice throws; distinct factories don't.

## Verification
`pnpm build` green — **293/293 tasks**, 100% coverage. Changeset: `@real-router/validation-plugin` `patch`.

Closes #726