### PR TITLE
fix(preload-plugin): structural-mutation State-cache invalidation + sync-throw isolation (#805 #806)

### DIFF
--- a/.changeset/preload-runpreload-806-fix.md
+++ b/.changeset/preload-runpreload-806-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preload-plugin": patch
+---
+
+Isolate synchronous throws / non-Promise returns from a preload function (#806)
+
+The fire-and-forget call `preload.fn(params).catch(() => {})` only caught a **promise rejection**. A `preload` function that threw synchronously — or returned a non-Promise — escaped before `.catch`, surfacing as an `uncaughtException` from the `setTimeout` callback (a global uncaught with no user code in the stack, hard to diagnose), despite the documented "errors silently caught" contract. Both timers now route through a shared `#runPreload` that guards the synchronous call with `try/catch` and normalizes the return via `Promise.resolve` before attaching `.catch`.

--- a/.changeset/preload-statecache-805-fix.md
+++ b/.changeset/preload-statecache-805-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preload-plugin": patch
+---
+
+Invalidate the pre-resolved State cache on structural `routes.update`/`add` (#805)
+
+A structural tree mutation — `forwardTo`/`defaultParams`/`encodeParams`/`decodeParams` via `routes.update`, or an `add` that intercepts an already-cached href — previously left `getPreloadedState(href)` returning a stale snapshot built with the old resolution. A `<FastLink>` consumer would then commit the pre-mutation `State`, bypassing the fresh config. `#onTreeChanged` now clears the href-keyed snapshot cache on **any** structural op, matching the existing `remove`/`replace`/`clear` behavior. `#compiledPreloads` is untouched — its lazy factory-reference revalidation already covers `add`/`update`.

--- a/packages/preload-plugin/ARCHITECTURE.md
+++ b/packages/preload-plugin/ARCHITECTURE.md
@@ -56,7 +56,8 @@ DOM event (mouseover / touchstart)
     │
     ├── empty touches guard (touchstart/touchmove only) → skip if event.touches.length === 0
     │
-    └── setTimeout(delay) → preload(state.params).catch(() => {})
+    └── setTimeout(delay) → #runPreload: try{ preload(state.params) } catch → return
+                            → Promise.resolve(result).catch(() => {})  (swallows sync-throw / non-Promise / rejection)
 ```
 
 ## Ghost Event Suppression

--- a/packages/preload-plugin/CLAUDE.md
+++ b/packages/preload-plugin/CLAUDE.md
@@ -18,7 +18,7 @@
 3. On `touchstart`: finds the anchor, starts a `TOUCH_PRELOAD_DELAY` (100ms) timer
 4. On `touchmove`: cancels the touch timer if vertical scroll > `TOUCH_SCROLL_THRESHOLD` (10px)
 5. On timer fire: calls `router.matchUrl?.(anchor.href)` → `api.getRouteConfig(name)?.preload`
-6. Calls `preload(params)` as fire-and-forget; errors silently caught
+6. Calls `preload(params)` as fire-and-forget; errors silently caught (async rejection, synchronous throw, or non-Promise return)
 
 Ghost mouse event suppression: touch devices fire a synthetic `mouseover` after `touchstart`. The plugin records the last touch target/timestamp and suppresses any `mouseover` from the same target within 2500ms.
 
@@ -51,11 +51,11 @@ Intended consumer pattern: a custom `<FastLink>` wrapper reads the cached State 
 
 The cache is also populated when a hovered route has no `preload` factory — the State is still useful for fast navigation. The 32-entry bound covers viewport-visible link counts; oldest evicted on overflow, re-hovering same `href` refreshes recency.
 
-Cache cleared on `onStop` and `teardown` (via `#cleanup`), and also on **structural tree mutations** (`remove`/`replace`/`clear` via the `TREE_CHANGED` subscription) — otherwise `getPreloadedState(href)` could hand a consumer a `State` pointing at a route that no longer exists, and `navigateToState` would commit a navigation to a removed route. The cache is href-keyed (not name-keyed), so it is cleared wholesale on any structural mutation and repopulates on the next hover. The extension is removed in `teardown`.
+Cache cleared on `onStop` and `teardown` (via `#cleanup`), and also on **any structural tree mutation** (`add`/`update`/`remove`/`replace`/`clear` via the `TREE_CHANGED` subscription) — otherwise `getPreloadedState(href)` could hand a consumer a `State` built with stale resolution: a removed route that no longer exists, an `update` that changed `forwardTo`/`defaultParams`, or an `add` that intercepts an already-cached href. `navigateToState` would then commit the stale snapshot. The cache is href-keyed (not name-keyed) and has no lazy revalidation path (it is read externally), so it is cleared wholesale on any structural mutation and repopulates on the next hover (#805). The extension is removed in `teardown`.
 
 ### Fire-and-forget
 
-`preload(params)` is called without awaiting. Return values and errors are discarded. The plugin is a transport layer only — it does not cache, deduplicate, or track preload status.
+`preload(params)` is called without awaiting, through `#runPreload`. Return values and errors are discarded — and "errors" means all three escape modes: a rejected promise, a **synchronous throw** before the promise is created, and a **non-Promise return** (`#runPreload` guards the sync call with `try/catch` and normalizes the return via `Promise.resolve` before `.catch`). Without this, a misbehaving user `preload` fn would surface as an `uncaughtException` from the `setTimeout` callback with no user code in the stack (#806). The plugin is a transport layer only — it does not cache, deduplicate, or track preload status.
 
 ### Event delegation
 
@@ -73,7 +73,7 @@ The factory function checks `typeof document === "undefined"` before instantiati
 
 `#compiledPreloads` caches compiled preload functions by `state.name`. The `PreloadFnFactory(router, getDependency)` call happens at most once per route name for the lifetime of the plugin instance. **Config-change invalidation is lazy:** on the next hover/touch, `#resolvePreload` re-reads `getRouteConfig` and recompiles when the `factory` reference differs (so `update`/`replace` that swap the factory are picked up automatically). If the factory throws, the result is not cached and the factory is retried on next hover/touch.
 
-**Removed-route cleanup (TREE_CHANGED):** the plugin subscribes to `getRoutesApi(router).subscribeChanges()` and deletes `#compiledPreloads` entries for routes removed via `remove`/`replace`, and clears the whole map on `clear`. Without this, those entries would be unreachable dead memory until teardown (`matchUrl` never resolves a removed route, so the lazy path can't reclaim them). `add`/`update` need no handling — lazy revalidation covers them.
+**Removed-route cleanup (TREE_CHANGED):** the plugin subscribes to `getRoutesApi(router).subscribeChanges()` and deletes `#compiledPreloads` entries for routes removed via `remove`/`replace`, and clears the whole map on `clear`. Without this, those entries would be unreachable dead memory until teardown (`matchUrl` never resolves a removed route, so the lazy path can't reclaim them). `add`/`update` need no `#compiledPreloads` handling — lazy revalidation covers them. (The href-keyed `#stateCache` is different: it has no lazy path, so the same `TREE_CHANGED` handler clears it wholesale on **every** structural op — see the State-cache gotcha above, #805.)
 
 ### Module augmentation
 

--- a/packages/preload-plugin/src/plugin.ts
+++ b/packages/preload-plugin/src/plugin.ts
@@ -198,7 +198,7 @@ export class PreloadPlugin {
 
     this.#hoverTimer = setTimeout(() => {
       this.#hoverTimer = null;
-      preload.fn(preload.params).catch(() => {});
+      this.#runPreload(preload);
     }, this.#options.delay);
   };
 
@@ -219,7 +219,7 @@ export class PreloadPlugin {
 
     this.#touchTimer = setTimeout(() => {
       this.#touchTimer = null;
-      preload.fn(preload.params).catch(() => {});
+      this.#runPreload(preload);
     }, TOUCH_PRELOAD_DELAY);
   };
 
@@ -234,6 +234,29 @@ export class PreloadPlugin {
       this.#cancelTouch();
     }
   };
+
+  // Fire-and-forget invocation of a resolved preload. The plugin is a transport
+  // layer only — return values and errors are discarded. The `try/catch` guards
+  // the *synchronous* call: a user fn that throws before returning would escape
+  // and surface as an `uncaughtException` from the timer callback with no user
+  // code in the stack. `Promise.resolve` then normalizes a non-Promise return
+  // (a JS consumer ignoring `() => Promise`) so `.catch` can swallow a rejection
+  // without a `.catch of undefined` TypeError. (#806)
+  #runPreload(preload: { fn: PreloadFn; params: Params }): void {
+    let result: unknown;
+
+    try {
+      // The declared `() => Promise<unknown>` is the happy-path contract; a JS
+      // consumer can ignore it (the whole reason for this guard), so the result
+      // is treated as `unknown` and normalized below rather than assumed thenable.
+      result = (preload.fn as (params: Params) => unknown)(preload.params);
+    } catch {
+      // sync-throw from a user fn — same fire-and-forget contract
+      return;
+    }
+
+    void Promise.resolve(result).catch(() => {});
+  }
 
   #findAnchor(target: EventTarget | null): HTMLAnchorElement | null {
     return target instanceof Element

--- a/packages/preload-plugin/src/plugin.ts
+++ b/packages/preload-plugin/src/plugin.ts
@@ -153,8 +153,15 @@ export class PreloadPlugin {
 
         break;
       }
-      // "add" / "update": lazy factory-reference revalidation in
-      // #resolvePreload handles these — no eager cleanup needed.
+      default: {
+        // "add" / "update" (and any future structural op): `#compiledPreloads`
+        // is lazily revalidated in `#resolvePreload` (factory-reference compare)
+        // so it needs no eager cleanup — but `#stateCache` has no lazy path; it
+        // is read externally via `getPreloadedState`. Any structural mutation can
+        // restale a cached href — `update` changes resolution, `add` can intercept
+        // an already-cached href — so drop the snapshots wholesale. (#805)
+        this.#invalidateStateCache();
+      }
     }
   }
 

--- a/packages/preload-plugin/tests/functional/hover.test.ts
+++ b/packages/preload-plugin/tests/functional/hover.test.ts
@@ -210,6 +210,54 @@ describe("preload-plugin — hover", () => {
     router.stop();
   });
 
+  it("silently catches a synchronously-thrown error from preload function (#806)", async () => {
+    const preloadFn = vi.fn(() => {
+      throw new Error("sync-boom");
+    });
+    const { router } = createTestRouter([
+      { name: "home", path: "/", preload: () => preloadFn },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    const anchor = createAnchor("/");
+
+    fireMouseOver(anchor);
+
+    // A synchronous throw fires before `.catch` is reached. It must not escape
+    // the setTimeout callback (in a real app it surfaces as an uncaughtException
+    // with no user code in the stack); the fire-and-forget contract swallows it.
+    await expect(waitForTimer(65)).resolves.toBeUndefined();
+    expect(preloadFn).toHaveBeenCalledTimes(1);
+
+    router.stop();
+  });
+
+  it("silently tolerates a non-Promise return from preload function (#806)", async () => {
+    // A JS consumer ignoring the `() => Promise<unknown>` type returns undefined.
+    const preloadFn = vi.fn(() => undefined as unknown as Promise<unknown>);
+    const { router } = createTestRouter([
+      { name: "home", path: "/", preload: () => preloadFn },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    const anchor = createAnchor("/");
+
+    fireMouseOver(anchor);
+
+    // Without normalization, `undefined.catch(...)` throws synchronously
+    // (`.catch of undefined`) and escapes the timer callback.
+    await expect(waitForTimer(65)).resolves.toBeUndefined();
+    expect(preloadFn).toHaveBeenCalledTimes(1);
+
+    router.stop();
+  });
+
   it("supports custom delay option", async () => {
     const preloadFn = vi.fn().mockResolvedValue(undefined);
     const { router } = createTestRouter([

--- a/packages/preload-plugin/tests/functional/lifecycle.test.ts
+++ b/packages/preload-plugin/tests/functional/lifecycle.test.ts
@@ -355,7 +355,8 @@ describe("preload-plugin — lifecycle", () => {
 
     const routesApi = getRoutesApi(router);
 
-    // add / update: the no-op fall-through branches of the TREE_CHANGED handler.
+    // add / update: no eager #compiledPreloads cleanup (lazy factory-reference
+    // revalidation); they hit the default branch, which invalidates #stateCache (#805).
     routesApi.add({ name: "added", path: "/added" });
     routesApi.update("home", { defaultParams: { a: "1" } });
 
@@ -407,6 +408,72 @@ describe("preload-plugin — lifecycle", () => {
 
     // The stale snapshot must be gone — otherwise a <FastLink> click would
     // navigate to a route that no longer exists.
+    expect(router.getPreloadedState?.(anchor.href)).toBeUndefined();
+
+    router.stop();
+  });
+
+  it("invalidates the pre-resolved state cache on a structural routes.update (#805)", async () => {
+    const { router } = createTestRouter([
+      { name: "home", path: "/" },
+      { name: "promo", path: "/promo" },
+      {
+        name: "users",
+        path: "/users",
+        children: [{ name: "view", path: "/:id" }],
+      },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    // Hover caches a State snapshot for /promo (control: it IS cached).
+    const anchor = createAnchor("/promo");
+
+    fireMouseOver(anchor);
+
+    expect(router.getPreloadedState?.(anchor.href)).toBeDefined();
+
+    // Re-hover to repopulate (single-use consumed it), then a structural update
+    // (forwardTo/defaultParams) — core emits TREE_CHANGED op:"update".
+    fireMouseOver(createAnchor("/promo"));
+    getRoutesApi(router).update("promo", {
+      forwardTo: "users.view",
+      defaultParams: { id: "42" },
+    });
+
+    // The stale pre-update snapshot must be gone — otherwise a <FastLink> click
+    // commits the pre-forward State and bypasses the fresh forwardTo/defaultParams.
+    expect(router.getPreloadedState?.(anchor.href)).toBeUndefined();
+
+    router.stop();
+  });
+
+  it("invalidates the pre-resolved state cache when add() intercepts a cached href (#805 §5)", async () => {
+    const { router } = createTestRouter([
+      { name: "home", path: "/" },
+      { name: "catchall", path: "/*rest" },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    // /promo currently resolves to the catch-all → the cached snapshot points
+    // at "catchall" (control).
+    const anchor = createAnchor("/promo");
+
+    fireMouseOver(anchor);
+
+    expect(router.getPreloadedState?.(anchor.href)?.name).toBe("catchall");
+
+    // Re-hover to repopulate, then add a more-specific /promo route. matchUrl
+    // now resolves /promo to the new exact route, so the catch-all snapshot is
+    // stale and must be dropped.
+    fireMouseOver(createAnchor("/promo"));
+    getRoutesApi(router).add({ name: "promo", path: "/promo" });
+
     expect(router.getPreloadedState?.(anchor.href)).toBeUndefined();
 
     router.stop();

--- a/packages/preload-plugin/tests/functional/touch.test.ts
+++ b/packages/preload-plugin/tests/functional/touch.test.ts
@@ -343,6 +343,29 @@ describe("preload-plugin — touch", () => {
     router.stop();
   });
 
+  it("silently catches a synchronously-thrown error from preload function on touch (#806)", async () => {
+    const preloadFn = vi.fn(() => {
+      throw new Error("sync-boom");
+    });
+    const { router } = createTestRouter([
+      { name: "home", path: "/", preload: () => preloadFn },
+    ]);
+
+    setupMatchUrl(router);
+    cleanup = router.usePlugin(preloadPluginFactory());
+    await router.start("/");
+
+    const anchor = createAnchor("/");
+
+    fireTouchStart(anchor);
+
+    // The synchronous throw must not escape the touch timer callback.
+    await expect(waitForTimer(TOUCH_PRELOAD_DELAY)).resolves.toBeUndefined();
+    expect(preloadFn).toHaveBeenCalledTimes(1);
+
+    router.stop();
+  });
+
   it("handles touchstart with empty touches array gracefully", async () => {
     const preloadFn = vi.fn().mockResolvedValue(undefined);
     const { router } = createTestRouter([


### PR DESCRIPTION
## PR-24 (preload-plugin) — Wave-1 audit tail

Closes #805
Closes #806

The last open tail of the Wave-1 audit epic (#756). Two independent preload-plugin defects in **non-overlapping** regions of `src/plugin.ts`, grouped into one PR (one CI run). Each ships as its own commit + changeset.

### #805 — stale State snapshot after a structural `routes.update`/`add` (medium)

`#onTreeChanged` invalidated the href-keyed `#stateCache` only on `remove`/`replace`/`clear`; `add`/`update` fell through with a comment that conflated `#compiledPreloads` (lazily revalidated) with `#stateCache` (no lazy path — read externally via `getPreloadedState`). A structural `update` (`forwardTo`/`defaultParams`/`encodeParams`/`decodeParams`) or an `add` that intercepts an already-cached href left `getPreloadedState(href)` returning a snapshot built with the **old** resolution — a `<FastLink>` consumer then committed the stale `State`, bypassing the fresh config.

**Fix:** a `default` branch invalidates `#stateCache` on **any** structural op — the broad option from the issue, which also closes the §5 `add`-interception class for negligible cost and makes the `#invalidateStateCache` "removed/**changed** route" invariant comment accurate. `#compiledPreloads` is untouched (lazy factory-reference revalidation already covers `add`/`update`).

### #806 — sync-throw / non-Promise from a preload fn escapes `.catch` (low)

`preload.fn(params).catch(() => {})` caught only a **promise rejection**. A `preload` fn that threw **synchronously** fired before `.catch` (→ `uncaughtException` from the `setTimeout` callback, no user code in the stack), and a **non-Promise return** threw `.catch of undefined` — both contradicting the documented "errors silently caught" fire-and-forget contract.

**Fix:** both the hover and touch timers route through a shared `#runPreload` — `try/catch` guards the synchronous invocation, `Promise.resolve` normalizes the return before `.catch` swallows any rejection.

### Tests

- **#805** (`lifecycle.test.ts`): invalidation on a structural `update` (reproduced repro) + `add`-interception (§5 — `/promo` resolves to a catch-all, then a specific `/promo` is added).
- **#806** (`hover.test.ts` + `touch.test.ts`): synchronous throw (both timers) + non-Promise return.
- 100% coverage; functional (86) + property (16) + stress (11) all green.

### Docs

- `packages/preload-plugin/CLAUDE.md` + `ARCHITECTURE.md`: cache-invalidation scope, fire-and-forget contract, data-flow.
- Wiki `preload-plugin.md`: edge-case table + single-use staleness guarantee.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)