### PR TITLE
chore(config): adopt sonarjs/prefer-specific-assertions in tests (48 sites)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -925,13 +925,11 @@ export default tsEslint.config(
 
       // v4.1.0: New recommended test-assertion / float rules — disabled as
       // false positives or deliberate idioms for this codebase:
-      //  - prefer-specific-assertions: 48 cosmetic test nits, no autofix;
-      //    adoption tracked in #915
       //  - no-floating-point-equality: exact literal / mock values (e.g.
       //    Number("12.5") === 12.5), not float arithmetic
       //  - no-trivial-assertions: intentional `expect(true).toBe(true)` reach
       //    markers in stress/property tests + type-level `Equal` assertions
-      "sonarjs/prefer-specific-assertions": "off",
+      // (prefer-specific-assertions adopted in tests — #915)
       "sonarjs/no-floating-point-equality": "off",
       "sonarjs/no-trivial-assertions": "off",
     },

--- a/packages/angular/tests/functional/HttpStatusCode.test.ts
+++ b/packages/angular/tests/functional/HttpStatusCode.test.ts
@@ -71,9 +71,9 @@ describe("provideHttpStatusSink", () => {
   it("HTTP_STATUS_SINK is null without a provider when injected with optional", () => {
     TestBed.configureTestingModule({});
 
-    expect(TestBed.inject(HTTP_STATUS_SINK, null, { optional: true })).toBe(
-      null,
-    );
+    expect(
+      TestBed.inject(HTTP_STATUS_SINK, null, { optional: true }),
+    ).toBeNull();
   });
 
   it("equivalent to explicit useValue provider", () => {

--- a/packages/angular/tests/functional/injectDeferred.test.ts
+++ b/packages/angular/tests/functional/injectDeferred.test.ts
@@ -154,7 +154,7 @@ describe("injectDeferred", () => {
       ),
     ]);
 
-    expect(racer).toBe(undefined);
+    expect(racer).toBeUndefined();
     expect(fixture.componentInstance.missing()).toBeUndefined();
 
     fixture.destroy();

--- a/packages/browser-env/tests/unit/popstate-handler.test.ts
+++ b/packages/browser-env/tests/unit/popstate-handler.test.ts
@@ -461,7 +461,7 @@ describe("popstate handler", () => {
       lifecycle.onStop?.();
 
       expect(removeSpy).toHaveBeenCalledTimes(1);
-      expect(shared.removePopStateListener).toBe(undefined);
+      expect(shared.removePopStateListener).toBeUndefined();
     });
 
     it("onStop is a no-op when no listener is registered", () => {
@@ -479,7 +479,7 @@ describe("popstate handler", () => {
       lifecycle.teardown?.();
 
       expect(removeSpy).toHaveBeenCalledTimes(1);
-      expect(shared.removePopStateListener).toBe(undefined);
+      expect(shared.removePopStateListener).toBeUndefined();
       expect(cleanup).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/browser-env/tests/unit/popstate-utils.test.ts
+++ b/packages/browser-env/tests/unit/popstate-utils.test.ts
@@ -55,7 +55,7 @@ describe("getRouteFromEvent", () => {
   it("returns undefined when neither history.state nor the location match", () => {
     const evt = makePopStateEvent(undefined);
 
-    expect(getRouteFromEvent(evt, api, "/nope")).toBe(undefined);
+    expect(getRouteFromEvent(evt, api, "/nope")).toBeUndefined();
   });
 });
 

--- a/packages/core/tests/functional/api/getDependenciesApi/getDependencies.test.ts
+++ b/packages/core/tests/functional/api/getDependenciesApi/getDependencies.test.ts
@@ -51,7 +51,7 @@ describe("core/dependencies/getDependencies", () => {
     const depsObj = deps.getAll();
 
     expect(depsObj.foo).toBe(0);
-    expect(depsObj.bar).toBe(null);
+    expect(depsObj.bar).toBeNull();
   });
 
   it("should protect structure but not content (shallow copy)", () => {

--- a/packages/core/tests/functional/api/getDependenciesApi/setDependencies.test.ts
+++ b/packages/core/tests/functional/api/getDependenciesApi/setDependencies.test.ts
@@ -151,7 +151,7 @@ describe("core/dependencies/setDependencies", () => {
     });
 
     expect(deps.get("foo")).toBe(0);
-    expect(deps.get("bar")).toBe(null);
+    expect(deps.get("bar")).toBeNull();
     expect(deps.get("baz")).toBe(false);
     expect(deps.get("qux")).toStrictEqual({});
   });

--- a/packages/core/tests/functional/api/getDependenciesApi/setDependency.test.ts
+++ b/packages/core/tests/functional/api/getDependenciesApi/setDependency.test.ts
@@ -140,7 +140,7 @@ describe("core/dependencies/setDependency", () => {
     // @ts-expect-error: testing null value
     deps.set("foo", null);
 
-    expect(deps.get("foo")).toBe(null);
+    expect(deps.get("foo")).toBeNull();
     expect(deps.has("foo")).toBe(true);
   });
 

--- a/packages/core/tests/functional/api/getLifecycleApi/addActivateGuard.test.ts
+++ b/packages/core/tests/functional/api/getLifecycleApi/addActivateGuard.test.ts
@@ -42,7 +42,7 @@ describe("core/route-lifecycle/addActivateGuard", () => {
     try {
       await router.navigate("admin");
     } catch (error: any) {
-      expect(error).toBe(undefined);
+      expect(error).toBeUndefined();
     }
 
     expect(router.getState()?.name).toBe("admin");
@@ -55,7 +55,7 @@ describe("core/route-lifecycle/addActivateGuard", () => {
     try {
       await router.navigate("admin");
     } catch (error: any) {
-      expect(error).toBe(undefined);
+      expect(error).toBeUndefined();
     }
 
     expect(router.getState()?.name).toBe("admin");

--- a/packages/core/tests/functional/api/getPluginApi/buildState.test.ts
+++ b/packages/core/tests/functional/api/getPluginApi/buildState.test.ts
@@ -27,6 +27,6 @@ describe("buildState", () => {
   it("returns undefined if route is unknown", () => {
     const state = getPluginApi(router).buildState("unknown.route", {});
 
-    expect(state).toBe(undefined);
+    expect(state).toBeUndefined();
   });
 });

--- a/packages/core/tests/functional/dependencies/getDependency.test.ts
+++ b/packages/core/tests/functional/dependencies/getDependency.test.ts
@@ -31,7 +31,7 @@ describe("core/dependencies/getDependency", () => {
     // @ts-expect-error: testing null value
     deps.set("bar", null);
 
-    expect(deps.get("bar")).toBe(null);
+    expect(deps.get("bar")).toBeNull();
 
     // @ts-expect-error: testing false value
     deps.set("foo", false);

--- a/packages/core/tests/functional/error/RouterError.test.ts
+++ b/packages/core/tests/functional/error/RouterError.test.ts
@@ -11,8 +11,8 @@ describe("RouterError", () => {
     expect(err).toBeInstanceOf(RouterError);
     expect(err.code).toBe("ERR_CODE");
     expect(err.message).toBe("ERR_CODE");
-    expect(err.segment).toBe(undefined);
-    expect(err.redirect).toBe(undefined);
+    expect(err.segment).toBeUndefined();
+    expect(err.redirect).toBeUndefined();
   });
 
   it("should set message, segment, redirect and custom fields", () => {
@@ -156,7 +156,7 @@ describe("RouterError", () => {
     it("should return undefined for non-existing field", () => {
       const err = new RouterError("ERR");
 
-      expect(err.getField("nonExistent")).toBe(undefined);
+      expect(err.getField("nonExistent")).toBeUndefined();
     });
 
     it("should return value for built-in fields", () => {
@@ -283,7 +283,7 @@ describe("RouterError", () => {
     it("should return undefined when redirect is not set", () => {
       const err = new RouterError("ERR");
 
-      expect(err.redirect).toBe(undefined);
+      expect(err.redirect).toBeUndefined();
     });
   });
 

--- a/packages/core/tests/functional/plugins.test.ts
+++ b/packages/core/tests/functional/plugins.test.ts
@@ -119,7 +119,7 @@ describe("core/plugins", () => {
       // custom method added by plugin
       expect(
         (router as Router & { myCustomMethod?: Function }).myCustomMethod,
-      ).not.toBe(undefined);
+      ).toBeDefined();
 
       await router.navigate("orders", {});
 

--- a/packages/core/tests/functional/routes/matchPath.test.ts
+++ b/packages/core/tests/functional/routes/matchPath.test.ts
@@ -46,7 +46,7 @@ describe("core/routes/routePath/matchPath", () => {
     it("should return undefined for unmatched path", () => {
       const state = getPluginApi(router).matchPath("/unknown");
 
-      expect(state).toBe(undefined);
+      expect(state).toBeUndefined();
     });
 
     it("should return matched path as-is when rewritePathOnMatch is false", () => {

--- a/packages/core/tests/functional/state.test.ts
+++ b/packages/core/tests/functional/state.test.ts
@@ -31,7 +31,7 @@ describe("core/state", () => {
     it("returns undefined when router not started", () => {
       router.stop();
 
-      expect(router.getState()).toBe(undefined);
+      expect(router.getState()).toBeUndefined();
     });
 
     it("returns state after navigation", async () => {

--- a/packages/core/tests/property/error/constructor.properties.ts
+++ b/packages/core/tests/property/error/constructor.properties.ts
@@ -33,8 +33,8 @@ describe("RouterError Constructor Properties", () => {
         if (options.redirect) {
           expect(err1.redirect).toStrictEqual(err2.redirect);
         } else {
-          expect(err1.redirect).toBe(undefined);
-          expect(err2.redirect).toBe(undefined);
+          expect(err1.redirect).toBeUndefined();
+          expect(err2.redirect).toBeUndefined();
         }
       },
     );
@@ -92,7 +92,7 @@ describe("RouterError Constructor Properties", () => {
           expect(err.redirect).toBeDefined();
           expect(err.redirect).toStrictEqual(redirect);
         } else {
-          expect(err.redirect).toBe(undefined);
+          expect(err.redirect).toBeUndefined();
         }
       },
     );
@@ -192,7 +192,7 @@ describe("RouterError Constructor Properties", () => {
           // Verify original redirect is not modified
           expect(Object.isFrozen(redirect)).toBe(false);
         } else {
-          expect(err.redirect).toBe(undefined);
+          expect(err.redirect).toBeUndefined();
         }
       },
     );

--- a/packages/core/tests/property/error/methods.properties.ts
+++ b/packages/core/tests/property/error/methods.properties.ts
@@ -249,7 +249,7 @@ describe("RouterError Methods Properties", () => {
         const nonExistentKey = `__non_existent_${randomKey}__`;
 
         expect(err.hasField(nonExistentKey)).toBe(false);
-        expect(err.getField(nonExistentKey)).toBe(undefined);
+        expect(err.getField(nonExistentKey)).toBeUndefined();
       },
     );
 

--- a/packages/react/tests/functional/useRouteNode.test.tsx
+++ b/packages/react/tests/functional/useRouteNode.test.tsx
@@ -81,7 +81,7 @@ describe("useRouteNode", () => {
       await router.start();
     });
 
-    expect(result.current.route?.name).toStrictEqual(undefined);
+    expect(result.current.route?.name).toBeUndefined();
 
     await act(async () => {
       await router.navigate("items");

--- a/packages/search-params/tests/functional/strategies.test.ts
+++ b/packages/search-params/tests/functional/strategies.test.ts
@@ -30,11 +30,11 @@ describe("search-params strategies", () => {
       });
 
       it("should return null for undefined", () => {
-        expect(noneBooleanStrategy.decodeUndefined()).toBe(null);
+        expect(noneBooleanStrategy.decodeUndefined()).toBeNull();
       });
 
       it("should return null for decodeRaw (no raw matching)", () => {
-        expect(noneBooleanStrategy.decodeRaw("anything")).toBe(null);
+        expect(noneBooleanStrategy.decodeRaw("anything")).toBeNull();
       });
 
       it("should return value as-is for decodeValue", () => {
@@ -49,13 +49,13 @@ describe("search-params strategies", () => {
       });
 
       it("should return null for undefined", () => {
-        expect(autoBooleanStrategy.decodeUndefined()).toBe(null);
+        expect(autoBooleanStrategy.decodeUndefined()).toBeNull();
       });
 
       it("should parse true/false strings in decodeRaw", () => {
         expect(autoBooleanStrategy.decodeRaw("true")).toBe(true);
         expect(autoBooleanStrategy.decodeRaw("false")).toBe(false);
-        expect(autoBooleanStrategy.decodeRaw("other")).toBe(null);
+        expect(autoBooleanStrategy.decodeRaw("other")).toBeNull();
       });
 
       it("should return value as-is for decodeValue", () => {
@@ -78,7 +78,7 @@ describe("search-params strategies", () => {
       it("should decode raw 'true'/'false' to booleans, null otherwise", () => {
         expect(emptyTrueBooleanStrategy.decodeRaw("true")).toBe(true);
         expect(emptyTrueBooleanStrategy.decodeRaw("false")).toBe(false);
-        expect(emptyTrueBooleanStrategy.decodeRaw("anything")).toBe(null);
+        expect(emptyTrueBooleanStrategy.decodeRaw("anything")).toBeNull();
       });
 
       it("should return value as-is for decodeValue", () => {
@@ -104,8 +104,8 @@ describe("search-params strategies", () => {
   describe("number strategies", () => {
     describe("noneNumberStrategy", () => {
       it("should return null (passthrough)", () => {
-        expect(noneNumberStrategy.decode("123")).toBe(null);
-        expect(noneNumberStrategy.decode("abc")).toBe(null);
+        expect(noneNumberStrategy.decode("123")).toBeNull();
+        expect(noneNumberStrategy.decode("abc")).toBeNull();
       });
     });
 
@@ -123,12 +123,12 @@ describe("search-params strategies", () => {
       });
 
       it("should return null for non-numeric strings", () => {
-        expect(autoNumberStrategy.decode("abc")).toBe(null);
-        expect(autoNumberStrategy.decode("12abc")).toBe(null);
-        expect(autoNumberStrategy.decode("")).toBe(null);
-        expect(autoNumberStrategy.decode(".5")).toBe(null);
-        expect(autoNumberStrategy.decode("1.")).toBe(null);
-        expect(autoNumberStrategy.decode("1.2.3")).toBe(null);
+        expect(autoNumberStrategy.decode("abc")).toBeNull();
+        expect(autoNumberStrategy.decode("12abc")).toBeNull();
+        expect(autoNumberStrategy.decode("")).toBeNull();
+        expect(autoNumberStrategy.decode(".5")).toBeNull();
+        expect(autoNumberStrategy.decode("1.")).toBeNull();
+        expect(autoNumberStrategy.decode("1.2.3")).toBeNull();
       });
 
       it("should decode negative numbers (round-trips with build/navigate)", () => {
@@ -138,17 +138,17 @@ describe("search-params strategies", () => {
       });
 
       it("should return null for a bare minus or non-canonical negatives", () => {
-        expect(autoNumberStrategy.decode("-")).toBe(null);
-        expect(autoNumberStrategy.decode("-007")).toBe(null); // leading zero
-        expect(autoNumberStrategy.decode("-.5")).toBe(null); // dot right after sign
-        expect(autoNumberStrategy.decode("-5.")).toBe(null); // trailing dot
+        expect(autoNumberStrategy.decode("-")).toBeNull();
+        expect(autoNumberStrategy.decode("-007")).toBeNull(); // leading zero
+        expect(autoNumberStrategy.decode("-.5")).toBeNull(); // dot right after sign
+        expect(autoNumberStrategy.decode("-5.")).toBeNull(); // trailing dot
       });
 
       it("should return null for negative zero (not round-trippable)", () => {
         // `-0` is a valid number, but build(-0) emits "0" and String(-0) === "0",
         // so it can't round-trip; "-0"/"-0.0" must stay strings. (#898)
-        expect(autoNumberStrategy.decode("-0")).toBe(null);
-        expect(autoNumberStrategy.decode("-0.0")).toBe(null);
+        expect(autoNumberStrategy.decode("-0")).toBeNull();
+        expect(autoNumberStrategy.decode("-0.0")).toBeNull();
       });
 
       it("should preserve leading zeros as strings (not parse as numbers)", () => {

--- a/packages/sources/tests/unit/canonicalJson.test.ts
+++ b/packages/sources/tests/unit/canonicalJson.test.ts
@@ -26,7 +26,7 @@ describe("canonicalJson", () => {
   });
 
   it("handles undefined as JSON.stringify does", () => {
-    expect(canonicalJson(undefined)).toBe(undefined);
+    expect(canonicalJson(undefined)).toBeUndefined();
     expect(canonicalJson({ a: undefined, b: 1 })).toBe('{"b":1}');
   });
 

--- a/packages/svelte/tests/functional/useRouteNode.test.ts
+++ b/packages/svelte/tests/functional/useRouteNode.test.ts
@@ -34,8 +34,8 @@ describe("useRouteNode", () => {
     });
 
     expect(result!.navigator).toBe(getNavigator(router));
-    expect(result!.route.current).toStrictEqual(undefined);
-    expect(result!.previousRoute.current).toStrictEqual(undefined);
+    expect(result!.route.current).toBeUndefined();
+    expect(result!.previousRoute.current).toBeUndefined();
   });
 
   it("should not return a null route with a default route and the router started", async () => {
@@ -88,7 +88,7 @@ describe("useRouteNode", () => {
     await router.start();
     flushSync();
 
-    expect(result!.route.current?.name).toStrictEqual(undefined);
+    expect(result!.route.current?.name).toBeUndefined();
 
     await router.navigate("items");
     flushSync();


### PR DESCRIPTION
## Summary

Re-enables `sonarjs/prefer-specific-assertions` (drops the carve-out `off` added during the eslint-plugin-sonarjs 4.1.0 bump) and adopts it across the test suite — replacing **48** generic Vitest assertions with their specific matchers.

## Changes

- `eslint.config.mjs`: remove `"sonarjs/prefer-specific-assertions": "off"`. The two sibling rules disabled alongside it stay off — they are intentional, not cosmetic:
  - `no-floating-point-equality` — exact literal/mock values, not float arithmetic
  - `no-trivial-assertions` — deliberate `expect(true).toBe(true)` reach-markers + type-level `Equal` assertions
- **48 sites across 20 test files**, all behavior-preserving (equivalent Vitest matchers):
  - `.toBe(null)` / `.toStrictEqual(null)` → `.toBeNull()`
  - `.toBe(undefined)` / `.toStrictEqual(undefined)` → `.toBeUndefined()`
  - `.not.toBe(undefined)` presence check → `.toBeDefined()`

## Validation

- `pnpm build` — **293/293** (rule active, **0** violations; 100% coverage holds).

No changeset: only test files + lint config change, no public `src/`.

Closes #915