### PR TITLE
fix(preload-plugin): suppress SonarJS S1751 via NOSONAR in #cacheState eviction (#971)

### DIFF
--- a/.changeset/preload-s1751-nosonar-fix.md
+++ b/.changeset/preload-s1751-nosonar-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preload-plugin": patch
+---
+
+Suppress SonarJS S1751 false positive in `#cacheState` LRU eviction (#971)
+
+The single-eviction iterator destructuring (`const [oldest] = this.#stateCache.keys()`) is correct — insertion-order eviction at the 32-entry bound, 100% branch coverage — but SonarJS S1751 flags it (and the prior `for…of`+`break`) as a one-iteration loop, reding the SonarCloud quality gate (`new_reliability_rating` C). Annotate the line with `// NOSONAR` — the repo's established convention for verified false positives — instead of churning the code form a third time. No public API, behavioral, or runtime change.

--- a/packages/preload-plugin/src/plugin.ts
+++ b/packages/preload-plugin/src/plugin.ts
@@ -300,8 +300,10 @@ export class PreloadPlugin {
       this.#stateCache.delete(href);
     } else if (this.#stateCache.size >= STATE_CACHE_LIMIT) {
       // Evict the oldest (first-inserted) entry. size >= LIMIT > 0, so the
-      // iterator yields at least one key — destructuring it is safe.
-      const [oldest] = this.#stateCache.keys();
+      // iterator yields at least one key — destructuring it is safe. This is
+      // an intentional single-eviction idiom, not a real loop; SonarJS S1751
+      // flags this form (and the prior for-of+break) as a false positive (#971).
+      const [oldest] = this.#stateCache.keys(); // NOSONAR -- intentional single-eviction LRU idiom, not a real loop
 
       this.#stateCache.delete(oldest);
     }


### PR DESCRIPTION
## Problem

SonarCloud's `typescript:S1751` flags the LRU-eviction line in `#cacheState` as a one-iteration loop, raising `new_reliability_rating` to C — the only failing quality-gate condition. Changing the code *form* has failed twice: `for…of`+`break` → C, then iterator destructuring (#972) → still C. S1751 is not locally reproducible (`no-one-iteration-loop` isn't in our `eslint-plugin-sonarjs`), so each form-swap is a blind shot verified only post-merge on master.

## Fix

Annotate the line with `// NOSONAR` — the repo's established convention for verified false positives (already used in `core` NavigationNamespace / StateNamespace / guardPhase and `rx` pipe-overloads, all passing the gate). The suppression directive doesn't depend on *why* S1751 fires, so it ends the form-churning loop. The eviction code is correct and unchanged: insertion-order eviction at the 32-entry bound, 100% branch coverage, no `!`/`as`, no public API / behavioral / runtime change.

## Verification

Unlike the prior attempts (verified post-merge on master, where Sonar doesn't run on push), this PR runs SonarCloud on `pull_request`. **Do not merge until the PR's SonarCloud quality gate is green** — that's the direct lesson from #972's reopening.

Closes #971
