### PR TITLE
fix(core): error-flow audit fixes (#933, #947, #948, #949)

### DIFF
--- a/.changeset/emit-pending-error-949-fix.md
+++ b/.changeset/emit-pending-error-949-fix.md
@@ -1,0 +1,11 @@
+---
+"@real-router/core": patch
+---
+
+Clear `EventBusNamespace` pending-error fields after emit (#949)
+
+`#emitPendingError()` read `#pendingToState` / `#pendingFromState` / `#pendingError` to emit
+`TRANSITION_ERROR` but did not clear them, leaving the last error's `State` / `RouterError`
+pinned on the instance until the next `sendFail()` / `sendCancel()` overwrote them. The
+fields are now cleared once consumed. State hygiene only — every consumer already overwrites
+the fields before re-reading, so there is no observable behaviour change.

--- a/.changeset/handle-guard-error-933-fix.md
+++ b/.changeset/handle-guard-error-933-fix.md
@@ -1,0 +1,17 @@
+---
+"@real-router/core": patch
+---
+
+Preserve a guard-thrown `RouterError(TRANSITION_CANCELLED)` instead of re-coding it (#933)
+
+A route guard that throws `RouterError(TRANSITION_CANCELLED)` to quietly cancel a
+transition was observed by the caller as `CANNOT_ACTIVATE` / `CANNOT_DEACTIVATE`.
+`handleGuardError` only special-cased a `DOMException` `AbortError`, so an explicit
+cancellation `RouterError` fell through to `rethrowAsRouterError`, whose `setCode`
+overwrote the code — turning the intended quiet cancel into a reported transition
+error (`onTransitionError` fired, `routeTransitionError` emitted a fail).
+
+`handleGuardError` now preserves a thrown `RouterError` whose code is already
+`TRANSITION_CANCELLED`, mirroring the existing `AbortError` → `TRANSITION_CANCELLED`
+handling. Other thrown `RouterError`s (e.g. `TRANSITION_ERR`) are still re-coded as
+before.

--- a/.changeset/send-fail-safe-948-docs.md
+++ b/.changeset/send-fail-safe-948-docs.md
@@ -1,0 +1,12 @@
+---
+"@real-router/core": patch
+---
+
+Document `EventBusNamespace.sendFailSafe()` semantics and state-branching (#948)
+
+Add JSDoc clarifying that the "Safe" suffix means the error event is never dropped
+regardless of FSM state — not that the method catches every error (errors thrown inside a
+`TRANSITION_ERROR` listener are isolated separately via the `EventEmitter`'s
+`onListenerError` sink). Also document why the method reads its own FSM state to choose
+between the FSM-routed `FAIL` action (in `READY`) and a direct `TRANSITION_ERROR` emit
+(otherwise). No behaviour change.

--- a/.changeset/wrap-sync-error-947-fix.md
+++ b/.changeset/wrap-sync-error-947-fix.md
@@ -1,0 +1,16 @@
+---
+"@real-router/core": patch
+---
+
+Stop a guard-thrown thenable from making the wrapped `RouterError` thenable (#947)
+
+When a transition step (e.g. a route guard) throws a thenable — a non-`Error` object
+exposing a `then` method — `wrapSyncError()` spread its own-enumerable properties onto the
+`RouterError` metadata, filtering only the reserved keys `code` / `segment` / `path`. `then`
+was not filtered, so the produced `RouterError` carried a `then` function and was itself
+thenable: a consumer that `await`ed it (or passed it through `Promise.resolve`, or returned
+it from an `async` function) had it assimilated as a Promise instead of treated as a plain
+rejection reason.
+
+`wrapSyncError()` now also excludes `then` from the spread. Other own properties are still
+copied onto the error metadata.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -771,7 +771,7 @@ Key types:
 
 Cancellation: Pass `{ signal }` via `NavigationOptions` for external `AbortController` cancellation. `router.stop()`, `router.dispose()`, and concurrent navigation abort the internal controller automatically. 
 Guards receive `signal` as optional 3rd parameter for cooperative cancellation (e.g., `fetch(url, { signal })`). 
-`AbortError` thrown in guards is auto-converted to `TRANSITION_CANCELLED`.
+`AbortError` thrown in guards is auto-converted to `TRANSITION_CANCELLED`. A guard may also throw `RouterError(TRANSITION_CANCELLED)` directly to signal a quiet cancel — it is **preserved** (not re-coded to `CANNOT_ACTIVATE`/`CANNOT_DEACTIVATE`), so the navigation rejects with `TRANSITION_CANCELLED` and `onTransitionError` does **not** fire (#933). Any other thrown `RouterError` is still re-coded to the guard's `CANNOT_ACTIVATE`/`CANNOT_DEACTIVATE`.
 
 ## See Also
 

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -257,6 +257,25 @@ export class EventBusNamespace {
     }
   }
 
+  /**
+   * Surfaces a `TRANSITION_ERROR` for callers that do **not** know — or do not
+   * control — the current FSM state: the plugin-facing `emitTransitionError`
+   * primitive (`getPluginApi`), the dispose chain, and validator / same-state
+   * rejections. It is the state-agnostic counterpart to {@link sendFail}.
+   *
+   * **What "Safe" means here.** The error event is never *dropped*, whatever the
+   * FSM state — it does **not** mean the method catches every error. Errors
+   * thrown *inside* a `TRANSITION_ERROR` listener are isolated by the
+   * `EventEmitter`'s per-listener `onListenerError` sink, not by this method.
+   *
+   * **Why it branches on its own FSM state.** When the FSM is settled in `READY`
+   * (no transition in flight) it routes through the FSM `FAIL` action via
+   * {@link sendFail}, so the error rides the normal FSM-driven emit. Otherwise —
+   * the router may be starting, mid-transition, or torn down — it emits
+   * `TRANSITION_ERROR` directly: a fire-and-forget error report from an unknown
+   * state must not drive a second FSM transition that could collide with an
+   * in-flight one. Both branches guarantee the event reaches subscribers.
+   */
   sendFailSafe(toState?: State, fromState?: State, error?: unknown): void {
     if (this.isReady()) {
       this.sendFail(toState, fromState, error);

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -603,6 +603,17 @@ export class EventBusNamespace {
       this.#pendingFromState,
       this.#pendingError as RouterError | undefined,
     );
+
+    // Clear the pending payload once this FAIL action has consumed it. `#pending*`
+    // is only meaningful in the window between the sendFail()/sendFailSafe() that
+    // sets it and this emit; keeping it afterwards pins a stale State/RouterError
+    // on the instance and leaves an implicit "valid only in this window" coupling
+    // (#949). Hygiene only — every consumer overwrites the fields before
+    // re-reading (handleCancel reads what its own sendCancel just set), so there
+    // is no observable behaviour change.
+    this.#pendingToState = undefined;
+    this.#pendingFromState = undefined;
+    this.#pendingError = undefined;
   }
 
   #setupFSMActions(): void {

--- a/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
@@ -81,7 +81,15 @@ export function rethrowAsRouterError(
   throw new RouterError(errorCode, wrapSyncError(error, segment));
 }
 
-const reservedRouterErrorProps = new Set(["code", "segment", "path"]);
+// Own-enumerable keys that must never be copied from a thrown object onto the
+// RouterError metadata:
+// - `code` / `segment` / `path` are reserved — the RouterError constructor
+//   throws a TypeError on them (#39).
+// - `then` would make the RouterError itself thenable, so a consumer that
+//   awaits it (or passes it through Promise.resolve / returns it from an async
+//   function) would have it assimilated as a Promise instead of treated as a
+//   plain rejection reason (#947).
+const reservedRouterErrorProps = new Set(["code", "segment", "path", "then"]);
 
 /**
  * Wraps a synchronously thrown value into structured error metadata.
@@ -118,7 +126,8 @@ export function wrapSyncError(
     const filtered: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(thrown)) {
-      // Issue #39: Skip reserved properties to avoid RouterError constructor TypeError
+      // Skip reserved / hazardous keys: #39 (constructor TypeError on code/
+      // segment/path) and #947 (`then` would make the error thenable).
       if (!reservedRouterErrorProps.has(key)) {
         filtered[key] = value;
       }

--- a/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
@@ -33,6 +33,20 @@ export function handleGuardError(
     throw new RouterError(errorCodes.TRANSITION_CANCELLED);
   }
 
+  // A guard can also signal a quiet cancel by throwing
+  // RouterError(TRANSITION_CANCELLED) directly — the same intent as a thrown
+  // AbortError. Preserve it as-is instead of letting rethrowAsRouterError
+  // overwrite the code with CANNOT_ACTIVATE / CANNOT_DEACTIVATE: that code
+  // drives the downstream suppression (routeTransitionError early-returns,
+  // fire-and-forget stays silent), so re-coding would surface the intended
+  // quiet cancel as a reported transition error (#933).
+  if (
+    error instanceof RouterError &&
+    error.code === errorCodes.TRANSITION_CANCELLED
+  ) {
+    throw error;
+  }
+
   rethrowAsRouterError(error, errorCode, segment);
 }
 

--- a/packages/core/tests/functional/navigation/errorHandling.test.ts
+++ b/packages/core/tests/functional/navigation/errorHandling.test.ts
@@ -144,6 +144,26 @@ describe("handleGuardError — AbortError detection", () => {
   });
 });
 
+describe("handleGuardError — explicit RouterError(TRANSITION_CANCELLED) is preserved", () => {
+  it("a guard that throws RouterError(TRANSITION_CANCELLED) keeps that code (not re-coded to CANNOT_ACTIVATE)", async () => {
+    // A guard that throws RouterError(TRANSITION_CANCELLED) is explicitly
+    // signalling a quiet cancel — the same intent as a thrown AbortError.
+    // It must NOT be re-coded to CANNOT_ACTIVATE (#933), otherwise the quiet
+    // cancel turns into a reported transition error.
+    const onTransitionError = vi.fn();
+    const router = routerWithActivateGuard(() => {
+      throw new RouterError(errorCodes.TRANSITION_CANCELLED);
+    });
+
+    router.usePlugin(() => ({ onTransitionError }));
+
+    const error = await navigateError(router);
+
+    expect(error?.code).toBe(errorCodes.TRANSITION_CANCELLED);
+    expect(onTransitionError).not.toHaveBeenCalled();
+  });
+});
+
 describe("rethrowAsRouterError — RouterError keeps identity, gets re-coded", () => {
   it("re-codes a thrown RouterError instead of wrapping it (message preserved)", async () => {
     const error = await navigateError(

--- a/packages/core/tests/functional/navigation/errorHandling.test.ts
+++ b/packages/core/tests/functional/navigation/errorHandling.test.ts
@@ -231,6 +231,36 @@ describe("wrapSyncError — metadata extraction (via the rejected RouterError)",
     expect((error as unknown as { kept: string }).kept).toBe("v"); // non-reserved survives
   });
 
+  it("does not leak `then` from a thrown thenable onto the RouterError (#947)", async () => {
+    const router = routerWithActivateGuard(() => {
+      // A thenable thrown by a guard would otherwise make the wrapped
+      // RouterError itself thenable — a foot-gun for any consumer that awaits
+      // (or Promise.resolve()s / returns from async) the error.
+      // eslint-disable-next-line @typescript-eslint/only-throw-error, unicorn/no-thenable -- deliberately throwing a thenable object to exercise wrapSyncError's `then` filter (#947)
+      throw { then: () => {}, kept: "v" };
+    });
+
+    await router.start("/");
+
+    // Capture the rejection WITHOUT returning the error from the handler: a
+    // thenable returned into a resolving position is assimilated, and a no-op
+    // `then` would hang the test — exactly the foot-gun #947 guards against.
+    let caught: unknown;
+
+    await router.navigate("page").then(
+      () => undefined,
+      (error: unknown) => {
+        caught = error;
+      },
+    );
+
+    expect(caught).toBeInstanceOf(RouterError);
+    expect((caught as RouterError).code).toBe(errorCodes.CANNOT_ACTIVATE);
+    expect(typeof (caught as { then?: unknown }).then).not.toBe("function");
+    // The fix is surgical — non-`then` own props still flow through as metadata.
+    expect((caught as { kept: string }).kept).toBe("v");
+  });
+
   it("returns base-only metadata for a primitive throw (no enumerable spread)", async () => {
     const error = await navigateError(
       routerWithActivateGuard(() => {


### PR DESCRIPTION
Batch of four `@real-router/core` error-flow fixes from the foundation audit epic (#756). Each is an independent commit with its own changeset.

## #933 — guard-thrown `RouterError(TRANSITION_CANCELLED)` was re-coded
`handleGuardError` only converted a `DOMException` `AbortError` to `TRANSITION_CANCELLED`; an explicit `RouterError(TRANSITION_CANCELLED)` thrown by a guard fell through to `rethrowAsRouterError`, whose `setCode` overwrote it with `CANNOT_ACTIVATE`/`CANNOT_DEACTIVATE` — turning a quiet cancel into a reported transition error (`onTransitionError` fired, `routeTransitionError` no longer early-returned). Now preserved, mirroring the `AbortError` branch. Other thrown `RouterError` codes are still re-coded.

## #947 — guard-thrown thenable made the `RouterError` thenable
`wrapSyncError` spread a thrown object's own-enumerable props onto the error metadata, filtering only `code`/`segment`/`path`. A thrown `{ then }` leaked `then`, making the `RouterError` itself thenable (assimilated when awaited / `Promise.resolve`d / returned from async). `then` is now excluded from the spread.

## #948 — `sendFailSafe` docs (no behaviour change)
Added JSDoc: "Safe" = the error event is never **dropped** regardless of FSM state (NOT a try/catch — errors thrown inside a listener go to `onListenerError`), plus the FSM state-branching rationale (`READY` → FSM `FAIL`; otherwise direct emit). No rename — no clearly-better name, and it would churn the internal call sites.

## #949 — `#emitPendingError` pending-state hygiene (no behaviour change)
`#emitPendingError` never cleared `#pendingToState`/`#pendingFromState`/`#pendingError`, pinning a stale `State`/`RouterError` until the next `sendFail`/`sendCancel`. Now cleared once consumed. No observable change — every consumer overwrites the fields before re-reading.

## Tests & validation
- `errorHandling.test.ts`: new tests for **#933** (explicit `RouterError(TRANSITION_CANCELLED)` preserved, no `onTransitionError`) and **#947** (thrown thenable → resulting error is not thenable).
- **#948 / #949** are non-behavioural (docs / state hygiene): no discriminating test exists; the full functional suite (2445) is green at 100% coverage, property suite (279) green.

Closes #933
Closes #947
Closes #948
Closes #949
