### PR TITLE
perf(angular): shared active-name selector fast path for RealLink/RealLinkActive (#1103)

### DIFF
--- a/.changeset/angular-link-fastpath-perf.md
+++ b/.changeset/angular-link-fastpath-perf.md
@@ -1,0 +1,29 @@
+---
+"@real-router/angular": patch
+---
+
+Speed up `RealLink` / `RealLinkActive` mount via a shared active-name selector fast path (#1103)
+
+A default-options `RealLink` / `RealLinkActive` (a non-empty `routeName`, no
+custom `routeParams`, non-strict, query params ignored, no `hash`) now resolves
+its active state through the per-router `createActiveNameSelector` — a single
+shared `router.subscribe` handle for any number of distinct-`routeName` links —
+instead of allocating a per-link `createActiveRouteSource` (a `BaseSource` plus
+its own router subscription for every link). Because `activeClassName` defaults
+to `"active"`, *every* `RealLink` tracked active state by default, so a
+link-heavy page opened one router subscription per link.
+
+The path decision lives in the new internal `createActiveSource` helper; the
+selector is wrapped as a `RouterSource<boolean>` so the directives' existing
+`subscribeSourceToSignal` pipeline is unchanged. This ports the Svelte adapter's
+fix ([#1101](https://github.com/greydragon888/real-router/pull/1101)) to Angular.
+On the `link-build` benchmark (mount 1000 links) it removes the per-link source
+setup — ~14.8 → ~12.9 ms / 1000 links — and collapses 1000 router subscriptions
+to one.
+
+Active-class semantics are unchanged (non-strict, query-ignoring, name-only
+matching is exactly what the default `createActiveRouteSource` did). Any
+deviation from the defaults — custom `routeParams`, `activeStrict`,
+`ignoreQueryParams: false`, hash-aware (#532), **or an empty `routeName`** (a
+misuse where the selector's root-active semantics would differ) — keeps the
+full-fidelity per-link slow path.

--- a/packages/angular/src/directives/RealLink.ts
+++ b/packages/angular/src/directives/RealLink.ts
@@ -7,11 +7,10 @@ import {
   input,
   signal,
 } from "@angular/core";
-import { createActiveRouteSource } from "@real-router/sources";
 
 import { buildHref, navigateWithHash, shouldNavigate } from "../dom-utils";
 import { injectRouter } from "../functions/injectRouter";
-import { buildActiveRouteOptions } from "../internal/buildActiveRouteOptions";
+import { createActiveSource } from "../internal/createActiveSource";
 import { createStableParams } from "../internal/createStableParams";
 import { subscribeSourceToSignal } from "../internal/subscribeSourceToSignal";
 
@@ -90,15 +89,15 @@ export class RealLink {
     // source whenever any input changes; `onCleanup` tears the previous
     // subscription down.
     effect((onCleanup) => {
-      const source = createActiveRouteSource(
+      // Fast path (#1103) for default-options links — shared name selector
+      // instead of a per-link source; see `createActiveSource`.
+      const source = createActiveSource(
         this.router,
         this.routeName(),
         this.stableParams(),
-        buildActiveRouteOptions(
-          this.activeStrict(),
-          this.ignoreQueryParams(),
-          this.hash(),
-        ),
+        this.activeStrict(),
+        this.ignoreQueryParams(),
+        this.hash(),
       );
 
       onCleanup(

--- a/packages/angular/src/directives/RealLinkActive.ts
+++ b/packages/angular/src/directives/RealLinkActive.ts
@@ -6,11 +6,10 @@ import {
   input,
   signal,
 } from "@angular/core";
-import { createActiveRouteSource } from "@real-router/sources";
 
 import { applyLinkA11y } from "../dom-utils";
 import { injectRouter } from "../functions/injectRouter";
-import { buildActiveRouteOptions } from "../internal/buildActiveRouteOptions";
+import { createActiveSource } from "../internal/createActiveSource";
 import { createStableParams } from "../internal/createStableParams";
 import { subscribeSourceToSignal } from "../internal/subscribeSourceToSignal";
 
@@ -50,15 +49,16 @@ export class RealLinkActive {
     // Reactive source-creation effect (#630 fix) — see
     // `packages/angular/CLAUDE.md` → "Directives use constructor + effect()".
     effect((onCleanup) => {
-      const source = createActiveRouteSource(
+      // Fast path (#1103) for default-options links — shared name selector
+      // instead of a per-link source; see `createActiveSource`. RealLinkActive
+      // has no `hash` input, so it is always passed `undefined`.
+      const source = createActiveSource(
         this.router,
         this.routeName(),
         this.stableParams(),
-        buildActiveRouteOptions(
-          this.activeStrict(),
-          this.ignoreQueryParams(),
-          undefined,
-        ),
+        this.activeStrict(),
+        this.ignoreQueryParams(),
+        undefined,
       );
 
       onCleanup(

--- a/packages/angular/src/internal/createActiveSource.ts
+++ b/packages/angular/src/internal/createActiveSource.ts
@@ -1,0 +1,70 @@
+import {
+  createActiveNameSelector,
+  createActiveRouteSource,
+} from "@real-router/sources";
+
+import { buildActiveRouteOptions } from "./buildActiveRouteOptions";
+
+import type { Params, Router } from "@real-router/core";
+import type { RouterSource } from "@real-router/sources";
+
+const NOOP = (): void => {};
+
+/**
+ * Build the active-route `RouterSource<boolean>` for a Link-style directive
+ * (`RealLink`, `RealLinkActive`), choosing a fast or slow path from the inputs.
+ *
+ * **Fast path (#1103)** — a default-options link (a non-empty `routeName`, no
+ * custom `params`, non-strict, query params ignored, no `hash`) shares the
+ * per-router `createActiveNameSelector`: ONE `router.subscribe` handle serves
+ * any number of distinct-`routeName` links, instead of a per-link
+ * `createActiveRouteSource` (which allocates a `BaseSource` AND opens its own
+ * router subscription for every link). This mirrors the Svelte adapter's fast
+ * path ([#1101](https://github.com/greydragon888/real-router/pull/1101)) and the
+ * Solid `routeSelector`. The selector is wrapped as a `RouterSource<boolean>`
+ * (its `isActive` is exactly non-strict, query-ignoring, name-only matching —
+ * identical to the default `createActiveRouteSource`) so the caller's existing
+ * `subscribeSourceToSignal` pipeline is unchanged. `destroy()` is a no-op: the
+ * selector is per-router cached and lives with the router; the returned
+ * subscribe's unsubscribe removes just this link's listener.
+ *
+ * **Slow path** — any deviation from the defaults (custom `params`,
+ * `activeStrict`, `ignoreQueryParams: false`, hash-aware #532) falls to the
+ * per-link `createActiveRouteSource`, whose cache handles the full argument
+ * surface. An **empty `routeName`** also takes the slow path: it is a misuse (it
+ * builds no `href` and logs a `console.error`), and the selector's root-active
+ * semantics (`isActive("") === true`) would flip a misused link to active,
+ * whereas `router.isActiveRoute("")` returns `false` — the slow path preserves
+ * that behaviour.
+ */
+export function createActiveSource(
+  router: Router,
+  routeName: string,
+  params: Params | undefined,
+  strict: boolean,
+  ignoreQueryParams: boolean,
+  hash: string | undefined,
+): RouterSource<boolean> {
+  if (
+    routeName !== "" &&
+    params === undefined &&
+    !strict &&
+    ignoreQueryParams &&
+    hash === undefined
+  ) {
+    const selector = createActiveNameSelector(router);
+
+    return {
+      subscribe: (listener) => selector.subscribe(routeName, listener),
+      getSnapshot: () => selector.isActive(routeName),
+      destroy: NOOP,
+    };
+  }
+
+  return createActiveRouteSource(
+    router,
+    routeName,
+    params,
+    buildActiveRouteOptions(strict, ignoreQueryParams, hash),
+  );
+}

--- a/packages/angular/tests/functional/createActiveSource.test.ts
+++ b/packages/angular/tests/functional/createActiveSource.test.ts
@@ -1,0 +1,215 @@
+import { createRouter } from "@real-router/core";
+import { createActiveRouteSource } from "@real-router/sources";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { createActiveSource } from "../../src/internal/createActiveSource";
+
+import type { Router } from "@real-router/core";
+
+// `createActiveSource` is the fast/slow active-source selector shared by
+// `RealLink` and `RealLinkActive` (#1103). It takes the router explicitly (no
+// injection context), so it is directly unit-testable — which matters because
+// JIT TestBed cannot bind non-default signal inputs to the directives, so the
+// fast path (non-empty routeName, default options) is otherwise unreachable in
+// unit tests (the documented ~97% JIT ceiling). These tests pin the path
+// decision + the fast-path reactive contract without AOT.
+//
+// Discriminator for "fast path was taken": a fast-path source is backed by the
+// shared `createActiveNameSelector` and never builds the per-link
+// `createActiveRouteSource`, so the canonical slow-path source for the same
+// arguments is still UNBUILT — asking for it is a cache MISS that runs
+// `router.isActiveRoute` once. A slow-path `createActiveSource` builds that
+// exact source, so the same later call is a cache HIT (no `isActiveRoute`).
+describe("createActiveSource", () => {
+  const routes = [
+    { name: "home", path: "/" },
+    {
+      name: "users",
+      path: "/users",
+      children: [{ name: "list", path: "/list" }],
+    },
+  ];
+
+  let router: Router;
+
+  beforeEach(async () => {
+    router = createRouter(routes);
+    await router.start("/");
+  });
+
+  afterEach(() => {
+    router.stop();
+  });
+
+  it("default options + non-empty routeName → shared selector fast path (no per-link source)", () => {
+    const source = createActiveSource(
+      router,
+      "home",
+      undefined,
+      false,
+      true,
+      undefined,
+    );
+
+    // Fast path reflects the current active state via the selector.
+    expect(source.getSnapshot()).toBe(true);
+
+    // The canonical slow-path source was NOT built → cache MISS runs isActiveRoute.
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "home", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+    });
+
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("fast path is non-strict (descendant match) and name-only", () => {
+    // "users" is active as an ancestor of the current route once navigated.
+    const source = createActiveSource(
+      router,
+      "users",
+      undefined,
+      false,
+      true,
+      undefined,
+    );
+
+    expect(source.getSnapshot()).toBe(false);
+  });
+
+  it("custom params → slow path (per-link createActiveRouteSource)", () => {
+    createActiveSource(router, "home", { id: "1" }, false, true, undefined);
+
+    // The slow path built the source → asking for the identical source is a HIT.
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(
+      router,
+      "home",
+      { id: "1" },
+      {
+        strict: false,
+        ignoreQueryParams: true,
+      },
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("activeStrict → slow path", () => {
+    createActiveSource(router, "home", undefined, true, true, undefined);
+
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "home", undefined, {
+      strict: true,
+      ignoreQueryParams: true,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("ignoreQueryParams=false → slow path", () => {
+    createActiveSource(router, "home", undefined, false, false, undefined);
+
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "home", undefined, {
+      strict: false,
+      ignoreQueryParams: false,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("hash-aware (#532) → slow path", () => {
+    createActiveSource(router, "home", undefined, false, true, "frag");
+
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "home", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+      hash: "frag",
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("empty routeName → slow path (misuse, not fast-pathed)", () => {
+    // routeName="" is a misuse (no href, console.error). It must NOT take the
+    // fast path — the selector reports root-active `true` for "", whereas the
+    // slow path's isActiveRoute("") is false. Keeping "" on the slow path
+    // preserves that behaviour (and matches every JIT directive test).
+    createActiveSource(router, "", undefined, false, true, undefined);
+
+    const spy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+
+  it("fast-path source updates on navigation (reactive)", async () => {
+    const source = createActiveSource(
+      router,
+      "users",
+      undefined,
+      false,
+      true,
+      undefined,
+    );
+
+    let notified = 0;
+    const unsub = source.subscribe(() => {
+      notified++;
+    });
+
+    expect(source.getSnapshot()).toBe(false);
+
+    await router.navigate("users.list");
+
+    expect(notified).toBeGreaterThan(0);
+    expect(source.getSnapshot()).toBe(true);
+
+    unsub();
+  });
+
+  it("fast-path source destroy() is a no-op and unsubscribe is idempotent-safe", () => {
+    const source = createActiveSource(
+      router,
+      "home",
+      undefined,
+      false,
+      true,
+      undefined,
+    );
+    const unsub = source.subscribe(() => {});
+
+    // The shared selector survives destroy() (per-router cached).
+    expect(() => {
+      source.destroy();
+      unsub();
+    }).not.toThrow();
+
+    // Snapshot still readable after teardown.
+    expect(source.getSnapshot()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **`@real-router/angular` `RealLink` / `RealLinkActive` fast path (#1103).** A default-options link (a non-empty `routeName`, no custom `routeParams`, non-strict, query params ignored, no `hash`) now resolves its active state through the per-router `createActiveNameSelector` — a single shared `router.subscribe` handle for any number of distinct-`routeName` links — instead of allocating a per-link `createActiveRouteSource` (a `BaseSource` **plus its own router subscription** for every link). Because `activeClassName` defaults to `"active"`, *every* `RealLink` tracked active state, so a link-heavy page opened one router subscription per link.
- **`link-build` @1000 (angular cohort, median/10, in-session): 14.83 → 12.95 ms**, and **1000 router subscriptions → 1**. Directly parallels #1099 → #1101 (Svelte: 14.53 → 12.62, 1000 → 1).
- The path decision lives in a new internal `createActiveSource` helper; the selector is wrapped as a `RouterSource<boolean>` so the directives' existing `subscribeSourceToSignal` pipeline is unchanged. Active-class semantics are identical.

No public API change (`createActiveSource` is internal; the directive inputs and behaviour are unchanged).

## Isolation (the #1094/#1099 discipline)

Before/after on the real benchmark (which measures the production dist) isolates the per-link-source slice:

| variant | link-build @1000 |
|---|---|
| baseline (per-link `createActiveRouteSource`) | 14.83 ms |
| **fast path (shared selector)** | **12.95 ms** |

The removed ~1.9 ms is the per-link source setup (`BaseSource` + `router.subscribe` ×1000 → ×1). The residual (the reverse-matcher `buildPath` per link + Angular directive DI / effect) is framework floor, not adapter-attributable — the same split the issue and the Svelte parallel (#1101) established.

## Empty `routeName` stays on the slow path (deliberate)

`routeName === ""` is excluded from the fast path. It is a misuse (no `href`, logs a `console.error`), and the selector's root-active semantics report `isActive("") === true`, whereas `router.isActiveRoute("")` is `false`. Keeping `""` on the slow path preserves that behaviour — and, practically, keeps every JIT directive test passing unchanged (JIT TestBed cannot bind non-default signal inputs, so its `<a realLink>` always has the default `routeName=""`; several tests assert no `active` class / source-dedup on it).

## Test plan

- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes — angular: **398 unit + 190 property + 105 stress** green
- [x] Coverage maintained: **97.38 / 93.59 / 98.78 / 97.33** vs the package's JIT-ceiling thresholds **97 / 93 / 98 / 97**
- [x] The fast path is unreachable through JIT-bound directive templates (the documented ~97% ceiling — signal inputs aren't bindable in JIT), so it is covered by a **direct `createActiveSource` unit test**: fast vs slow path per input, the `""` exclusion, non-strict descendant matching, and reactive update on navigation
- [x] `real-link-fanout` / `is-active-route-fanout` stress heap guards still hold (the fast path is heap-neutral for the stress suites' `routeName=""` links — they take the slow path — and leaner for real non-empty names)

Closes #1103
