### PR TITLE
perf(angular): stabilize routeParams in link directives (#988)

### DIFF
--- a/.changeset/angular-link-params-perf.md
+++ b/.changeset/angular-link-params-perf.md
@@ -1,0 +1,9 @@
+---
+"@real-router/angular": patch
+---
+
+Content-stabilize `RealLink` / `RealLinkActive` route params (#988)
+
+The directives created their active-route source inside a constructor `effect()` (the #630 reactivity fix) that read `routeParams()` directly. Angular re-allocates an inline `[routeParams]="{ id: 1 }"` literal on every change detection, so the raw signal input changed identity each navigation even when the param content was unchanged — re-running the effect, tearing down and re-creating the cached active-route source (`canonicalJson` cache-key churn + sub/unsub) and re-running `buildHref`, once per navigation per directive.
+
+A new internal `createStableParams` helper collapses structurally-equal params to a reference-stable value via `shallowEqual` (the same contract as the Vue `<Link>` fix and the React `Link` `memo` comparator), so the source-creation effect and the `href` computed only re-run on real content change. Behavior is unchanged — the stabilized params are always content-equal to the input; binding a stable reference still produces zero churn.

--- a/packages/angular/ARCHITECTURE.md
+++ b/packages/angular/ARCHITECTURE.md
@@ -241,19 +241,20 @@ Opt-in via `provideRealRouter(router, { viewTransitions: true })`. Same wiring p
 RealLink (@Directive, selector: a[realLink])
 ├── routeName, routeParams, routeOptions, activeClassName, activeStrict, ignoreQueryParams, hash = input()
 ├── isActive = signal(false)                               # local active state
-├── href = computed(() => buildHref(...))                  # primitive-string output; Object.is dedup
+├── stableParams = createStableParams(routeParams)         # shallowEqual content-stabilization (#988)
+├── href = computed(() => buildHref(..., stableParams()))  # primitive-string output; Object.is dedup
 ├── prevActive, prevHref, prevActiveClass                  # skip-same-value caches (audit §8b)
-├── effect((onCleanup) => createActiveRouteSource + subscribeSourceToSignal + skip-same-value branch)
+├── effect((onCleanup) => createActiveRouteSource(..., stableParams()) + subscribeSourceToSignal + skip-same-value branch)
 ├── updateHref() → el.setAttribute("href", ...) iff href !== prevHref
 ├── updateActiveClass() → classList.toggle(activeClass, isActive()) iff active flipped
 └── onClick(event) → shouldNavigate(event) ∧ target≠"_blank" → navigateWithHash(...).catch(NOOP_CATCH)
 ```
 
-Subscription setup runs inside `effect(...)` scheduled from the **constructor** (#630) — signal inputs are readable inside the effect's first execution, so reading `routeName()`/`routeParams()`/`hash()` makes the source creation reactive. The previous `ngOnInit` pattern captured inputs once at mount and silently drifted under AOT signal-input bindings.
+Subscription setup runs inside `effect(...)` scheduled from the **constructor** (#630) — signal inputs are readable inside the effect's first execution, so reading `routeName()`/`stableParams()`/`hash()` makes the source creation reactive. The previous `ngOnInit` pattern captured inputs once at mount and silently drifted under AOT signal-input bindings. `routeParams` is routed through `createStableParams` (`computed` + `shallowEqual`) so an inline `[routeParams]="{ id: 1 }"` literal re-allocated on every change detection does not re-create the source or re-run `buildHref` until the param content actually changes (#988 — mirrors the Vue `<Link>` fix; behavior unchanged, stabilized params are always content-equal).
 
 ### RealLinkActive
 
-Same subscription pattern as `RealLink` (constructor `effect()` + `subscribeSourceToSignal` helper + skip-same-value `prevActive`). Applies a CSS class to any element (not just `<a>`) via `classList.toggle`. Calls `applyLinkA11y` in the constructor to set `role="link"` and `tabindex="0"` on non-interactive elements (skip-list: `<a>`, `<button>` — see [audit §5.2 Bug 4](.claude/review-2026-05-16.md) for the known a11y limitation on `<details>` / `<summary>` / native interactive elements).
+Same subscription pattern as `RealLink` (constructor `effect()` + `subscribeSourceToSignal` helper + skip-same-value `prevActive` + `createStableParams` content-stabilization of `routeParams`, #988). Applies a CSS class to any element (not just `<a>`) via `classList.toggle`. Calls `applyLinkA11y` in the constructor to set `role="link"` and `tabindex="0"` on non-interactive elements (skip-list: `<a>`, `<button>` — see [audit §5.2 Bug 4](.claude/review-2026-05-16.md) for the known a11y limitation on `<details>` / `<summary>` / native interactive elements).
 
 ## Build Notes
 

--- a/packages/angular/CLAUDE.md
+++ b/packages/angular/CLAUDE.md
@@ -55,7 +55,8 @@ src/                            # Main entry — client API
 ├── internal/                   # Internal helpers (not re-exported)
 │   ├── install.ts              # installScrollRestoration + installScrollSpy + installViewTransitions — shared by providers + providersFactory
 │   ├── subscribeSourceToSignal.ts  # subscribe → setState → cleanup pattern (RealLink, RealLinkActive, RouteView)
-│   └── buildActiveRouteOptions.ts  # Build ActiveRouteSourceOptions honoring exactOptionalPropertyTypes
+│   ├── buildActiveRouteOptions.ts  # Build ActiveRouteSourceOptions honoring exactOptionalPropertyTypes
+│   └── createStableParams.ts   # shallowEqual content-stabilization for routeParams (RealLink, RealLinkActive) — #988
 ├── providers.ts                # ROUTER, NAVIGATOR, ROUTE tokens + provideRealRouter
 ├── providersFactory.ts         # provideRealRouterFactory (SSR/SSG per-request clones)
 ├── sourceToSignal.ts           # RouterSource → Signal bridge
@@ -301,7 +302,9 @@ This pattern replaces the legacy `ngOnInit`-based setup that captured input valu
 
 Effect cleanup is bound automatically to the host directive's injection-context `DestroyRef` — no explicit `inject(DestroyRef).onDestroy(...)` wiring is required (effects self-register).
 
-**Consequence for tests**: full reactive-input verification (e.g., changing `[realLink]="signal()"` and asserting `.active` class re-binds) requires AOT compilation — JIT mode rejects signal-input template bindings with `NG0303`. Use `@analogjs/vite-plugin-angular` or e2e via Playwright against a production-mode example app.
+**`routeParams` is content-stabilized before the effect reads it (#988).** Angular re-allocates an inline `[routeParams]="{ id: 1 }"` literal on every change detection, so reading the raw input signal inside the effect would re-create the cached active-route source (`canonicalJson` cache-key churn + sub/unsub) and re-run `buildHref` on every navigation even when the param content is unchanged. `RealLink` / `RealLinkActive` route their `routeParams` through the internal `createStableParams` helper (`computed` + `shallowEqual`), which re-emits a reference-stable value until the param content actually changes — so the source-creation effect and the `href` computed bail on same-content navigations. Binding a stable reference (a component field or signal) already produced zero churn; this closes the gap for inline-literal binds. Mirrors the Vue `<Link>` fix. Behavior is unchanged — the stabilized params are always content-equal to the input. Nested-object param *values* fall back to per-render recompute (`shallowEqual` compares them by reference) — bind a stable `signal`/`computed` if it matters.
+
+**Consequence for tests**: full reactive-input verification (e.g., changing `[realLink]="signal()"` and asserting `.active` class re-binds) requires AOT compilation — JIT mode rejects signal-input template bindings with `NG0303`. Use `@analogjs/vite-plugin-angular` or e2e via Playwright against a production-mode example app. The content-stabilization is unit-tested via the JIT-safe toy pattern (`tests/functional/createStableParams.test.ts`) — a plain `signal<Params>()` drives the same `createStableParams` helper the directives feed their input signal into (the effect-re-run mechanism is identical for `input()` and `signal()`).
 
 ### No RxJS
 
@@ -379,11 +382,11 @@ Coverage thresholds are **94%/84%/94%/94%** (statements/branches/functions/lines
 | File:Lines | Why unreachable without AOT |
 |---|---|
 | `RouteView.ts:56-60,69` | `contentChildren(RouteMatch/RouteNotFound)` returns empty — structural directives on `ng-template` with signal inputs aren't registered in JIT. Verified: `view.matches().length === 0` |
-| `RealLink.ts:52-53` | Subscription callback fires only when `isActive` changes. With `routeName=""` (JIT default), `isActiveRoute("")` always returns `false` — no state transitions |
-| `RealLink.ts:80` | `setAttribute("href", href)` skipped because `buildHref(router, "", {})` always returns `undefined` for empty routeName |
-| `RealLink.ts:86` | `classList.remove(prevActiveClass)` requires class transition. `activeClassName` input stays at default `"active"` — `prevActiveClass` never changes |
-| `RealLinkActive.ts:49-50` | Same subscription callback pattern as RealLink |
-| `RealLinkActive.ts:67` | `classList.toggle` early-returns at line 63 because `realLinkActive=""` (JIT default) |
+| `RealLink.ts:99-102` | Subscription callback fires only when `isActive` changes. With `routeName=""` (JIT default), `isActiveRoute("")` always returns `false` — no state transitions |
+| `RealLink.ts:133` | `setAttribute("href", href)` skipped because `buildHref(router, "", {})` always returns `undefined` for empty routeName |
+| `RealLink.ts:143` | `classList.remove(prevActiveClass)` requires class transition. `activeClassName` input stays at default `"active"` — `prevActiveClass` never changes |
+| `RealLinkActive.ts:62` | Same subscription callback pattern as RealLink |
+| `RealLinkActive.ts:80` | `classList.toggle` early-returns at line 77 because `realLinkActive=""` (JIT default) |
 
 **What IS covered:**
 - Full `provideRealRouter` / DI wiring

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -430,6 +430,20 @@ Navigation directive for `<a>` elements. Handles click events, sets `href`, and 
 
 Active class is hash-aware — only the matching tab lights up. Live demo: [`examples/web/react/hash-examples/link-hash/`](../../examples/web/react/hash-examples/link-hash/) — behavior is identical across adapters, only template syntax differs. See the [Hash Fragment Support](https://github.com/greydragon888/real-router/wiki/Hash) wiki page for the full surface.
 
+#### Object `routeParams` — content-stabilized
+
+`RealLink` and `RealLinkActive` stabilize `routeParams` by **content** (`shallowEqual` — `Object.is` per key, key-order-insensitive), so an inline `[routeParams]="{ id: '123' }"` literal that Angular re-allocates on every change detection does **not** re-create the active-route source or re-run `buildHref` until the param content actually changes (#988). Binding a stable reference (a component field or signal) was already churn-free; this closes the gap for inline literals.
+
+Caveat: nested object/array param **values** are compared by reference, not deep — stabilize them with a `signal`/`computed` if it matters:
+
+```ts
+// flat params — stable across change detection, recompute only on real change
+@Component({ template: `<a realLink routeName="items.item" [routeParams]="{ id }" />` })
+// nested value — fresh ref each CD → href/active recompute every CD; stabilize:
+readonly params = computed(() => ({ filters: [1, 2] }));
+// <a realLink routeName="search" [routeParams]="params()" />
+```
+
 ### `[realLinkActive]`
 
 Applies an active CSS class to any element when a route is active. Use this when you need active state on a non-`<a>` element, or when the clickable element and the styled element are different.
@@ -708,6 +722,8 @@ The adapter is signal-first and does not depend on Zone.js. It works with `provi
 ### Reactive Source Setup via `effect()` (#630)
 
 `RealLink`, `RealLinkActive`, and `RouteView` create their subscription sources inside `effect(...)` blocks scheduled from the **constructor** (not `ngOnInit`). Reading signal inputs inside `effect()` makes the source-creation REACTIVE — when `[realLink]`, `[routeParams]`, `[hash]`, `[realLinkActive]`, or `[routeNode]` change in AOT, the effect tears down the previous source via `onCleanup` and creates a new one with the current input values. The legacy `ngOnInit` setup captured inputs once at mount and produced a real AOT bug (#630). Effect cleanup is bound automatically to the host directive's injection-context `DestroyRef`.
+
+In `RealLink` / `RealLinkActive`, `[routeParams]` is routed through `shallowEqual` content-stabilization before the effect reads it, so an inline-literal binding re-allocated on every change detection only re-creates the source on real content change (see [Object `routeParams`](#object-routeparams--content-stabilized), #988).
 
 ## Signal Bridge
 

--- a/packages/angular/src/directives/RealLink.ts
+++ b/packages/angular/src/directives/RealLink.ts
@@ -12,6 +12,7 @@ import { createActiveRouteSource } from "@real-router/sources";
 import { buildHref, navigateWithHash, shouldNavigate } from "../dom-utils";
 import { injectRouter } from "../functions/injectRouter";
 import { buildActiveRouteOptions } from "../internal/buildActiveRouteOptions";
+import { createStableParams } from "../internal/createStableParams";
 import { subscribeSourceToSignal } from "../internal/subscribeSourceToSignal";
 
 import type { Params, NavigationOptions } from "@real-router/core";
@@ -43,6 +44,13 @@ export class RealLink {
   private readonly anchor = inject(ElementRef)
     .nativeElement as HTMLAnchorElement;
   private readonly isActive = signal(false);
+  // Content-stable `routeParams` (#988). Angular re-allocates an inline
+  // `[routeParams]="{ id: 1 }"` literal on every change detection, so the raw
+  // signal input changes identity each navigation even when the param content
+  // is unchanged. Feeding the stabilized signal to the `href` computed and the
+  // source-creation effect lets both bail (Object.is on the cached reference)
+  // until param content actually changes — mirrors the Vue `<Link>` fix.
+  private readonly stableParams = createStableParams(this.routeParams);
   // `href` is computed from signal inputs only — Angular's default Object.is
   // equality already collapses repeated `string` results, so no custom
   // comparator is required (review §8b note 3 — applies after verifying that
@@ -53,7 +61,7 @@ export class RealLink {
     return buildHref(
       this.router,
       this.routeName(),
-      this.routeParams(),
+      this.stableParams(),
       hashValue === undefined ? undefined : { hash: hashValue },
     );
   });
@@ -74,7 +82,7 @@ export class RealLink {
       const source = createActiveRouteSource(
         this.router,
         this.routeName(),
-        this.routeParams(),
+        this.stableParams(),
         buildActiveRouteOptions(
           this.activeStrict(),
           this.ignoreQueryParams(),

--- a/packages/angular/src/directives/RealLinkActive.ts
+++ b/packages/angular/src/directives/RealLinkActive.ts
@@ -11,6 +11,7 @@ import { createActiveRouteSource } from "@real-router/sources";
 import { applyLinkA11y } from "../dom-utils";
 import { injectRouter } from "../functions/injectRouter";
 import { buildActiveRouteOptions } from "../internal/buildActiveRouteOptions";
+import { createStableParams } from "../internal/createStableParams";
 import { subscribeSourceToSignal } from "../internal/subscribeSourceToSignal";
 
 import type { Params } from "@real-router/core";
@@ -26,6 +27,10 @@ export class RealLinkActive {
   private readonly router = injectRouter();
   private readonly element = inject(ElementRef).nativeElement as HTMLElement;
   private readonly isActive = signal(false);
+  // Content-stable `routeParams` (#988) — see the matching field in `RealLink`.
+  // Lets the source-creation effect bail until param content actually changes
+  // instead of churning on every fresh inline-literal binding.
+  private readonly stableParams = createStableParams(this.routeParams);
   // Skip-same-value: only touch `classList.toggle` when the active flag
   // actually flipped. Saves one DOM write per RealLinkActive per unrelated
   // navigation (review §8b MEDIUM).
@@ -43,7 +48,7 @@ export class RealLinkActive {
       const source = createActiveRouteSource(
         this.router,
         this.routeName(),
-        this.routeParams(),
+        this.stableParams(),
         buildActiveRouteOptions(
           this.activeStrict(),
           this.ignoreQueryParams(),

--- a/packages/angular/src/internal/createStableParams.ts
+++ b/packages/angular/src/internal/createStableParams.ts
@@ -1,0 +1,50 @@
+import { computed } from "@angular/core";
+
+import { shallowEqual } from "../dom-utils";
+
+import type { Signal } from "@angular/core";
+import type { Params } from "@real-router/core";
+
+/**
+ * Content-stable `routeParams` signal. Angular re-allocates an inline
+ * `[routeParams]="{ id: 1 }"` literal on every change detection, so a signal
+ * input changes identity each navigation even when the param CONTENT is
+ * unchanged (`Object.is` equality). Reading that raw input inside `RealLink` /
+ * `RealLinkActive`'s constructor `effect()` (added by the #630 fix) would tear
+ * down and re-create the cached active-route source — re-running `canonicalJson`
+ * for the cache key plus sub/unsub churn — and re-run `buildHref`, once per
+ * navigation per directive (#988).
+ *
+ * `shallowEqual` (`Object.is` per key, key-order-insensitive — the same
+ * contract as the React adapter's Link `memo` comparator and the Vue Link fix)
+ * collapses structurally-equal params to a reference-stable value. Because the
+ * returned `computed` re-emits the cached reference, Angular's `Object.is`
+ * output equality keeps the effect / `href` computed from re-running until the
+ * param content actually changes.
+ *
+ * Hot path on Link-heavy pages: replaces a per-navigation `canonicalJson`
+ * (JSON.stringify + key sort) with a per-navigation `shallowEqual` (no
+ * allocation), and lets same-shape navigations skip the source re-creation and
+ * `buildHref` entirely. Nested-object param VALUES fall back to per-render
+ * recompute (`shallowEqual` compares them by reference) — bind a stable
+ * `signal`/`computed` if it matters, exactly as documented for the Vue/React
+ * Link.
+ *
+ * @param read - reads the raw params (the directive's `routeParams` input).
+ * @returns a `Signal<Params>` that only changes identity on real content change.
+ */
+export function createStableParams(read: () => Params): Signal<Params> {
+  let cached: Params | undefined;
+
+  return computed(() => {
+    const next = read();
+
+    if (cached !== undefined && shallowEqual(cached, next)) {
+      return cached;
+    }
+
+    cached = next;
+
+    return next;
+  });
+}

--- a/packages/angular/tests/functional/createStableParams.test.ts
+++ b/packages/angular/tests/functional/createStableParams.test.ts
@@ -1,0 +1,132 @@
+import { Component, signal, effect } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { createRouter } from "@real-router/core";
+import { createActiveRouteSource } from "@real-router/sources";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { injectRouter } from "../../src/functions/injectRouter";
+import { buildActiveRouteOptions } from "../../src/internal/buildActiveRouteOptions";
+import { createStableParams } from "../../src/internal/createStableParams";
+import { subscribeSourceToSignal } from "../../src/internal/subscribeSourceToSignal";
+import { provideRealRouter } from "../../src/providers";
+
+import type { Params } from "@real-router/core";
+
+const routes = [
+  { name: "home", path: "/" },
+  { name: "users", path: "/users" },
+];
+
+// `RealLink` / `RealLinkActive` create their active-route source inside a
+// constructor `effect()` that reads `routeParams()`. Angular re-allocates an
+// inline `[routeParams]="{ id: 1 }"` literal on every change detection, so a
+// raw read changes identity each navigation even when the param CONTENT is
+// unchanged — re-running the effect, re-creating the cached source
+// (`canonicalJson` cache-key churn + sub/unsub). `createStableParams` collapses
+// structurally-equal params to a reference-stable value so the effect bails.
+//
+// Signal inputs cannot be driven from JIT TestBed (the documented 94% coverage
+// ceiling — `setInput` does not propagate to signal inputs), so these tests
+// drive a plain `signal<Params>()`. The effect-re-run mechanism is identical
+// for `input()` and `signal()` (#988 evidence).
+describe("createStableParams", () => {
+  describe("reference identity (pure)", () => {
+    it("returns a reference-stable value while shallow content is unchanged", () => {
+      const params = signal<Params>({ id: 1 });
+      const stable = createStableParams(() => params());
+      const first = stable();
+
+      params.set({ id: 1 }); // fresh literal, same content
+
+      expect(stable()).toBe(first);
+    });
+
+    it("returns the new reference when shallow content changes", () => {
+      const params = signal<Params>({ id: 1 });
+      const stable = createStableParams(() => params());
+      const first = stable();
+      const next: Params = { id: 2 };
+
+      params.set(next);
+
+      expect(stable()).toBe(next);
+      expect(stable()).not.toBe(first);
+    });
+
+    it("is order-insensitive (mirrors shallowEqual contract)", () => {
+      const params = signal<Params>({ a: 1, b: 2 });
+      const stable = createStableParams(() => params());
+      const first = stable();
+
+      params.set({ b: 2, a: 1 }); // same content, different key order
+
+      expect(stable()).toBe(first);
+    });
+  });
+
+  describe("source re-creation (the #988 lever)", () => {
+    let router: ReturnType<typeof createRouter>;
+
+    // Single host shared by both cases: replicates the directives' exact
+    // `effect()` + `createActiveRouteSource` pattern, but reads the stabilized
+    // params signal. `recreations` counts source re-creations.
+    @Component({ template: "" })
+    class Host {
+      readonly params = signal<Params>({ id: 1 });
+      recreations = 0;
+      private readonly router = injectRouter();
+      private readonly stableParams = createStableParams(() => this.params());
+
+      constructor() {
+        effect((onCleanup) => {
+          const source = createActiveRouteSource(
+            this.router,
+            "users",
+            this.stableParams(),
+            buildActiveRouteOptions(false, true, undefined),
+          );
+
+          this.recreations++;
+          onCleanup(subscribeSourceToSignal(source, () => {}));
+        });
+      }
+    }
+
+    beforeEach(async () => {
+      router = createRouter(routes);
+      await router.start("/");
+      TestBed.configureTestingModule({
+        providers: [provideRealRouter(router)],
+      });
+    });
+
+    afterEach(() => {
+      router.stop();
+    });
+
+    it("does NOT re-create the active-route source for fresh-equal param literals", async () => {
+      const fixture = TestBed.createComponent(Host);
+
+      fixture.detectChanges(); // initial effect run
+
+      for (let i = 0; i < 10; i++) {
+        fixture.componentInstance.params.set({ id: 1 }); // fresh literal
+        fixture.detectChanges();
+        await fixture.whenStable();
+      }
+
+      expect(fixture.componentInstance.recreations).toBe(1);
+    });
+
+    it("re-creates the active-route source when param content actually changes", async () => {
+      const fixture = TestBed.createComponent(Host);
+
+      fixture.detectChanges(); // initial → 1
+      fixture.componentInstance.params.set({ id: 2 }); // real change
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.recreations).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `RealLink` and `RealLinkActive` no longer re-create their active-route source or re-run `buildHref` on every navigation when bound with an inline `[routeParams]="{ id: 1 }"` literal — the per-navigation `canonicalJson` cache-key churn + sub/unsub is eliminated for fresh-literal binds.
- Behavior is unchanged: the stabilized params are always content-equal to the input, so active state and `href` resolve identically; only redundant work is removed. Stable-reference binds were already churn-free — this closes the gap for inline literals.
- Brings Angular to parity with the Vue `<Link>` content-stabilization fix — the last adapter that carried this lever (Preact/React/Svelte were already clean).

### #988 — RealLink/RealLinkActive recreate the active-route source on every fresh-literal routeParams
- **Root cause:** the directives read `routeParams()` directly inside the constructor `effect()` added by #630. Angular re-allocates an inline `[routeParams]="{ id: 1 }"` literal on every change detection, so the signal input's `Object.is` equality sees a fresh identity each navigation even when the param content is unchanged — re-running the effect (tear down + re-create the cached active-route source, `canonicalJson` cache-key recompute + sub/unsub) and re-running `buildHref`, once per navigation per directive.
- **Fix:** a new internal `createStableParams` helper (`computed` + `shallowEqual`) re-emits a reference-stable params value until the content actually changes; both directives feed it to the `href` computed and the source-creation effect, so Angular's `Object.is` output equality collapses same-content navigations. Extracted to `internal/` (two consumers) rather than inlined — which also yields a JIT-testable surface. Mirrors the Vue `<Link>` fix.

## Test plan

- [x] `tests/functional/createStableParams.test.ts` — `does NOT re-create the active-route source for fresh-equal param literals` (the #988 lever: 10 fresh `{ id: 1 }` sets → **1** source creation; was **11**), `re-creates … when param content actually changes`, plus reference-identity (stable / changed / order-insensitive). RED verified first against a pass-through stub (`expected 11 to be 1`).
- [x] Unit-tested via the JIT-safe toy pattern (signal-driven) — the documented 94% coverage ceiling blocks driving signal inputs from TestBed; the directives feed the **same** `createStableParams` helper the test exercises.
- [x] `pnpm build` passes (verified via the pre-push hook: build + lint:types + lint:package, full turbo graph)
- [x] Package coverage thresholds maintained (94/84/94/94); new `createStableParams.ts` is 100% stmts/funcs/lines

Closes #988
