### PR TITLE
fix(vue): skip v-link directive-stack push on SSR (#779)

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -19,12 +19,11 @@ pnpm changeset --since=develop
 
 ## Principles
 
-- **One changeset per package** — when a change affects multiple packages, create **separate changeset files** for each package (cleaner CHANGELOG)
+- **One package per file** — exactly one package in each changeset's frontmatter. A change spanning multiple packages becomes **separate changeset files**, one per package (cleaner CHANGELOG). Multi-package files are **rejected** by `pnpm lint:changeset` (pre-push).
 - **One file per logical change** — each changeset describes one feature, fix, or refactor
 - **Separate by type** — don't mix features, fixes, and performance improvements in one changeset
 - **Public packages only** — skip private packages (`"private": true` in package.json)
 - **Include PR/issue reference** — add `(#XX)` to title for traceability in release notes. Issue references like `#123` are auto-linked to GitHub in generated CHANGELOGs
-- Multi-package changeset (one file, multiple packages) = same text copied to ALL packages' CHANGELOGs (use only when truly identical change)
 
 ## File Naming Convention
 
@@ -51,24 +50,14 @@ Short title describing the change (#XX)
 Optional detailed description with context, examples, or migration notes.
 ```
 
-**Multiple packages (only when truly identical change):**
-
-```markdown
----
-"@real-router/core": minor
-"@real-router/types": minor
----
-
-Short title describing the change (#XX)
-
-This exact text will appear in BOTH packages' CHANGELOGs.
-```
+A change that touches several packages is **one file per package** — never one
+file listing many packages. See the separate-files example below.
 
 ### Frontmatter (YAML)
 
 - **Package names** must match exactly (with quotes)
-- **Version bump** must be one of: `major`, `minor`, `patch`
-- List all affected **public** packages
+- **Version bump** must be one of: `major`, `minor`, `patch` (pre-1.0 packages never take `major` — use `minor` for breaking changes)
+- Exactly **one public** package per file
 
 ### Description
 
@@ -144,34 +133,6 @@ Add `useNavigator()` hook and update React bindings (#37)
 - Each package gets its own CHANGELOG entry with relevant details
 - Breaking changes only appear in affected package's CHANGELOG
 - Easier to track which package introduced which feature
-
-### Feature (Multiple Packages - Single File)
-
-Use only when the change is **truly identical** across packages:
-
-**File:** `.changeset/novalidate-feature.md`
-
-```markdown
----
-"@real-router/core": minor
-"@real-router/types": minor
----
-
-Add `noValidate` option to disable validation in production (#XX)
-
-New configuration option for performance-critical environments:
-
-\`\`\`typescript
-const router = createRouter(routes, {
-noValidate: process.env.NODE_ENV === 'production'
-});
-\`\`\`
-
-When enabled, skips ~40 validation calls per navigation cycle.
-Constructor always validates options object itself.
-```
-
-**Note:** This exact text will appear in BOTH packages' CHANGELOGs.
 
 ### Bug Fix (Single Package)
 
@@ -294,20 +255,34 @@ Add new `noValidate` option
 5. **On merge to master**, changesets bot creates version PR
 6. **Merge version PR** to publish packages
 
-## CI Integration
+## Validation
 
-Our CI enforces changeset rules (all checks block merge):
+Changeset rules are enforced in two complementary places:
 
-```yaml
-# .github/workflows/changeset-check.yml
-- If source files changed → changeset REQUIRED
-- If changeset exists:
-    - Must include PR/issue reference (#XX)
-    - Must contain only one package per file
-    - Must not reference private packages
+**Pre-push — content validity** (`pnpm lint:changeset`, `.changeset/check-changeset.mjs`):
+runs first in the pre-push hook (fast fail-fast). Validates every pending
+`.changeset/*.md` that is present — **no files → no-op**, so a WIP or infra-only
+push is never blocked. What it checks:
+
+```
+- Frontmatter is present and well-formed (--- … ---)
+- Package names are quoted and match a real workspace package
+- Bump level is major | minor | patch (pre-1.0 packages reject major)
+- The package is public (not "private": true)
+- Exactly one package per file
+- A PR/issue reference (#NN) appears in the description
 ```
 
-**Escape hatch:** Add `#trivial` to PR title to skip changeset requirement.
+> Not machine-checked (semantic): "one logical change per file", "don't mix
+> features/fixes", "right bump for the change type". Those are on the author.
+
+**CI — changeset presence** (`.github/workflows/changeset-check.yml`, blocks PR merge):
+
+```yaml
+- If public-package source files changed → a changeset is REQUIRED
+```
+
+**Escape hatch:** Add `#trivial` to PR title to skip the requirement.
 
 ## Additional Resources
 

--- a/.changeset/check-changeset.mjs
+++ b/.changeset/check-changeset.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Changeset validity linter (pre-push fast-block).
+ *
+ * Problem: `.changeset/README.md` documents a set of rules every changeset must
+ * obey (quoted package names, valid bump level, public packages only, PR/issue
+ * reference, one package per file). The CI workflow `changeset-check.yml` only
+ * checks that a changeset *exists* when public src changes — it never validates
+ * the *contents*. A malformed changeset (unknown package, typo'd bump level,
+ * private package, missing #ref) therefore slips through every gate until it
+ * blows up — or silently misbehaves — at `changeset version` on the release run.
+ *
+ * Solution: validate every pending `.changeset/*.md` against the machine-checkable
+ * subset of those rules, on pre-push, before the heavy build (fail-fast). No
+ * changeset files present → exit 0 (a WIP push or an infra-only push is fine;
+ * the "changeset required" question stays in CI). Files present but invalid →
+ * exit 1 and block the push.
+ *
+ * Why a separate script (not the CI workflow): the rules are policy that the
+ * author should hear *before* push, not after a red CI round-trip. The package
+ * registry (name → private/version) is read straight from each package.json,
+ * so "unknown package" and "private package" can never drift from reality.
+ *
+ * NOT checked here (semantic — not derivable from the file text): "one logical
+ * change per file", "don't mix features/fixes", "right bump for the change type",
+ * "descriptive title". Those need understanding of the diff, not the changeset.
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const CHANGESET_DIR = join(ROOT, ".changeset");
+const PKG_DIR = join(ROOT, "packages");
+const VALID_LEVELS = new Set(["major", "minor", "patch"]);
+
+/**
+ * Registry of workspace packages: name → { private, version }.
+ * Source of truth for "unknown package" and "private package" checks.
+ * @returns {Map<string, { private: boolean, version: string }>}
+ */
+function loadPackages() {
+  const registry = new Map();
+  for (const entry of readdirSync(PKG_DIR)) {
+    const pkgJsonPath = join(PKG_DIR, entry, "package.json");
+    if (!existsSync(pkgJsonPath)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+      if (pkg.name) {
+        registry.set(pkg.name, {
+          private: pkg.private === true,
+          version: typeof pkg.version === "string" ? pkg.version : "0.0.0",
+        });
+      }
+    } catch {
+      // A package.json we can't parse isn't our concern here — other gates own it.
+    }
+  }
+  return registry;
+}
+
+/**
+ * Validate a single changeset file's content.
+ * @param {string} name file name (e.g. "foo-fix.md")
+ * @param {string} content raw file content
+ * @param {Map<string, { private: boolean, version: string }>} registry
+ * @returns {{ errors: string[], warnings: string[] }}
+ */
+function validateChangeset(name, content, registry) {
+  const errors = [];
+  const warnings = [];
+
+  // File-naming convention (kebab-case) — cosmetic, so warn, never block.
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*\.md$/.test(name)) {
+    warnings.push(
+      `file name is not kebab-case (e.g. "middleware-unsubscribe-fix.md")`,
+    );
+  }
+
+  // Frontmatter must be present and terminated.
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) {
+    errors.push("missing or unterminated YAML frontmatter (--- … ---)");
+    return { errors, warnings };
+  }
+
+  // Parse frontmatter entries — one `"package": level` per non-empty line.
+  const entries = [];
+  let nonEmptyLines = 0;
+  for (const rawLine of fm[1].split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "") continue;
+    nonEmptyLines++;
+
+    const quoted = line.match(/^"([^"]+)":\s*(\S+)\s*$/);
+    if (quoted) {
+      entries.push({ pkg: quoted[1], level: quoted[2] });
+      continue;
+    }
+    // Unquoted "pkg: level" — the most common malformation (README pitfall).
+    const unquoted = line.match(/^([^":\s][^:]*):\s*(\S+)\s*$/);
+    if (unquoted) {
+      errors.push(
+        `package name must be quoted: \`"${unquoted[1].trim()}": ${unquoted[2]}\``,
+      );
+      continue;
+    }
+    errors.push(`unparseable frontmatter line: \`${line}\``);
+  }
+
+  // At least one package entry. Only flag emptiness when the frontmatter was
+  // genuinely blank — if lines were present but malformed, the per-line errors
+  // above already explain it (don't pile on a confusing "no packages").
+  if (entries.length === 0 && nonEmptyLines === 0) {
+    errors.push("frontmatter lists no packages");
+  }
+
+  // One package per file (project convention + CI Integration section of README).
+  if (entries.length > 1) {
+    errors.push(
+      `${entries.length} packages in one file — split into one changeset per package`,
+    );
+  }
+
+  for (const { pkg, level } of entries) {
+    if (!VALID_LEVELS.has(level)) {
+      errors.push(
+        `invalid bump level "${level}" for "${pkg}" (must be major | minor | patch)`,
+      );
+      continue;
+    }
+    const meta = registry.get(pkg);
+    if (!meta) {
+      errors.push(`unknown package "${pkg}" — not a workspace package`);
+      continue;
+    }
+    if (meta.private) {
+      errors.push(
+        `"${pkg}" is private — changeset the public consumer whose behavior changed`,
+      );
+    }
+    // Pre-1.0 (0.x) packages never take a major bump (README pre-1.0 guideline;
+    // mirrors cap-major-bumps.mjs). Auto-relaxes once a package reaches 1.0.
+    if (level === "major" && /^0\./.test(meta.version)) {
+      errors.push(
+        `"${pkg}" is pre-1.0 (${meta.version}) — use "minor" for breaking changes, not "major"`,
+      );
+    }
+  }
+
+  // PR/issue reference (#NN) somewhere in the body (traceability in release notes).
+  const body = content.slice(fm[0].length);
+  if (!/#\d+/.test(body)) {
+    errors.push("missing PR/issue reference (#NN) in the description");
+  }
+
+  return { errors, warnings };
+}
+
+function main() {
+  if (!existsSync(CHANGESET_DIR)) {
+    return; // No .changeset dir at all — nothing to validate.
+  }
+
+  const files = readdirSync(CHANGESET_DIR)
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .sort();
+
+  if (files.length === 0) {
+    // No pending changesets — a WIP/infra push. Pass silently.
+    console.log("📝 No changesets to validate.");
+    return;
+  }
+
+  const registry = loadPackages();
+  let invalid = 0;
+  let warned = 0;
+
+  for (const file of files) {
+    const content = readFileSync(join(CHANGESET_DIR, file), "utf8");
+    const { errors, warnings } = validateChangeset(file, content, registry);
+
+    for (const w of warnings) {
+      console.warn(`⚠️  .changeset/${file}: ${w}`);
+      warned++;
+    }
+    for (const e of errors) {
+      console.error(`❌ .changeset/${file}: ${e}`);
+    }
+    if (errors.length > 0) invalid++;
+  }
+
+  if (invalid > 0) {
+    console.error(
+      `\n❌ ${invalid} of ${files.length} changeset file(s) invalid. ` +
+        `Fix them before pushing.\n` +
+        `   Rules: .changeset/README.md`,
+    );
+    process.exit(1);
+  }
+
+  const suffix = warned > 0 ? ` (${warned} warning(s))` : "";
+  console.log(`✅ ${files.length} changeset file(s) valid${suffix}.`);
+}
+
+main();

--- a/.changeset/vlink-ssr-779-fix.md
+++ b/.changeset/vlink-ssr-779-fix.md
@@ -1,0 +1,14 @@
+---
+"@real-router/vue": patch
+---
+
+Fix per-request router leak in the `v-link` directive stack under SSR (#779)
+
+`RouterProvider` pushed its router onto the module-level `v-link` directive
+stack unconditionally in `setup()`, but the release runs in `onScopeDispose`,
+which never fires during `renderToString` (the canonical per-request SSR flow
+never calls `app.unmount()`). The stack therefore grew by one entry per request
+and strong-referenced every per-request router — a leak `router.dispose()`
+cannot clear. The push is now guarded to the browser (`typeof document`), since
+the directive only ever runs in mounted client DOM; the client and hydration
+contract is unchanged.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,6 +2,8 @@
 
 # Pre-push hook: artifact validation before pushing
 #
+# - lint:changeset: Validate pending changeset files (fast fail-fast, runs
+#                   first; no files → no-op)
 # - lint:duplicates: Copy-paste detection (jscpd)
 # - build: Final build to ensure compilation
 # - lint:types: Validate TypeScript types in dist (arethetypeswrong)
@@ -18,6 +20,12 @@
 set -e
 
 echo "🚀 Running pre-push checks..."
+
+# Validate pending changeset files first — cheap (~10ms) static check, so it
+# fails fast before the expensive build. No-op when .changeset/ holds no
+# changesets (WIP/infra push).
+echo "📝 Validating changesets..."
+pnpm lint:changeset
 
 # Check for code duplication
 echo "📋 Checking for code duplication..."

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -255,6 +255,7 @@ Enforces conventional commits. Types and scopes defined in `commitlint.config.mj
 
 `.husky/pre-push` runs (artifact validation, NOT a superset of pre-commit):
 
+- `pnpm lint:changeset` (validates pending `.changeset/*.md` **content** — **runs first**, ~10 ms fail-fast; no changeset files → no-op — see "Changeset content validation" below)
 - `pnpm lint:duplicates` (jscpd — copy-paste detection across the full tree)
 - `pnpm turbo run build lint:package lint:types --filter='!./examples/**'` (full build + validate package.json exports via publint + validate `.d.ts` via arethetypeswrong)
 - `pnpm lint:unused` (knip — dead code detection across the full tree)
@@ -265,6 +266,22 @@ Enforces conventional commits. Types and scopes defined in `commitlint.config.mj
 **Rationale:** Pre-commit validates correctness in <2 min so it stays painless on every commit. Pre-push validates artifacts (full build pipeline + dist surface area + dep consistency + GHSA audit) — slower, runs once per push. `lint:deps` lives in **both** layers: pre-commit catches workspace version drift the moment a `package.json` is staged (~1s static check), pre-push acts as the final gate. `lint:package`/`lint:types`/`lint:unused` **also run in CI** now (#813 — see below); only `lint:duplicates`' hard threshold stays pre-push-only (CI keeps an informational jscpd SARIF channel). `lint:audit` was added after PR #643 (see "Local Dependency Audit" below) so contributors can catch CVEs locally before CI Dependency Review flags them.
 
 The full build orchestrator (`pnpm turbo run build`) is wired in `turbo.json` to depend on `bundle`, `test`, `test:properties`, AND `test:stress` — so pre-push exercises stress tests for every human push. Stress coverage is intentionally **not** duplicated in CI workflows (see "CI: `test:stress` lives only in pre-push" below).
+
+#### Changeset content validation (pre-push fast-block)
+
+**Problem.** `.changeset/README.md` documented a contract for changeset files — quoted package names, a valid bump level, public packages only, a PR/issue reference, one package per file — and its "CI Integration" section *claimed* CI enforced the content rules. It did not: `.github/workflows/changeset-check.yml` only checks that a changeset **exists** when public-package `src/` changes. Nothing validated the **contents**. A malformed changeset (unknown package, typo'd bump level like `mihor`, a private package such as `route-tree`, a missing `#NN`, two packages in one file) sailed through every gate and only surfaced at `changeset version` on the release run — the slowest, most expensive place to find it.
+
+**Solution.** `.changeset/check-changeset.mjs` (`pnpm lint:changeset`), wired **first** in `.husky/pre-push` so it fails fast before the heavy build. It validates the machine-checkable subset of the README contract against every pending `.changeset/*.md`:
+
+- frontmatter present and terminated (`--- … ---`)
+- package names quoted **and** matching a real workspace package (registry read live from `packages/*/package.json` → "unknown package" / "private package" can't drift)
+- bump level ∈ `{major, minor, patch}`; `major` rejected for any package still on `0.x` (mirrors `cap-major-bumps.mjs`; auto-relaxes at 1.0 by reading the package's own version)
+- exactly one package per file
+- a `#NN` reference in the body
+
+**No changeset files present → exit 0, silently.** A WIP push or an infra-only push (which by repo convention carries no changeset) is never blocked — so there is no opt-out env flag: when changesets *are* present, they must be valid (the only blunt override is git's own `--no-verify`, which skips the whole hook).
+
+**Why pre-push, not CI.** The rules are author-facing policy — better heard before the push than after a red CI round-trip. It's a static `git`-free filesystem read (~10 ms), cheaper than every other pre-push gate, so it earns first place. **Not** machine-checked (semantic, left to the author): "one logical change per file", "don't mix features/fixes", "right bump for the change type". The same commit corrected `.changeset/README.md`, which contradicted itself — Principles + a "Multiple Packages — Single File" example permitted multi-package files while the CI-Integration section forbade them; the real practice (and now the linter) is **one package per file, always**.
 
 #### Local SAST: semgrep diff scan + eslint-plugin-security
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:deps": "syncpack lint",
     "lint:deps:fix": "syncpack fix && pnpm dedupe && pnpm install",
     "lint:dedupe": "pnpm dedupe --check",
+    "lint:changeset": "node .changeset/check-changeset.mjs",
     "resolve:dependabot": "bash scripts/resolve-dependabot.sh",
     "type-check": "turbo run type-check",
     "sonar": "dotenv -- sonar -Dsonar.login=$SONAR_TOKEN",

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -562,6 +562,18 @@ stack regardless of position.
 </RouterProvider>
 ```
 
+**SSR: the push is client-only (#779).** `RouterProvider` pushes onto the stack
+only in the browser (`typeof document !== "undefined"`). During `renderToString`
+the directive never mounts (it runs solely in client DOM) and `onScopeDispose`
+— the release hook — never fires, so a server-side push would strand every
+per-request router (with its route tree, plugins, subscriptions) in the
+module-level array, a leak `router.dispose()` cannot clear. Skipping the push on
+the server keeps the stack empty across requests, so `getDirectiveRouter()`
+throws server-side exactly as it does before any provider mounts. On the client
+(and during hydration) the push/release contract is unchanged — the release is
+registered in its own `onScopeDispose` so the server path leaves no dead
+teardown branch.
+
 ### v-link Defensive Validation
 
 `v-link` validates `binding.value` on mount and update. Passing `null`/`undefined`/`{name: undefined}` logs `console.error` and skips handler attachment instead of throwing inside a click handler. Use this if your binding is computed and may be unset transiently.
@@ -591,7 +603,7 @@ setDirectiveRouter(router);
 
 ## SSR
 
-SSR-friendly without a separate entry. The same `RouterProvider`, `Link`, `RouteView`, and composables work under `vue/server-renderer` (`renderToString` / `renderToWebStream`) — no SSR-specific imports, no `if (typeof window !== "undefined")` shims, no platform branches in hot paths.
+SSR-friendly without a separate entry. The same `RouterProvider`, `Link`, `RouteView`, and composables work under `vue/server-renderer` (`renderToString` / `renderToWebStream`) — no SSR-specific imports and no platform branches in hot paths. The lone environment guard is in `RouterProvider`'s `setup()` (it runs once per mount, not a hot path): it skips the client-only `v-link` directive-stack push on the server (`typeof document !== "undefined"`), which otherwise leaks one router per request (#779).
 
 Verified end-to-end across three example apps:
 

--- a/packages/vue/src/RouterProvider.ts
+++ b/packages/vue/src/RouterProvider.ts
@@ -144,7 +144,23 @@ export const RouterProvider = defineComponent({
     // Push this provider's router on the v-link directive stack so nested
     // RouterProviders behave like nested DI scopes (LIFO). Release on unmount
     // restores the outer router for any v-link still mounted in the parent.
-    const releaseDirective = pushDirectiveRouter(props.router);
+    //
+    // #779: only push in the browser. The v-link directive runs solely in
+    // mounted client DOM, so the server never reads the stack — while
+    // onScopeDispose (the release hook) never fires during renderToString, so a
+    // server-side push would strand every per-request router in this
+    // module-level array, a leak router.dispose() cannot clear. `typeof
+    // document` mirrors the SSR guard used across shared/dom-utils. The release
+    // gets its own onScopeDispose so the server path leaves no dead teardown
+    // branch (a combined callback would only ever run on the client).
+    const releaseDirective =
+      typeof document === "undefined"
+        ? undefined
+        : pushDirectiveRouter(props.router);
+
+    if (releaseDirective) {
+      onScopeDispose(releaseDirective);
+    }
 
     // #778 P2: eagerly create the per-router error source at Provider mount so a
     // navigation error that fires BEFORE a RouterErrorBoundary mounts (a lazy app
@@ -157,10 +173,7 @@ export const RouterProvider = defineComponent({
     const { navigator, route, previousRoute, unsubscribe } =
       setupRouteProvision(props.router);
 
-    onScopeDispose(() => {
-      releaseDirective();
-      unsubscribe();
-    });
+    onScopeDispose(unsubscribe);
 
     provide(RouterKey, props.router);
     provide(NavigatorKey, navigator);

--- a/packages/vue/tests/functional/RouterProvider.ssr-leak.test.ts
+++ b/packages/vue/tests/functional/RouterProvider.ssr-leak.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { createRouter } from "@real-router/core";
+import { describe, it, expect, beforeEach } from "vitest";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import {
+  getDirectiveRouter,
+  setDirectiveRouter,
+} from "../../src/directives/vLink";
+import { RouterProvider } from "../../src/RouterProvider";
+
+import type { Router } from "@real-router/core";
+
+// This file runs under `node` (see the @vitest-environment docblock above), so
+// `document`/`window` are undefined — exactly like a real SSR process. The rest
+// of the vue suite runs in jsdom, where the CLIENT push/release path is
+// exercised (vLink.test.ts "nested provider isolation" mounts + unmounts a real
+// RouterProvider; RouterProvider.test.ts "should call unsubscribe on unmount").
+const ssrHost = (router: Router) =>
+  createSSRApp({ render: () => h(RouterProvider, { router }) });
+
+describe("RouterProvider — SSR v-link directive-stack leak (#779)", () => {
+  beforeEach(() => {
+    // The directive stack is module-level state; start each test from empty.
+    setDirectiveRouter(null);
+  });
+
+  it("does not retain per-request routers on the v-link stack across SSR renders", async () => {
+    // Confirms we are genuinely on the server path the fix guards.
+    expect(typeof document).toBe("undefined");
+
+    const r1 = createRouter([{ name: "home", path: "/" }]);
+    const r2 = createRouter([{ name: "home", path: "/" }]);
+
+    // Canonical per-request SSR: a fresh app per request, renderToString, and
+    // NO app.unmount() — so onScopeDispose (the directive-stack release hook)
+    // never fires. Before the fix, setup() pushed unconditionally: the
+    // module-level stack grew +1 per request, strong-referenced every
+    // per-request router (route tree, plugins, subscriptions), and
+    // getDirectiveRouter() returned the last one instead of throwing.
+    await renderToString(ssrHost(r1));
+    await renderToString(ssrHost(r2));
+
+    // Fixed: the server never pushes, so the stack stays empty and the
+    // directive's "no RouterProvider ancestor" guard still fires.
+    expect(() => getDirectiveRouter()).toThrow(
+      /requires a RouterProvider ancestor/,
+    );
+
+    // router.dispose() cannot clear a module-level array (the issue's core
+    // point). The fix sidesteps that entirely by never growing the stack, so
+    // disposal is irrelevant — the stack was already empty.
+    r1.dispose();
+    r2.dispose();
+
+    expect(() => getDirectiveRouter()).toThrow(
+      /requires a RouterProvider ancestor/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the only own-code memory leak found in the 6-adapter SSR audit series.

- A long-lived Vue SSR process no longer accumulates one router per request. Previously every `renderToString` of a tree containing `<RouterProvider>` retained that request's router (with its route tree, plugins, and subscriptions) in a module-level array, and `router.dispose()` could not reclaim it.
- Client and hydration behaviour is unchanged — `v-link` still resolves to the innermost provider's router via the LIFO stack.

**Root cause:** `RouterProvider.setup()` pushed its router onto the module-level `v-link` directive stack unconditionally, but the release runs in `onScopeDispose`, which never fires during `renderToString` (the canonical per-request SSR flow never calls `app.unmount()`). The stack grew +1 per request and strong-referenced each router. The fix guards the push to the browser (`typeof document !== "undefined"` — the directive only runs in mounted client DOM, so the server never reads the stack) and registers the release in its own `onScopeDispose`, so the server path leaves no dead teardown branch.

### Tooling (no issue) — `build(config): validate changeset content on pre-push`

- Adds a pre-push hook (`.changeset/check-changeset.mjs`) that validates changeset content (PR/issue reference, one package per file, no private packages), plus `IMPLEMENTATION_NOTES.md` rationale. Infrastructure-only — touches no `packages/*/src/`. Bundled here at the author's request; normally infra lands directly on `master`.

## Test plan

- [x] `packages/vue/tests/functional/RouterProvider.ssr-leak.test.ts` (node env) — asserts the directive stack stays empty across two `renderToString` calls with no unmount; fails before the fix (returns the 2nd router), passes after, dispose-independent
- [x] Existing client coverage intact — `vLink.test.ts` "nested provider isolation", `RouterProvider.test.ts` "should call unsubscribe on unmount"
- [x] `@real-router/vue` type-check + lint + test (383 passed) + relevant stress (mount/unmount/lifecycle/vlink, 23 passed); 100% statements/lines/functions, 97.05% branches
- [x] Pre-commit turbo graph green (123 tasks); full validation runs on pre-push

Closes #779
