### PR TITLE
perf(core): reuse EMPTY_PARAMS for empty-params navigation

### DIFF
--- a/.changeset/empty-params-singleton-reuse.md
+++ b/.changeset/empty-params-singleton-reuse.md
@@ -1,0 +1,9 @@
+---
+"@real-router/core": patch
+---
+
+Reuse the `EMPTY_PARAMS` singleton for empty-params navigations (#1027)
+
+`normalizeParams` now returns the shared frozen `EMPTY_PARAMS` singleton when the result is empty (empty input, or every value `undefined`) instead of always allocating a fresh `{}`. This lets `makeState`'s `params === EMPTY_PARAMS` reuse branch fire, so a navigation to a route with no params (and no `defaultParams`) allocates zero transient objects instead of two.
+
+Behavior-preserving: `state.params` is still an empty frozen object and the `undefined`-strip contract is unchanged.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -664,6 +664,7 @@ Both options default to on. `matchPath()` rebuilds `state.path` via `buildPath()
 - **`getFunctions()` cached tuple** — `RouteLifecycleNamespace` returns pre-allocated `[deactivate, activate]` array (no alloc per navigate)
 - **Segment array reuse** — `toActivate`/`toDeactivate` reuse arrays from `getTransitionPath()`
 - **`buildNavigateState()`** — single-pass state construction (merged forwardState + buildPath + makeState)
+- **Empty-params reuse** — `normalizeParams()` returns the shared frozen `EMPTY_PARAMS` singleton when nothing survives (empty input, or all values `undefined`), so `makeState`'s `params === EMPTY_PARAMS` branch reuses it: an empty-params navigation allocates **zero** transient `{}` (lazy allocation in `normalizeParams` + singleton reuse, #1027)
 - **Single-pass freeze** — `freezeStateInPlace` consolidated into one recursive traversal
 
 ### General

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,6 +1,6 @@
 // packages/core/src/helpers.ts
 
-import { DEFAULT_LIMITS } from "./constants";
+import { DEFAULT_LIMITS, EMPTY_PARAMS } from "./constants";
 
 import type { Limits } from "./types";
 import type { Params, State, LimitsConfig } from "@real-router/types";
@@ -62,8 +62,13 @@ export function createLimits(userLimits: Partial<LimitsConfig> = {}): Limits {
  * - The contract is verifiable at core's own test surface (doesn't depend on
  *   engine behavior for regression detection)
  *
- * Single pass. Always returns a fresh object when input is defined
- * (reference identity is not preserved — callers must not rely on it).
+ * Single pass. When nothing survives (empty input, or every value `undefined`)
+ * it returns the shared frozen `EMPTY_PARAMS` singleton, so `makeState`'s
+ * `params === EMPTY_PARAMS` reuse branch fires and an empty-params navigation
+ * allocates zero transient `{}` (#1027); a non-empty input returns a fresh
+ * object. Either way reference identity is not preserved across calls, and the
+ * result MUST be treated as read-only — callers must not mutate it (the empty
+ * case is a shared frozen singleton).
  */
 export function normalizeParams(params: Params): Params;
 
@@ -78,7 +83,7 @@ export function normalizeParams(
     return params;
   }
 
-  const normalized: Params = {};
+  let normalized: Params | undefined;
 
   for (const key in params) {
     if (!Object.hasOwn(params, key)) {
@@ -88,9 +93,13 @@ export function normalizeParams(
     const value = params[key];
 
     if (value !== undefined) {
+      // Lazy allocation: an all-empty / all-undefined input costs zero objects.
+      normalized ??= {};
       normalized[key] = value;
     }
   }
 
-  return normalized;
+  // Reuse the shared singleton when nothing survived so makeState's
+  // `params === EMPTY_PARAMS` reuse branch fires (#1027).
+  return normalized ?? EMPTY_PARAMS;
 }

--- a/packages/core/tests/functional/navigation/navigate/empty-params-reuse.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/empty-params-reuse.test.ts
@@ -1,0 +1,50 @@
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+
+import { createTestRouter } from "../../../helpers";
+
+import type { Router } from "@real-router/core";
+
+// #1027: an empty-params navigation (a static/root route with no params and no
+// defaultParams) must reuse one shared frozen params singleton for state.params
+// instead of allocating a fresh frozen {} per navigation. `makeState` has the
+// reuse branch (params === EMPTY_PARAMS), but `normalizeParams` always returned
+// a fresh {} so the branch missed. Identity is publicly observable here because
+// navigate returns the committed State (unlike buildPath, which consumes params
+// internally — see normalizeParams.test.ts), so distinct empty-params
+// navigations must commit the SAME params reference.
+describe("router.navigate() - empty-params reuse one frozen params singleton (#1027)", () => {
+  let router: Router;
+
+  beforeEach(async () => {
+    router = createTestRouter();
+
+    await router.start("/home");
+  });
+
+  afterEach(() => {
+    router.stop();
+  });
+
+  it("shares one frozen params reference across distinct empty-params navigations", async () => {
+    const a = await router.navigate("sign-in");
+    const b = await router.navigate("index");
+    const c = await router.navigate("home");
+
+    // Public observability of the reuse: every empty-params navigation commits
+    // the SAME params reference. Before the fix each allocated its own fresh {},
+    // so a.params !== b.params. The shared object is empty and frozen.
+    expect(a.params).toBe(b.params);
+    expect(b.params).toBe(c.params);
+    expect(Object.keys(a.params)).toStrictEqual([]);
+    expect(Object.isFrozen(a.params)).toBe(true);
+  });
+
+  it("does not reuse the singleton when the navigation carries params", async () => {
+    const empty = await router.navigate("sign-in");
+    const withParam = await router.navigate("items", { id: "42" });
+
+    // A params-bearing navigation must NOT collapse onto the empty singleton.
+    expect(withParam.params).not.toBe(empty.params);
+    expect(withParam.params).toStrictEqual({ id: "42" });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1027.

`makeState` has a reuse branch that returns the shared frozen `EMPTY_PARAMS` singleton for empty params (`StateNamespace.ts:123-124`), but `buildNavigateState` fed it the output of `normalizeParams`, which always allocated a fresh `{}` even for empty input. So the `params === EMPTY_PARAMS` reuse branch never matched, and every empty-params navigation allocated **2 transient `{}`** — one in `normalizeParams`, one in `makeState`'s `Object.freeze({ ...params })`.

`normalizeParams` now lazily allocates and returns the `EMPTY_PARAMS` singleton when nothing survives (empty input, or every value `undefined`). The reuse branch fires → **0 transient objects** for an empty-params navigation (the lazy allocation also removes the would-be allocation in `normalizeParams` itself, so the empty path costs nothing).

## Behavior preservation

- `state.params` is still an empty frozen object.
- The `undefined`-strip contract is unchanged (`normalizeParams.test.ts` stays green).
- All 3 `normalizeParams` callers (`Router.ts:416`, `Router.ts:600`, `RouterWiringBuilder.ts:151`) are read-only — they pass the result into `buildPath`/`makeState`/guards and never mutate it — so returning the frozen singleton is safe. JSDoc updated for the new identity contract.

## Tests

`tests/functional/navigation/navigate/empty-params-reuse.test.ts` (RED→GREEN), via public observability only (no white-box import):
- distinct empty-params navigations commit the **same** frozen params reference;
- a params-bearing navigation does **not** collapse onto the singleton.

## Validation

`type-check` ✓ · `lint` ✓ · functional **2463 passed, coverage 100%** · property **283** · stress (memory/state) **8** ✓. Changeset: `@real-router/core: patch`.
