### PR TITLE
refactor(core): harden module-constant freezing & buildPath options-cache invariant (#937, #941, #957)

### DIFF
--- a/.changeset/buildpath-options-immutability-957-refactor.md
+++ b/.changeset/buildpath-options-immutability-957-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Assert per-instance options immutability in `RoutesNamespace.#getBuildPathOptions` (#957)
+
+`#getBuildPathOptions` caches its result on the first call and returns it on every subsequent call, ignoring the `options` argument. This is safe because the sole caller (`Router.buildPath`) always passes the same immutable, deep-frozen per-instance options (`this.#options.get()`). A dev-build assertion now logs a warning if a future caller passes a differing `options` reference, making the cache-ignores-argument contract explicit and catchable. No behavior change for supported usage.

--- a/.changeset/lifecycle-replace-opts-941-refactor.md
+++ b/.changeset/lifecycle-replace-opts-941-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Inline `Object.freeze` for `REPLACE_OPTS` (#941)
+
+Combine the split declaration + `Object.freeze` of `REPLACE_OPTS` in `RouterLifecycleNamespace` into a single `const … = Object.freeze(…)` form (matching the `REVALIDATE_OPTS` house style in `api/getRoutesApi.ts`), removing the window where a future edit could insert a mutation between declaration and freeze. Behaviorally inert — the constant was already frozen at runtime.

--- a/.changeset/navigation-frozen-consts-937-refactor.md
+++ b/.changeset/navigation-frozen-consts-937-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Inline `Object.freeze` for `FROZEN_ACTIVATED` / `FROZEN_REPLACE_OPTS` (#937)
+
+Combine the split declaration + `Object.freeze` of the module-level constants in `NavigationNamespace` into a single `const … = Object.freeze(…)` form, removing the window where a future edit could insert a mutation between declaration and freeze. Behaviorally inert — both constants were already frozen at runtime.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -679,7 +679,7 @@ Both options default to on. `matchPath()` rebuilds `state.path` via `buildPath()
 - `createInterceptable()` — empty-array fast path skips iteration when no interceptors registered
 - FSM `canSend()` — O(1) via cached `#currentTransitions`
 - `getNavigator()` — WeakMap cache keyed by router, one frozen navigator per router instance
-- `buildPath` options cached per router instance (`#cachedBuildPathOpts`)
+- `buildPath` options cached per router instance (`#cachedBuildPathOpts`) — the cache ignores its `options` argument after the first call, valid because router options are immutable per instance (see above); a dev-build `logger.warn` asserts against a future caller passing a varying `options` reference (`#cachedOptionsSource`, #957)
 
 ### Async subscribeLeave overhead
 - **0 listeners (hot path):** on the no-guards path `#handleNoGuardsLeave` runs only `sendLeaveApprove` + a `hasLeaveListeners()` check + a `navigationId` check — no `{nav}` context, no `LeaveState`, no `AbortController` (all allocated only when listeners exist)

--- a/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/NavigationNamespace.ts
@@ -24,12 +24,10 @@ import type {
   TransitionMeta,
 } from "@real-router/types";
 
-const FROZEN_ACTIVATED: string[] = [constants.UNKNOWN_ROUTE];
-
-Object.freeze(FROZEN_ACTIVATED);
-const FROZEN_REPLACE_OPTS: NavigationOptions = { replace: true };
-
-Object.freeze(FROZEN_REPLACE_OPTS);
+const FROZEN_ACTIVATED: string[] = Object.freeze([
+  constants.UNKNOWN_ROUTE,
+]) as unknown as string[];
+const FROZEN_REPLACE_OPTS: NavigationOptions = Object.freeze({ replace: true });
 
 function forceReplaceFromUnknown(
   opts: NavigationOptions,

--- a/packages/core/src/namespaces/RouterLifecycleNamespace/RouterLifecycleNamespace.ts
+++ b/packages/core/src/namespaces/RouterLifecycleNamespace/RouterLifecycleNamespace.ts
@@ -6,9 +6,7 @@ import { RouterError } from "../../RouterError";
 import type { RouterLifecycleDependencies } from "./types";
 import type { NavigationOptions, State } from "@real-router/types";
 
-const REPLACE_OPTS: NavigationOptions = { replace: true };
-
-Object.freeze(REPLACE_OPTS);
+const REPLACE_OPTS: NavigationOptions = Object.freeze({ replace: true });
 
 /**
  * Independent namespace for managing router lifecycle.

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -1,5 +1,7 @@
 // packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
 
+import { logger } from "@real-router/logger";
+
 import { DEFAULT_ROUTE_NAME } from "./constants";
 import {
   matchSourceTrailingSlash,
@@ -83,6 +85,9 @@ export class RoutesNamespace<
 > {
   readonly #store: RoutesStore<Dependencies>;
   #cachedBuildPathOpts: CachedBuildPathOpts | undefined;
+  // Source `options` reference captured on the first #getBuildPathOptions call;
+  // used only by the dev-build immutability assertion below (#957).
+  #cachedOptionsSource: Options | undefined;
 
   get #deps(): RoutesDependencies<Dependencies> {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -519,8 +524,18 @@ export class RoutesNamespace<
   #getBuildPathOptions(options?: Options): CachedBuildPathOpts {
     // Stryker disable next-line BlockStatement: equivalent — cache short-circuit; emptying the early-return rebuilds the identical buildPath options (deterministic) and re-caches them. (ConditionalExpression stays live: `→false` always rebuilds but a real consumer test pins the cached identity.)
     if (this.#cachedBuildPathOpts) {
+      /* v8 ignore next 5 -- @preserve: dev assertion guarding a future caller that passes per-call varying options; the sole caller (Router.buildPath, always via this.#options.get()) passes the same immutable, deep-frozen per-instance options, so this branch is unreachable through the public API by construction (#957) */
+      if (options !== this.#cachedOptionsSource) {
+        logger.warn(
+          "router.buildPath",
+          "`options` differs from the cached source reference; router options are immutable per router instance, so the first-cached buildPath options are reused (#957).",
+        );
+      }
+
       return this.#cachedBuildPathOpts;
     }
+
+    this.#cachedOptionsSource = options;
 
     const ts = options?.trailingSlash;
 


### PR DESCRIPTION
## Summary

Three low-severity code-quality fixes from the foundation-audit epic (#756),
all in `@real-router/core` namespaces (non-overlapping files), batched into one PR.

| Issue | File | Change |
| --- | --- | --- |
| #937 | `NavigationNamespace.ts` | Inline `Object.freeze` for `FROZEN_ACTIVATED` / `FROZEN_REPLACE_OPTS` |
| #941 | `RouterLifecycleNamespace.ts` | Inline `Object.freeze` for `REPLACE_OPTS` |
| #957 | `RoutesNamespace.ts` | Dev-build assertion of the per-instance options-immutability invariant in `#getBuildPathOptions` |

### #937 / #941 — split const/`Object.freeze` antipattern

Both used `const X = …;` + blank line + `Object.freeze(X);`, leaving a window where a
future edit could insert a mutation between declaration and freeze. Combined into the
atomic `const X = Object.freeze(…)` form (matching the `REVALIDATE_OPTS` / `FROZEN_EMPTY_SEGMENTS`
house styles). Behaviorally inert — both were already frozen at runtime; covered by the
existing `navigateToNotFound` freeze assertions and `lifecycle.properties.ts`.

### #957 — `#getBuildPathOptions` ignores its `options` argument after the first call

The cache short-circuits on every call after the first without inspecting `options`. Safe
today because the sole caller (`Router.buildPath`) always passes the same immutable,
deep-frozen per-instance options (`this.#options.get()`). Per maintainer decision, added a
dev-build `logger.warn` assertion that fires if a future caller passes a differing `options`
reference (captured in `#cachedOptionsSource`). The assertion branch is unreachable through
the public API by construction, so it is excluded from coverage via `v8 ignore` with an
explanatory `@preserve` note (house pattern for defensive/unreachable-by-construction guards).
The invariant is also documented in `packages/core/CLAUDE.md`.

## Validation

- `@real-router/core`: type-check ✓, lint ✓, test ✓ (2458 passed, **100% coverage**), test:properties ✓ (279 passed)
- Pre-push full turbo validation passed (223/223 tasks); the worktree `lint:audit` (osv-scanner) failure is the known spurious filesystem-walk-from-`/` issue — verified clean (`No issues found`) in the main checkout, branch touches no dependency files.

## Changesets

Three `patch` changesets for `@real-router/core` (internal refactor / robustness), one per issue.

Closes #937
Closes #941
Closes #957
