### PR TITLE
bench: re-profile guard pipeline — #938 premise obsolete (0→1 guard ≠ 4.6µs)

### DIFF
--- a/benchmarks/core/audit-probes/navigate-2026-05-21/RESULTS.md
+++ b/benchmarks/core/audit-probes/navigate-2026-05-21/RESULTS.md
@@ -20,6 +20,13 @@ Implication for audit summary table row #6: downgrade severity. The `forceReplac
 
 ## probe-02: sync vs async guard branch cost
 
+> ⚠️ **Headline superseded by probe-05 (2026-06-27).** The ~4.6 µs "0→1 guard" figure
+> below was measured against **dist @ 2026-05-21** and **no longer reproduces** at current
+> HEAD: against current dist the sync-guard overhead is ~0.2 µs (below noise). The
+> "sync ≈ async" reading was an artifact of the contended variant C (see caveat). See the
+> probe-05 section at the end of this file. The probe-02 numbers are retained as a
+> historical baseline.
+
 | Variant | avg | p50 | σ | rme |
 |---|---|---|---|---|
 | A. navigate, no guards (sync hot path) | 534.8 ns | 461.0 ns | 147.7 ns | 4.08% |
@@ -77,3 +84,55 @@ Last leave payload:         { route: 'home', nextRoute: 'target' }
 ## Notes on noise floor
 
 `σ/avg ≈ 25%` on the navigate ping-pong variants is high. Likely cause: V8 inline-cache megamorphism — multiple router instances created across variants in the same process polluted prototype-method ICs (documented in `benchmarks/CLAUDE.md` § "Section 2 — IC Megamorphism Artifact"). Re-running each probe in a fresh node process would reduce σ, but the verdicts (all three below noise) are robust to that — improvements would only widen the floor.
+
+---
+
+## probe-05: guard-pipeline re-profile @ current HEAD (2026-06-27) — #938
+
+Re-measurement that (1) runs against **current HEAD** instead of the 2026-05-21 tree and
+(2) **awaits** each navigate so the async pipeline drains between iterations — removing the
+fire-and-forget contention that made probe-02's variant C uninterpretable. All three
+variants share the identical awaited harness (40 batches × 2000 navigates, warmup 4000), so
+the deltas are clean. Source: `probe-05-guard-pipeline-reprofile.ts`.
+
+Environment: macOS (Darwin 25.5), Apple M3 Pro, AC power. Runner: `npx tsx` (dist) and
+`NODE_OPTIONS='--conditions=@real-router/internal-source' npx tsx` (src). Current-HEAD dist
+built via `turbo run bundle --filter=@real-router/core`.
+
+**Against current `dist` (what ships):**
+
+| Variant | avg | p50 | σ |
+|---|---|---|---|
+| A. navigate, no guards | ~613 ns | ~596 ns | ~116 ns |
+| B. navigate, 1 sync guard | ~849 ns | ~807 ns | ~114 ns |
+| C. navigate, 1 async guard (awaited) | ~1.05 µs | ~1.02 µs | ~81 ns |
+
+- **Sync-guard overhead (B − A) = ~236 ns** — noise floor ~233 ns → **at/below noise** (`[НЕ ПОДТВЕРЖДЕНО]`).
+- **Async-branch overhead (C − B) = ~195 ns** — noise floor ~229 ns → **below noise** (`[НЕ ПОДТВЕРЖДЕНО]`).
+- **Total 0→1 guard (C − A) = ~430 ns.**
+
+**Against current `src` (live source via tsx, ~3× the dist absolute as expected):**
+
+| Variant | avg | B − A | C − B |
+|---|---|---|---|
+| A ~706 ns · B ~1.40 µs · C ~1.78 µs | — | **~692 ns** (confirmed) | ~380 ns (below noise) |
+
+### Verdict — both #938 questions resolved
+
+1. **The ~4.6 µs / ×9.7 "0→1 guard" premise is gone.** Against current dist the *entire*
+   0→1-guard cost (C − A, async guard included and awaited) is **~430 ns** — an order of
+   magnitude under the ~4.6 µs probe-02 attributed to B − A alone. The plain-`tsx`
+   re-run of probe-02 at current dist agrees: B − A ≈ 234 ns (below noise). The regression
+   was eliminated by guard-path work landed after 2026-05-21 (candidates — not bisected:
+   boolean-factory cache #962, sync-guard observability/parity #970/#958/#959, error-flow
+   refactors #933/#947/#948/#949).
+2. **"sync ≈ async" was a measurement artifact, not a property.** Once the async navigate is
+   awaited (no contention, no "Concurrent navigation" warnings), the async branch C − B is
+   below noise. probe-02's apparent equality came from variant C carrying
+   `#abortPreviousNavigation` cancellation churn (~4.5 µs), which it flagged as
+   `[NOISE — contended]`. Sync and async guards are both near-free now.
+
+**Implication for #936 (deferred):** the AbortController/closure micro-allocations #936
+targets (<0.5 µs) are inside a sync-guard path whose *total* measured overhead is ~236 ns
+(below noise). There is no measurable lever left to pull there — flame-graphing a
+below-noise delta would be chasing noise, so no flame graph was produced.

--- a/benchmarks/core/audit-probes/navigate-2026-05-21/probe-05-guard-pipeline-reprofile.ts
+++ b/benchmarks/core/audit-probes/navigate-2026-05-21/probe-05-guard-pipeline-reprofile.ts
@@ -1,0 +1,186 @@
+/**
+ * Probe 05: guard-pipeline re-profile @ current HEAD — #938 follow-up (2026-06-27).
+ *
+ * Context. probe-02 (2026-05-21, measured against **dist**) reported that adding the
+ * first guard costs ~4.6 µs (×9.7 over the ~535 ns no-guards baseline), and that a
+ * sync guard costs almost as much as an async one. #938 asked to profile
+ * `executeGuardPipeline` with a flame graph and explain that sync ≈ async puzzle.
+ *
+ * Two flaws made the original picture misleading:
+ *
+ *   1. **Stale.** The guard path changed substantially after 2026-05-21 (boolean-factory
+ *      cache #962, sync-guard observability/parity #970/#958/#959, error-flow refactors
+ *      #933/#947/#948/#949, …). The ~4.6 µs no longer reproduces at current HEAD.
+ *
+ *   2. **Contended async variant.** probe-02 fired navigates fire-and-forget
+ *      (`void router.navigate(...)`) in mitata's sync loop, so the async variant fired the
+ *      next navigate before the previous async pipeline resolved — every async sample
+ *      carried a `#abortPreviousNavigation` cancellation (the flood of "Concurrent
+ *      navigation detected" warnings). probe-02 itself flagged C-B as `[NOISE — contended]`.
+ *      So "sync ≈ async" was a measurement artifact, never a real cost.
+ *
+ * This probe fixes both: it re-measures at current HEAD and AWAITS each navigate, so the
+ * async pipeline drains between iterations (no contention, no warnings). All three variants
+ * are measured with the identical awaited harness, so the deltas are clean.
+ *
+ * Run BOTH ways (resolution is chosen by the runner, not the probe):
+ *   - dist (what ships):  npx tsx <this file>
+ *   - src  (live source): NODE_OPTIONS='--conditions=@real-router/internal-source' npx tsx <this file>
+ *
+ * Finding (see RESULTS.md § probe-05): against current **dist**, B−A (sync-guard overhead)
+ * is ~0.2 µs and **below the noise floor** — the ~4.6 µs / ×9.7 premise of #938 is gone.
+ * Awaited async (C) is also cheap once the contention is removed; sync ≈ async holds only
+ * in the trivial sense that both are now near-free.
+ */
+
+import { createRouter } from "@real-router/core";
+import { getLifecycleApi } from "@real-router/core/api";
+
+import type { Route } from "@real-router/core";
+
+interface Stats {
+  avg: number;
+  p50: number;
+  stddev: number;
+}
+
+/** Batched, awaited measurement: K batches × M awaited navigates each. */
+async function measureAwaited(
+  navigateOnce: () => Promise<unknown>,
+  { warmup = 4000, batches = 40, batchSize = 2000 } = {},
+): Promise<Stats> {
+  // Warmup — let V8 tier up and settle ICs before timing.
+  for (let i = 0; i < warmup; i++) {
+    try {
+      await navigateOnce();
+    } catch {
+      /* same-state rejection / block — irrelevant to timing */
+    }
+  }
+
+  const batchMeansNs: number[] = [];
+
+  for (let b = 0; b < batches; b++) {
+    const t0 = performance.now();
+
+    for (let i = 0; i < batchSize; i++) {
+      try {
+        await navigateOnce();
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const t1 = performance.now();
+
+    batchMeansNs.push(((t1 - t0) * 1e6) / batchSize);
+  }
+
+  const n = batchMeansNs.length;
+  const avg = batchMeansNs.reduce((s, x) => s + x, 0) / n;
+  const variance = batchMeansNs.reduce((s, x) => s + (x - avg) ** 2, 0) / n;
+  const stddev = Math.sqrt(variance);
+  const sorted = batchMeansNs.toSorted((a, c) => a - c);
+  const p50 = sorted[Math.floor(n / 2)];
+
+  return { avg, p50, stddev };
+}
+
+const fmt = (ns: number): string =>
+  ns >= 1e3 ? `${(ns / 1e3).toFixed(2)} µs` : `${ns.toFixed(1)} ns`;
+
+function report(name: string, s: Stats): void {
+  console.log(
+    `  ${name.padEnd(56)} avg=${fmt(s.avg)}  p50=${fmt(s.p50)}  σ=${fmt(s.stddev)}`,
+  );
+}
+
+const routes: Route[] = [
+  { name: "home", path: "/" },
+  { name: "about", path: "/about" },
+];
+
+/**
+ * Ping-pong starting at `about` (router boots at `home` via start("/")), so every
+ * navigate is a real transition — no same-state no-ops to pollute the measurement.
+ */
+function makeNavigator(
+  router: ReturnType<typeof createRouter>,
+): () => Promise<unknown> {
+  const names = ["about", "home"];
+  let i = 0;
+
+  return () => router.navigate(names[i++ & 1]);
+}
+
+async function main(): Promise<void> {
+  console.log(
+    "=== probe-05: guard-pipeline re-profile @ current HEAD (awaited, uncontended) ===\n",
+  );
+
+  // A. No guards (sync hot path baseline).
+  let resultA: Stats;
+
+  {
+    const router = createRouter(routes);
+
+    await router.start("/");
+    resultA = await measureAwaited(makeNavigator(router));
+    report("A. navigate, no guards", resultA);
+  }
+
+  // B. 1 sync guard returning true (still sync pipeline).
+  let resultB: Stats;
+
+  {
+    const router = createRouter(routes);
+    const lifecycle = getLifecycleApi(router);
+
+    lifecycle.addActivateGuard("home", () => () => true);
+    lifecycle.addActivateGuard("about", () => () => true);
+    await router.start("/");
+    resultB = await measureAwaited(makeNavigator(router));
+    report("B. navigate, 1 sync guard", resultB);
+  }
+
+  // C. 1 async guard returning Promise.resolve(true) — awaited, so NO contention.
+  let resultC: Stats;
+
+  {
+    const router = createRouter(routes);
+    const lifecycle = getLifecycleApi(router);
+
+    lifecycle.addActivateGuard("home", () => () => Promise.resolve(true));
+    lifecycle.addActivateGuard("about", () => () => Promise.resolve(true));
+    await router.start("/");
+    resultC = await measureAwaited(makeNavigator(router));
+    report("C. navigate, 1 async guard (awaited)", resultC);
+  }
+
+  console.log("\n--- Verdict ---");
+
+  const syncGuard = resultB.avg - resultA.avg;
+  const asyncBranch = resultC.avg - resultB.avg;
+  const noiseAB = 2 * Math.max(resultA.stddev, resultB.stddev);
+  const noiseBC = 2 * Math.max(resultB.stddev, resultC.stddev);
+
+  console.log(
+    `  Sync-guard overhead   (B-A): ${syncGuard.toFixed(1)} ns  (noise floor ${noiseAB.toFixed(1)} ns)${
+      Math.abs(syncGuard) < noiseAB ? "  → [НЕ ПОДТВЕРЖДЕНО]" : ""
+    }`,
+  );
+  console.log(
+    `  Async-branch overhead (C-B): ${asyncBranch.toFixed(1)} ns  (noise floor ${noiseBC.toFixed(1)} ns)${
+      Math.abs(asyncBranch) < noiseBC ? "  → [НЕ ПОДТВЕРЖДЕНО]" : ""
+    }`,
+  );
+  console.log(
+    `\n  0→1-guard total (C-A): ${(resultC.avg - resultA.avg).toFixed(1)} ns` +
+      `  — cf. probe-02 dist@2026-05-21 reported ~4.6 µs for B-A alone.`,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Adds `probe-05` (`benchmarks/core/audit-probes/navigate-2026-05-21/probe-05-guard-pipeline-reprofile.ts`) re-measuring `executeGuardPipeline` at current HEAD with an **awaited** (uncontended) harness, plus a `RESULTS.md` § probe-05 documenting the finding.

## Why

#938 asked to profile the "0→1 guard = ~4.6 µs (×9.7)" cost and explain why a sync guard costs ≈ an async one. Both turned out to be stale/artifactual:

- **The 4.6 µs is gone.** probe-02's figure was measured against **dist @ 2026-05-21**. At current HEAD, current dist shows sync-guard overhead `B−A ≈ 236 ns` — *below the noise floor*; the whole 0→1-guard cost (`C−A`, async guard awaited) is `≈ 430 ns`. Current src: `B−A ≈ 692 ns` (still ~7× under the old 4.6 µs).
- **"sync ≈ async" was a measurement artifact.** probe-02 fired navigates fire-and-forget, so variant C carried `#abortPreviousNavigation` cancellation churn (~4.5 µs) — it flagged `C−B` as `[NOISE — contended]`. Awaited, the async branch `C−B` is below noise. Sync and async guards are both near-free now.

Regression eliminated by guard-path work landed after 2026-05-21 (not bisected; candidates #962 #970 #958 #959 #933 #947 #948 #949).

No flame graph produced — there is no longer a 4.6 µs delta to attribute; profiling a below-noise delta would chase noise.

## Scope

Benchmark artifact only — `audit-probes` are outside CI gating; no public-package change, **no changeset**. No behavior or public-docs change.

Closes #938

(#936 intentionally left open — deferred; its <0.5 µs micro-opt target now sits in a sync-guard path whose total overhead is below noise.)

https://claude.ai/code/session_01MWGUDWnXkCM5pvpRNpHd61
