### PR TITLE
docs(browser-env): name buildHashLocation in getRouteFromEvent fallback JSDoc (#760)

### DIFF
--- a/.changeset/popstate-utils-760-jsdoc-docs.md
+++ b/.changeset/popstate-utils-760-jsdoc-docs.md
@@ -1,0 +1,5 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Clarify the `getRouteFromEvent` matchPath-fallback JSDoc in shared `popstate-utils` — name hash-plugin's `buildHashLocation(location.hash, ...)` mechanism so the comment (read by both URL plugins' maintainers) correctly explains why the fallback resolves the hash route (#760)

--- a/shared/browser-env/popstate-utils.ts
+++ b/shared/browser-env/popstate-utils.ts
@@ -16,8 +16,10 @@ import type { PluginApi } from "@real-router/core/api";
  * - Otherwise (e.g. manually entered URL with no recorded state), fall back
  *   to `api.matchPath(location)`. `location` is the route location the caller
  *   captured when the popstate event fired — each plugin derives it from its
- *   own `browser.getLocation()` (URL pathname for browser-plugin, hash-derived
- *   path for hash-plugin), so the fallback works for both.
+ *   own `browser.getLocation()`, and both return a path the matcher understands
+ *   (browser-plugin: the History pathname; hash-plugin: the hash route via
+ *   `buildHashLocation(location.hash, ...)`), so the fallback works for both.
+ *   (#760)
  * - `undefined` when neither path produces a match.
  *
  * The caller passes the location it snapshotted at event time rather than


### PR DESCRIPTION
## Summary

Completes the `getRouteFromEvent` matchPath-fallback JSDoc in shared `popstate-utils.ts` (read by both `browser-plugin` and `hash-plugin` maintainers). The comment already stated the fallback works for both plugins, but did not name **why** hash-plugin's `browser.getLocation()` returns a matchable path. It now names the mechanism — `buildHashLocation(location.hash, ...)` — so the shared comment is self-explanatory.

- **Docs-only, zero runtime change** — no behavior, tests, or public API affected.
- Completes the suggested wording from #760. The wrong *"returns the History pathname, not the hash"* claim it originally flagged was already corrected by #759's JSDoc rewrite; this adds the remaining precision (the concrete `buildHashLocation` mechanism).

> **CI note (unrelated to the docs content):** because this is a `shared/browser-env/*.ts` change, it is also the first PR to exercise the input-aware shard-membership fix (#1067) end-to-end. `check` routes `sharded` via `touchesSharedSources`, and the `url-plugin` + `internal` shards resolve the `shared/browser-env` consumers that `turbo query affected` alone does not surface (the pre-fix planner would have emitted an empty/partial matrix here).

## Test plan

- [x] Docs-only (JSDoc comment) — no code path changed; TS parse + prettier verified
- [x] Changeset `patch @real-router/hash-plugin`, validated by `.changeset/check-changeset.mjs`
- [x] `pnpm build` — passed via pre-push (shared-input hash change re-validated the browser-env consumers: browser-plugin, hash-plugin, navigation-plugin)
- [x] 100% coverage maintained (no code change)

Closes #760
