### PR TITLE
fix(hash-plugin): sync router on external hashchange events (#759)

### DIFF
--- a/.changeset/browser-plugin-759-browser-type.md
+++ b/.changeset/browser-plugin-759-browser-type.md
@@ -1,0 +1,7 @@
+---
+"@real-router/browser-plugin": minor
+---
+
+`Browser` interface now includes `addHashChangeListener` (#759)
+
+The shared `Browser` type exported from browser-plugin gains an `addHashChangeListener` method, added so hash-plugin can track external URL fragment changes. browser-plugin's own runtime behavior is unchanged — it registers only a `popstate` listener, never `hashchange`. Code that supplies a hand-written `Browser` via the (test-only) `browser` factory argument must add this method.

--- a/.changeset/hash-plugin-759-hashchange-fix.md
+++ b/.changeset/hash-plugin-759-hashchange-fix.md
@@ -1,0 +1,11 @@
+---
+"@real-router/hash-plugin": minor
+---
+
+Sync the router on external URL fragment changes (#759)
+
+hash-plugin now listens to `hashchange` in addition to `popstate`, so external fragment changes — a native `<a href="#/x">`, a manual address-bar hash edit, or `location.hash = "..."` from app/third-party code — synchronize the router. Previously only programmatic navigation (`<Link>` / `router.navigate`) and back/forward (popstate) were tracked; an external hash mutation updated the URL while the router stayed on the old route.
+
+A hash-changing back/forward fires both `popstate` and `hashchange`; the two are deduped (order-independent, microtask-scoped) so exactly one navigation runs — never a double-navigate.
+
+**Type note:** the exported `Browser` interface now requires `addHashChangeListener`. Code that supplies a hand-written `Browser` via the (test-only) `browser` factory argument must add this method.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -3267,6 +3267,22 @@ For hash, both URL plugins use a **lazy read** in `onTransitionSuccess`: on the 
 
 `#` is the route delimiter in hash-plugin → URL fragments are structurally incompatible. `pluginBuildUrl` accepts `hash` option for typing parity (TS interface merge needs identical signatures across all 3 URL plugins) but ignores it at runtime + emits one-time `console.warn`. Inline `let warned = false` pattern — existing `createWarnOnce` from `shared/browser-env/ssr-fallback.ts` has SSR-specific signature `(context) => (method) => void` and didn't fit.
 
+## `hashchange` listener for hash-plugin — external fragment changes (#759)
+
+**Problem.** `hash-plugin` synced the router only on `popstate`. But per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event), `popstate` fires only on history **traversal** (back/forward). A same-document **fragment navigation** — a native `<a href="#/users">`, a manual address-bar hash edit, or `location.hash = "..."` from app/third-party code — fires `hashchange`, not `popstate`. So an external hash change updated the URL while the router stayed on the old route. (browser-plugin is unaffected: for it a path change is a full navigation / popstate.)
+
+**Solution.** A new `createHashSyncLifecycle` in `shared/browser-env/popstate-handler.ts` (hash-plugin's variant of `createPopstateLifecycle`) registers **both** `popstate` and `hashchange`, routing both through the *same* `createPopstateHandler`. A `hashchange` carries no `history.state`, so `getRouteFromEvent` resolves it via the `matchPath(location)` fallback — the URL is the source of truth for an external change, which is exactly right. Wiring:
+
+- `HistoryBrowser.addHashChangeListener` added symmetrically to `addPopstateListener` (`history-api.ts`, `safe-browser.ts`, no-op SSR fallback in `ssr-fallback.ts`).
+- `getRouteFromEvent` widened to `PopStateEvent | HashChangeEvent`; the `"state" in evt` guard skips the `makeState` branch for hashchange. Behaviour for `PopStateEvent` is byte-identical (it always has `state`), so browser-plugin is untouched.
+- Both listeners share the single `SharedFactoryState.removePopStateListener` slot as a **combined remover**, preserving the factory-pool last-wins cleanup (#758) with no new slot.
+
+**Dedup (order-independent).** A hash-changing back/forward fires the `popstate`+`hashchange` pair synchronously (one browser task). Handling both double-navigates. Two type-scoped flags (`sawPopstate` / `sawHashchange`), reset on a `queueMicrotask`, drop whichever of the pair arrives **second** — regardless of the browser's firing order (browsers have historically varied), so the fix does not depend on an unverified ordering fact. The microtask reset scopes the guard to a single synchronous pair: distinct gestures (separate tasks) are never coalesced, and same-type bursts (two rapid `popstate`s → the existing deferred-event path) are unaffected because a `popstate` only blocks a following `hashchange`, never another `popstate`.
+
+**Why this layer.** `hashchange` lives in `browser-env` (the History-API abstraction) symmetric to `popstate`, but is wired **only** by hash-plugin's lifecycle — browser-plugin keeps `createPopstateLifecycle` (popstate only), so it never grows a `hashchange` listener it doesn't want. Clean split, zero behaviour change for browser-plugin / navigation-plugin.
+
+**RED-test caveat (jsdom).** Not reproducible via a naive `location.hash =` in jsdom: jsdom fires a *spurious* `popstate` (`state=undefined`) **in addition to** `hashchange` on a `location.hash=` assignment, so the pre-fix popstate path masks the gap and the router *appears* to sync. Real browsers fire `hashchange` alone for a same-document fragment navigation. The RED test therefore dispatches `new HashChangeEvent("hashchange")` **directly** (URL pre-set via `replaceState`, which fires neither event) to isolate the missing channel. Because `shared/browser-env` is coverage-gated in the `packages/browser-env` test package (not in the symlink consumers, whose coverage `include` misses the real `shared/**` path), the dedup and listener wiring are unit-tested there against 100% thresholds; hash-plugin adds integration-level tests through the public plugin.
+
 ## `invalidate(router, namespace)` — CSR revalidation channel for SSR loader plugins (#605)
 
 ### Problem
@@ -4761,3 +4777,22 @@ Pilot on `core` proved parity + two non-obvious facts:
 `always` (not `ci-only`): keeps local coverage — pre-push `bundle` catches publint/attw errors before push, exactly as the old separate tasks did. Validation is now inseparable from the build (can't bundle without validating). publint `0.3.21` (already in devDeps, satisfies tsdown peer `^0.3.8`) + `@arethetypeswrong/cli 0.18.4` — no new deps.
 
 **Exceptions — NOT tsdown, deliberately keep separate validation:** `solid` (rollup) retains `lint:package`/`lint:types`; the turbo tasks stay **for it alone** (turbo run resolves to `@real-router/solid:lint:package` only — the 21 tsdown packages no longer have the scripts, turbo skips them). `angular` (ng-packagr) and `svelte` (svelte-package) never had publint/attw. The pre-push `pnpm turbo run build lint:package lint:types` line is unchanged: `build`→`bundle` validates the 21 tsdown packages inline; `lint:package`/`lint:types` cover solid. The turbo graph stays mixed — that asymmetry is the price of solid/angular/svelte not being tsdown-built, and is the reason the tasks aren't deleted outright.
+
+## Dependabot npm ecosystem auto-halted by pnpm-override-managed transitive advisories (2026-07-01)
+
+### Problem
+
+Dependabot stopped opening **any** npm PRs for ~2 weeks (only the `github-actions` ecosystem kept working — e.g. `actions/cache 5→6`), while `pnpm outdated` showed 30+ available bumps (angular, tanstack, preact, svelte, rollup, eslint plugins, …). The Dependabot update-log (`/network/updates`) showed every npm job **errored**, culminating in a repository-level auto-pause:
+
+> *Dependabot updates have stopped for your repository due to repeated errors.*
+> *Dependabot cannot update undici to a non-vulnerable version. The latest possible version of undici that can be installed is 7.27.2. The earliest fixed version is 7.28.0.*
+
+Root cause: three OSV/GHSA advisories on **transitive** deps were resolved by `overrides` in `pnpm-workspace.yaml` — `js-yaml` (2026-06-17, via `read-yaml-file '>=2.1.0'`), then `undici '>=7.28.0 <8.0.0'` + `piscina '>=5.2.0 <6.0.0'` (2026-06-18). The installed tree is genuinely clean (`undici@7.28.0`, `piscina@5.2.0`, `js-yaml@4.3.0`; `lint:audit`/osv-scanner: 1755 pkgs, no issues). **But Dependabot does not apply pnpm `overrides` during its own resolution** — it re-resolves each dep to its natural transitive ceiling (undici 7.27.2 < fixed 7.28.0), concludes it "cannot update to a non-vulnerable version", and **errors the entire npm job → zero PRs**. Successive errors (js-yaml → piscina → undici) tripped Dependabot's repo-wide auto-halt. **Not a pnpm-11 regression** — all three errors predate the 11.9 migration (2026-06-25); the overrides lived in `package.json#pnpm.overrides` at the time and Dependabot ignored them there too (it never honors pnpm overrides, in either location).
+
+### Solution
+
+Add the three transitive, override-pinned deps to the npm ecosystem's `ignore` list in `.github/dependabot.yml` (`ignore` filters a dep out of **both** version and security updates — GitHub docs). This removes the un-satisfiable advisory targets from Dependabot's resolution, so the weekly version job stops erroring and produces the backlog. After the config is on `master`, click **Check for updates** on the `package.json` ecosystem at `/network/updates` to lift the auto-halt (Dependabot reads config from the default branch; the halt only clears on a manual re-trigger). Coverage of these transitive advisories is unchanged — `lint:audit` (osv-scanner) remains the real gate; Dependabot could never PR an override-pinned transitive dep anyway.
+
+### Why this and not the alternatives
+
+**Not removing/loosening the overrides** — they are the actual fix that makes osv-scanner clean; dropping them re-opens the vulnerabilities. **Not disabling Dependabot security updates repo-wide** — that would blind us to advisories on *direct* deps (Dependabot's real job). **Not adding undici/piscina as direct devDeps** — pollutes manifests with transitive internals, and wouldn't help: Dependabot's resolver still can't reach 7.28.0 through the parent chain. The `ignore` list is surgical and codified. **Recurring-pattern note (in the config comment):** every future transitive-advisory-via-override adds another `ignore` entry, or Dependabot re-halts the whole npm ecosystem.

--- a/packages/browser-env/ARCHITECTURE.md
+++ b/packages/browser-env/ARCHITECTURE.md
@@ -10,9 +10,9 @@
 ```
 shared/browser-env/
 ├── detect.ts               — isBrowserEnvironment()
-├── history-api.ts          — pushState, replaceState, addPopstateListener, getHash
+├── history-api.ts          — pushState, replaceState, addPopstateListener, addHashChangeListener, getHash
 ├── plugin-utils.ts         — createStartInterceptor, createReplaceHistoryState, shouldReplaceHistory
-├── popstate-handler.ts     — createPopstateHandler, createPopstateLifecycle
+├── popstate-handler.ts     — createPopstateHandler, createPopstateLifecycle, createHashSyncLifecycle
 ├── popstate-utils.ts       — getRouteFromEvent, updateBrowserState
 ├── safe-browser.ts         — createSafeBrowser
 ├── ssr-fallback.ts         — createWarnOnce, createHistoryFallbackBrowser
@@ -31,6 +31,7 @@ interface HistoryBrowser {
   pushState: (state: unknown, path: string) => void;
   replaceState: (state: unknown, path: string) => void;
   addPopstateListener: (fn: (evt: PopStateEvent) => void) => () => void;
+  addHashChangeListener: (fn: (evt: HashChangeEvent) => void) => () => void; // #759 — used by hash-plugin only
   getHash: () => string;
 }
 
@@ -53,10 +54,27 @@ live location — re-reading it at replay time would resolve the wrong target (#
 errors (anything that isn't a `RouterError`) trigger a `replaceState` recovery that rolls
 the URL back to the router's current state.
 
-`getRouteFromEvent(evt, api, location)` tries `isState(evt.state)` first; on failure it
-falls back to `api.matchPath(location)`, where `location` is the snapshot the handler
-captured at event time. `updateBrowserState(state, url, replace, browser)`
+`getRouteFromEvent(evt, api, location)` accepts `PopStateEvent | HashChangeEvent` (#759). It
+tries `"state" in evt && isState(evt.state)` first; on failure — always, for a `hashchange`,
+which carries no `state` — it falls back to `api.matchPath(location)`, where `location` is
+the snapshot the handler captured at event time. `updateBrowserState(state, url, replace, browser)`
 writes `{ name, params, path }` — nothing else — into `history.state`.
+
+### `createHashSyncLifecycle` — popstate + hashchange for hash-plugin (#759)
+
+hash-plugin uses `createHashSyncLifecycle` instead of `createPopstateLifecycle`: it registers
+**both** `popstate` and `hashchange` (via `addHashChangeListener`) through the *same* handler,
+so external fragment changes (native anchors, address-bar edits, `location.hash=`) — which fire
+`hashchange` only — reach the router. browser-plugin keeps `createPopstateLifecycle` (popstate
+only); it has no use for `hashchange`, so the split keeps that listener off its path entirely.
+
+A hash-changing back/forward fires **both** events synchronously. To avoid double-navigating,
+two type-scoped flags (`sawPopstate` / `sawHashchange`), reset on a `queueMicrotask`, drop
+whichever of the pair arrives **second** — order-independent, and never coalescing separate
+gestures (distinct tasks) or same-type bursts (a `popstate` blocks only a following
+`hashchange`, never another `popstate`, preserving the deferred-event path above). Both
+listeners share the single `SharedFactoryState.removePopStateListener` slot as a combined
+remover, keeping the factory-pool last-wins cleanup (#758) intact.
 
 ## Pure URL utilities
 

--- a/packages/browser-env/tests/property/helpers.ts
+++ b/packages/browser-env/tests/property/helpers.ts
@@ -161,6 +161,7 @@ export function createSpyBrowser(): SpyBrowser {
       calls.push({ method: "replaceState", state, url });
     },
     addPopstateListener: () => () => {},
+    addHashChangeListener: () => () => {},
     getHash: () => "",
     getLocation: () => "/",
     getCalls: () => calls,

--- a/packages/browser-env/tests/unit/history-api.test.ts
+++ b/packages/browser-env/tests/unit/history-api.test.ts
@@ -4,6 +4,7 @@ import {
   pushState,
   replaceState,
   addPopstateListener,
+  addHashChangeListener,
   getHash,
 } from "../../src/history-api";
 
@@ -41,6 +42,19 @@ describe("history-api", () => {
     cleanup();
 
     expect(removeSpy).toHaveBeenCalledWith("popstate", fn);
+  });
+
+  it("addHashChangeListener registers and returns cleanup (#759)", () => {
+    const addSpy = vi.spyOn(globalThis, "addEventListener");
+    const removeSpy = vi.spyOn(globalThis, "removeEventListener");
+    const fn = vi.fn();
+    const cleanup = addHashChangeListener(fn);
+
+    expect(addSpy).toHaveBeenCalledWith("hashchange", fn);
+
+    cleanup();
+
+    expect(removeSpy).toHaveBeenCalledWith("hashchange", fn);
   });
 
   it("getHash returns current location hash", () => {

--- a/packages/browser-env/tests/unit/popstate-handler.test.ts
+++ b/packages/browser-env/tests/unit/popstate-handler.test.ts
@@ -2,7 +2,11 @@ import { createRouter, errorCodes, RouterError } from "@real-router/core";
 import { getPluginApi } from "@real-router/core/api";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { createPopstateHandler, createPopstateLifecycle } from "../../src";
+import {
+  createPopstateHandler,
+  createPopstateLifecycle,
+  createHashSyncLifecycle,
+} from "../../src";
 
 import type {
   Browser,
@@ -28,6 +32,7 @@ function makeFakeBrowser(location = "/"): Browser {
     pushState: vi.fn(),
     replaceState: vi.fn(),
     addPopstateListener: vi.fn(() => () => {}),
+    addHashChangeListener: vi.fn(() => () => {}),
     getLocation: () => location,
     getHash: () => "",
   };
@@ -35,6 +40,12 @@ function makeFakeBrowser(location = "/"): Browser {
 
 function makePopStateEvent(state: unknown): PopStateEvent {
   return { state } as PopStateEvent;
+}
+
+// A hashchange event carries no history `state` — the handler resolves it via
+// the matchPath fallback. The synthetic object omits `state` on purpose.
+function makeHashChangeEvent(): HashChangeEvent {
+  return {} as HashChangeEvent;
 }
 
 async function flushAsync(): Promise<void> {
@@ -490,6 +501,191 @@ describe("popstate handler", () => {
 
       expect(removeSpy).not.toHaveBeenCalled();
       expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("createHashSyncLifecycle (#759)", () => {
+    function makeHashSyncDeps(): {
+      shared: SharedFactoryState;
+      removePopSpy: ReturnType<typeof vi.fn>;
+      removeHashSpy: ReturnType<typeof vi.fn>;
+      addPopSpy: ReturnType<typeof vi.fn>;
+      addHashSpy: ReturnType<typeof vi.fn>;
+      handler: ReturnType<typeof vi.fn>;
+      cleanup: ReturnType<typeof vi.fn>;
+      lifecycle: ReturnType<typeof createHashSyncLifecycle>;
+      firePopstate: (state?: unknown) => void;
+      fireHashchange: () => void;
+    } {
+      const shared: SharedFactoryState = { removePopStateListener: undefined };
+      const removePopSpy = vi.fn();
+      const removeHashSpy = vi.fn();
+      let popstateListener: ((evt: PopStateEvent) => void) | undefined;
+      let hashchangeListener: ((evt: HashChangeEvent) => void) | undefined;
+      const addPopSpy = vi.fn((fn: (evt: PopStateEvent) => void) => {
+        popstateListener = fn;
+
+        return removePopSpy;
+      });
+      const addHashSpy = vi.fn((fn: (evt: HashChangeEvent) => void) => {
+        hashchangeListener = fn;
+
+        return removeHashSpy;
+      });
+      const browser: Browser = {
+        ...makeFakeBrowser(),
+        addPopstateListener: addPopSpy,
+        addHashChangeListener: addHashSpy,
+      };
+      const handler = vi.fn();
+      const cleanup = vi.fn();
+      const lifecycle = createHashSyncLifecycle({
+        browser,
+        shared,
+        handler,
+        cleanup,
+      });
+
+      return {
+        shared,
+        removePopSpy,
+        removeHashSpy,
+        addPopSpy,
+        addHashSpy,
+        handler,
+        cleanup,
+        lifecycle,
+        firePopstate: (state: unknown = null) => {
+          popstateListener?.(makePopStateEvent(state));
+        },
+        fireHashchange: () => {
+          hashchangeListener?.(makeHashChangeEvent());
+        },
+      };
+    }
+
+    it("onStart registers BOTH popstate and hashchange listeners", () => {
+      const { shared, addPopSpy, addHashSpy, lifecycle } = makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+
+      expect(addPopSpy).toHaveBeenCalledTimes(1);
+      expect(addHashSpy).toHaveBeenCalledTimes(1);
+      expect(shared.removePopStateListener).toBeTypeOf("function");
+    });
+
+    it("onStart removes a previous instance's listeners before re-registering", () => {
+      const { removePopSpy, removeHashSpy, addPopSpy, addHashSpy, lifecycle } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      lifecycle.onStart?.();
+
+      expect(removePopSpy).toHaveBeenCalledTimes(1);
+      expect(removeHashSpy).toHaveBeenCalledTimes(1);
+      expect(addPopSpy).toHaveBeenCalledTimes(2);
+      expect(addHashSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("onStop removes both listeners and clears the shared slot", () => {
+      const { shared, removePopSpy, removeHashSpy, lifecycle } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      lifecycle.onStop?.();
+
+      expect(removePopSpy).toHaveBeenCalledTimes(1);
+      expect(removeHashSpy).toHaveBeenCalledTimes(1);
+      expect(shared.removePopStateListener).toBeUndefined();
+    });
+
+    it("onStop is a no-op when no listeners are registered", () => {
+      const { removePopSpy, removeHashSpy, lifecycle } = makeHashSyncDeps();
+
+      lifecycle.onStop?.();
+
+      expect(removePopSpy).not.toHaveBeenCalled();
+      expect(removeHashSpy).not.toHaveBeenCalled();
+    });
+
+    it("teardown removes both listeners and runs cleanup", () => {
+      const { shared, removePopSpy, removeHashSpy, cleanup, lifecycle } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      lifecycle.teardown?.();
+
+      expect(removePopSpy).toHaveBeenCalledTimes(1);
+      expect(removeHashSpy).toHaveBeenCalledTimes(1);
+      expect(shared.removePopStateListener).toBeUndefined();
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it("teardown still runs cleanup when no listeners are registered", () => {
+      const { removePopSpy, cleanup, lifecycle } = makeHashSyncDeps();
+
+      lifecycle.teardown?.();
+
+      expect(removePopSpy).not.toHaveBeenCalled();
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards a lone external hashchange to the handler (no popstate)", () => {
+      const { handler, lifecycle, fireHashchange } = makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      fireHashchange();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedups a traversal pair — popstate first drops the paired hashchange", () => {
+      const { handler, lifecycle, firePopstate, fireHashchange } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      firePopstate();
+      fireHashchange();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedups a traversal pair — hashchange first drops the paired popstate (order-independent)", () => {
+      const { handler, lifecycle, firePopstate, fireHashchange } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      fireHashchange();
+      firePopstate();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets the dedup guard on a microtask so separate tasks are both handled", async () => {
+      const { handler, lifecycle, fireHashchange, firePopstate } =
+        makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      fireHashchange();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Flush the microtask that clears the guard, then a new task's popstate
+      // must NOT be treated as the pair of the earlier hashchange.
+      await Promise.resolve();
+      firePopstate();
+
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not coalesce same-type bursts — two popstates in one task both run", () => {
+      const { handler, lifecycle, firePopstate } = makeHashSyncDeps();
+
+      lifecycle.onStart?.();
+      firePopstate();
+      firePopstate();
+
+      expect(handler).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/browser-env/tests/unit/popstate-utils.test.ts
+++ b/packages/browser-env/tests/unit/popstate-utils.test.ts
@@ -16,6 +16,7 @@ function makeFakeBrowser(location = "/"): Browser {
     pushState: vi.fn(),
     replaceState: vi.fn(),
     addPopstateListener: vi.fn(() => () => {}),
+    addHashChangeListener: vi.fn(() => () => {}),
     getLocation: () => location,
     getHash: () => "",
   };
@@ -56,6 +57,16 @@ describe("getRouteFromEvent", () => {
     const evt = makePopStateEvent(undefined);
 
     expect(getRouteFromEvent(evt, api, "/nope")).toBeUndefined();
+  });
+
+  it("resolves a HashChangeEvent (no history.state) via api.matchPath(location) (#759)", () => {
+    // A hashchange event has no `state` property at all — the `"state" in evt`
+    // guard must skip the makeState branch and fall back to matchPath.
+    const evt = {} as HashChangeEvent;
+
+    const matched = getRouteFromEvent(evt, api, "/users");
+
+    expect(matched).toMatchObject({ name: "users" });
   });
 });
 

--- a/packages/browser-env/tests/unit/ssr-fallback.test.ts
+++ b/packages/browser-env/tests/unit/ssr-fallback.test.ts
@@ -76,6 +76,19 @@ describe("createHistoryFallbackBrowser", () => {
     }).not.toThrow();
   });
 
+  it("addHashChangeListener returns cleanup function and warns (#759)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const browser = createHistoryFallbackBrowser("ctx");
+    const cleanup = browser.addHashChangeListener(vi.fn());
+
+    expect(typeof cleanup).toBe("function");
+    expect(() => {
+      cleanup();
+    }).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("addHashChangeListener");
+  });
+
   it("getHash returns empty string", () => {
     const browser = createHistoryFallbackBrowser("ctx");
 

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -52,7 +52,7 @@ External dependencies:
 | Dependency          | What it provides                                                        | Used in                                                     |
 | ------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `@real-router/core` | `getPluginApi`, types (`Router`, `PluginApi`, `State`, etc.)            | `factory.ts`, `plugin.ts`, `index.ts`                       |
-| `browser-env`       | Browser abstraction, popstate handling, validation, URL parsing helpers | `factory.ts`, `plugin.ts`, `validation.ts`, `hash-utils.ts` |
+| `browser-env`       | Browser abstraction, popstate + hashchange handling, validation, URL parsing helpers | `factory.ts`, `plugin.ts`, `validation.ts`, `hash-utils.ts` |
 | `type-guards`       | `isStateStrict` (`history.state` validation)                            | `index.ts` (re-exported as `isState`)                       |
 
 ## Factory + Class Pattern
@@ -82,7 +82,7 @@ hashPluginFactory(opts?, browser?)   ← factory.ts
                             │  - registers start interceptor (via browser-env)
                             │  - pre-computes urlPrefix = `${base}#${hashPrefix}`
                             │  - calls api.extendRouter({buildUrl, matchUrl, replaceHistoryState})
-                            │  - creates popstate handler and lifecycle (via browser-env)
+                            │  - creates popstate handler + hash-sync lifecycle (popstate & hashchange, via browser-env)
                             │
                             └── .getPlugin()  → Plugin { onStart, onStop, ... }
 ```
@@ -239,7 +239,7 @@ this.#lifecycle = createPopstateLifecycle({
 });
 ```
 
-`teardown` removes the popstate listener, then calls the `cleanup` callback which unregisters the start interceptor and router extensions.
+`teardown` removes the popstate **and** hashchange listeners (both stored under the single `removePopStateListener` slot as a combined remover, #759), then calls the `cleanup` callback which unregisters the start interceptor and router extensions.
 
 As a safety net, `router.dispose()` also cleans up any extensions that plugins failed to remove in their `teardown`.
 
@@ -275,16 +275,16 @@ interface SharedFactoryState {
 }
 ```
 
-The `shared` object is created once in `hashPluginFactory()` and passed to `createPopstateLifecycle` from `browser-env`.
+The `shared` object is created once in `hashPluginFactory()` and passed to `createHashSyncLifecycle` from `browser-env` (hash-plugin's variant of `createPopstateLifecycle` that also wires `hashchange`, #759).
 
 **Why is it needed?**
 
 The factory may be called again — for example, during hot module replacement (HMR) or when reusing the factory with different routers.
-Each new plugin instance registers its own popstate listener in `onStart`. Without `shared`, the previous listener would remain in memory.
+Each new plugin instance registers its own popstate + hashchange listeners in `onStart`. Without `shared`, the previous listeners would remain in memory.
 
 `shared` is intentionally mutable. It's the only shared state between instances of the same factory.
 
-**Factory pool — last-wins (concurrent-live caveat, #758).** Because the single `removePopStateListener` slot is shared, each `onStart` removes the previous instance's listener before installing its own. The pattern is built for a pool where routers are created/destroyed **sequentially** (one live router at a time). If two routers from the same factory are live **at the same time** on one window, only the **last-started** one tracks `popstate` — the earlier one silently desyncs from the URL. There is a single `popstate` stream and a single URL, so this mutual exclusivity is inherent. For genuinely concurrent routers, give each its own factory instance. Locked by `tests/stress/plugin-lifecycle-churn.stress.ts`.
+**Factory pool — last-wins (concurrent-live caveat, #758).** Because the single `removePopStateListener` slot is shared, each `onStart` removes the previous instance's listeners before installing its own. (For hash-plugin the slot holds a combined remover for **both** the popstate and hashchange listeners, #759.) The pattern is built for a pool where routers are created/destroyed **sequentially** (one live router at a time). If two routers from the same factory are live **at the same time** on one window, only the **last-started** one tracks `popstate`/`hashchange` — the earlier one silently desyncs from the URL. There is a single event stream and a single URL, so this mutual exclusivity is inherent. For genuinely concurrent routers, give each its own factory instance. Locked by `tests/stress/plugin-lifecycle-churn.stress.ts`.
 
 ## Data Flow: Navigation
 
@@ -311,15 +311,15 @@ router.navigate(name, params, opts)
 
 **Note:** Unlike browser-plugin, hash-plugin does NOT preserve hash fragments (the hash IS the route).
 
-## Data Flow: popstate (back/forward buttons)
+## Data Flow: popstate (back/forward buttons) + hashchange (external fragment changes)
 
-Popstate handling is fully delegated to `browser-env` via `createPopstateHandler` + `createPopstateLifecycle`. The flow is identical for browser-plugin and hash-plugin:
+Event handling is delegated to `browser-env` via `createPopstateHandler`. browser-plugin wires it with `createPopstateLifecycle` (popstate only); hash-plugin wires it with `createHashSyncLifecycle` (popstate **and** hashchange, #759). Both events reach the **same** handler; the flow below is shared:
 
 ```
-User clicks back or forward
-        │
+User clicks back/forward (popstate) OR changes the fragment externally (hashchange)
+        │  external = native <a href="#/x">, address-bar edit, location.hash=
         ▼
-  browser.addPopstateListener → handler(evt)  (from createPopstateHandler)
+  addPopstateListener / addHashChangeListener → handler(evt)  (from createPopstateHandler)
         │
         ├── location = browser.getLocation()   (snapshot at fire time, #757)
         │
@@ -331,8 +331,8 @@ User clicks back or forward
         │
         ├── getRouteFromEvent(evt, api, location)
         │     │
-        │     ├── isState(evt.state)?
-        │     │     YES: { name: evt.state.name, params: evt.state.params }
+        │     ├── "state" in evt && isState(evt.state)?   (popstate carries history.state;
+        │     │     YES: { name, params, path } from state    hashchange never does → fallback)
         │     │
         │     └── NO: api.matchPath(location)
         │               └── Hash URL matching as fallback
@@ -361,6 +361,15 @@ The `isTransitioning` flag blocks concurrent processing.
 New events are written to the single-slot `deferred = { evt, location }` queue — each one overwrites the previous (last-write-wins).
 The `location` is snapshotted when the event fires, not when it is replayed: the in-flight navigation's `onTransitionSuccess → replaceState` overwrites the live hash location before `processDeferredEvent()` runs, so re-reading it then would resolve the wrong target (#757).
 After the current transition completes, `processDeferredEvent()` processes the last deferred event against its snapshotted location.
+
+### popstate/hashchange dedup (#759)
+
+`createHashSyncLifecycle` registers both listeners but must not act on both when a **hash-changing back/forward** fires the pair synchronously (one browser task) — that would double-navigate. Two type-scoped flags (`sawPopstate` / `sawHashchange`), reset on a microtask, drop whichever of the pair arrives **second**. The dedup is **order-independent** (works whether the browser fires popstate or hashchange first) and does not coalesce:
+
+- **Separate gestures** land in separate tasks → the microtask reset clears the flags between them, so each is handled.
+- **Same-type bursts** (two rapid `popstate`s → the deferred path above) are unaffected: a `popstate` only blocks a following `hashchange`, never another `popstate`.
+
+An **external** fragment change fires `hashchange` alone (no popstate), so it is never dropped — that is the gap #759 closed.
 
 See [browser-env/ARCHITECTURE.md](../browser-env/ARCHITECTURE.md) for implementation details.
 
@@ -439,8 +448,8 @@ router.start()
         │
         ▼
   Plugin.onStart()
-        ├── Removes previous popstate listener (if any)
-        └── Registers new popstate listener
+        ├── Removes previous popstate + hashchange listeners (if any)
+        └── Registers new popstate + hashchange listeners (combined remover, #759)
 
 router.navigate() → success
         │
@@ -452,13 +461,13 @@ router.stop()
         │
         ▼
   Plugin.onStop()
-        └── Removes popstate listener
+        └── Removes popstate + hashchange listeners
 
 unsubscribe() or router.dispose()
         │
         ▼
   Plugin.teardown()
-        ├── Removes popstate listener
+        ├── Removes popstate + hashchange listeners
         ├── Unregisters start interceptor (#removeStartInterceptor)
         └── Removes router extensions (#removeExtensions)
 ```
@@ -513,6 +522,7 @@ buildUrl("users.profile", { id: "123" })
 | URL format         | `/app/users/123`                           | `#!/users/123`                                  |
 | Path extraction    | `String.startsWith` + `slice`              | Pre-computed RegExp via `createHashPrefixRegex` |
 | Hash preservation  | Preserves hash when paths match            | N/A — hash IS the route                         |
+| Event sources      | `popstate` only (`createPopstateLifecycle`) | `popstate` + `hashchange`, deduped (`createHashSyncLifecycle`, #759) |
 | Regex              | Not needed                                 | Pre-computed once at factory time               |
 | Server config      | Requires fallback (all paths → index.html) | No server config needed                         |
 | `buildUrl` formula | `base + path`                              | `urlPrefix + path` (pre-computed prefix)        |

--- a/packages/hash-plugin/CLAUDE.md
+++ b/packages/hash-plugin/CLAUDE.md
@@ -22,7 +22,12 @@ Router Navigation:
 
 Browser Back/Forward:
   popstate → handler (browser-env) → router.navigate()/navigateToNotFound()/navigateToDefault() → pushState/replaceState
+
+External Fragment Change (native <a href="#/x">, address-bar edit, location.hash=):
+  hashchange → handler (browser-env) → router.navigate()/navigateToNotFound() → replaceState
 ```
+
+Both `popstate` and `hashchange` route through the **same** `createPopstateHandler`. A hash-changing history traversal fires **both** events; `createHashSyncLifecycle` dedups the pair (see [Gotchas](#hashchange-listener--popstatehashchange-dedup-759)) so exactly one navigation runs.
 
 ### Promise-Based API
 
@@ -43,6 +48,13 @@ Click back again → event DEFERRED (not lost)
 Transition completes → process deferred event
 ```
 Only the **last** deferred event is kept (intermediate states skipped).
+
+### Hashchange listener + popstate/hashchange dedup (#759)
+Unlike browser-plugin (which uses `createPopstateLifecycle`, popstate only), hash-plugin uses `createHashSyncLifecycle` from `browser-env` — it registers **both** `popstate` and `hashchange`. This is what makes external fragment changes reach the router: a native `<a href="#/x">`, a manual address-bar hash edit, or `location.hash = "..."` fire `hashchange` **only** (never `popstate`; `pushState`/`replaceState` — the plugin's own writes — never fire `hashchange` either), so a popstate-only listener would silently ignore them.
+
+A hash-changing **back/forward** traversal fires **both** events synchronously (one browser task). Handling both double-navigates, so the second of the pair is dropped. The dedup is **order-independent**: two type-scoped flags (`sawPopstate` / `sawHashchange`), reset on a microtask, drop whichever of the pair arrives second — regardless of which the browser fires first. The reset scopes the guard to a single synchronous pair, so distinct user gestures (separate tasks) are never coalesced, and same-type bursts (two rapid `popstate`s → the deferred-event path above) are unaffected because a `popstate` only ever blocks a following `hashchange`, never another `popstate`.
+
+Both listeners share the single `shared.removePopStateListener` slot as a combined remover, so the factory-pool last-wins cleanup (#758) is unchanged.
 
 ### Base Path Normalization
 ```typescript

--- a/packages/hash-plugin/src/plugin.ts
+++ b/packages/hash-plugin/src/plugin.ts
@@ -1,6 +1,6 @@
 import {
   createPopstateHandler,
-  createPopstateLifecycle,
+  createHashSyncLifecycle,
   createStartInterceptor,
   createReplaceHistoryState,
   shouldReplaceHistory,
@@ -104,7 +104,7 @@ export class HashPlugin {
       buildUrl: pluginBuildUrl,
     });
 
-    this.#lifecycle = createPopstateLifecycle({
+    this.#lifecycle = createHashSyncLifecycle({
       browser,
       shared,
       handler,

--- a/packages/hash-plugin/tests/functional/popstate.test.ts
+++ b/packages/hash-plugin/tests/functional/popstate.test.ts
@@ -517,4 +517,110 @@ describe("Hash Plugin — Popstate & Error Recovery", async () => {
       expect(router.getState()).toStrictEqual(stateBefore);
     });
   });
+
+  describe("Hashchange — external fragment changes (#759)", () => {
+    beforeEach(async () => {
+      router.usePlugin(hashPluginFactory({}, mockedBrowser));
+      await router.start();
+    });
+
+    it("syncs the router on an external hashchange with no popstate (native anchor / address-bar edit / location.hash=)", async () => {
+      // Router boots at "index" ("/"). An external fragment change — a native
+      // `<a href="#/users/list">`, a manual address-bar hash edit, or
+      // `location.hash = ...` from app/third-party code — updates location.hash
+      // and fires `hashchange` ONLY (popstate fires on traversal; pushState/
+      // replaceState never fire hashchange). Before #759 the plugin listened to
+      // popstate alone, so this external channel never reached the router.
+      expect(router.getState()?.name).toBe("index");
+
+      globalThis.history.replaceState({}, "", "/#/users/list");
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.list");
+    });
+
+    it("does not double-navigate when a hash traversal fires popstate then hashchange", async () => {
+      // Back/forward over a hash entry fires BOTH events synchronously. The
+      // dedup drops the second of the pair, so exactly one navigation runs.
+      globalThis.history.replaceState({}, "", "/#/users/list");
+      const navSpy = vi.spyOn(getPluginApi(router), "navigateToState");
+
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.list");
+      expect(navSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not double-navigate when a hash traversal fires hashchange then popstate (reverse order)", async () => {
+      // Same traversal, opposite arrival order — the dedup is order-independent,
+      // so the popstate is the one dropped here. Still exactly one navigation.
+      globalThis.history.replaceState({}, "", "/#/users/list");
+      const navSpy = vi.spyOn(getPluginApi(router), "navigateToState");
+
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+      globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.list");
+      expect(navSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles hashchanges from separate tasks independently (dedup guard resets per task)", async () => {
+      // Two distinct external changes in separate browser tasks must BOTH be
+      // handled — the guard resets on a microtask, so it never coalesces
+      // separate user gestures into one.
+      globalThis.history.replaceState({}, "", "/#/users/list");
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.list");
+
+      globalThis.history.replaceState({}, "", "/#/home");
+      globalThis.dispatchEvent(new HashChangeEvent("hashchange"));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("home");
+    });
+
+    it("removes the hashchange listener on stop", async () => {
+      const removeEventSpy = vi.spyOn(globalThis, "removeEventListener");
+
+      router.stop();
+
+      expect(removeEventSpy).toHaveBeenCalledWith(
+        "hashchange",
+        expect.any(Function),
+      );
+
+      removeEventSpy.mockRestore();
+    });
+
+    it("registers a hashchange listener on start", async () => {
+      // Fresh router — the shared beforeEach already started one; assert the
+      // hashchange listener is wired alongside popstate on start.
+      router.stop();
+
+      const addEventSpy = vi.spyOn(globalThis, "addEventListener");
+      const freshRouter = createRouter(routerConfig, { defaultRoute: "home" });
+
+      freshRouter.usePlugin(hashPluginFactory({}, mockedBrowser));
+      await freshRouter.start();
+
+      expect(addEventSpy).toHaveBeenCalledWith(
+        "hashchange",
+        expect.any(Function),
+      );
+
+      freshRouter.stop();
+      addEventSpy.mockRestore();
+    });
+  });
 });

--- a/shared/browser-env/history-api.ts
+++ b/shared/browser-env/history-api.ts
@@ -18,4 +18,14 @@ export const addPopstateListener: HistoryBrowser["addPopstateListener"] = (
   };
 };
 
+export const addHashChangeListener: HistoryBrowser["addHashChangeListener"] = (
+  fn,
+) => {
+  globalThis.addEventListener("hashchange", fn);
+
+  return () => {
+    globalThis.removeEventListener("hashchange", fn);
+  };
+};
+
 export const getHash = (): string => globalThis.location.hash;

--- a/shared/browser-env/index.ts
+++ b/shared/browser-env/index.ts
@@ -6,6 +6,7 @@ export {
   pushState,
   replaceState,
   addPopstateListener,
+  addHashChangeListener,
   getHash,
 } from "./history-api.js";
 
@@ -36,6 +37,7 @@ export { createSafeBrowser } from "./safe-browser.js";
 export {
   createPopstateHandler,
   createPopstateLifecycle,
+  createHashSyncLifecycle,
 } from "./popstate-handler.js";
 
 export type {

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -75,13 +75,16 @@ function resolveHashOptions(
 
 export function createPopstateHandler(
   deps: PopstateHandlerDeps,
-): (evt: PopStateEvent) => void {
+): (evt: PopStateEvent | HashChangeEvent) => void {
   let isTransitioning = false;
   // Snapshot the route location alongside the event: a deferred popstate is
   // replayed only after the in-flight navigation's onTransitionSuccess →
   // replaceState has overwritten the live location, so re-reading it at
   // replay time would resolve the wrong target (#757).
-  let deferred: { evt: PopStateEvent; location: string } | null = null;
+  let deferred: {
+    evt: PopStateEvent | HashChangeEvent;
+    location: string;
+  } | null = null;
 
   function processDeferredEvent(): void {
     if (deferred) {
@@ -134,7 +137,7 @@ export function createPopstateHandler(
   }
 
   async function onPopState(
-    evt: PopStateEvent,
+    evt: PopStateEvent | HashChangeEvent,
     location: string,
   ): Promise<void> {
     if (isTransitioning) {
@@ -193,14 +196,14 @@ export function createPopstateHandler(
 
   // Snapshot the location the instant the event fires — before any in-flight
   // navigation can overwrite it via replaceState (#757).
-  return (evt: PopStateEvent) =>
+  return (evt: PopStateEvent | HashChangeEvent) =>
     void onPopState(evt, deps.browser.getLocation());
 }
 
 export interface PopstateLifecycleDeps {
   browser: Browser;
   shared: SharedFactoryState;
-  handler: (evt: PopStateEvent) => void;
+  handler: (evt: PopStateEvent | HashChangeEvent) => void;
   cleanup: () => void;
 }
 
@@ -231,6 +234,98 @@ export function createPopstateLifecycle(
         deps.shared.removePopStateListener = undefined;
       }
 
+      deps.cleanup();
+    },
+  };
+}
+
+/**
+ * Lifecycle for hash-plugin (#759): syncs the router with the URL fragment on
+ * BOTH `popstate` (back/forward) and `hashchange` (external fragment changes —
+ * native anchors, address-bar edits, `location.hash = ...`). browser-plugin
+ * keeps `createPopstateLifecycle` (popstate only) — for it a path change is a
+ * full navigation, and `hashchange` would be noise.
+ *
+ * Dedup: a hash-changing history traversal fires the `popstate`+`hashchange`
+ * pair synchronously (one browser task). Handling both double-navigates, so the
+ * second of the pair is dropped. The two `saw*` flags are **type-scoped** and
+ * **order-independent** — whichever of the pair arrives first is handled and
+ * blocks the other, no matter which the browser fires first. They reset on a
+ * microtask, so the guard spans only the synchronous pair: distinct user
+ * gestures land in separate tasks and are never coalesced, and same-type bursts
+ * (two rapid `popstate`s → the deferred-event path) are unaffected because a
+ * `popstate` only blocks a following `hashchange`, never another `popstate`.
+ *
+ * Both listeners are stored under the single `shared.removePopStateListener`
+ * slot as a combined remover, preserving the factory-pool last-wins cleanup
+ * (#758) unchanged.
+ */
+export function createHashSyncLifecycle(
+  deps: PopstateLifecycleDeps,
+): Pick<Plugin, "onStart" | "onStop" | "teardown"> {
+  let sawPopstate = false;
+  let sawHashchange = false;
+  let resetScheduled = false;
+
+  const scheduleReset = (): void => {
+    if (resetScheduled) {
+      return;
+    }
+
+    resetScheduled = true;
+    queueMicrotask(() => {
+      sawPopstate = false;
+      sawHashchange = false;
+      resetScheduled = false;
+    });
+  };
+
+  const onPopstate = (evt: PopStateEvent): void => {
+    // The paired hashchange already handled this traversal — drop the popstate.
+    if (sawHashchange) {
+      return;
+    }
+
+    sawPopstate = true;
+    scheduleReset();
+    deps.handler(evt);
+  };
+
+  const onHashchange = (evt: HashChangeEvent): void => {
+    // The paired popstate already handled this traversal — drop the hashchange.
+    if (sawPopstate) {
+      return;
+    }
+
+    sawHashchange = true;
+    scheduleReset();
+    deps.handler(evt);
+  };
+
+  const removeListeners = (): void => {
+    if (deps.shared.removePopStateListener) {
+      deps.shared.removePopStateListener();
+      deps.shared.removePopStateListener = undefined;
+    }
+  };
+
+  return {
+    onStart: () => {
+      removeListeners();
+
+      const removePopstate = deps.browser.addPopstateListener(onPopstate);
+      const removeHashchange = deps.browser.addHashChangeListener(onHashchange);
+
+      deps.shared.removePopStateListener = () => {
+        removePopstate();
+        removeHashchange();
+      };
+    },
+
+    onStop: removeListeners,
+
+    teardown: () => {
+      removeListeners();
       deps.cleanup();
     },
   };

--- a/shared/browser-env/popstate-utils.ts
+++ b/shared/browser-env/popstate-utils.ts
@@ -30,14 +30,21 @@ import type { PluginApi } from "@real-router/core/api";
  * the State directly to `router.navigateToState(state, opts)` and skip
  * the redundant `forwardState`/`buildPath` round-trip in
  * `buildNavigateState` (issue #525).
+ *
+ * Accepts `HashChangeEvent` too (#759): a `hashchange` carries no history
+ * `state`, so it always resolves via the `matchPath(location)` fallback — the
+ * correct source of truth for an external fragment change, where the URL, not
+ * a plugin-recorded entry, defines the target.
  */
 export function getRouteFromEvent(
-  evt: PopStateEvent,
+  evt: PopStateEvent | HashChangeEvent,
   api: PluginApi,
   location: string,
 ): State | undefined {
-  if (isState(evt.state)) {
-    return api.makeState(evt.state.name, evt.state.params, evt.state.path);
+  const state: unknown = "state" in evt ? evt.state : undefined;
+
+  if (isState(state)) {
+    return api.makeState(state.name, state.params, state.path);
   }
 
   return api.matchPath(location);

--- a/shared/browser-env/safe-browser.ts
+++ b/shared/browser-env/safe-browser.ts
@@ -3,6 +3,7 @@ import {
   pushState,
   replaceState,
   addPopstateListener,
+  addHashChangeListener,
   getHash,
 } from "./history-api.js";
 import {
@@ -21,6 +22,7 @@ export function createSafeBrowser(
       pushState,
       replaceState,
       addPopstateListener,
+      addHashChangeListener,
       getLocation,
       getHash,
     };

--- a/shared/browser-env/ssr-fallback.ts
+++ b/shared/browser-env/ssr-fallback.ts
@@ -34,6 +34,11 @@ export const createHistoryFallbackBrowser = (
 
       return NOOP;
     },
+    addHashChangeListener: () => {
+      warnOnce("addHashChangeListener");
+
+      return NOOP;
+    },
     getHash: () => {
       warnOnce("getHash");
 

--- a/shared/browser-env/types.ts
+++ b/shared/browser-env/types.ts
@@ -2,6 +2,15 @@ export interface HistoryBrowser {
   pushState: (state: unknown, path: string) => void;
   replaceState: (state: unknown, path: string) => void;
   addPopstateListener: (fn: (evt: PopStateEvent) => void) => () => void;
+  /**
+   * Subscribe to `hashchange`. Fired for same-document fragment navigations
+   * that the plugin did NOT drive itself — native anchors (`<a href="#/x">`),
+   * manual address-bar hash edits, and `location.hash = ...` from app code.
+   * `pushState`/`replaceState` (the plugin's own writes) never fire it, so it
+   * is a clean external-change channel. Used only by hash-plugin, where `#`
+   * carries the route (browser-plugin leaves it unused). (#759)
+   */
+  addHashChangeListener: (fn: (evt: HashChangeEvent) => void) => () => void;
   getHash: () => string;
 }
 


### PR DESCRIPTION
## Summary

- `@real-router/hash-plugin` now synchronizes the router on **external** URL fragment changes — a native `<a href="#/users">`, a manual address-bar hash edit, or `location.hash = "..."` from app/third-party code. Previously these silently desynced: the URL changed while the router stayed on the old route.
- **Root cause:** the plugin wired only `popstate`, which fires on history traversal (back/forward) only. A same-document fragment navigation fires `hashchange`, not `popstate`, so an external hash change never reached the router.
- **Fix:** a new `createHashSyncLifecycle` registers **both** `popstate` and `hashchange` through the same handler. A hash-changing back/forward fires both events, so the pair is deduped — **order-independent** (does not depend on the browser's firing order) and microtask-scoped, so exactly one navigation runs and separate gestures are never coalesced.
- `browser-plugin` and `navigation-plugin` are unchanged: browser-plugin keeps its popstate-only wiring (a path change there is a full navigation), and navigation-plugin's `NavigationBrowser` is independent of the shared `HistoryBrowser`.

## New API

The shared `Browser` interface (exported from both `hash-plugin` and `browser-plugin`) gains one method, added symmetric to `addPopstateListener`:

```ts
interface HistoryBrowser {
  // …
  addHashChangeListener: (fn: (evt: HashChangeEvent) => void) => () => void;
}
```

Runtime behavior of browser-plugin is unchanged (it never registers a `hashchange` listener). A hand-written `Browser` supplied via the test-only `browser` factory argument must now include this method — shipped as `minor` for both packages (pre-1.0 convention for a public-type change).

## Test plan

- [x] **RED isolates the gap:** `hash-plugin` — `syncs the router on an external hashchange with no popstate ...` dispatches `HashChangeEvent` directly (not reproducible via naive `location.hash =` in jsdom, which fires a spurious masking `popstate`)
- [x] **Dedup, both orders, mutationally validated:** `... popstate then hashchange` + `... hashchange then popstate (reverse order)` assert exactly one `navigateToState`; removing the dedup makes both fail with 2 navigations
- [x] **browser-env unit (100% gated in the `packages/browser-env` wrapper):** 158 tests — `createHashSyncLifecycle` registration/dedup/reset/same-type-burst, `addHashChangeListener` (history-api + SSR fallback), `getRouteFromEvent` hashchange branch
- [x] Regression: `hash-plugin` 95 functional + 33 property + 28 stress; `browser-plugin` 136; `navigation-plugin` 237
- [x] `type-check` + `lint` across all four affected packages; pre-commit hook (123 turbo tasks) passed
- [ ] full `pnpm build` — deferred to CI/reviewer
- [x] 100% test coverage maintained

Closes #759
