### PR TITLE
test(route-tree): raise mutation score 94.62% → 98.90% (#928)

### DIFF
--- a/.changeset/route-tree-mutation-refactor.md
+++ b/.changeset/route-tree-mutation-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Harden the internal `route-tree` dependency via mutation testing (#928)
+
+Test-only and runtime-no-op changes to `route-tree` (consumed by `@real-router/core`): kill surviving mutants with targeted tests, remove dead write-only `MutableRouteNode` fields, and document/disable proven-equivalent mutants — raising its mutation score from 94.62% to 98.90%. No observable behavior change in `@real-router/core`.

--- a/packages/route-tree/src/builder/buildTree.ts
+++ b/packages/route-tree/src/builder/buildTree.ts
@@ -24,10 +24,6 @@ export interface MutableRouteNode {
   absolute: boolean;
   children: MutableRouteNode[];
   parent: MutableRouteNode | null;
-
-  // These are computed later by computeCaches
-  nonAbsoluteChildren: MutableRouteNode[];
-  fullName: string;
 }
 
 // =============================================================================
@@ -62,9 +58,6 @@ function createNode(
     absolute,
     children: [],
     parent,
-    // These will be computed by computeCaches
-    nonAbsoluteChildren: [],
-    fullName: "",
   };
 
   // Recursively add children

--- a/packages/route-tree/src/builder/computeCaches.ts
+++ b/packages/route-tree/src/builder/computeCaches.ts
@@ -133,6 +133,7 @@ function processNode(
     children: undefined as unknown as ReadonlyMap<string, RouteTree>,
     paramMeta,
     nonAbsoluteChildren: undefined as unknown as RouteTree[],
+    // Stryker disable next-line StringLiteral: equivalent — placeholder overwritten unconditionally on the next statement (`node.fullName = computeFullName(node)`); the initial value is never observed.
     fullName: "",
     paramTypeMap,
   };
@@ -190,6 +191,7 @@ function processNode(
  */
 export function computeCaches(
   mutableRoot: MutableRouteNode,
+  // Stryker disable next-line BooleanLiteral: equivalent — defensive default expressing the package's immutable-by-default contract; the sole caller (createRouteTree) always passes `freeze` explicitly, so the default is never exercised (NoCoverage artifact).
   freeze = true,
 ): RouteTree {
   return processNode(mutableRoot, null, freeze);

--- a/packages/route-tree/src/validation/route-batch.ts
+++ b/packages/route-tree/src/validation/route-batch.ts
@@ -235,6 +235,7 @@ function findNodeByFullName(
   fullName: string,
 ): RouteTree | undefined {
   // Fast path: single-segment names don't need splitting
+  // Stryker disable next-line ConditionalExpression,StringLiteral,BlockStatement: equivalent — the fast path is a pure optimization; for a dotless name the general path below yields the identical result (`name.split(".")` → `[name]`, a one-iteration `children.get(name)`). (BooleanLiteral stays live: dropping the `!` runs the fast path for a dotted name → `children.get("a.b")` is undefined = killed.)
   if (!fullName.includes(".")) {
     return rootNode.children.get(fullName);
   }

--- a/packages/route-tree/tests/functional/builder.test.ts
+++ b/packages/route-tree/tests/functional/builder.test.ts
@@ -140,6 +140,21 @@ describe("createRouteTree", () => {
       }).toThrow(TypeError);
       expect(node.paramMeta.urlParams).not.toContain("HACKED");
     });
+
+    // A leaf node (no children) gets its empty children map / nonAbsoluteChildren
+    // from the shared *frozen* sentinels — not a fresh per-node allocation. If the
+    // leaf fast-path were skipped (children built via the general path), those
+    // collections would be freshly allocated and left unfrozen, leaking a mutable
+    // surface on a supposedly-immutable tree. Assert the leaf collections are frozen.
+    it("should freeze a leaf node's empty children map and nonAbsoluteChildren", () => {
+      const tree = createRouteTree("", "", [{ name: "home", path: "/" }]);
+      const leaf = tree.children.get("home")!;
+
+      expect(leaf.children.size).toBe(0);
+      expect(leaf.nonAbsoluteChildren).toHaveLength(0);
+      expect(Object.isFrozen(leaf.children)).toBe(true);
+      expect(Object.isFrozen(leaf.nonAbsoluteChildren)).toBe(true);
+    });
   });
 });
 

--- a/packages/route-tree/tests/functional/createMatcher.test.ts
+++ b/packages/route-tree/tests/functional/createMatcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { createRouteTree } from "../../src/builder/createRouteTree";
 import { createMatcher } from "../../src/createMatcher";
 
 import type { Matcher } from "../../src/createMatcher";
@@ -37,6 +38,22 @@ describe("createMatcher", () => {
     });
 
     expect(matcher).toBeDefined();
+  });
+
+  it("should forward caseSensitive:false to the matcher (case-insensitive lookup)", () => {
+    // SegmentMatcher defaults to caseSensitive:true. createMatcher must forward
+    // an explicit caseSensitive:false so an upper-cased URL still matches a
+    // lower-cased route. If the option were dropped, matching would fall back to
+    // the case-sensitive default and "/USERS" would not match "/users".
+    const tree = createRouteTree("", "", [{ name: "users", path: "/users" }]);
+    const matcher = createMatcher({ caseSensitive: false });
+
+    matcher.registerTree(tree);
+
+    const result = matcher.match("/USERS");
+
+    expect(result).toBeDefined();
+    expect(result?.segments.at(-1)?.name).toBe("users");
   });
 
   it("should inject parseQueryString from search-params", () => {

--- a/packages/route-tree/tests/functional/validation-route-batch.test.ts
+++ b/packages/route-tree/tests/functional/validation-route-batch.test.ts
@@ -41,6 +41,22 @@ describe("validateRoute", () => {
       }).toThrow(TypeError);
     });
 
+    it("should report 'must be an object' (not 'plain object') for a truthy primitive", () => {
+      // A truthy non-object primitive (string/number/boolean) is rejected by the
+      // `typeof route !== "object"` operand, not by `!route`. The wording must be
+      // the early "Route must be an object", distinct from the downstream
+      // prototype check's "Route must be a plain object".
+      expect(() => {
+        validateRoute("string", methodName);
+      }).toThrow("[router.add] Route must be an object, got string");
+      expect(() => {
+        validateRoute(123, methodName);
+      }).toThrow("[router.add] Route must be an object, got number");
+      expect(() => {
+        validateRoute(true, methodName);
+      }).toThrow("[router.add] Route must be an object, got boolean");
+    });
+
     it("should throw TypeError for class instances", () => {
       class RouteClass {
         name = "class-route";
@@ -194,6 +210,14 @@ describe("validateRoute", () => {
       expect(() => {
         validateRoute({ name: "café", path: "/cafe" }, methodName);
       }).toThrow(/Invalid route name/);
+      // Full message: both concatenated halves (prefix + format hint) must appear.
+      expect(() => {
+        validateRoute({ name: "café", path: "/cafe" }, methodName);
+      }).toThrow(
+        '[router.add] Invalid route name "café". ' +
+          "Name must start with a letter or underscore, " +
+          "followed by letters, numbers, underscores, or hyphens.",
+      );
     });
 
     it("should throw for missing path", () => {
@@ -537,6 +561,13 @@ describe("validateRoute", () => {
       expect(() => {
         validateRoute({ name: "users.profile", path: "/profile" }, methodName);
       }).toThrow(/cannot contain dots/);
+      // Full message includes the actionable second sentence.
+      expect(() => {
+        validateRoute({ name: "users.profile", path: "/profile" }, methodName);
+      }).toThrow(
+        '[router.add] Route name "users.profile" cannot contain dots. ' +
+          "Use children array or { parent } option in addRoute() instead.",
+      );
     });
 
     it("should throw TypeError for multi-level dot-notation", () => {


### PR DESCRIPTION
## Summary

- Raises `route-tree` mutation score from **94.62% to 98.90%** by giving every survivor a verdict — killed, dead-code-removed, disabled (proven equivalent), or documented (entangled).
- Strengthens the suite around error-message exactness, leaf-node immutability, and matcher option forwarding. All `src` deltas are runtime no-ops; `route-tree` is private, so the changeset records a `patch` on its public consumer `@real-router/core`.

### #928 — route-tree mutation score 94.62% → 98.90%

- **Killed (6, via tests):** `route-batch` error-message guards (truthy-primitive `typeof` guard exact text; dots / invalid-name full messages), `computeCaches` leaf-node frozen sentinels (existing tests only checked the root, a non-leaf), `createMatcher` `caseSensitive: false` forwarding.
- **Dead code removed:** write-only vestigial `MutableRouteNode.fullName` + `.nonAbsoluteChildren` — set in `createNode`, never read on a mutable node (`computeCaches` builds fresh skeletons; the "computed later" comment was stale post Segment-Trie migration). grep-verified, type-check clean.
- **Equivalents disabled (5, proven by injection):** `findNodeByFullName` fast-path ×3, skeleton `fullName` placeholder, `computeCaches` `freeze` default-param.
- **Equivalents documented (3, entangled — not suppressible):** `computeCaches` `if (mutable.children.length > 0)` (`ConditionalExpression` + `EqualityOperator`, killed siblings on the line), `getSegmentsByName` `includes(".")` (`StringLiteral`, killed sibling by column).
- No suspected bugs.

### Maintainability

- Removes two dead fields from the internal `MutableRouteNode` shape; the remaining `// Stryker disable` comments each carry a proven-equivalence reason.

## Test plan

- [x] `tests/functional/builder.test.ts` — a leaf node's empty `children` / `nonAbsoluteChildren` are frozen (fails before, passes after)
- [x] `tests/functional/createMatcher.test.ts` — `caseSensitive: false` yields a case-insensitive match (fails before, passes after)
- [x] `tests/functional/validation-route-batch.test.ts` — exact error-message assertions (typeof-guard text, dots message, invalid-name message)
- [x] 224 tests green, 100% coverage maintained
- [x] Verified via targeted non-incremental Stryker — 98.51% on changed files; the 3 residual survivors are documented entangled equivalents
- [x] Pre-push validation passed (`pnpm build` + `lint:types` + `lint:package` + knip + jscpd)

Closes #928
