### PR TITLE
fix(core): guard subscribeChanges() after dispose() (#982)

### DIFF
--- a/.changeset/subscribechanges-bound-dispose-982-fix.md
+++ b/.changeset/subscribechanges-bound-dispose-982-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Throw `ROUTER_DISPOSED` from a bound `subscribeChanges()` reference used after `dispose()` (#982)
+
+A `getRoutesApi(router).subscribeChanges()` reference captured before `dispose()` — `const s = routes.subscribeChanges.bind(routes)` — reached the unguarded `EventBusNamespace.subscribeTreeChanged`, the internal route-tree counterpart of the `subscribe`/`subscribeLeave` channels fixed in #946. Since `dispose()` had already run `clearAll()`, `emitter.on` recreated the `TREE_CHANGED` listener `Set` and added the listener — which could then NEVER fire (the FSM is `DISPOSED` and the route tree is torn down, no future emit): a silent no-op. Core now enforces the disposed state inside `subscribeTreeChanged` itself, completing the guard across all three subscription primitives (`subscribe`/`subscribeLeave`/`subscribeTreeChanged`), so a pre-bound `subscribeChanges` reference throws `RouterError(ROUTER_DISPOSED)` — consistent with the sibling `getRoutesApi` methods (`add`/`remove`/`update`/`clear`) and with a direct post-dispose call.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -499,7 +499,7 @@ const unsubscribe = routes.subscribeChanges((event) => {
 | **Clone isolation** | A cloned router has an independent emitter; mutations never cross the clone boundary. |
 | **Scope** | Internal-only channel: `TREE_CHANGED` is not in the public `EventName` union / `events.*` registry / `Plugin` interface. There is no `router.subscribeTree()` and no `addEventListener` path — by design (tree mutations are infrastructural, not app-level). |
 
-`dispose()` releases all `subscribeChanges` listeners (during the `clearAll` events step) before the route teardown, so no event fires during disposal.
+`dispose()` releases all `subscribeChanges` listeners (during the `clearAll` events step) before the route teardown, so no event fires during disposal. After disposal, `subscribeChanges` throws `RouterError(ROUTER_DISPOSED)` — including via a reference bound before `dispose()` (`const s = routes.subscribeChanges.bind(routes)`) — rather than silently re-registering a listener that can never fire (#982). This mirrors the `router.subscribe` / `subscribeLeave` guard (#946) and the sibling `getRoutesApi` mutators (`add` / `remove` / `update` / `clear`), which all throw `ROUTER_DISPOSED` after `dispose()`.
 
 ### Recommended pattern: declarative reactive cache invalidation
 

--- a/packages/core/INVARIANTS.md
+++ b/packages/core/INVARIANTS.md
@@ -267,6 +267,7 @@ Guards registered via `getLifecycleApi(router)` run during the transition pipeli
 | 9   | Listener error isolation           | A throwing handler is reported via `onListenerError`; other handlers still run and the CRUD caller never sees a re-throw (except the `RecursionDepthError` carve-out from #6).                          |
 | 10  | FIFO + snapshot delivery           | Handlers fire in registration order. A handler registered re-entrantly during emit `E1` is not invoked for `E1` (snapshot iteration); it participates from the next event onward.                       |
 | 11  | dispose silences the channel       | `router.dispose()` releases all `TREE_CHANGED` listeners (step 4 of cleanup) before the internal route teardown — no event is emitted during disposal (the public `clear()` wrapper is bypassed).      |
+| 12  | subscribe-after-dispose throws     | A `subscribeChanges` reference used after `dispose()` — including one bound before disposal (`const s = routes.subscribeChanges.bind(routes)`) — throws `RouterError(ROUTER_DISPOSED)` instead of silently re-registering a listener that can never fire (the route tree is torn down during dispose). The internal-route-tree counterpart of the `subscribe`/`subscribeLeave` guard (#946). Verified functionally in `tests/functional/api/getRoutesApi/getRoutesApi.test.ts`. |
 
 ## getDependenciesApi (CRUD)
 

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -189,6 +189,20 @@ export class EventBusNamespace {
   subscribeTreeChanged(
     handler: (event: TreeChangedEvent) => void,
   ): Unsubscribe {
+    // Same disposed-state enforcement as subscribe()/subscribeLeave() (#946),
+    // completing the guard across all three subscription primitives — extended
+    // here to the internal route-tree channel (#982). A `subscribeChanges`
+    // reference bound before dispose() (`const s = routes.subscribeChanges
+    // .bind(routes)`) reaches this method via the getRoutesApi delegate, which
+    // — unlike its add/remove/update siblings — does not itself check
+    // isDisposed(). Without this guard, `emitter.on` would re-register a
+    // TREE_CHANGED listener that can never fire (clearAll already ran, the FSM
+    // is DISPOSED, the route tree is torn down, no future emit) — a silent
+    // no-op, the internal-channel counterpart of the #946 hazard.
+    if (this.isDisposed()) {
+      throw new RouterError(errorCodes.ROUTER_DISPOSED);
+    }
+
     return this.#emitter.on(TREE_CHANGED, (event: TreeChangedEvent) => {
       handler(event);
     });

--- a/packages/core/tests/functional/api/getRoutesApi/getRoutesApi.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/getRoutesApi.test.ts
@@ -261,5 +261,30 @@ describe("getRoutesApi()", () => {
       expect(caught).toBeInstanceOf(RouterError);
       expect((caught as RouterError).code).toBe(errorCodes.ROUTER_DISPOSED);
     });
+
+    // #982 — a `subscribeChanges` reference bound BEFORE dispose() (e.g.
+    // `const s = routes.subscribeChanges.bind(routes)`) used to reach the
+    // unguarded `EventBusNamespace.subscribeTreeChanged` and silently
+    // re-register a TREE_CHANGED listener that can never fire (the route tree
+    // is torn down during dispose, no future emit) — a silent no-op, the
+    // internal-channel counterpart of the subscribe/subscribeLeave fix (#946).
+    it("subscribeChanges should throw RouterError(ROUTER_DISPOSED)", () => {
+      const freshRouter = createTestRouter();
+      const freshApi = getRoutesApi(freshRouter);
+      const boundSubscribeChanges = freshApi.subscribeChanges.bind(freshApi);
+
+      freshRouter.dispose();
+
+      let caught: unknown;
+
+      try {
+        boundSubscribeChanges(() => undefined);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(RouterError);
+      expect((caught as RouterError).code).toBe(errorCodes.ROUTER_DISPOSED);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- A `getRoutesApi(router).subscribeChanges()` reference bound before `dispose()` no longer silently no-ops — it now throws `RouterError(ROUTER_DISPOSED)`, so a stale post-dispose subscription is a loud programming error instead of a listener that can never fire.
- Brings the internal route-tree channel in line with `router.subscribe` / `subscribeLeave` (#946) and the sibling `getRoutesApi` mutators (`add` / `remove` / `update` / `clear`), which all already throw `ROUTER_DISPOSED` after dispose.

### #982 — Bound `subscribeChanges()` reference used after `dispose()` is a silent no-op

- **Root cause:** `EventBusNamespace.subscribeTreeChanged` — the primitive behind `subscribeChanges()` — had no disposed-state guard. A reference bound before `dispose()` reached `emitter.on(TREE_CHANGED, …)`, which recreated the listener `Set` and added a listener that can never fire (the FSM is `DISPOSED`, the route tree is torn down, no future emit).
- **Fix:** add `if (this.isDisposed()) throw new RouterError(errorCodes.ROUTER_DISPOSED);` at the top of `subscribeTreeChanged`, mirroring the #946 guard and completing it across all three subscription primitives (`subscribe` / `subscribeLeave` / `subscribeTreeChanged`). Behaviour is otherwise unchanged — the guard only triggers in the `DISPOSED` state, so every live-router subscription path (and the three plugin consumers: lifecycle / preload / search-schema) is untouched.

## Test plan

- [x] `tests/functional/api/getRoutesApi/getRoutesApi.test.ts` → `getRoutesApi() > when router is disposed > subscribeChanges should throw RouterError(ROUTER_DISPOSED)` — binds the reference before `dispose()` and asserts the specific code (fails before the fix: no throw, `caught` undefined; passes after)
- [x] `pnpm build` passes — full turbo graph green via pre-commit + pre-push hooks (type-check → lint → test → bundle, plus `lint:types` / `lint:package` / `lint:audit` / semgrep)
- [x] 100% coverage maintained (core: statements / branches / functions / lines all 100%)

Closes #982
