### PR TITLE
fix(logger-plugin): perf-mark / console.group correctness + User Timing buffer cleanup (#793 #794 #795 #796)

### DIFF
--- a/.changeset/logger-plugin-793-fix.md
+++ b/.changeset/logger-plugin-793-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/logger-plugin": patch
+---
+
+Skip the Performance API branch of `onTransitionError`/`onTransitionCancel` when the transition slot was already cleared (#793)
+
+With `usePerformanceMarks: true`, an out-of-band terminal — a guard-redirect (core emits a `cancel` + `error` pair, the `error` landing after the redirect target's `success` already reset the slot) or a `ROUTE_NOT_FOUND` with no preceding start — used to `mark`/`measure` against an empty `#startMarkName`, producing a garbage empty-label `router:transition-error:` mark and a `console.warn("Failed to create performance measure")` on every such redirect / not-found. The perf branch is now gated on a non-empty start mark, so an unpaired terminal leaves no mark and emits no warning. The `console.error` log for the error itself is unchanged.

--- a/.changeset/logger-plugin-794-fix.md
+++ b/.changeset/logger-plugin-794-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/logger-plugin": patch
+---
+
+Gate the `"Router transition"` console group on the transition log level (#794)
+
+`onTransitionStart` opened a `console.group` unconditionally, so at `level: "none"` (and `"errors"`) the plugin still emitted an empty, expandable group on every transition — a `console.group` is itself console output, breaking the "completely silent" guarantee of INVARIANTS Completeness Inv 3. The group is now opened only when `#logTransition` is set (i.e. it will actually be populated); the idempotent close path is unchanged. The Inv 3 / Level-Filtering property assertions were extended to also verify no `console.group`/`console.groupEnd` calls at `level: "none"`/`"errors"`.

--- a/.changeset/logger-plugin-795-fix.md
+++ b/.changeset/logger-plugin-795-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/logger-plugin": patch
+---
+
+Clear the plugin's own Performance API marks/measures by name so the User Timing buffer stays bounded (#795)
+
+With `usePerformanceMarks: true`, the plugin created ~3 marks + 1 measure per transition (`transition-start`, the standalone `leave-approved`, the terminal `transition-end`/`-cancel`/`-error`, and the `transition:*` measure) and never cleared them — the User Timing buffer is unbounded per spec, so a long dev session accumulated tens of thousands of entries. The tracker's `measure()` now clears its start/end marks and the measure by name (in a `finally`, so a failed measure still reclaims its inputs), and the standalone `leave-approved` mark — never an endpoint of a measure — is cleared in `#resetTransitionState`. Only the plugin's own names are cleared, so the app's marks/measures are untouched; the trace events already emitted to an in-progress DevTools recording are unaffected.

--- a/packages/logger-plugin/CLAUDE.md
+++ b/packages/logger-plugin/CLAUDE.md
@@ -48,7 +48,7 @@ Follows the same pattern as `BrowserPlugin` and `PersistentParamsPlugin`. The cl
 
 ### Pre-computed flags avoid runtime branching
 
-All `config.level` checks are resolved once in the constructor into boolean flags (`#logLifecycle`, `#logTransition`, `#logWarning`, `#logError`). Hooks only check booleans, never compare strings at runtime.
+All `config.level` checks are resolved once in the constructor into boolean flags (`#logLifecycle`, `#logTransition`, `#logError`). Hooks only check booleans, never compare strings at runtime. (The cancel branch's `console.warn` is gated by `#logTransition` — there is no separate `#logWarning` field.)
 
 ### `#resetTransitionState()` ordering
 
@@ -90,7 +90,7 @@ src/
 ├── factory.ts              — loggerPluginFactory: validates options, merges defaults,
 │                             returns PluginFactory → new LoggerPlugin(config).getPlugin()
 ├── plugin.ts               — LoggerPlugin class: pre-computes flags in constructor,
-│                             getPlugin() returns Plugin with 6 lifecycle hooks + teardown
+│                             getPlugin() returns Plugin with 7 lifecycle hooks + teardown
 ├── validation.ts           — validateOptions: level, context, boolean flags (TypeError)
 ├── constants.ts            — LOGGER_CONTEXT, ERROR_PREFIX, DEFAULT_CONFIG
 ├── types.ts                — LoggerPluginConfig, LogLevel

--- a/packages/logger-plugin/INVARIANTS.md
+++ b/packages/logger-plugin/INVARIANTS.md
@@ -8,7 +8,7 @@
 | --- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Transition start is always logged at level:all   | Every `navigate()` call with `level: "all"` produces at least one log entry containing `"Transition:"`. The plugin never silently drops transition events.          |
 | 2   | Transition success is always logged at level:all | Every successful navigation produces a log entry containing `"Transition success"`. Both the start and the completion of a transition are always recorded together. |
-| 3   | No output at level:none                          | With `level: "none"`, no calls to `console.log`, `console.warn`, or `console.error` are made for any navigation. The plugin is completely silent.                   |
+| 3   | No output at level:none                          | With `level: "none"`, no calls to `console.log`, `console.warn`, `console.error`, `console.group`, or `console.groupEnd` are made for any navigation. The plugin is completely silent — a `console.group` is itself console output, so the group is never opened. |
 
 ## No-Throw
 
@@ -31,7 +31,7 @@
 | #   | Invariant                                                       | Description                                                                                                                                                                                   |
 | --- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | `level:"transitions"` suppresses lifecycle, retains transitions | With `level: "transitions"`, no `"Router started"` or `"Router stopped"` messages appear, but `"Transition"` messages are still logged. Lifecycle output is gated by the `logLifecycle` flag. |
-| 2   | `level:"errors"` suppresses transition logs                     | With `level: "errors"`, no `console.log` or `console.warn` calls occur during navigation. Only error-level output remains enabled.                                                            |
+| 2   | `level:"errors"` suppresses transition logs                     | With `level: "errors"`, no `console.log`, `console.warn`, or `console.group` calls occur during navigation. Only error-level output remains enabled.                                          |
 
 ## Params Diff
 

--- a/packages/logger-plugin/src/internal/performance-marks.ts
+++ b/packages/logger-plugin/src/internal/performance-marks.ts
@@ -17,6 +17,7 @@ export const supportsPerformanceAPI = (): boolean => {
 export interface PerformanceTracker {
   mark: (name: string) => void;
   measure: (measureName: string, startMark: string, endMark: string) => void;
+  clearMarks: (name: string) => void;
 }
 
 /**
@@ -46,8 +47,16 @@ export const createPerformanceTracker = (
     },
 
     /**
-     * Creates a performance measure between two marks.
-     * Logs a warning if the marks don't exist.
+     * Creates a performance measure between two marks, then clears the two
+     * marks and the measure by name.
+     *
+     * The User Timing buffer is unbounded per spec, so leaving entries behind
+     * accumulates thousands over a long dev session. Clearing happens in a
+     * `finally` (so a failed measure still reclaims its input marks) and only
+     * targets our own names — the app's marks/measures are never touched. The
+     * trace events for an in-progress DevTools recording were already emitted
+     * when the mark/measure was created, so clearing does not erase them from
+     * the timeline. Logs a warning if the marks don't exist. (#795)
      */
     measure(measureName: string, startMark: string, endMark: string): void {
       if (!isSupported) {
@@ -61,7 +70,24 @@ export const createPerformanceTracker = (
           `[${context}] Failed to create performance measure: ${measureName}`,
           error,
         );
+      } finally {
+        performance.clearMarks(startMark);
+        performance.clearMarks(endMark);
+        performance.clearMeasures(measureName);
       }
+    },
+
+    /**
+     * Clears a single performance mark by name. Used for standalone marks that
+     * are never an endpoint of a measure (e.g. `router:leave-approved:*`), so
+     * `measure()`'s name-based cleanup cannot reclaim them. (#795)
+     */
+    clearMarks(name: string): void {
+      if (!isSupported) {
+        return;
+      }
+
+      performance.clearMarks(name);
     },
   };
 };

--- a/packages/logger-plugin/src/plugin.ts
+++ b/packages/logger-plugin/src/plugin.ts
@@ -243,6 +243,16 @@ export class LoggerPlugin {
 
   #resetTransitionState(): void {
     this.#groups.close();
+
+    // The leave-approved mark is a standalone timeline marker — never an
+    // endpoint of a measure — so measure()'s name-based cleanup cannot reclaim
+    // it. Clear it here (the single chokepoint every terminal runs through) so
+    // the User Timing buffer stays bounded across navigations. Skipped when the
+    // slot was already cleared by a prior terminal (empty label). (#795)
+    if (this.#usePerf && this.#transitionLabel !== "") {
+      this.#perf.clearMarks(`router:leave-approved:${this.#transitionLabel}`);
+    }
+
     this.#transitionLabel = "";
     this.#startMarkName = "";
     this.#transitionStartTime = null;

--- a/packages/logger-plugin/src/plugin.ts
+++ b/packages/logger-plugin/src/plugin.ts
@@ -142,7 +142,11 @@ export class LoggerPlugin {
       },
 
       onTransitionCancel: (toState: State, fromState?: State) => {
-        if (this.#usePerf) {
+        // Skip the perf branch when the slot was already cleared by a prior
+        // terminal (e.g. a redirect target's success) — an out-of-band cancel
+        // has no start mark to measure against, only an unpaired empty-label
+        // mark + a failing measure (#793).
+        if (this.#usePerf && this.#startMarkName !== "") {
           const label = this.#transitionLabel;
           const cancelMark = `router:transition-cancel:${label}`;
 
@@ -173,7 +177,11 @@ export class LoggerPlugin {
         fromState: State | undefined,
         err: RouterError,
       ) => {
-        if (this.#usePerf) {
+        // Skip the perf branch when the slot was already cleared by a prior
+        // terminal (guard-redirect double terminal, or a ROUTE_NOT_FOUND with
+        // no preceding start) — there is no start mark to measure against, so
+        // measuring would only emit an empty-label mark + a console.warn (#793).
+        if (this.#usePerf && this.#startMarkName !== "") {
           const label = this.#transitionLabel;
           const errorMark = `router:transition-error:${label}`;
 

--- a/packages/logger-plugin/src/plugin.ts
+++ b/packages/logger-plugin/src/plugin.ts
@@ -79,7 +79,14 @@ export class LoggerPlugin {
       },
 
       onTransitionStart: (toState: State, fromState?: State) => {
-        this.#groups.open("Router transition");
+        // A console.group is itself console output — open it only when the
+        // transition log below will populate it, so level "none"/"errors" stay
+        // silent instead of emitting an empty expandable group per transition
+        // (#794). Close (#resetTransitionState) is idempotent, so it is unchanged.
+        if (this.#logTransition) {
+          this.#groups.open("Router transition");
+        }
+
         this.#transitionStartTime = this.#shouldShowTiming ? now() : null;
 
         const fromRoute = formatRouteName(fromState);

--- a/packages/logger-plugin/tests/functional/internal/performance-marks.test.ts
+++ b/packages/logger-plugin/tests/functional/internal/performance-marks.test.ts
@@ -96,6 +96,43 @@ describe("performance-marks utilities", () => {
         );
       });
 
+      it("should clear its own start/end marks and the measure by name (#795)", () => {
+        const clearMarksSpy = vi
+          .spyOn(performance, "clearMarks")
+          .mockImplementation(noop);
+        const clearMeasuresSpy = vi
+          .spyOn(performance, "clearMeasures")
+          .mockImplementation(noop);
+        const tracker = createPerformanceTracker(true, TEST_CONTEXT);
+
+        tracker.measure("test-measure", "start-mark", "end-mark");
+
+        expect(clearMarksSpy).toHaveBeenCalledWith("start-mark");
+        expect(clearMarksSpy).toHaveBeenCalledWith("end-mark");
+        expect(clearMeasuresSpy).toHaveBeenCalledWith("test-measure");
+      });
+
+      it("should still clear its entries when measure throws (#795)", () => {
+        measureSpy.mockImplementation(() => {
+          throw new Error("Marks not found");
+        });
+
+        const clearMarksSpy = vi
+          .spyOn(performance, "clearMarks")
+          .mockImplementation(noop);
+        const clearMeasuresSpy = vi
+          .spyOn(performance, "clearMeasures")
+          .mockImplementation(noop);
+        const tracker = createPerformanceTracker(true, TEST_CONTEXT);
+
+        tracker.measure("test-measure", "start-mark", "end-mark");
+
+        expect(warnSpy).toHaveBeenCalled();
+        expect(clearMarksSpy).toHaveBeenCalledWith("start-mark");
+        expect(clearMarksSpy).toHaveBeenCalledWith("end-mark");
+        expect(clearMeasuresSpy).toHaveBeenCalledWith("test-measure");
+      });
+
       it("should handle measure errors gracefully", () => {
         measureSpy.mockImplementation(() => {
           throw new Error("Marks not found");
@@ -111,6 +148,17 @@ describe("performance-marks utilities", () => {
           `[${TEST_CONTEXT}] Failed to create performance measure: test`,
           expect.any(Error),
         );
+      });
+
+      it("clearMarks should clear a mark by name (#795)", () => {
+        const clearMarksSpy = vi
+          .spyOn(performance, "clearMarks")
+          .mockImplementation(noop);
+        const tracker = createPerformanceTracker(true, TEST_CONTEXT);
+
+        tracker.clearMarks("router:leave-approved:a→b");
+
+        expect(clearMarksSpy).toHaveBeenCalledWith("router:leave-approved:a→b");
       });
 
       it("should handle multiple marks", () => {
@@ -156,6 +204,17 @@ describe("performance-marks utilities", () => {
         tracker.measure("test", "start", "end");
 
         expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it("should not clear marks (#795)", () => {
+        const clearMarksSpy = vi
+          .spyOn(performance, "clearMarks")
+          .mockImplementation(noop);
+        const tracker = createPerformanceTracker(false, TEST_CONTEXT);
+
+        tracker.clearMarks("test");
+
+        expect(clearMarksSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/logger-plugin/tests/functional/plugin.test.ts
+++ b/packages/logger-plugin/tests/functional/plugin.test.ts
@@ -711,6 +711,40 @@ describe("@real-router/logger-plugin", () => {
     });
   });
 
+  describe("perf entry accumulation (#795)", () => {
+    afterEach(() => {
+      performance.clearMarks();
+      performance.clearMeasures();
+    });
+
+    it("clears its own marks/measures so the User Timing buffer stays bounded across navigations", async () => {
+      performance.clearMarks();
+      performance.clearMeasures();
+
+      router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+      await router.start("/");
+
+      const N = 30;
+
+      for (let i = 0; i < N; i++) {
+        await router.navigate(i % 2 ? "users" : "admin");
+      }
+
+      const routerMarks = performance
+        .getEntriesByType("mark")
+        .filter((entry) => entry.name.startsWith("router:"));
+      const routerMeasures = performance
+        .getEntriesByType("measure")
+        .filter((entry) => entry.name.startsWith("router:"));
+
+      // Pre-fix this grows ~3 marks + 1 measure per navigation (~94 / ~31 for
+      // N=30). Post-fix only the standalone `router:start` mark survives until
+      // the router stops — everything else is cleared by name as it terminates.
+      expect(routerMarks.length).toBeLessThanOrEqual(4);
+      expect(routerMeasures.length).toBeLessThanOrEqual(1);
+    });
+  });
+
   describe("Multiple error codes", () => {
     it("should log CANNOT_ACTIVATE error code", async () => {
       lifecycle.addActivateGuard("users", () => () => false);

--- a/packages/logger-plugin/tests/functional/plugin.test.ts
+++ b/packages/logger-plugin/tests/functional/plugin.test.ts
@@ -631,6 +631,64 @@ describe("@real-router/logger-plugin", () => {
     });
   });
 
+  describe("out-of-band terminal on a cleared slot (#793)", () => {
+    let perfMarkSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      perfMarkSpy = vi.spyOn(performance, "mark");
+    });
+
+    it("does not create an empty-label error mark or warn on ROUTE_NOT_FOUND after a successful transition", async () => {
+      router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+      await router.start("/");
+      // A successful transition clears the perf slot (#startMarkName = "").
+      await router.navigate("users");
+
+      perfMarkSpy.mockClear();
+      warnSpy.mockClear();
+
+      // The not-found error is an out-of-band terminal with no preceding start.
+      await expect(router.navigate("nonexistent")).rejects.toMatchObject({
+        code: errorCodes.ROUTE_NOT_FOUND,
+      });
+
+      expect(perfMarkSpy).not.toHaveBeenCalledWith("router:transition-error:");
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Failed to create performance measure"),
+        expect.anything(),
+      );
+    });
+
+    it("does not create an empty-label error mark or warn on a guard-redirect", async () => {
+      // Classic guard-redirect: guard navigates elsewhere and returns false.
+      // Core emits a double terminal (cancel + error) for the one redirect; the
+      // late error lands after the redirect target's success cleared the slot.
+      lifecycle.addActivateGuard("users", () => () => {
+        void router.navigate("admin");
+
+        return false;
+      });
+      router.usePlugin(loggerPluginFactory({ usePerformanceMarks: true }));
+      await router.start("/");
+
+      perfMarkSpy.mockClear();
+      warnSpy.mockClear();
+
+      await expect(router.navigate("users")).rejects.toMatchObject({
+        code: errorCodes.CANNOT_ACTIVATE,
+      });
+
+      // Let the redirect's success + the trailing out-of-band error settle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(perfMarkSpy).not.toHaveBeenCalledWith("router:transition-error:");
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Failed to create performance measure"),
+        expect.anything(),
+      );
+    });
+  });
+
   describe("Multiple error codes", () => {
     it("should log CANNOT_ACTIVATE error code", async () => {
       lifecycle.addActivateGuard("users", () => () => false);

--- a/packages/logger-plugin/tests/functional/plugin.test.ts
+++ b/packages/logger-plugin/tests/functional/plugin.test.ts
@@ -260,6 +260,28 @@ describe("@real-router/logger-plugin", () => {
       // Should use groups if available
       expect(consoleGroupSpy).toHaveBeenCalled();
     });
+
+    it("should NOT open a group at level 'none' (#794)", async () => {
+      router.usePlugin(loggerPluginFactory({ level: "none" }));
+      await router.start("/");
+
+      await router.navigate("users");
+      await router.navigate("admin");
+
+      // A console.group is itself console output — at level "none" the plugin
+      // must be completely silent, with no empty expandable groups.
+      expect(consoleGroupSpy).not.toHaveBeenCalled();
+    });
+
+    it("should NOT open a group at level 'errors' (#794)", async () => {
+      router.usePlugin(loggerPluginFactory({ level: "errors" }));
+      await router.start("/");
+
+      await router.navigate("users");
+
+      // Transition logging is gated off; the group must be too.
+      expect(consoleGroupSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("Edge Cases", () => {

--- a/packages/logger-plugin/tests/property/loggerPlugin.properties.ts
+++ b/packages/logger-plugin/tests/property/loggerPlugin.properties.ts
@@ -79,9 +79,10 @@ describe("completeness: each transition generates log entries", () => {
       const logSpy = vi.spyOn(console, "log").mockImplementation(noop);
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
       const errorSpy = vi.spyOn(console, "error").mockImplementation(noop);
-
-      vi.spyOn(console, "group").mockImplementation(noop);
-      vi.spyOn(console, "groupEnd").mockImplementation(noop);
+      const groupSpy = vi.spyOn(console, "group").mockImplementation(noop);
+      const groupEndSpy = vi
+        .spyOn(console, "groupEnd")
+        .mockImplementation(noop);
 
       const router = await createLoggerRouter({ level: "none" });
 
@@ -94,6 +95,11 @@ describe("completeness: each transition generates log entries", () => {
       expect(logSpy).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
+      // A console.group is itself console output — "completely silent" (Inv 3)
+      // means no group is opened either (#794). The group/groupEnd spies are
+      // intentionally not cleared, so this also covers the start transition.
+      expect(groupSpy).not.toHaveBeenCalled();
+      expect(groupEndSpy).not.toHaveBeenCalled();
 
       router.stop();
     },
@@ -329,7 +335,8 @@ describe("level filtering", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(noop);
 
       vi.spyOn(console, "error").mockImplementation(noop);
-      vi.spyOn(console, "group").mockImplementation(noop);
+      const groupSpy = vi.spyOn(console, "group").mockImplementation(noop);
+
       vi.spyOn(console, "groupEnd").mockImplementation(noop);
 
       const router = await createLoggerRouter({ level: "errors" });
@@ -342,6 +349,8 @@ describe("level filtering", () => {
       // No transition logs at all
       expect(logSpy).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
+      // Transition logging is gated off, so the group is too (#794).
+      expect(groupSpy).not.toHaveBeenCalled();
 
       router.stop();
     },


### PR DESCRIPTION
Four logger-plugin defects from the logger-plugin audit, one independent commit each.

### fix: out-of-band terminal on a cleared slot (#793)

With `usePerformanceMarks: true`, an out-of-band terminal — a guard-redirect (core emits a cancel + error pair, the error landing after the redirect target's success reset the slot) or a `ROUTE_NOT_FOUND` with no preceding start — marked/measured against an empty `#startMarkName`, leaving a garbage empty-label `router:transition-error:` mark + a `console.warn("Failed to create performance measure")` per redirect/not-found. The perf branch of `onTransitionError`/`onTransitionCancel` is now gated on a non-empty start mark. The `console.error` log for the error itself is unchanged.

### fix: gate the console group on log level (#794)

`onTransitionStart` opened a `console.group("Router transition")` unconditionally, so `level: "none"`/`"errors"` still emitted an empty, expandable group per transition — a `console.group` is itself console output, falsifying INVARIANTS Completeness Inv 3 ("completely silent"). The group now opens only when `#logTransition` is set; the idempotent close path is unchanged. Inv 3 / level:errors property assertions were extended to verify no `console.group`/`groupEnd` at `level: "none"`/`"errors"`.

### fix: bound the User Timing buffer (#795)

`usePerformanceMarks` created ~3 marks + 1 measure per transition (`transition-start`, the standalone `leave-approved`, the terminal mark, and the `transition:*` measure) and never cleared them — the User Timing buffer is unbounded per spec, so a long dev session accumulated tens of thousands of entries. The tracker's `measure()` now clears its start/end marks + the measure by name (in a `finally`, so a failed measure still reclaims its inputs), and the standalone `leave-approved` mark — never an endpoint of a measure — is cleared in `#resetTransitionState`. Only the plugin's own names are cleared, so the app's marks/measures are untouched; trace events already emitted to an in-progress DevTools recording are unaffected.

### docs: CLAUDE.md structural fixes (#796)

Dropped the non-existent `#logWarning` private flag from the pre-computed-flags list (the code declares only `#logLifecycle`/`#logTransition`/`#logError`; the cancel branch's `console.warn` is gated by `#logTransition`) and corrected the "6 lifecycle hooks" → 7 count.

---

100% coverage retained (171 functional + unit, 13 property). No public API change. Three `patch` changesets (#796 is doc-only, no changeset).

Closes #793
Closes #794
Closes #795
Closes #796
