### PR TITLE
fix(core): getStaticPaths RangeError on large static route sections (#920)

### DIFF
--- a/.changeset/get-static-paths-spread-fix.md
+++ b/.changeset/get-static-paths-spread-fix.md
@@ -1,0 +1,14 @@
+---
+"@real-router/core": patch
+---
+
+Fix `getStaticPaths` crashing with `RangeError` on a large static route section (#920)
+
+`getStaticPaths` enumerated a subtree's leaf routes via
+`result.push(...getLeafRouteNames(child))`. The spread passes one argument per
+leaf, and V8 caps spread/apply arguments (~124k on Node 24), so a section with
+more static leaf routes than that limit threw
+`RangeError: Maximum call stack size exceeded` — a cryptic failure that reads
+like infinite recursion, not "too many routes". Leaf collection now accumulates
+into a shared array (no spread), which also removes the per-subtree
+intermediate-array allocation. Enumeration order and output are unchanged.

--- a/packages/core/src/utils/getStaticPaths.ts
+++ b/packages/core/src/utils/getStaticPaths.ts
@@ -8,16 +8,26 @@ export type StaticPathEntries = Record<
   () => Promise<Record<string, string>[]>
 >;
 
-function getLeafRouteNames(node: RouteTree): string[] {
-  const result: string[] = [];
-
+function collectLeafRouteNames(node: RouteTree, result: string[]): void {
   for (const child of node.children.values()) {
     if (child.children.size === 0) {
       result.push(child.fullName);
     } else {
-      result.push(...getLeafRouteNames(child));
+      // Accumulate into the shared array rather than
+      // `result.push(...getLeafRouteNames(child))`: the spread passes one
+      // argument per leaf, and V8 caps spread/apply arguments (~124k on Node 24),
+      // so a section with that many static leaf routes threw
+      // `RangeError: Maximum call stack size exceeded`. Accumulating also drops
+      // the per-subtree intermediate-array allocation.
+      collectLeafRouteNames(child, result);
     }
   }
+}
+
+function getLeafRouteNames(node: RouteTree): string[] {
+  const result: string[] = [];
+
+  collectLeafRouteNames(node, result);
 
   return result;
 }

--- a/packages/core/tests/stress/get-static-paths-scale.stress.ts
+++ b/packages/core/tests/stress/get-static-paths-scale.stress.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getStaticPaths } from "@real-router/core/utils";
+
+import { measureTimeAsync } from "./helpers";
+
+/**
+ * Leaf-enumeration robustness + throughput for `getStaticPaths` (the SSG path
+ * enumerator). It walks the route tree collecting leaf route names, then
+ * `buildPath`s each — run at build time over a project's full route set.
+ *
+ * SKEPTICAL HYPOTHESIS (not behavior-pinning): `getLeafRouteNames` accumulates
+ * a subtree's leaves with `result.push(...getLeafRouteNames(child))` — a SPREAD
+ * whose argument count equals the number of leaves in that subtree. V8 caps
+ * spread/apply arguments (~124k on Node 24, measured); past that, `push(...big)`
+ * throws `RangeError: Maximum call stack size exceeded` — a cryptic failure that
+ * reads like infinite recursion, not "too many routes". A large content site
+ * (many static leaf routes under one section) can cross that line.
+ *
+ * Discrimination: a single intermediate node with > the spread limit of static
+ * leaf children. Correct code enumerates all of them; the spread regression
+ * throws. Plus a no-drop count + order check and a catastrophe-only timing
+ * ceiling (enumeration is O(leaves) by construction).
+ */
+describe("S28. getStaticPaths leaf enumeration at scale", () => {
+  // Above the measured ~124,395 spread-argument limit, with margin, so the
+  // spread path throws deterministically across engine-version drift.
+  const LEAVES = 200_000;
+
+  it(`enumerates ${LEAVES} static leaves under one parent without RangeError`, async () => {
+    const children = Array.from({ length: LEAVES }, (_, i) => ({
+      name: `p${i}`,
+      path: `/p${i}`,
+    }));
+    const router = createRouter([{ name: "g", path: "/g", children }]);
+
+    const { result: paths, durationMs } = await measureTimeAsync(() =>
+      getStaticPaths(router),
+    );
+
+    // No drop: every leaf enumerated, in tree order.
+    expect(paths).toHaveLength(LEAVES);
+    expect(paths[0]).toBe("/g/p0");
+    expect(paths.at(-1)).toBe(`/g/p${LEAVES - 1}`);
+
+    // Catastrophe-only ceiling (linear enumeration + buildPath per leaf).
+    expect(
+      durationMs,
+      `enumerated ${paths.length} paths in ${durationMs.toFixed(0)}ms`,
+    ).toBeLessThan(10_000);
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/stress/serialize-state-xss.stress.ts
+++ b/packages/core/tests/stress/serialize-state-xss.stress.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeState } from "@real-router/core/utils";
+
+import { measureTime } from "./helpers";
+
+/**
+ * XSS-escape correctness at scale for `serializeState` (the SSR/SSG boot path).
+ *
+ * `serializeState` embeds app/router state into an inline `<script>` via three
+ * GLOBAL escapes — `<`→`<`, `>`→`>`, `&`→`&`
+ * (`src/utils/serializeState.ts:59-62`). Those `replaceAll`s are the ONLY barrier
+ * against `</script>` breakout / HTML-entity injection in the server-rendered
+ * HTML, and they run on app-supplied data of unbounded size.
+ *
+ * Why a STRESS test (not redundant with `serializeState.test.ts`): the functional
+ * suite asserts `expect(result).toContain("<")` — that AT LEAST ONE
+ * dangerous char was escaped. That passes even if a global `replaceAll`
+ * regresses to a single-occurrence `replace`: with N copies of `<`, only the
+ * first is escaped, `.toContain` is still satisfied, and N-1 raw `<` leak into
+ * the HTML — a live XSS. The round-trip test does not catch it either (`<`/`>`/`&`
+ * are valid inside a JSON string, so an under-escaped payload still re-parses).
+ * Only MANY occurrences + an EXHAUSTIVE "zero raw dangerous char remains"
+ * assertion discriminates that regression. Canonical "stress catches what a
+ * functional N=1 test cannot", on a security-critical path.
+ *
+ * Discrimination is CORRECTNESS-at-scale, not timing: the escaped output must
+ * contain ZERO raw `<`/`>`/`&` and EXACTLY as many escape sequences as the
+ * pre-escape serialization had raw chars (independent oracle: count on
+ * `JSON.stringify`). Mutating `replaceAll`→`replace` in `serializeState.ts`
+ * leaves N-1 raw chars → the "zero raw" + exact-count asserts trip. The wallclock
+ * line is a generous catastrophe guard ONLY — the escape is O(n) by construction
+ * (three linear string passes), so there is no quadratic to anchor a tight bound.
+ */
+describe("S27. serializeState XSS-escape correctness at scale", () => {
+  // Each token contributes 2× `<` (`</script>`, `<img …>`), 2× `>` and 1× `&`.
+  const TOKEN = "</script><img src=x onerror=alert(1)>&amp;";
+  const N = 50_000;
+
+  it(`escapes every one of >${N} dangerous chars — zero raw <, >, & survive`, () => {
+    const attack = TOKEN.repeat(N);
+    // Dangerous chars sit in a string param AND a top-level field, so the escape
+    // must cover the whole serialized payload, not just one slot.
+    const state = {
+      name: "home",
+      path: "/x",
+      params: { q: attack },
+      evil: attack,
+    };
+
+    // Independent oracle: count raw dangerous chars on the UN-escaped
+    // serialization (exactly what serializeState's JSON.stringify produces and
+    // then escapes over), so the expected escape counts are derived, not mirrored.
+    const raw = JSON.stringify(state);
+    const expectedLt = (raw.match(/</g) ?? []).length;
+    const expectedGt = (raw.match(/>/g) ?? []).length;
+    const expectedAmp = (raw.match(/&/g) ?? []).length;
+
+    // The payload genuinely exercises all three escapes far past N (so a
+    // single-occurrence `replace` regression leaves a huge raw residue).
+    expect(expectedLt).toBeGreaterThan(N);
+    expect(expectedGt).toBeGreaterThan(N);
+    expect(expectedAmp).toBeGreaterThan(N);
+
+    const { result, durationMs } = measureTime(() => serializeState(state));
+
+    // (1) EXHAUSTIVE: not one raw dangerous char survives. This is the assertion
+    // the functional `.toContain` lacks — it is what trips on replaceAll→replace.
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+    expect(result).not.toContain("&");
+
+    // (2) The literal breakout token must be gone from the embeddable output.
+    expect(result).not.toContain("</script>");
+
+    // (3) Exact counts: every raw char became its escape — none dropped/doubled.
+    expect(result.match(/\\u003c/g) ?? []).toHaveLength(expectedLt);
+    expect(result.match(/\\u003e/g) ?? []).toHaveLength(expectedGt);
+    expect(result.match(/\\u0026/g) ?? []).toHaveLength(expectedAmp);
+
+    // (4) Catastrophe-only timing guard (escape is O(n) — three linear passes).
+    expect(
+      durationMs,
+      `escape of ${formatLength(result.length)} took ${durationMs.toFixed(1)}ms`,
+    ).toBeLessThan(500);
+  });
+});
+
+function formatLength(n: number): string {
+  return n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M chars` : `${n} chars`;
+}


### PR DESCRIPTION
Closes #920.

## Summary

`getStaticPaths` threw `RangeError: Maximum call stack size exceeded` when a single route section had more static leaf routes than V8's spread-argument limit (~124,395 on Node 24). Root cause: `getLeafRouteNames` accumulated leaves via `result.push(...getLeafRouteNames(child))` — the spread passes one argument per leaf. Fixed by accumulating into a shared array (no spread), which also drops the per-subtree intermediate-array allocation. Output and enumeration order are unchanged.

## How it was found

The `/stress-scenarios` skill's **skeptical-probe** pass — hypothesis "`push(...spread)` from data of unknown size hits the engine arg-limit". Empirically `[].push(...Array(N))` throws at N ≈ 124,395 (Node 24.16); the real `getStaticPaths` throws on a 200k-leaf section.

## Changes (2 independent commits)

- **`fix(core)`** — `getLeafRouteNames` → accumulator (`collectLeafRouteNames`), no spread. Regression stress test: 200k leaves under one parent, asserts no `RangeError` + no drop + tree order.
- **`test(core)`** — `serializeState` XSS-escape exhaustive-at-scale stress test. Separate gap from the same pass (`utils/` had **zero** stress coverage). Guards a `replaceAll`→single-`replace` regression that the functional `.toContain` suite silently passes (only the first `</script>` escaped → live XSS leak); the stress test asserts "zero raw `<`/`>`/`&` remain" + exact escaped counts vs an independent oracle.

## Validation

- TDD: Red (`RangeError` on 200k) → fix → Green.
- 9 existing `getStaticPaths` functional tests still pass (behavior-preserving).
- Full core stress suite: 28 files / 98 tests green; `type-check` clean.

## Notes

- `patch` bump (bug fix), changeset included.
- 2 independent commits — **rebase-merge** preferred to keep them separate.