### PR TITLE
fix(#778): RouterErrorBoundary sees a pre-mount navigation error (P2, all 6 adapters)

### DIFF
--- a/.changeset/angular-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/angular-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/angular": patch
+---
+
+fix(angular): RouterErrorBoundary instantiated after an error shows the error (#778)
+
+`provideRealRouter` now eagerly creates the per-router error source at bootstrap (via a `provideEnvironmentInitializer`), so a navigation error that fires BEFORE a `RouterErrorBoundary` is instantiated (a lazily-rendered error region, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary is created. Previously the boundary created the error source lazily on init — after the error had already fired with no subscriber — so it never rendered. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/.changeset/preact-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/preact-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preact": patch
+---
+
+fix(preact): RouterErrorBoundary mounted after an error shows the fallback (#778)
+
+`RouterProvider` now eagerly creates the per-router error source at mount, so a navigation error that fires BEFORE a `RouterErrorBoundary` mounts (a lazily-loaded app shell, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary mounts. Previously the boundary created the error source lazily on mount — after the error had already fired with no subscriber — so the fallback never appeared. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/.changeset/react-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/react-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": patch
+---
+
+fix(react): RouterErrorBoundary mounted after an error shows the fallback (#778)
+
+`RouterProvider` now eagerly creates the per-router error source at mount, so a navigation error that fires BEFORE a `RouterErrorBoundary` mounts (a lazily-loaded app shell, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary mounts. Previously the boundary created the error source lazily on mount — after the error had already fired with no subscriber — so the fallback never appeared. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/.changeset/solid-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/solid-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/solid": patch
+---
+
+fix(solid): RouterErrorBoundary mounted after an error shows the fallback (#778)
+
+`RouterProvider` now eagerly creates the per-router error source at mount, so a navigation error that fires BEFORE a `RouterErrorBoundary` mounts (a lazily-loaded app shell, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary mounts. Previously the boundary created the error source lazily on mount — after the error had already fired with no subscriber — so the fallback never appeared. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/.changeset/sources-prime-error-source-778.md
+++ b/.changeset/sources-prime-error-source-778.md
@@ -1,0 +1,7 @@
+---
+"@real-router/sources": minor
+---
+
+feat(sources): add `primeErrorSource(router)` — tolerant eager error-source priming (#778)
+
+`primeErrorSource(router)` eagerly creates (and subscribes) the per-router error source when the router supports the plugin API, and is a no-op otherwise. Framework adapters' `RouterProvider` call it at mount so a navigation error that fires before a `RouterErrorBoundary` mounts is still captured — without crashing on a router-like that has no internals-registry entry (a test stub, an `Object.create`-derived object). `getErrorSource` stays strict (throws for an invalid router); `primeErrorSource` is the don't-crash-the-Provider wrapper the boundary-pre-mount-error fix relies on.

--- a/.changeset/svelte-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/svelte-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/svelte": patch
+---
+
+fix(svelte): RouterErrorBoundary mounted after an error shows the fallback (#778)
+
+`RouterProvider` now eagerly creates the per-router error source at mount, so a navigation error that fires BEFORE a `RouterErrorBoundary` mounts (a lazily-loaded app shell, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary mounts. Previously the boundary created the error source lazily on mount — after the error had already fired with no subscriber — so the fallback never appeared. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/.changeset/vue-boundary-pre-mount-error-778-fix.md
+++ b/.changeset/vue-boundary-pre-mount-error-778-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/vue": patch
+---
+
+fix(vue): RouterErrorBoundary mounted after an error shows the fallback (#778)
+
+`RouterProvider` now eagerly creates the per-router error source at mount, so a navigation error that fires BEFORE a `RouterErrorBoundary` mounts (a lazily-loaded app shell, a failed boot navigation — the ordinary load order) is captured and surfaced once the boundary mounts. Previously the boundary created the error source lazily on mount — after the error had already fired with no subscriber — so the fallback never appeared. Pairs with the #765 reconnect-reconcile fix: the boundary's `createDismissableError` catches up to the already-captured error on first subscribe.

--- a/packages/angular/src/providers.ts
+++ b/packages/angular/src/providers.ts
@@ -5,7 +5,7 @@ import {
   type EnvironmentProviders,
 } from "@angular/core";
 import { getNavigator, type Router, type Navigator } from "@real-router/core";
-import { createRouteSource } from "@real-router/sources";
+import { createRouteSource, getErrorSource } from "@real-router/sources";
 
 import {
   installScrollRestoration,
@@ -50,6 +50,15 @@ export function provideRealRouter(
         navigator,
       }),
     },
+    // #778 P2: eagerly create the per-router error source at bootstrap so a
+    // navigation error that fires BEFORE a RouterErrorBoundary is instantiated
+    // (a lazily-rendered shell, a failed boot navigation) is still captured. The
+    // boundary's createDismissableError reuses this cached source and catches up
+    // (#765); without it the error source is created lazily on boundary init —
+    // after the error — and never sees it.
+    provideEnvironmentInitializer(() => {
+      getErrorSource(router);
+    }),
   ];
 
   if (options?.scrollRestoration) {

--- a/packages/angular/src/providers.ts
+++ b/packages/angular/src/providers.ts
@@ -5,7 +5,7 @@ import {
   type EnvironmentProviders,
 } from "@angular/core";
 import { getNavigator, type Router, type Navigator } from "@real-router/core";
-import { createRouteSource, getErrorSource } from "@real-router/sources";
+import { createRouteSource, primeErrorSource } from "@real-router/sources";
 
 import {
   installScrollRestoration,
@@ -57,7 +57,7 @@ export function provideRealRouter(
     // (#765); without it the error source is created lazily on boundary init —
     // after the error — and never sees it.
     provideEnvironmentInitializer(() => {
-      getErrorSource(router);
+      primeErrorSource(router);
     }),
   ];
 

--- a/packages/angular/tests/functional/reactive-lifecycle.test.ts
+++ b/packages/angular/tests/functional/reactive-lifecycle.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/no-extraneous-class -- Angular test host components use empty classes with @Component decorators */
 import {
+  Component,
   createEnvironmentInjector,
   effect,
   EnvironmentInjector,
@@ -6,12 +8,14 @@ import {
   signal,
 } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { createRouter } from "@real-router/core";
 import { createActiveRouteSource } from "@real-router/sources";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
+import { RouterErrorBoundary } from "../../src/components/RouterErrorBoundary";
 import { injectRouteNode } from "../../src/functions/injectRouteNode";
-import { provideRealRouter } from "../../src/providers";
+import { provideRealRouter, ROUTER } from "../../src/providers";
 
 import type { Params, Router } from "@real-router/core";
 
@@ -145,5 +149,44 @@ describe("reactive lifecycle (#778)", () => {
 
     scope.destroy();
     vi.restoreAllMocks();
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary is instantiated (the ordinary load order — a lazily
+  // rendered error region, or a failed boot navigation) is invisible to a
+  // boundary that creates its error source lazily on init, AFTER the error.
+  // provideRealRouter now eagerly creates the per-router error source at
+  // bootstrap (a provideEnvironmentInitializer), so it captures the error from
+  // app init; the boundary's createDismissableError catches up (#765) and
+  // renders the error.
+  it("P2: a RouterErrorBoundary instantiated AFTER a navigation error shows the error", async () => {
+    @Component({
+      template: `<router-error-boundary
+        ><span>app</span></router-error-boundary
+      >`,
+      imports: [RouterErrorBoundary],
+    })
+    class BoundaryHost {}
+
+    // Instantiate the environment injector so the #778 P2 initializer eagerly
+    // subscribes getErrorSource BEFORE the error fires.
+    TestBed.inject(ROUTER);
+
+    // Navigation error BEFORE the boundary is created.
+    await router.navigate("nonexistent").catch(() => {});
+
+    // Now create the boundary (e.g. a lazily-rendered error region).
+    const fixture = TestBed.createComponent(BoundaryHost);
+
+    fixture.detectChanges();
+
+    const boundary = fixture.debugElement.query(
+      By.directive(RouterErrorBoundary),
+    ).componentInstance as RouterErrorBoundary;
+
+    const ctx = boundary.errorContext();
+
+    expect(ctx).not.toBeNull();
+    expect(ctx!.$implicit.code).toBe("ROUTE_NOT_FOUND");
   });
 });

--- a/packages/preact/src/RouterProvider.tsx
+++ b/packages/preact/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource } from "@real-router/sources";
+import { createRouteSource, getErrorSource } from "@real-router/sources";
 import { useEffect, useMemo } from "preact/hooks";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
@@ -120,6 +120,15 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
   // change identity and trigger an unsubscribe/resubscribe loop on every
   // render. `useMemo([router])` gives one source per router-instance lifetime.
   const store = useMemo(() => createRouteSource(router), [router]);
+
+  // #778 P2: eagerly create the per-router error source so a navigation error
+  // that fires BEFORE a RouterErrorBoundary mounts (a lazy app shell, a failed
+  // boot navigation) is still captured. The boundary's createDismissableError
+  // reuses this cached source and catches up (#765); without it the error source
+  // is created lazily on boundary mount — after the error — and never sees it.
+  useEffect(() => {
+    getErrorSource(router);
+  }, [router]);
 
   // useSyncExternalStore manages the router subscription lifecycle:
   // subscribe connects to router on first listener, unsubscribes on last.

--- a/packages/preact/src/RouterProvider.tsx
+++ b/packages/preact/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource, getErrorSource } from "@real-router/sources";
+import { createRouteSource, primeErrorSource } from "@real-router/sources";
 import { useEffect, useMemo } from "preact/hooks";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
@@ -127,7 +127,7 @@ export const RouterProvider: FunctionComponent<RouteProviderProps> = ({
   // reuses this cached source and catches up (#765); without it the error source
   // is created lazily on boundary mount — after the error — and never sees it.
   useEffect(() => {
-    getErrorSource(router);
+    primeErrorSource(router);
   }, [router]);
 
   // useSyncExternalStore manages the router subscription lifecycle:

--- a/packages/preact/tests/integration/reactive-lifecycle.test.tsx
+++ b/packages/preact/tests/integration/reactive-lifecycle.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, act } from "@testing-library/preact";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
-import { useRoute, useRouteNode, RouterProvider } from "@real-router/preact";
+import {
+  useRoute,
+  useRouteNode,
+  RouterErrorBoundary,
+  RouterProvider,
+} from "@real-router/preact";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
@@ -103,5 +108,43 @@ describe("reactive lifecycle (#778)", () => {
     rerender(<Tree show />);
 
     expect(screen.getByTestId("node").textContent).toBe("users.view");
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary mounts (the ordinary load order — a lazy app shell, or a
+  // failed boot navigation) is invisible to a boundary that creates its error
+  // source lazily on mount, AFTER the error. RouterProvider now eagerly creates
+  // the per-router error source, so it captures the error from Provider mount;
+  // the boundary's createDismissableError catches up (#765) and shows the
+  // fallback.
+  it("P2: a RouterErrorBoundary mounted AFTER a navigation error shows the fallback", async () => {
+    await router.start("/users/list");
+
+    const Shell = ({ withBoundary }: { withBoundary: boolean }) => (
+      <RouterProvider router={router}>
+        {withBoundary ? (
+          <RouterErrorBoundary
+            fallback={(error) => <div data-testid="fb">{error.code}</div>}
+          >
+            <div>app</div>
+          </RouterErrorBoundary>
+        ) : (
+          <div>app</div>
+        )}
+      </RouterProvider>
+    );
+
+    const { rerender } = render(<Shell withBoundary={false} />);
+
+    // Navigation error BEFORE the boundary mounts.
+    await act(async () => {
+      await router.navigate("nonexistent").catch(() => {});
+    });
+
+    // Mount the boundary now (e.g. a lazily-loaded app shell).
+    rerender(<Shell withBoundary />);
+
+    expect(screen.getByTestId("fb")).not.toBeNull();
+    expect(screen.getByTestId("fb").textContent).toBe("ROUTE_NOT_FOUND");
   });
 });

--- a/packages/react/src/RouterProvider.tsx
+++ b/packages/react/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource } from "@real-router/sources";
+import { createRouteSource, getErrorSource } from "@real-router/sources";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
@@ -125,6 +125,15 @@ export const RouterProvider: FC<RouteProviderProps> = ({
   // ABOVE any Activity boundary — see the "Keep RouterProvider above any
   // <Activity> / keepAlive boundary" gotcha in CLAUDE.md.
   const store = useMemo(() => createRouteSource(router), [router]);
+
+  // #778 P2: eagerly create the per-router error source so a navigation error
+  // that fires BEFORE a RouterErrorBoundary mounts (a lazy app shell, a failed
+  // boot navigation) is still captured. The boundary's createDismissableError
+  // reuses this cached source and catches up (#765); without it the error source
+  // is created lazily on boundary mount — after the error — and never sees it.
+  useEffect(() => {
+    getErrorSource(router);
+  }, [router]);
   // Use snapshot reference directly. createRouteSource via stabilizeState
   // returns the SAME snapshot reference when route.path is unchanged, so
   // useMemo below sees stable deps for idempotent navigations and

--- a/packages/react/src/RouterProvider.tsx
+++ b/packages/react/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource, getErrorSource } from "@real-router/sources";
+import { createRouteSource, primeErrorSource } from "@real-router/sources";
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 
 import { NavigatorContext, RouteContext, RouterContext } from "./context";
@@ -132,7 +132,7 @@ export const RouterProvider: FC<RouteProviderProps> = ({
   // reuses this cached source and catches up (#765); without it the error source
   // is created lazily on boundary mount — after the error — and never sees it.
   useEffect(() => {
-    getErrorSource(router);
+    primeErrorSource(router);
   }, [router]);
   // Use snapshot reference directly. createRouteSource via stabilizeState
   // returns the SAME snapshot reference when route.path is unchanged, so

--- a/packages/react/tests/integration/reactive-lifecycle.test.tsx
+++ b/packages/react/tests/integration/reactive-lifecycle.test.tsx
@@ -2,7 +2,12 @@ import { act, render, screen } from "@testing-library/react";
 import { Activity } from "react";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
-import { Link, RouterProvider, useRoute } from "@real-router/react";
+import {
+  Link,
+  RouterErrorBoundary,
+  RouterProvider,
+  useRoute,
+} from "@real-router/react";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
@@ -17,7 +22,9 @@ describe("reactive lifecycle (#778)", () => {
   beforeEach(async () => {
     router = createTestRouterWithADefaultRouter();
     await router.start();
-    await router.navigate("users.list");
+    // .catch: browser-plugin shares jsdom's window.location across tests, so a
+    // prior test may have left us on /users/list → SAME_STATES (harmless here).
+    await router.navigate("users.list").catch(() => {});
   });
 
   afterEach(() => {
@@ -121,5 +128,45 @@ describe("reactive lifecycle (#778)", () => {
     expect(active).toBeLessThanOrEqual(2);
 
     vi.restoreAllMocks();
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary mounts (the ordinary load order — a lazy app shell, or
+  // a failed boot navigation) is invisible to a boundary that creates its error
+  // source lazily on mount, AFTER the error. RouterProvider now eagerly creates
+  // the per-router error source, so it captures the error from Provider mount;
+  // the boundary's createDismissableError catches up (#765) and shows the
+  // fallback.
+  it("P2: a RouterErrorBoundary mounted AFTER a navigation error shows the fallback", async () => {
+    const Shell = ({
+      withBoundary,
+    }: {
+      withBoundary: boolean;
+    }): React.JSX.Element => (
+      <RouterProvider router={router}>
+        {withBoundary ? (
+          <RouterErrorBoundary
+            fallback={(error) => <div data-testid="fb">{error.code}</div>}
+          >
+            <div>app</div>
+          </RouterErrorBoundary>
+        ) : (
+          <div>app</div>
+        )}
+      </RouterProvider>
+    );
+
+    const { rerender } = render(<Shell withBoundary={false} />);
+
+    // Navigation error BEFORE the boundary mounts.
+    await act(async () => {
+      await router.navigate("nonexistent").catch(() => {});
+    });
+
+    // Mount the boundary now (e.g. a lazily-loaded app shell).
+    rerender(<Shell withBoundary />);
+
+    expect(screen.getByTestId("fb")).not.toBeNull();
+    expect(screen.getByTestId("fb").textContent).toBe("ROUTE_NOT_FOUND");
   });
 });

--- a/packages/solid/src/RouterProvider.tsx
+++ b/packages/solid/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource, getErrorSource } from "@real-router/sources";
+import { createRouteSource, primeErrorSource } from "@real-router/sources";
 import { createSelector, onCleanup, onMount } from "solid-js";
 
 import { RouterContext, RouteContext } from "./context";
@@ -69,7 +69,7 @@ export function RouterProvider(
   // boot navigation) is still captured. The boundary's createDismissableError
   // reuses this cached source and catches up (#765); without it the error source
   // is created lazily on boundary mount — after the error — and never sees it.
-  getErrorSource(props.router);
+  primeErrorSource(props.router);
 
   const routeSignal = createSignalFromSource(routeSource);
 

--- a/packages/solid/src/RouterProvider.tsx
+++ b/packages/solid/src/RouterProvider.tsx
@@ -1,5 +1,5 @@
 import { getNavigator } from "@real-router/core";
-import { createRouteSource } from "@real-router/sources";
+import { createRouteSource, getErrorSource } from "@real-router/sources";
 import { createSelector, onCleanup, onMount } from "solid-js";
 
 import { RouterContext, RouteContext } from "./context";
@@ -63,6 +63,14 @@ export function RouterProvider(
   // below ride on top of it.
   const navigator = getNavigator(props.router);
   const routeSource = createRouteSource(props.router);
+
+  // #778 P2: eagerly create the per-router error source so a navigation error
+  // that fires BEFORE a RouterErrorBoundary mounts (a lazy app shell, a failed
+  // boot navigation) is still captured. The boundary's createDismissableError
+  // reuses this cached source and catches up (#765); without it the error source
+  // is created lazily on boundary mount — after the error — and never sees it.
+  getErrorSource(props.router);
+
   const routeSignal = createSignalFromSource(routeSource);
 
   const routeSelector = createSelector(

--- a/packages/solid/tests/functional/reactive-lifecycle.test.tsx
+++ b/packages/solid/tests/functional/reactive-lifecycle.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@solidjs/testing-library";
 import { createSignal, Show } from "solid-js";
 import { describe, afterEach, it, expect } from "vitest";
 
-import { createSignalFromSource } from "@real-router/solid";
+import {
+  createSignalFromSource,
+  RouterErrorBoundary,
+  RouterProvider,
+} from "@real-router/solid";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
@@ -63,5 +67,41 @@ describe("reactive lifecycle (#778)", () => {
     setShow(true);
 
     expect(screen.getByTestId("reader").textContent).toBe("about");
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary mounts (the ordinary load order — a lazy app shell, or a
+  // failed boot navigation) is invisible to a boundary that creates its error
+  // source lazily on mount, AFTER the error. RouterProvider now eagerly creates
+  // the per-router error source, so it captures the error from Provider mount;
+  // the boundary's createDismissableError catches up (#765) and shows the
+  // fallback.
+  it("P2: a RouterErrorBoundary mounted AFTER a navigation error shows the fallback", async () => {
+    router = createTestRouterWithADefaultRouter();
+
+    await router.start();
+
+    const [show, setShow] = createSignal(false);
+
+    render(() => (
+      <RouterProvider router={router}>
+        <Show when={show()} fallback={<div>app</div>}>
+          <RouterErrorBoundary
+            fallback={(error) => <div data-testid="fb">{error.code}</div>}
+          >
+            <div>app</div>
+          </RouterErrorBoundary>
+        </Show>
+      </RouterProvider>
+    ));
+
+    // Navigation error BEFORE the boundary mounts.
+    await router.navigate("nonexistent").catch(() => {});
+
+    // Mount the boundary now (e.g. a lazily-loaded app shell).
+    setShow(true);
+
+    expect(screen.getByTestId("fb")).not.toBeNull();
+    expect(screen.getByTestId("fb").textContent).toBe("ROUTE_NOT_FOUND");
   });
 });

--- a/packages/sources/CLAUDE.md
+++ b/packages/sources/CLAUDE.md
@@ -15,6 +15,7 @@
 | `getTransitionSource(router)` | Transition state — **per-router cached**, safe for adapters |
 | `createErrorSource(router)` | Navigation error observable — **non-cached** advanced-use factory |
 | `getErrorSource(router)` | Navigation error — **per-router cached**, safe for adapters |
+| `primeErrorSource(router)` | **Side-effect only** (returns `void`) — eagerly create+subscribe `getErrorSource` IF the router is registered, else no-op. Adapters' `RouterProvider` call it at mount so a boundary mounting after an error still sees it (#778), without crashing on a router-like with no internals (test stub / `Object.create` clone). `getErrorSource` stays strict (throws); this is the don't-crash-the-Provider wrapper. |
 | `createDismissableError(router)` | Dismissable error wrapper over `getErrorSource` — **per-router cached**, snapshot includes `resetError` |
 | `createActiveNameSelector(router)` | O(1) active-name checker — **per-router cached** shared selector (Link fast-path) |
 

--- a/packages/sources/src/createErrorSource.ts
+++ b/packages/sources/src/createErrorSource.ts
@@ -113,3 +113,25 @@ export function getErrorSource(
 
   return cached;
 }
+
+/**
+ * Eagerly create (and thus subscribe) the per-router error source IF the router
+ * supports the plugin API — used by framework adapters' `RouterProvider` to
+ * capture a navigation error that fires BEFORE a `RouterErrorBoundary` mounts
+ * (#778). A router-like without an internals-registry entry (a test stub, an
+ * `Object.create`-derived object, or anything not produced by `createRouter`)
+ * makes `getErrorSource` throw via `getPluginApi`; here that degrades to a no-op.
+ *
+ * The asymmetry is deliberate: `createRouteSource` tolerates such routers (it is
+ * lazy and only touches `router.subscribe`), so a Provider that eagerly primes
+ * the stricter error source must not crash where the route source would not. A
+ * boundary mounting later still creates the error source lazily and surfaces a
+ * genuine invalid-router error there.
+ */
+export function primeErrorSource(router: Router): void {
+  try {
+    getErrorSource(router);
+  } catch {
+    // Router has no internals-registry entry — nothing to prime eagerly.
+  }
+}

--- a/packages/sources/src/index.ts
+++ b/packages/sources/src/index.ts
@@ -19,7 +19,11 @@ export {
   getTransitionSource,
 } from "./createTransitionSource";
 
-export { createErrorSource, getErrorSource } from "./createErrorSource";
+export {
+  createErrorSource,
+  getErrorSource,
+  primeErrorSource,
+} from "./createErrorSource";
 
 export { createDismissableError } from "./createDismissableError";
 

--- a/packages/sources/tests/unit/createErrorSource.test.ts
+++ b/packages/sources/tests/unit/createErrorSource.test.ts
@@ -2,7 +2,7 @@ import { createRouter, errorCodes } from "@real-router/core";
 import { getLifecycleApi } from "@real-router/core/api";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { createErrorSource } from "../../src";
+import { createErrorSource, getErrorSource, primeErrorSource } from "../../src";
 
 import type { Router } from "@real-router/core";
 
@@ -279,6 +279,49 @@ describe("createErrorSource", () => {
     expect(listener).not.toHaveBeenCalled();
     expect(() => {
       unsubscribe();
+    }).not.toThrow();
+  });
+});
+
+describe("primeErrorSource (#778)", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    router = createRouter([
+      { name: "home", path: "/" },
+      { name: "dashboard", path: "/dashboard" },
+    ]);
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+  });
+
+  it("eagerly subscribes the error source so an error fired before getErrorSource is captured", async () => {
+    // Prime BEFORE the error. Without it, the first getErrorSource call AFTER
+    // the error would create the eager source too late and miss it (the #778
+    // boundary-after-error window).
+    primeErrorSource(router);
+
+    await expect(router.navigate("nonexistent")).rejects.toThrow();
+
+    // getErrorSource returns the SAME cached source the prime created — it was
+    // subscribed in time, so it captured the error.
+    const snap = getErrorSource(router).getSnapshot();
+
+    expect(snap.error?.code).toBe(errorCodes.ROUTE_NOT_FOUND);
+  });
+
+  it("is a no-op (does not throw) for a router with no internals-registry entry", () => {
+    // An Object.create-derived router-like (a test stub, or a not-yet-registered
+    // clone) has a fresh identity → getPluginApi/getInternals throws. prime must
+    // swallow it so a Provider eagerly priming the error source never crashes on
+    // a router the lazy route source would tolerate.
+    const stub = Object.create(router) as Router;
+
+    expect(() => {
+      primeErrorSource(stub);
     }).not.toThrow();
   });
 });

--- a/packages/svelte/src/RouterProvider.svelte
+++ b/packages/svelte/src/RouterProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getNavigator } from "@real-router/core";
-  import { createRouteSource, getErrorSource } from "@real-router/sources";
+  import { createRouteSource, primeErrorSource } from "@real-router/sources";
   import {
     createRouteAnnouncer,
     createScrollRestoration,
@@ -111,7 +111,7 @@
   // reuses this cached source and catches up (#765); without it the error source
   // is created lazily on boundary mount — after the error — and never sees it.
   // svelte-ignore state_referenced_locally
-  getErrorSource(router);
+  primeErrorSource(router);
   const reactive = createReactiveSource(source);
   const routeContext = createRouteContext(navigator, reactive);
 

--- a/packages/svelte/src/RouterProvider.svelte
+++ b/packages/svelte/src/RouterProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getNavigator } from "@real-router/core";
-  import { createRouteSource } from "@real-router/sources";
+  import { createRouteSource, getErrorSource } from "@real-router/sources";
   import {
     createRouteAnnouncer,
     createScrollRestoration,
@@ -105,6 +105,13 @@
   // svelte-ignore state_referenced_locally
   // The route source intentionally captures the initial router instance.
   const source = createRouteSource(router);
+  // #778 P2: eagerly create the per-router error source so a navigation error
+  // that fires BEFORE a RouterErrorBoundary mounts (a lazy app shell, a failed
+  // boot navigation) is still captured. The boundary's createDismissableError
+  // reuses this cached source and catches up (#765); without it the error source
+  // is created lazily on boundary mount — after the error — and never sees it.
+  // svelte-ignore state_referenced_locally
+  getErrorSource(router);
   const reactive = createReactiveSource(source);
   const routeContext = createRouteContext(navigator, reactive);
 

--- a/packages/svelte/tests/functional/reactive-lifecycle.test.ts
+++ b/packages/svelte/tests/functional/reactive-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { flushSync } from "svelte";
 import { describe, afterEach, it, expect } from "vitest";
 
 import { createTestRouterWithADefaultRouter } from "../helpers";
+import GatedErrorBoundary from "../helpers/GatedErrorBoundary.svelte";
 import GatedRouteReader from "../helpers/GatedRouteReader.svelte";
 
 import type { Router } from "@real-router/core";
@@ -50,5 +51,35 @@ describe("reactive lifecycle (#778)", () => {
     flushSync();
 
     expect(screen.getByTestId("route-name").textContent).toBe("about");
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary mounts (the ordinary load order — a lazy app shell, or a
+  // failed boot navigation) is invisible to a boundary that creates its error
+  // source lazily on mount, AFTER the error. RouterProvider now eagerly creates
+  // the per-router error source, so it captures the error from Provider mount;
+  // the boundary's createDismissableError catches up (#765) and shows the
+  // fallback.
+  it("P2: a RouterErrorBoundary mounted AFTER a navigation error shows the fallback", async () => {
+    router = createTestRouterWithADefaultRouter();
+
+    await router.start();
+
+    const { rerender } = render(GatedErrorBoundary, {
+      props: { router, show: false },
+    });
+
+    flushSync();
+
+    // Navigation error BEFORE the boundary mounts.
+    await router.navigate("nonexistent").catch(() => {});
+    flushSync();
+
+    // Mount the boundary now (e.g. a lazily-loaded app shell).
+    await rerender({ router, show: true });
+    flushSync();
+
+    expect(screen.getByTestId("fb")).not.toBeNull();
+    expect(screen.getByTestId("fb").textContent).toBe("ROUTE_NOT_FOUND");
   });
 });

--- a/packages/svelte/tests/helpers/GatedErrorBoundary.svelte
+++ b/packages/svelte/tests/helpers/GatedErrorBoundary.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import RouterErrorBoundary from "../../src/components/RouterErrorBoundary.svelte";
+  import TestRouterProvider from "./TestRouterProvider.svelte";
+
+  import type { Router, RouterError } from "@real-router/core";
+
+  // #778 P2 fixture: the RouterErrorBoundary mounts only when `show` is true, so
+  // a test can trigger a navigation error BEFORE the boundary exists and then
+  // mount it. TestRouterProvider wraps the REAL RouterProvider (which eagerly
+  // creates the error source), so the error is captured from Provider mount.
+  let { router, show }: { router: Router; show: boolean } = $props();
+</script>
+
+<TestRouterProvider {router}>
+  {#if show}
+    <RouterErrorBoundary>
+      {#snippet children()}
+        <div>app</div>
+      {/snippet}
+      {#snippet fallback(error: RouterError)}
+        <div data-testid="fb">{error.code}</div>
+      {/snippet}
+    </RouterErrorBoundary>
+  {:else}
+    <div>app</div>
+  {/if}
+</TestRouterProvider>

--- a/packages/vue/src/RouterProvider.ts
+++ b/packages/vue/src/RouterProvider.ts
@@ -1,3 +1,4 @@
+import { getErrorSource } from "@real-router/sources";
 import { defineComponent, onScopeDispose, provide, watch } from "vue";
 
 import { NavigatorKey, RouteKey, RouterKey } from "./context";
@@ -144,6 +145,14 @@ export const RouterProvider = defineComponent({
     // RouterProviders behave like nested DI scopes (LIFO). Release on unmount
     // restores the outer router for any v-link still mounted in the parent.
     const releaseDirective = pushDirectiveRouter(props.router);
+
+    // #778 P2: eagerly create the per-router error source at Provider mount so a
+    // navigation error that fires BEFORE a RouterErrorBoundary mounts (a lazy app
+    // shell, a failed boot navigation) is still captured. The boundary's
+    // createDismissableError reuses this cached source and catches up (#765);
+    // without it the error source is created lazily on boundary mount — after the
+    // error — and never sees it.
+    getErrorSource(props.router);
 
     const { navigator, route, previousRoute, unsubscribe } =
       setupRouteProvision(props.router);

--- a/packages/vue/src/RouterProvider.ts
+++ b/packages/vue/src/RouterProvider.ts
@@ -1,4 +1,4 @@
-import { getErrorSource } from "@real-router/sources";
+import { primeErrorSource } from "@real-router/sources";
 import { defineComponent, onScopeDispose, provide, watch } from "vue";
 
 import { NavigatorKey, RouteKey, RouterKey } from "./context";
@@ -152,7 +152,7 @@ export const RouterProvider = defineComponent({
     // createDismissableError reuses this cached source and catches up (#765);
     // without it the error source is created lazily on boundary mount — after the
     // error — and never sees it.
-    getErrorSource(props.router);
+    primeErrorSource(props.router);
 
     const { navigator, route, previousRoute, unsubscribe } =
       setupRouteProvision(props.router);

--- a/packages/vue/tests/functional/reactive-lifecycle.test.ts
+++ b/packages/vue/tests/functional/reactive-lifecycle.test.ts
@@ -2,11 +2,12 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { describe, afterEach, it, expect } from "vitest";
 import { defineComponent, h, KeepAlive, nextTick, ref } from "vue";
 
+import { RouterErrorBoundary } from "../../src/components/RouterErrorBoundary";
 import { useRouteNode } from "../../src/composables/useRouteNode";
 import { RouterProvider } from "../../src/RouterProvider";
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
-import type { Router } from "@real-router/core";
+import type { Router, RouterError } from "@real-router/core";
 
 // Reactive-lifecycle regression invariants (#778) — the gap the audit flagged:
 // INVARIANTS/property suites cover only pure functions, none asserts that the
@@ -91,6 +92,63 @@ describe("reactive lifecycle (#778)", () => {
     await flushPromises();
 
     expect(wrapper.find("[data-testid='node']").text()).toBe("none");
+
+    wrapper.unmount();
+  });
+
+  // #765 1.2 manifestation: a navigation error that fires BEFORE a
+  // RouterErrorBoundary mounts (the ordinary load order — a lazy app shell, or a
+  // failed boot navigation) is invisible to a boundary that creates its error
+  // source lazily on mount, AFTER the error. RouterProvider now eagerly creates
+  // the per-router error source, so it captures the error from Provider mount;
+  // the boundary's createDismissableError catches up (#765) and shows the
+  // fallback.
+  it("P2: a RouterErrorBoundary mounted AFTER a navigation error shows the fallback", async () => {
+    router = createTestRouterWithADefaultRouter();
+
+    await router.start();
+
+    const showBoundary = ref(false);
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h(
+            RouterProvider,
+            { router },
+            {
+              default: () =>
+                showBoundary.value
+                  ? h(
+                      RouterErrorBoundary,
+                      {
+                        fallback: (error: RouterError) =>
+                          h("div", { "data-testid": "fb" }, error.code),
+                      },
+                      { default: () => h("div", "app") },
+                    )
+                  : h("div", "app"),
+            },
+          );
+      },
+    });
+
+    const wrapper = mount(App);
+
+    await nextTick();
+    await flushPromises();
+
+    // Navigation error BEFORE the boundary mounts.
+    await router.navigate("nonexistent").catch(() => {});
+    await nextTick();
+    await flushPromises();
+
+    // Mount the boundary now (e.g. a lazily-loaded app shell).
+    showBoundary.value = true;
+    await nextTick();
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='fb']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='fb']").text()).toBe("ROUTE_NOT_FOUND");
 
     wrapper.unmount();
   });


### PR DESCRIPTION
Closes #778

Completes #778 (reactive-lifecycle regression invariants — the audit's sources manifestations live in an untested gap). The P1/P3 regression locks and Wave-1 anti-stale guards already landed on `master` directly (test-only — `c10c1147`, `557752c7`). **This PR is P2 — boundary-sees-pre-mount-error** across all 6 adapters, which needs adapter `src` changes (hence a PR + changesets).

## P2 — RouterErrorBoundary sees an error that fired before it mounted

A navigation error during the ordinary boot/load order (a lazily-rendered error region, a failed boot navigation) that fired **before** any `RouterErrorBoundary` mounted was lost: the boundary created its error source lazily on mount — after the error, with no subscriber. Now each `RouterProvider` eagerly **primes** the per-router error source at mount, so the error is captured from Provider mount; the boundary's `createDismissableError` catches up (#765) and shows the fallback.

| Adapter | Eager-prime site |
|---|---|
| react / preact | `useEffect` in `RouterProvider` |
| vue / solid | `setup()` call |
| svelte | `<script>` call |
| angular | `provideEnvironmentInitializer` in `provideRealRouter` |

Each adapter gains a `P2` regression test (RED→GREEN; angular RED-verified by reverting the initializer).

## sources — `primeErrorSource(router)` (tolerant wrapper)

`getErrorSource` validates the router via `getPluginApi` → `getInternals`, which **throws** for a router-like with no internals-registry entry (test stubs, `Object.create` clones, identity-broken mocks). The lazy `createRouteSource` tolerates such routers; the eager error source did not — so a Provider priming it directly crashed those (8 existing adapter tests across vue/svelte/angular that mount the Provider with a stub router and never mount a boundary). New `primeErrorSource(router)` wraps `getErrorSource` in try/catch: eager-subscribe for real routers, no-op for stubs — covered once in `sources`.

## Validation

Per-package type-check + lint + full suites green: react 510 · preact 364 · vue 381 · svelte 269 · solid 368 · angular 356 · **sources 257 (100%)**. Full `pnpm build` deferred to CI.

## Changesets

6 adapter `patch` (boundary-pre-mount-error) + 1 sources `minor` (`primeErrorSource`).
