### PR TITLE
fix(sources): reconnect-staleness reconcile, lazy active-route source, selector isolation + docs (#765 #766 #767 #768)

### DIFF
--- a/.changeset/sources-active-name-selector-isolation-767-fix.md
+++ b/.changeset/sources-active-name-selector-isolation-767-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": patch
+---
+
+fix(sources): isolate listener exceptions in createActiveNameSelector (#767)
+
+`createActiveNameSelector`'s notification loop had no per-listener exception isolation: a single throwing listener aborted notifications to the remaining listeners of the same route name AND every later name in the iteration, leaving their cached active state stale (a sibling `Link`'s active class frozen until the next related navigation). The loop now wraps each `listener()` in `try/catch` and re-throws asynchronously via `queueMicrotask` — mirroring `BaseSource.notify` (INVARIANTS "BaseSource 3"). One broken Link no longer freezes its siblings.

--- a/.changeset/sources-active-route-lazy-766-fix.md
+++ b/.changeset/sources-active-route-lazy-766-fix.md
@@ -1,0 +1,11 @@
+---
+"@real-router/sources": minor
+---
+
+fix(sources): make createActiveRouteSource lazy to close the listener-limit crash (#766)
+
+`createActiveRouteSource` previously connected to the router **eagerly** at construction and cached every distinct `(name | params | options)` key with a no-op `destroy()`, so each unique key held a permanent `router.subscribe` handle that survived all Link unmounts. A long-lived router with per-item-params Links (infinite feed, virtualized table, pagination by id) accumulated handles until the `EventEmitter` listener limit (10000) threw in the render path.
+
+It now uses the **lazy connection** the docs already promised: subscribe on the first listener, disconnect on the last, reconcile the snapshot on re-subscribe (same pattern as `createRouteNodeSource` / #765). The cache entry stays (a cheap closure) but holds no router subscription while it has zero listeners — unmounted Links stop costing a listener, and creating an unbounded number of unique keys no longer crashes.
+
+**BREAKING:** the snapshot no longer updates while the source has zero subscribers (the previously-undocumented eager behaviour). Consumers that read `getSnapshot()` without subscribing must subscribe first; framework adapters (which bridge via `useSyncExternalStore` / signals) are unaffected.

--- a/.changeset/sources-docs-cleanup-768-fix.md
+++ b/.changeset/sources-docs-cleanup-768-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": patch
+---
+
+fix(sources): freeze INITIAL_SNAPSHOT + docs cleanup (#768)
+
+`createErrorSource`'s shared `INITIAL_SNAPSHOT` singleton (returned by every error source until the first error) is now `Object.freeze`d — mirroring `createTransitionSource`'s frozen `IDLE_SNAPSHOT` — so a consumer can no longer mutate it and corrupt the shared singleton for every error source of every router. Plus documentation fixes: INVARIANTS "Cache Identity 3" now states the hash-aware contract precisely (non-empty hash → `false`; `hash: ""` → `true` under no URL plugin), the ARCHITECTURE filtering-pipeline diagram shows the `hashFlip` pre-filter branch (#532), the `canonicalJson` JSDoc notes the `Date` ↔ ISO-string cache-key collision, and a stale `createRouteSource` test comment is corrected.

--- a/.changeset/sources-reconnect-staleness-765-fix.md
+++ b/.changeset/sources-reconnect-staleness-765-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": patch
+---
+
+fix(sources): reconcile lazy sources on reconnect — missed navigations/errors are caught up on re-subscribe (#765)
+
+`createRouteSource` now reconciles its snapshot with the current router state on first subscribe — previously only `createRouteNodeSource` did — so a navigation that lands while the source has **zero subscribers** (a `RouterProvider` under a React `<Activity>` hide→navigate→show cycle, or all `.current` readers gated behind a Svelte `{#if}`) is caught up on re-subscribe instead of replaying a stale route. The reconcile fires only when the route actually changed (no spurious re-render on a no-nav hide/show); `previousRoute` resets to `undefined` on catch-up, since the real previous route can't be reconstructed outside a live subscribe payload. `createDismissableError` likewise catches up on first subscribe, so a `RouterErrorBoundary` mounting after a boot-time navigation error now observes it.

--- a/packages/sources/ARCHITECTURE.md
+++ b/packages/sources/ARCHITECTURE.md
@@ -95,13 +95,13 @@ The predicate is created once per source instance — safe, because `createRoute
 
 ```
 Router event
-  → areRoutesRelated pre-filter
-  → isActiveRoute check
+  → pre-filter: areRoutesRelated (new/prev route) OR hashFlip (#532)
+  → isActiveRoute check (+ state.context.url.hash equality when opts.hash is set)
   → Object.is dedup guard
   → listener notification
 ```
 
-`areRoutesRelated` is a cheap string comparison that skips the `isActiveRoute` call entirely when the navigated route is unrelated to the tracked route.
+`areRoutesRelated` is a cheap string comparison that skips the `isActiveRoute` call entirely when the navigated route is unrelated to the tracked route. Hash-aware sources (`opts.hash` set) add a third pre-filter branch — `hashFlip` — that passes the filter on a same-path, different-hash transition (`state.context.url.hashChanged`), which the route comparison alone would miss.
 
 ## Internal Modules
 

--- a/packages/sources/INVARIANTS.md
+++ b/packages/sources/INVARIANTS.md
@@ -110,7 +110,7 @@
 | --- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | Params equivalent under `canonicalJson` hit the same cache entry                           | `{a:1, b:2}` and reordered `{b:2, a:1}` deterministically yield the same source instance.                                         |
 | 2   | Different routers are isolated under the same `(name, params, options)` key                | WeakMap keying prevents cross-router cache collisions.                                                                            |
-| 3   | Hash-aware monotonicity under no-url-plugin fixture                                        | When `opts.hash !== undefined` and the router has no URL-publishing plugin, the snapshot is `false` across every navigation (#532). |
+| 3   | Hash-aware monotonicity under no-url-plugin fixture                                        | When `opts.hash` is a **non-empty** string and the router has no URL-publishing plugin, the snapshot is `false` across every navigation — `readContextHash` returns `""`, which never equals a non-empty fragment. Exception: `opts.hash === ""` matches the empty fragment, so an active route returns `true` even with no plugin (#532). |
 | 4   | Hash-aware variants are cache-isolated from hash-less variants                             | The same `(name, params, options-without-hash)` and `(name, params, options-with-hash)` calls return different instances.         |
 
 ## createActiveRouteSource — Destroy

--- a/packages/sources/src/canonicalJson.ts
+++ b/packages/sources/src/canonicalJson.ts
@@ -19,7 +19,11 @@
  * Edge cases:
  * - Arrays preserve order (canonical: index-ordered already).
  * - `undefined` values are dropped (standard JSON behaviour).
- * - `Date` is serialized via its `toJSON` method (ISO string).
+ * - `Date` is serialized via its `toJSON` method (ISO string). **Collision
+ *   caveat:** `{ d: new Date(0) }` and `{ d: "1970-01-01T00:00:00.000Z" }`
+ *   produce the **same** cache key (both reduce to the ISO string), so the two
+ *   inputs share one cached source. Harmless in practice — `Date` params are
+ *   exotic and `isActiveRoute` stringifies them identically post-encoding.
  * - `Symbol` becomes `undefined` (standard JSON behaviour).
  * - `BigInt` throws via `JSON.stringify` defaults.
  * - `Map`, `Set`, `RegExp`, `WeakMap`, `WeakSet` would silently collapse to

--- a/packages/sources/src/createActiveNameSelector.ts
+++ b/packages/sources/src/createActiveNameSelector.ts
@@ -109,8 +109,21 @@ export function createActiveNameSelector(router: Router): ActiveNameSelector {
         }
 
         activeByName.set(routeName, nextActive);
+        // Per-listener exception isolation — mirrors `BaseSource.notify`
+        // (INVARIANTS "BaseSource 3"). Without it, one throwing Link listener
+        // would abort notifications to the remaining listeners of this name AND
+        // every later name in the iteration, leaving their `activeByName` state
+        // stale (#767). `activeByName.set` already ran above, so the per-name
+        // diff is committed before any listener fires. Re-throw asynchronously
+        // so the genuine bug still surfaces to global error handlers.
         for (const listener of listeners) {
-          listener();
+          try {
+            listener();
+          } catch (error) {
+            queueMicrotask(() => {
+              throw error;
+            });
+          }
         }
       }
     });

--- a/packages/sources/src/createActiveRouteSource.ts
+++ b/packages/sources/src/createActiveRouteSource.ts
@@ -168,55 +168,88 @@ function buildActiveRouteSource(
 
   let routerUnsubscribe: (() => void) | undefined;
 
+  const disconnect = (): void => {
+    const unsub = routerUnsubscribe;
+
+    routerUnsubscribe = undefined;
+    unsub?.();
+  };
+
   const source = new BaseSource(initialValue, {
-    onDestroy: () => {
-      routerUnsubscribe?.();
-      routerUnsubscribe = undefined;
+    onFirstSubscribe: () => {
+      // Reconcile before connecting: while disconnected (zero listeners) the
+      // source missed navigations, so the active boolean may be stale.
+      // Recompute against the current router state and notify the just-added
+      // listener — BaseSource registers it before onFirstSubscribe. Mirrors the
+      // reconnect reconcile of createRouteNodeSource / createRouteSource (#765).
+      const reconciled = computeActive(
+        router,
+        routeName,
+        params,
+        strict,
+        ignoreQueryParams,
+        hash,
+      );
+
+      if (!Object.is(source.getSnapshot(), reconciled)) {
+        source.updateSnapshot(reconciled);
+      }
+
+      // Lazy connection (#766): subscribe on the FIRST listener, disconnect on
+      // the LAST (onLastUnsubscribe). Previously this source subscribed eagerly
+      // at construction with a no-op destroy on the cached wrapper, so every
+      // unique cache key held a PERMANENT router subscription that survived all
+      // Link unmounts — a long-lived router with per-item-params Links
+      // accumulated handles until the EventEmitter listener limit (10000)
+      // crashed the render path. The cache entry still lives with the router
+      // (cheap: a closure), but now holds no subscription while it has zero
+      // listeners; the non-cached fallback (BigInt / circular params) likewise
+      // detaches through `disconnect`.
+      routerUnsubscribe = router.subscribe((next) => {
+        const isNewRelated = areRoutesRelated(routeName, next.route.name);
+        const isPrevRelated =
+          next.previousRoute &&
+          areRoutesRelated(routeName, next.previousRoute.name);
+
+        // Hash-aware sources also flip on same-path-different-hash transitions.
+        // The route comparison alone misses these (route is identical), but the
+        // hash claim updated, so we must re-evaluate. Detect via the
+        // `hashChanged` flag published by URL plugins.
+        const hashFlip =
+          hash !== undefined &&
+          ((
+            next.route.context as
+              | { url?: { hashChanged?: boolean } }
+              | undefined
+          )?.url?.hashChanged ??
+            false);
+
+        if (!isNewRelated && !isPrevRelated && !hashFlip) {
+          return;
+        }
+
+        // If new route is not related, we know the route is inactive —
+        // avoid calling isActiveRoute for the optimization. (Hash check would
+        // also fail without route-match, so this short-circuit holds for
+        // hash-aware sources too.)
+        const newValue = isNewRelated
+          ? computeActive(
+              router,
+              routeName,
+              params,
+              strict,
+              ignoreQueryParams,
+              hash,
+            )
+          : false;
+
+        if (!Object.is(source.getSnapshot(), newValue)) {
+          source.updateSnapshot(newValue);
+        }
+      });
     },
-  });
-
-  // Eager connection: subscribe to router immediately. For the cached path,
-  // the returned wrapper has a no-op destroy and the handle lives with the
-  // router (released on router GC). For the non-cached fallback (BigInt /
-  // circular params), the handle is unwound through `onDestroy` above.
-  routerUnsubscribe = router.subscribe((next) => {
-    const isNewRelated = areRoutesRelated(routeName, next.route.name);
-    const isPrevRelated =
-      next.previousRoute &&
-      areRoutesRelated(routeName, next.previousRoute.name);
-
-    // Hash-aware sources also flip on same-path-different-hash transitions.
-    // The route comparison alone misses these (route is identical), but the
-    // hash claim updated, so we must re-evaluate. Detect via the `hashChanged`
-    // flag published by URL plugins.
-    const hashFlip =
-      hash !== undefined &&
-      ((next.route.context as { url?: { hashChanged?: boolean } } | undefined)
-        ?.url?.hashChanged ??
-        false);
-
-    if (!isNewRelated && !isPrevRelated && !hashFlip) {
-      return;
-    }
-
-    // If new route is not related, we know the route is inactive —
-    // avoid calling isActiveRoute for the optimization. (Hash check would
-    // also fail without route-match, so this short-circuit holds for
-    // hash-aware sources too.)
-    const newValue = isNewRelated
-      ? computeActive(
-          router,
-          routeName,
-          params,
-          strict,
-          ignoreQueryParams,
-          hash,
-        )
-      : false;
-
-    if (!Object.is(source.getSnapshot(), newValue)) {
-      source.updateSnapshot(newValue);
-    }
+    onLastUnsubscribe: disconnect,
+    onDestroy: disconnect,
   });
 
   return source;

--- a/packages/sources/src/createDismissableError.ts
+++ b/packages/sources/src/createDismissableError.ts
@@ -66,6 +66,23 @@ export function createDismissableError(
         unsubFromError = errorSource.subscribe(() => {
           source.updateSnapshot(buildDismissableSnapshot());
         });
+
+        // Catch up: the eager underlying error source may already hold (or have
+        // since cleared) an error that changed while this wrapper had zero
+        // subscribers — at first-ever subscribe, or after a disconnect/reconnect
+        // cycle (onLastUnsubscribe below). Without this, a RouterErrorBoundary
+        // mounting AFTER a boot-time error would never see it (#765.2). Guard on
+        // the resolved `error` so the common no-error case stays a no-op: the
+        // listener was added before this callback (BaseSource ordering), so an
+        // unconditional updateSnapshot would notify it redundantly and break the
+        // "subscribers fire only on state-relevant actions" contract. The
+        // `version` field can skip values for an error cycle fully missed during
+        // a disconnect — harmless, monotonicity still holds.
+        const caughtUp = buildDismissableSnapshot();
+
+        if (caughtUp.error !== source.getSnapshot().error) {
+          source.updateSnapshot(caughtUp);
+        }
       },
       onLastUnsubscribe: () => {
         disconnect();

--- a/packages/sources/src/createErrorSource.ts
+++ b/packages/sources/src/createErrorSource.ts
@@ -7,12 +7,16 @@ import { noopDestroy } from "./internal/noopDestroy.js";
 import type { RouterErrorSnapshot, RouterSource } from "./types.js";
 import type { Router, State, RouterError } from "@real-router/core";
 
-const INITIAL_SNAPSHOT: RouterErrorSnapshot = {
+// Frozen shared singleton — returned by every error source's getSnapshot()
+// until the first error. Mirrors createTransitionSource's IDLE_SNAPSHOT: a
+// consumer mutating it would corrupt the shared singleton for every error
+// source of every router (#768).
+const INITIAL_SNAPSHOT: RouterErrorSnapshot = Object.freeze({
   error: null,
   toRoute: null,
   fromRoute: null,
   version: 0,
-};
+});
 
 const errorSourceCache = new WeakMap<
   Router,

--- a/packages/sources/src/createRouteSource.ts
+++ b/packages/sources/src/createRouteSource.ts
@@ -28,6 +28,34 @@ export function createRouteSource(router: Router): RouterSource<RouteSnapshot> {
     },
     {
       onFirstSubscribe: () => {
+        // Reconcile the route with the current router state before connecting.
+        // While this source had zero listeners it was disconnected
+        // (onLastUnsubscribe below), so a navigation in that window was missed —
+        // the just-added listener would otherwise observe a stale route (#765).
+        // BaseSource registered the listener before this callback, so the
+        // updateSnapshot below reaches it.
+        //
+        // Emit ONLY when the route actually changed: a hide/show (Activity)
+        // cycle with no navigation in between must not fire a spurious
+        // re-render, and its still-valid `previousRoute` must survive. When a
+        // navigation WAS caught up, `previousRoute` resets to `undefined`: the
+        // catch-up is a snap to the current state, not an observed navigation,
+        // and the true previous route cannot be reconstructed outside a live
+        // subscribe payload (parity of intent with createRouteNodeSource, whose
+        // reconnect reconcile likewise drops previousRoute on catch-up).
+        const current = source.getSnapshot();
+        const reconciledRoute = stabilizeState(
+          current.route,
+          router.getState(),
+        );
+
+        if (reconciledRoute !== current.route) {
+          source.updateSnapshot({
+            route: reconciledRoute,
+            previousRoute: undefined,
+          });
+        }
+
         routerUnsubscribe = router.subscribe((next) => {
           const prev = source.getSnapshot();
           const newRoute = stabilizeState(prev.route, next.route);

--- a/packages/sources/tests/property/activeRouteSource.properties.ts
+++ b/packages/sources/tests/property/activeRouteSource.properties.ts
@@ -63,6 +63,9 @@ describe("boolean tracking", () => {
         options,
       );
 
+      // Lazy source tracks navigations only while subscribed (#766).
+      source.subscribe(() => {});
+
       await executeNavigations(router, navigations).catch(() => undefined);
 
       expect(source.getSnapshot()).toStrictEqual(
@@ -220,6 +223,9 @@ describe("areRoutesRelated filter", () => {
         params,
         options,
       );
+
+      // Lazy source tracks navigations only while subscribed (#766).
+      source.subscribe(() => {});
 
       for (const nav of navigations) {
         await router.navigate(nav.name, nav.params).catch(() => undefined);
@@ -499,6 +505,82 @@ describe("destroy (cached shared source — no-op)", () => {
 
       unsubscribe();
 
+      router.stop();
+    },
+  );
+});
+
+describe("lazy connection (#766)", () => {
+  test.prop([arbRouteName], { numRuns: NUM_RUNS.standard })(
+    "no router subscription before first source.subscribe()",
+    async (routeName) => {
+      const router = await createStartedRouter();
+      const spy = vi.spyOn(router, "subscribe");
+
+      createActiveRouteSource(router, routeName, paramsForRoute(routeName));
+
+      expect(spy).not.toHaveBeenCalled();
+
+      router.stop();
+    },
+  );
+
+  test.prop([arbRouteName], { numRuns: NUM_RUNS.standard })(
+    "connects on first listener, disconnects on last, reconnects on re-subscribe",
+    async (routeName) => {
+      const router = await createStartedRouter();
+      const spy = vi.spyOn(router, "subscribe");
+
+      const source = createActiveRouteSource(
+        router,
+        routeName,
+        paramsForRoute(routeName),
+      );
+
+      const unsub1 = source.subscribe(() => {});
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      unsub1();
+
+      // Re-subscribe after the last listener left creates a fresh router
+      // subscription (the previous one was released on onLastUnsubscribe).
+      const unsub2 = source.subscribe(() => {});
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      unsub2();
+      router.stop();
+    },
+  );
+
+  test.prop([fc.constantFrom("users.list", "users.view", "users.edit")], {
+    numRuns: NUM_RUNS.standard,
+  })(
+    "active state changed while disconnected is reconciled on re-subscribe",
+    async (childRoute) => {
+      const router = await createStartedRouter();
+      const source = createActiveRouteSource(router, "users");
+
+      // Connect at "home" (users inactive), then drop the last listener.
+      const unsub1 = source.subscribe(() => {});
+
+      expect(source.getSnapshot()).toBe(false);
+
+      unsub1();
+
+      // Navigate to a "users.*" descendant while the source has ZERO listeners.
+      await router.navigate(childRoute, paramsForRoute(childRoute));
+
+      // Re-subscribe: onFirstSubscribe reconciles the active boolean to the
+      // current router state (true) instead of replaying the stale `false`.
+      const listener = vi.fn();
+      const unsub2 = source.subscribe(listener);
+
+      expect(source.getSnapshot()).toBe(true);
+      expect(listener).toHaveBeenCalled();
+
+      unsub2();
       router.stop();
     },
   );

--- a/packages/sources/tests/property/createDismissableError.properties.ts
+++ b/packages/sources/tests/property/createDismissableError.properties.ts
@@ -202,4 +202,28 @@ describe("createDismissableError — invariants", () => {
       router.stop();
     },
   );
+
+  test.prop([arbMissingRoute], { numRuns: NUM_RUNS.standard })(
+    "error that occurred before first subscribe is caught up on subscribe (#765 reconnect staleness)",
+    async (route) => {
+      const router = await createStartedRouter();
+      const source = createDismissableError(router); // zero subscribers
+
+      // Error event while the wrapper has ZERO subscribers. The eager underlying
+      // getErrorSource captures it; the wrapper snapshot stays stale until the
+      // catch-up reconcile on first subscribe (BUG #765.2).
+      await router.navigate(route).catch(() => {});
+
+      const listener = vi.fn();
+      const unsub = source.subscribe(listener);
+
+      // Without the catch-up, getSnapshot() returns { error: null, version: 0 }.
+      expect(source.getSnapshot().error).not.toBeNull();
+      // The listener (added before onFirstSubscribe) receives the reconcile.
+      expect(listener).toHaveBeenCalled();
+
+      unsub();
+      router.stop();
+    },
+  );
 });

--- a/packages/sources/tests/property/routeSource.properties.ts
+++ b/packages/sources/tests/property/routeSource.properties.ts
@@ -331,10 +331,13 @@ describe("subscribe order (listener added before onFirstSubscribe)", () => {
   test.prop([arbListenerCount], { numRuns: NUM_RUNS.standard })(
     "first listener is registered BEFORE onFirstSubscribe runs (no missed notifications)",
     async (extraListeners) => {
-      // Drive the BaseSource invariant: if `onFirstSubscribe` itself triggered
-      // an `updateSnapshot`, the just-added listener must observe it. We can't
-      // see onFirstSubscribe directly, but we can prove the contract via the
-      // "reconcile on reconnect" path that exercises it (#605 reload bypass).
+      // Drive the BaseSource invariant: a listener added before onFirstSubscribe
+      // must observe any updateSnapshot that onFirstSubscribe triggers. This
+      // test exercises the INITIAL-snapshot path — the source is created after
+      // the nav, so the first subscribe seeds the connection without changing
+      // the snapshot. The reconcile-on-reconnect path (where onFirstSubscribe
+      // DOES updateSnapshot and the just-added listener must catch it) is
+      // covered by the "reconnect reconcile (#765)" describe.
       const router = await createStartedRouter();
 
       // Prime the router to a non-initial state so reconnect has something

--- a/packages/sources/tests/property/routeSource.properties.ts
+++ b/packages/sources/tests/property/routeSource.properties.ts
@@ -389,6 +389,52 @@ describe("subscribe order (listener added before onFirstSubscribe)", () => {
   );
 });
 
+// ===
+
+describe("reconnect reconcile (#765)", () => {
+  test.prop([arbNavigation], { numRuns: NUM_RUNS.async })(
+    "navigation while disconnected (zero subscribers) is reconciled on re-subscribe",
+    async (nav) => {
+      fc.pre(nav.name !== "home" && nav.name !== "admin.dashboard");
+
+      const router = await createStartedRouter();
+      const source = createRouteSource(router);
+
+      // Connect, observe a navigation, then fully unsubscribe → disconnect.
+      const unsub1 = source.subscribe(vi.fn());
+
+      await router.navigate("admin.dashboard");
+
+      expect(source.getSnapshot().route?.name).toBe("admin.dashboard");
+
+      unsub1();
+
+      // Navigation while the source has ZERO subscribers — the disconnected
+      // source never sees it (BUG #765: stale snapshot survives reconnect).
+      await router.navigate(nav.name, nav.params);
+
+      // Re-subscribe (Activity show / RouteView remount). onFirstSubscribe must
+      // reconcile the snapshot with the current router state, not replay the
+      // pre-disconnect snapshot.
+      const listener2 = vi.fn();
+      const unsub2 = source.subscribe(listener2);
+
+      expect(source.getSnapshot().route?.name).toBe(nav.name);
+      expect(source.getSnapshot().route?.name).toBe(router.getState()?.name);
+      // `previousRoute` resets to undefined on a catch-up reconcile — it is a
+      // snap to current state, not an observed navigation (mirrors
+      // createRouteNodeSource's `computeSnapshot(next?.previousRoute)`).
+      expect(source.getSnapshot().previousRoute).toBeUndefined();
+      // BaseSource registers the listener BEFORE onFirstSubscribe, so the
+      // reconcile's updateSnapshot reaches the just-added listener.
+      expect(listener2).toHaveBeenCalled();
+
+      unsub2();
+      router.stop();
+    },
+  );
+});
+
 describe("destroy", () => {
   test.prop([arbNavigation, arbNavigation], { numRuns: NUM_RUNS.async })(
     "destroy() removes router subscription",

--- a/packages/sources/tests/stress/active-route-source-cache-growth.stress.ts
+++ b/packages/sources/tests/stress/active-route-source-cache-growth.stress.ts
@@ -11,10 +11,12 @@ import type { RouterSource } from "@real-router/sources";
  * S12 createActiveRouteSource cache growth (audit-2026-05-16 §7 #6).
  *
  * Documents the current behaviour of the per-router cache in
- * `createActiveRouteSource`: it grows unboundedly for the lifetime of the
- * router. Each unique `(routeName, canonicalJson(params), options)` triple
- * adds an eagerly-subscribed `BaseSource` that holds a `router.subscribe`
- * handle until the router itself is garbage-collected.
+ * `createActiveRouteSource`: the cache grows unboundedly in ENTRIES for the
+ * lifetime of the router (one per unique `(routeName, canonicalJson(params),
+ * options)` triple). Since #766 each entry is **lazy** — a cheap closure that
+ * holds a `router.subscribe` handle only while it has listeners, releasing it
+ * on the last unsubscribe — so unmounted Links cost zero router subscriptions
+ * (S12.5 crosses the 10 000-listener limit without crashing).
  *
  * In SPAs with per-resource active-link checks (e.g. `<Link to="users.view"
  * params={{ id: userId }}>` rendered for thousands of users), the cache can
@@ -111,5 +113,25 @@ describe("S12 createActiveRouteSource cache growth", () => {
     for (const u of unsubs) {
       u();
     }
+  });
+
+  it("S12.5: >10 000 unique sources with mount/unmount do not crash the render path (lazy connection, #766)", () => {
+    // Regression for the eager-subscription crash: each unique cache key used to
+    // open a PERMANENT router.subscribe handle at construction (no-op destroy on
+    // the cached wrapper), so a long-lived router with per-item-params Links
+    // accumulated handles until the EventEmitter listener limit (10000) threw in
+    // the render path. With lazy connection a source holds a router subscription
+    // only while it has listeners, so a mount→unmount cycle nets zero — peak
+    // listener count stays at 1 no matter how many unique keys are created.
+    const COUNT = 10_050; // crosses the 10 000 listener limit
+
+    expect(() => {
+      for (let i = 0; i < COUNT; i++) {
+        const source = createActiveRouteSource(router, "users.view", { id: i });
+        const unsub = source.subscribe(() => {});
+
+        unsub(); // Link unmounts → onLastUnsubscribe disconnects from the router
+      }
+    }).not.toThrow();
   });
 });

--- a/packages/sources/tests/stress/eager-subscription-leak.stress.ts
+++ b/packages/sources/tests/stress/eager-subscription-leak.stress.ts
@@ -17,7 +17,12 @@ import {
 
 import type { Router } from "@real-router/core";
 
-describe("S3. Eager subscription — shared cached sources do not leak", () => {
+// S3. Shared cached sources do not leak. createActiveRouteSource is now lazy
+// (#766) — it connects on first listener and disconnects on last — while
+// createTransitionSource / createErrorSource stay eager (S3.7/S3.8). The heap
+// guards below hold for both: a shared cached source collapses every event into
+// one rolling snapshot with no per-call/per-event accumulation.
+describe("S3. Shared cached sources do not leak", () => {
   let router: Router;
 
   beforeEach(async () => {
@@ -157,7 +162,7 @@ describe("S3. Eager subscription — shared cached sources do not leak", () => {
     expect(delta).toBeLessThan(MB / 4);
   });
 
-  it("S3.5: lazy RouteSource auto-cleanup + eager ActiveRouteSource cached share — heap bounded", async () => {
+  it("S3.5: lazy RouteSource auto-cleanup + lazy ActiveRouteSource cached share — heap bounded", async () => {
     const heapBaseline = takeHeapSnapshot();
 
     const routeSources = createManySources(() => createRouteSource(router), 50);

--- a/packages/sources/tests/unit/createActiveNameSelector.test.ts
+++ b/packages/sources/tests/unit/createActiveNameSelector.test.ts
@@ -92,6 +92,57 @@ describe("createActiveNameSelector", () => {
     unsubAdmin();
   });
 
+  it("isolates throwing listeners — same-name siblings and later names still notified (#767)", async () => {
+    const selector = createActiveNameSelector(router);
+    const thrown = new Error("boom");
+    const sameNameSurvivor = vi.fn();
+    const otherNameSurvivor = vi.fn();
+
+    // Capture the asynchronously re-thrown error before vitest's default
+    // uncaughtException handler fails the test (mirrors BaseSource isolation).
+    const rethrown: unknown[] = [];
+    const previousListeners = [...process.listeners("uncaughtException")];
+
+    process.removeAllListeners("uncaughtException");
+    const captureHandler = (error: unknown): void => {
+      rethrown.push(error);
+    };
+
+    process.on("uncaughtException", captureHandler);
+
+    try {
+      // Two "users" listeners (throwing first), then a DIFFERENT name "home"
+      // whose active state also flips on the same navigation. Iteration order:
+      // "users" (subscribed first) before "home". Without per-listener
+      // isolation, the throw unwinds both nested loops → the same-name sibling
+      // AND every later name are skipped.
+      selector.subscribe("users", () => {
+        throw thrown;
+      });
+      selector.subscribe("users", sameNameSurvivor);
+      selector.subscribe("home", otherNameSurvivor);
+
+      // home → users.list: "users" flips false→true, "home" flips true→false.
+      await router.navigate("users.list");
+
+      // Same-name sibling notified despite the first listener throwing.
+      expect(sameNameSurvivor).toHaveBeenCalledTimes(1);
+      // A listener of a later-iterated name is NOT skipped by the throw.
+      expect(otherNameSurvivor).toHaveBeenCalledTimes(1);
+
+      // Drain the microtask queue so the queueMicrotask(throw) lands.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rethrown).toStrictEqual([thrown]);
+    } finally {
+      process.removeListener("uncaughtException", captureHandler);
+      for (const listener of previousListeners) {
+        process.on("uncaughtException", listener);
+      }
+    }
+  });
+
   it("N listeners for the same name share one router subscription", async () => {
     const originalSubscribe = router.subscribe.bind(router);
     const subscribeSpy = vi.spyOn(router, "subscribe");

--- a/packages/sources/tests/unit/createActiveRouteSource-cache.test.ts
+++ b/packages/sources/tests/unit/createActiveRouteSource-cache.test.ts
@@ -231,7 +231,7 @@ describe("createActiveRouteSource (per-router + canonical-args cache)", () => {
     regexpSource.destroy();
   });
 
-  it("non-cached fallback: destroy() unwinds the router subscription (no leak)", async () => {
+  it("non-cached fallback: lazy connect + destroy() unwinds the router subscription (no leak)", async () => {
     const bigintParams = { id: 1n } as unknown as Record<string, string>;
     const originalSubscribe = router.subscribe.bind(router);
     const unsubscribeSpies: ReturnType<typeof vi.fn>[] = [];
@@ -248,6 +248,11 @@ describe("createActiveRouteSource (per-router + canonical-args cache)", () => {
     });
 
     const source = createActiveRouteSource(router, "users", bigintParams);
+
+    // Lazy (#766): no router subscription until the first listener subscribes.
+    expect(unsubscribeSpies).toHaveLength(0);
+
+    source.subscribe(() => {});
 
     expect(unsubscribeSpies).toHaveLength(1);
     expect(unsubscribeSpies[0]).not.toHaveBeenCalled();

--- a/packages/sources/tests/unit/createActiveRouteStore.test.ts
+++ b/packages/sources/tests/unit/createActiveRouteStore.test.ts
@@ -78,6 +78,9 @@ describe("createActiveRouteSources", () => {
 
     source.subscribe(listener);
 
+    // Ignore the reconcile-on-subscribe isActiveRoute call (#766 lazy connect).
+    spy.mockClear();
+
     // Navigate home → admin (unrelated to users)
     await router.navigate("admin");
 
@@ -93,6 +96,9 @@ describe("createActiveRouteSources", () => {
     const source = createActiveRouteSource(router, "users", undefined, {
       strict: false,
     });
+
+    // Lazy source tracks navigations only while subscribed (#766).
+    source.subscribe(() => {});
 
     await router.navigate("users.view", { id: "1" });
 
@@ -112,7 +118,10 @@ describe("createActiveRouteSources", () => {
   it("ignoreQueryParams=true (default): isActiveRoute called with ignoreQueryParams=true", async () => {
     const spy = vi.spyOn(router, "isActiveRoute");
 
-    createActiveRouteSource(router, "users");
+    const source = createActiveRouteSource(router, "users");
+
+    // Lazy: connect so the subscribe handler runs on navigation (#766).
+    source.subscribe(() => {});
 
     spy.mockClear();
 
@@ -124,9 +133,12 @@ describe("createActiveRouteSources", () => {
   it("ignoreQueryParams=false: isActiveRoute called with ignoreQueryParams=false", async () => {
     const spy = vi.spyOn(router, "isActiveRoute");
 
-    createActiveRouteSource(router, "users", undefined, {
+    const source = createActiveRouteSource(router, "users", undefined, {
       ignoreQueryParams: false,
     });
+
+    // Lazy: connect so the subscribe handler runs on navigation (#766).
+    source.subscribe(() => {});
 
     spy.mockClear();
 
@@ -275,6 +287,32 @@ describe("createActiveRouteSources", () => {
     unsubscribe();
   });
 
+  it("reconnect: active state changed while disconnected is reconciled on re-subscribe (#766)", async () => {
+    const source = createActiveRouteSource(router, "users");
+
+    // Connect at "home" (users inactive), then drop the last listener so the
+    // lazy source disconnects from the router.
+    const unsub1 = source.subscribe(() => {});
+
+    expect(source.getSnapshot()).toBe(false);
+
+    unsub1();
+
+    // Navigate into the "users" subtree while the source has ZERO listeners.
+    await router.navigate("users.view", { id: "1" });
+
+    // Re-subscribe: onFirstSubscribe reconciles the boolean to the current
+    // router state (true) instead of replaying the stale `false`, and notifies
+    // the just-added listener.
+    const listener = vi.fn();
+    const unsub2 = source.subscribe(listener);
+
+    expect(source.getSnapshot()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsub2();
+  });
+
   describe("hash-aware active state (#532)", () => {
     function makeRouterWithUrlContext(initialHash = ""): Router {
       const r = createRouter([
@@ -391,6 +429,9 @@ describe("createActiveRouteSources", () => {
 
       const source = createActiveRouteSource(r, "settings");
 
+      // Lazy source tracks navigations only while subscribed (#766).
+      source.subscribe(() => {});
+
       expect(source.getSnapshot()).toBe(true);
 
       // Navigate to ensure subscribe path runs with hash === undefined —
@@ -413,6 +454,10 @@ describe("createActiveRouteSources", () => {
       const source = createActiveRouteSource(r, "settings", undefined, {
         hash: "billing",
       });
+
+      // Lazy: subscribe so the handler runs on navigation and exercises the
+      // hashFlip branch with a missing state.context.url (#766).
+      source.subscribe(() => {});
 
       // No URL plugin → state.context.url undefined → readContextHash returns ""
       // → does not equal "billing" → not active.

--- a/packages/sources/tests/unit/createDismissableError.test.ts
+++ b/packages/sources/tests/unit/createDismissableError.test.ts
@@ -69,6 +69,32 @@ describe("createDismissableError", () => {
     unsub();
   });
 
+  it("error before first subscribe is caught up on subscribe (#765.2)", async () => {
+    const source = createDismissableError(router); // zero subscribers
+
+    // Error while the wrapper has ZERO subscribers — only the eager underlying
+    // getErrorSource captures it; the wrapper snapshot stays stale until the
+    // catch-up reconcile on first subscribe.
+    await expect(router.navigate("nonexistent")).rejects.toThrow(
+      /ROUTE_NOT_FOUND/,
+    );
+
+    let notified = 0;
+    const unsub = source.subscribe(() => {
+      notified++;
+    });
+
+    const snap = source.getSnapshot();
+
+    expect(snap.error).not.toBeNull();
+    expect(snap.error!.code).toBe("ROUTE_NOT_FOUND");
+    // The listener (added before onFirstSubscribe by BaseSource) observes the
+    // catch-up notification.
+    expect(notified).toBe(1);
+
+    unsub();
+  });
+
   it("resetError() hides current error", async () => {
     const source = createDismissableError(router);
     const unsub = source.subscribe(() => {});

--- a/packages/sources/tests/unit/createErrorSource.test.ts
+++ b/packages/sources/tests/unit/createErrorSource.test.ts
@@ -33,6 +33,16 @@ describe("createErrorSource", () => {
     });
   });
 
+  it("initial snapshot is frozen — shared singleton cannot be corrupted by a consumer (#768)", () => {
+    // INITIAL_SNAPSHOT is shared across every error source of every router
+    // until the first error. Mirrors the frozen IDLE_SNAPSHOT of
+    // createTransitionSource — a consumer mutating it would corrupt the shared
+    // singleton for all consumers.
+    const source = createErrorSource(router);
+
+    expect(Object.isFrozen(source.getSnapshot())).toBe(true);
+  });
+
   it("TRANSITION_ERROR updates snapshot", async () => {
     const lifecycle = getLifecycleApi(router);
 

--- a/packages/sources/tests/unit/createRouteStore.test.ts
+++ b/packages/sources/tests/unit/createRouteStore.test.ts
@@ -127,28 +127,38 @@ describe("createRouteSources", () => {
     const source = createRouteSource(router);
     const listener = vi.fn();
 
-    // Step 1: pre-fill source with route="/users" and previousRoute="/" by
-    // navigating before subscribe so the initial snapshot reflects post-nav.
+    source.subscribe(listener);
+
+    // Settle into a steady state where route AND previousRoute share path
+    // "/users": the first force-nav flips previousRoute from "/" to "/users"
+    // (path change → update fires), after which both fields sit on "/users".
+    await router.navigate("users");
+    await router.navigate("users", {}, { force: true });
+
+    const callsAfterSetup = listener.mock.calls.length;
+
+    // A fully idempotent force-nav now: route "/users" and previousRoute
+    // "/users" both stabilize to prev (matched paths, no reload) → no update.
+    await router.navigate("users", {}, { force: true });
+
+    expect(listener).toHaveBeenCalledTimes(callsAfterSetup);
+  });
+
+  it("navigation before first subscribe is reconciled on subscribe (#765)", async () => {
+    const source = createRouteSource(router);
+    const listener = vi.fn();
+
+    // Navigate while the lazy source has ZERO listeners (never connected) — the
+    // snapshot is stale until the catch-up reconcile on first subscribe.
     await router.navigate("users");
 
     source.subscribe(listener);
 
-    // Step 2: force-navigate to "/users" again — path unchanged. With my
-    // fix, transition.reload is unset → stabilizer returns prev for both
-    // route and previousRoute (matched paths). False branch hit, source
-    // listener NOT called.
-    await router.navigate("users", {}, { force: true });
-
-    // After force-nav: prev.previousRoute had path "/" (initial), but
-    // next.previousRoute has path "/users". Paths differ → stabilizer
-    // returns next → update fires.
-    expect(listener).toHaveBeenCalledTimes(1);
-
-    // Step 3: force-navigate again — now prev.previousRoute and
-    // next.previousRoute both have path "/users", and same for route.
-    // Both branches stabilize to prev → false branch hit.
-    await router.navigate("users", {}, { force: true });
-
+    // onFirstSubscribe reconciles route to the current state; the listener
+    // (added before onFirstSubscribe by BaseSource) observes the catch-up.
+    // previousRoute is undefined — a catch-up is a snap, not an observed nav.
+    expect(source.getSnapshot().route?.name).toBe("users");
+    expect(source.getSnapshot().previousRoute).toBeUndefined();
     expect(listener).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

Batch of `@real-router/sources` fixes from the 6-adapter Fable audit — the root-cause sources defects behind the #777 adapter caveats — plus the coupled docs cleanup. One PR, one CI run; four independent commits (one per issue).

Closes #765
Closes #766
Closes #767
Closes #768

## Changes

- **#765 — reconnect staleness (patch).** `createRouteSource` and `createDismissableError` now reconcile their snapshot with the current router state on first subscribe, so a navigation / error that happened while the source had **zero subscribers** (a `RouterProvider` under a React `<Activity>` hide→navigate→show cycle, all readers gated behind a Svelte `{#if}`, or a `RouterErrorBoundary` mounted after a boot-time error) is caught up on re-subscribe instead of replaying a stale value. `createRouteSource` reconciles only when the route actually changed (no spurious re-render on a no-nav hide/show); `previousRoute` resets to `undefined` on catch-up (the real previous can't be reconstructed outside a live subscribe payload).

- **#766 — active-route listener-limit crash (minor, BREAKING).** `createActiveRouteSource` was **eager** (subscribed at construction with a no-op `destroy()`), so each unique cache key held a permanent `router.subscribe` handle that survived all Link unmounts — a long-lived router with per-item-params Links accumulated handles until the `EventEmitter` listener limit (10000) threw in the render path. It now uses the **lazy connection** the docs already promised: subscribe on first listener, disconnect on last, reconcile on re-subscribe. **BREAKING:** the snapshot no longer updates while the source has zero subscribers (framework adapters bridging via `useSyncExternalStore` / signals are unaffected).

- **#767 — selector exception isolation (patch).** `createActiveNameSelector`'s notification loop now isolates each listener (`try/catch` + `queueMicrotask` re-throw, mirroring `BaseSource.notify`) — one throwing Link no longer freezes its sibling Links' active state, nor every later route name in the iteration.

- **#768 — freeze `INITIAL_SNAPSHOT` + docs (patch).** `createErrorSource`'s shared `INITIAL_SNAPSHOT` is now `Object.freeze`d (mirrors `IDLE_SNAPSHOT`); INVARIANTS "Cache Identity 3" / ARCHITECTURE filtering pipeline / `canonicalJson` JSDoc corrected; a stale `createRouteSource` test comment fixed.

## Validation

Per-package (`@real-router/sources`): type-check ✓, lint ✓, unit+functional **255 ✓ (100% coverage)**, property **183 ✓**, stress **77 ✓**. RED→GREEN per bug — including the new stress **S12.5**, which creates >10000 unique sources and crashed pre-fix at the listener limit. Full cross-package build delegated (adapters consume `@real-router/sources` at runtime; public signatures unchanged).

## Notes

#765/#766 close the staleness/crash windows the #777 adapter caveats warn about. Those caveats (react/svelte/solid/angular/vue `CLAUDE.md`) can be softened in a follow-up once this ships.
