### PR TITLE
fix(preload-plugin): clear SonarJS S1751 in #cacheState LRU eviction (#971)

### DIFF
--- a/.changeset/preload-state-cache-eviction-fix.md
+++ b/.changeset/preload-state-cache-eviction-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preload-plugin": patch
+---
+
+Clear SonarJS S1751 in `#cacheState` LRU eviction (#971)
+
+Replace the single-iteration `for…of` + `break` that dropped the oldest cache entry with iterator destructuring (`const [oldest] = this.#stateCache.keys()`). Behavior is unchanged — insertion-order eviction at the 32-entry bound, 100% branch coverage preserved — this only removes a Major reliability finding (`new_reliability_rating` C) that was reding the SonarCloud quality gate. No public API or behavioral change.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@vitest/eslint-plugin": "1.6.20",
     "@vitest/ui": "4.1.8",
     "czg": "1.13.1",
-    "danger": "13.0.7",
+    "danger": "13.0.10",
     "dotenv-cli": "11.0.0",
     "eslint": "10.5.0",
     "eslint-config-prettier": "10.1.8",

--- a/packages/preload-plugin/src/plugin.ts
+++ b/packages/preload-plugin/src/plugin.ts
@@ -299,12 +299,11 @@ export class PreloadPlugin {
     if (this.#stateCache.has(href)) {
       this.#stateCache.delete(href);
     } else if (this.#stateCache.size >= STATE_CACHE_LIMIT) {
-      // size >= LIMIT > 0 → iterator has at least one key.
-      for (const oldest of this.#stateCache.keys()) {
-        this.#stateCache.delete(oldest);
+      // Evict the oldest (first-inserted) entry. size >= LIMIT > 0, so the
+      // iterator yields at least one key — destructuring it is safe.
+      const [oldest] = this.#stateCache.keys();
 
-        break;
-      }
+      this.#stateCache.delete(oldest);
     }
 
     this.#stateCache.set(href, state);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: 1.13.1
         version: 1.13.1
       danger:
-        specifier: 13.0.7
-        version: 13.0.7
+        specifier: 13.0.10
+        version: 13.0.10
       dotenv-cli:
         specifier: 11.0.0
         version: 11.0.0
@@ -10837,8 +10837,8 @@ packages:
     engines: {node: '>=v12.20.0'}
     hasBin: true
 
-  danger@13.0.7:
-    resolution: {integrity: sha512-H7Syz9P3np7tgOjTYs1DDogjlknPWYwBIJXUTFIK5iFZOQ0b8irkUz5swOLFUmw7j0aKuybhwkXTcfyHFvRzCQ==}
+  danger@13.0.10:
+    resolution: {integrity: sha512-qMa/YdfVP/a1HhuvMUsocTO0otgLphuiV5z4G5P7C4+qHvNtCSlzvZm3UuwBut2iwQ/r5NGcwcmD4t+8LjIS0A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11673,6 +11673,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -18926,7 +18927,7 @@ snapshots:
 
   czg@1.13.1: {}
 
-  danger@13.0.7:
+  danger@13.0.10:
     dependencies:
       '@gitbeaker/rest': 38.12.1
       '@octokit/rest': 20.1.2
@@ -18936,8 +18937,6 @@ snapshots:
       core-js: 3.49.0
       debug: 4.4.3
       fast-json-patch: 3.1.1
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
       hyperlinker: 1.0.0
       ini: 5.0.0
       json5: 2.2.3
@@ -18950,7 +18949,6 @@ snapshots:
       memfs-or-file-map-to-github-branch: 1.3.0
       micromatch: 4.0.8
       node-cleanup: 2.1.2
-      node-fetch: 2.7.0
       override-require: 1.1.1
       parse-diff: 0.7.1
       parse-github-url: 1.0.4
@@ -18961,8 +18959,8 @@ snapshots:
       regenerator-runtime: 0.13.11
       require-from-string: 2.0.2
       supports-hyperlinks: 4.4.0
+      undici: 7.28.0
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   data-urls@7.0.0(@noble/hashes@2.2.0):


### PR DESCRIPTION
## Summary

- Removes the only failing SonarCloud quality-gate condition on `master`: a Major SonarJS **S1751** ("Invalid loop. Its body allows only one iteration.") that pushed `new_reliability_rating` to C.
- No behavioral change for consumers — the `#cacheState` LRU cache still evicts the oldest entry in insertion order at the 32-entry bound.

### #971 — `#cacheState` LRU eviction trips SonarJS S1751

- **Root cause:** the oldest-entry eviction used a `for…of` + `break` over `this.#stateCache.keys()` — a loop body that always breaks on the first iteration, which S1751 flags as a reliability bug. No runtime defect; eviction was correct, but the finding red-lit the gate.
- **Fix:** replace the loop with iterator destructuring —
  ```ts
  const [oldest] = this.#stateCache.keys();
  this.#stateCache.delete(oldest);
  ```
  `oldest` types as `string` (iterator destructuring, no non-null assertion), the loop disappears (S1751 gone), behavior is identical.
- **Why not a `if (oldest !== undefined)` guard:** it would add an always-true branch whose false arm is never exercised, breaking the package's 100% branch coverage. Destructuring keeps coverage at 100% without any suppression.

## Test plan

- [x] No new behavioral test — S1751 is a static-analysis finding with no runtime symptom, and `no-one-iteration-loop` is not in the local `eslint-plugin-sonarjs` (SonarCloud-engine only), so there is no local repro to assert against. Existing behavioral coverage guards the refactor and stays green: `packages/preload-plugin/tests/functional/state-cache.test.ts` → `"evicts oldest entry past 32-item bound (insertion-order)"` and `"re-hovering same href refreshes recency"`.
- [x] `@real-router/preload-plugin` suite: 81/81 passing, 100% coverage (branches 60/60)
- [x] Full turbo validation green via pre-commit/pre-push (build → lint → type-check → test → test:properties → test:stress)

Closes #971