### PR TITLE
fix(persistent-params-plugin): defer param removal to commit (#803)

### DIFF
--- a/.changeset/persistent-params-803-fix.md
+++ b/.changeset/persistent-params-803-fix.md
@@ -1,0 +1,10 @@
+---
+"@real-router/persistent-params-plugin": patch
+---
+
+Fix persistent param removal committing before guards on a rejected/cancelled navigation (#803)
+
+Removing a persistent param via `navigate(name, { key: undefined })` no longer drops the param permanently when the navigation is rejected by a guard or superseded by a concurrent navigate. The removal is now committed in `onTransitionSuccess`, against the state that actually committed, so a transition that never commits leaves the param intact.
+
+- `forwardState` records removals transiently instead of mutating the tracked set/snapshot before guards run; the paired `buildPath` consumes the record so the built URL still drops the removed param for the current transition.
+- Permanent removal (from both the snapshot and the tracked param set) happens in `onTransitionSuccess`, keyed on the committed state — a successful removal stays permanent (unchanged), while a rejected/cancelled one rolls back.

--- a/packages/persistent-params-plugin/ARCHITECTURE.md
+++ b/packages/persistent-params-plugin/ARCHITECTURE.md
@@ -171,16 +171,13 @@ router.buildPath(routeName, navParams)
         ├── extractOwnParams(navParams ?? {})
         │     └── strips inherited properties (prototype pollution guard)
         │
-        ├── #withPersistentParams(safeParams)
-        │     ├── for each key in safeParams:
-        │     │     value === undefined && paramNamesSet.has(key)?
-        │     │       YES: paramNamesSet.delete(key)
-        │     │            delete from #persistentParams copy
-        │     │       NO:  validateParamValue(key, value)
-        │     │
-        │     └── mergeParams(#persistentParams, safeParams)
-        │           ├── copy all persistent keys with defined values
-        │           └── overlay safeParams (undefined → delete, else overwrite)
+        ├── #buildPathParams(safeParams)
+        │     ├── validateParamValue(key, value) for each key
+        │     ├── mergeParams(#persistentParams, safeParams)
+        │     │     ├── copy all persistent keys with defined values
+        │     │     └── overlay safeParams (undefined → delete, else overwrite)
+        │     └── drop #pendingRemovals keys (recorded by the paired
+        │           forwardState this transition), then clear #pendingRemovals
         │
         └── next(route, mergedParams)  → core builds path
 ```
@@ -196,13 +193,18 @@ router.navigate(name, params, opts)
         ├── result = next(routeName, routeParams)
         │     └── core builds State object
         │
-        ├── #withPersistentParams(result.params)
-        │     └── same merge logic as buildPath interceptor
+        ├── #forwardStateParams(result.params)  ← runs BEFORE buildPath, same tick
+        │     ├── clear #pendingRemovals
+        │     ├── for each key in safeParams:
+        │     │     value === undefined && paramNamesSet.has(key)?
+        │     │       YES: #pendingRemovals.add(key)  ← RECORD only, no mutation (#803)
+        │     │       NO:  validateParamValue(key, value)
+        │     └── mergeParams(#persistentParams, safeParams)  (undefined → delete)
         │
         └── return { ...result, params: mergedParams }
 ```
 
-Both interceptors call `#withPersistentParams`, which is the single merge point. The `undefined`-removal side effect (deleting from `paramNamesSet` and `#persistentParams`) happens here, before the state is committed.
+The two interceptors are two phases of core's synchronous `buildNavigateState` (forwardState, then buildPath). `#forwardStateParams` **records** removals into the transient `#pendingRemovals` set but does **not** mutate `paramNamesSet` / `#persistentParams` — that would drop the param before the deactivation/activation guards run, so a rejected or cancelled transition would lose it (#803). `#buildPathParams` consumes the record to keep the built URL consistent. The permanent removal is committed in `onTransitionSuccess`, against the state that actually committed.
 
 ### onTransitionSuccess: updating stored params and publishing to state context
 
@@ -213,8 +215,10 @@ Transition committed → onTransitionSuccess(toState)
         │     value = toState.params[key]
         │
         │     !hasOwn(toState.params, key) || value === undefined?
-        │       YES: defensive removal — if stored value was defined, delete it
-        │            (guards against navigateToState bypassing forwardState)
+        │       YES: PRIMARY removal (#803) — if stored value was defined,
+        │            delete it from #persistentParams AND paramNamesSet.
+        │            Covers explicit navigate({key: undefined}) removals and
+        │            navigateToState bypassing forwardState with one branch.
         │
         │     validateParamValue(key, value)
         │
@@ -304,11 +308,11 @@ Throws `TypeError` with a descriptive message on any violation. The factory neve
 
 ### Runtime param value validation (per navigation)
 
-`validateParamValue(key, value)` is called inside `#withPersistentParams` and `#onTransitionSuccess` for every persistent param encountered during navigation:
+`validateParamValue(key, value)` is called inside `#forwardStateParams` / `#buildPathParams` and `#onTransitionSuccess` for every persistent param encountered during navigation:
 
 | Value                         | Result                                                      |
 | ----------------------------- | ----------------------------------------------------------- |
-| `undefined`                   | Allowed — triggers permanent removal from tracking          |
+| `undefined`                   | Allowed — flags removal (committed on success)              |
 | `string`, `number`, `boolean` | Allowed                                                     |
 | `null`                        | Throws `TypeError` with "cannot be null" message            |
 | object, array                 | Throws `TypeError` with "must be a primitive value" message |
@@ -317,20 +321,31 @@ Throws `TypeError` with a descriptive message on any violation. The factory neve
 
 ## Parameter Removal Semantics
 
-Setting a persistent param to `undefined` is a permanent deletion, not a temporary omission:
+Setting a persistent param to `undefined` is a permanent deletion, not a temporary omission — **but the deletion is committed only when the navigation succeeds** (#803):
 
 ```
 navigate("route", { mode: undefined })
         │
         ▼
-  #withPersistentParams({ mode: undefined })
-        ├── paramNamesSet.delete("mode")   ← removed from tracking
+  #forwardStateParams({ mode: undefined })
+        └── #pendingRemovals.add("mode")   ← RECORD only; no mutation yet
+        │                                     (runs before guards — a rejected/
+        │                                      cancelled nav must not drop "mode")
+        ▼
+  #buildPathParams(...)  → drops "mode" from the built URL, clears #pendingRemovals
+        │
+        ▼
+  guards pass, transition commits → onTransitionSuccess(toState)
+        ├── paramNamesSet.delete("mode")      ← removed from tracking
         └── delete #persistentParams["mode"]  ← removed from stored values
         │
         ▼
   All subsequent navigations: "mode" is not injected
   Even if "mode" is passed explicitly, it won't be re-persisted
   (paramNamesSet no longer contains "mode")
+
+  If instead a guard rejects or a concurrent navigate supersedes the removal,
+  onTransitionSuccess never runs → "mode" stays persisted (rolled back).
 ```
 
 This is intentional. Once removed, the param behaves as if it was never in the config. Re-initialization (unsubscribe + usePlugin again) is the only way to restore tracking.

--- a/packages/persistent-params-plugin/CLAUDE.md
+++ b/packages/persistent-params-plugin/CLAUDE.md
@@ -25,26 +25,26 @@ Validation runs at factory call time (param names) and again at navigation time 
 ## Navigation Flow
 
 ```
-navigate(name, params)
-  → buildPath interceptor
-      → #withPersistentParams(navParams)   ← merges persistent into nav params
-      → next(route, mergedParams)
-
-navigate(name, params)
+navigate(name, params)  →  core buildNavigateState (synchronous):
   → forwardState interceptor
       → next(routeName, routeParams)       ← get base state
-      → #withPersistentParams(result.params) ← inject persistent into state params
+      → #forwardStateParams(result.params) ← inject persistent; RECORD removals (#pendingRemovals)
+  → buildPath interceptor
+      → #buildPathParams(forwardedParams)  ← inject persistent; DROP #pendingRemovals from URL; clear
+      → next(route, mergedParams)
 
-onTransitionSuccess(toState)
+onTransitionSuccess(toState)   ← only fires if the transition actually committed
   → reads toState.params for each tracked key
-  → updates #persistentParams snapshot
+  → updates #persistentParams snapshot; COMMITS removals (deletes from snapshot + #paramNamesSet)
   → claim.write(toState, #persistentParams)   ← publishes to state.context.persistentParams
 ```
 
-Both interceptors call `#withPersistentParams`, which:
-1. Runs `extractOwnParams` on incoming params (prototype pollution guard)
-2. Handles `undefined` values (removal)
-3. Calls `mergeParams(persistentParams, safeParams)`
+The two interceptors are **two phases of one synchronous window** (core's `buildNavigateState` runs `forwardState` then `buildPath` back-to-back):
+
+- **`#forwardStateParams`** (forwardState phase, runs first) — `extractOwnParams` → for a tracked param passed as `undefined`, RECORD it in the transient `#pendingRemovals` set (does **not** mutate the tracked set/snapshot — that would drop the param before guards run, #803) → `mergeParams` (honors `undefined` as a delete for this transition).
+- **`#buildPathParams`** (buildPath phase, runs second) — `extractOwnParams` → validate → `mergeParams` → drop the `#pendingRemovals` keys so the built URL matches the forwarded params (the `undefined` marker is gone by now, so a plain re-merge would re-inject the removed param) → clear `#pendingRemovals`. A standalone `router.buildPath()` sees an empty set and injects normally.
+
+**Permanent removal happens in `onTransitionSuccess`, not in the interceptors** — keyed on the committed state, so a rejected/cancelled navigation never drops the param (#803).
 
 ## State Context
 
@@ -59,16 +59,18 @@ Components can use `state.context.persistentParams` to distinguish persistent pa
 
 ## Gotchas
 
-### Parameter removal is permanent
+### Parameter removal is permanent — but only once the removal commits
 
 Passing `undefined` for a tracked param deletes it from `paramNamesSet` and from `#persistentParams`. It won't be re-persisted even if you pass it again later:
 
 ```typescript
-router.navigate("page", { lang: undefined }); // lang removed from Set
+router.navigate("page", { lang: undefined }); // lang removed once this navigation commits
 router.navigate("page", { lang: "en" });       // lang NOT re-added — Set no longer tracks it
 ```
 
 Once removed, the param is gone for the lifetime of the plugin instance.
+
+**The removal is committed in `onTransitionSuccess`, not in the interceptor (#803).** If the removal navigation is rejected by a guard or superseded by a concurrent navigate, it never reaches `onTransitionSuccess`, so the param stays persisted — the drop is not permanent until the transition actually commits. Within the current transition the param is still absent from both `state.params` and `state.path` (the `buildPath` phase honors the pending removal); it is only re-persisted for **later** navigations when the removal did not commit.
 
 ### `setRootPath` throws during `router.dispose()`
 
@@ -90,11 +92,11 @@ The factory creates one `paramNamesSet` from the config. Each `PluginFactory` in
 
 ### `mergeParams` does NOT self-sanitize
 
-`mergeParams(persistent, current)` assumes `current` is already sanitized. The caller (`#withPersistentParams`) must call `extractOwnParams` first. If you call `mergeParams` directly with an unsanitized object, inherited properties will leak through.
+`mergeParams(persistent, current)` assumes `current` is already sanitized. The callers (`#forwardStateParams` / `#buildPathParams`) must call `extractOwnParams` first. If you call `mergeParams` directly with an unsanitized object, inherited properties will leak through.
 
-### `onTransitionSuccess` is a secondary sync, not the primary source
+### `onTransitionSuccess` — secondary sync for injection, PRIMARY for removal
 
-The primary param injection happens in the interceptors. `onTransitionSuccess` only updates `#persistentParams` to reflect what actually committed. It also handles the defensive case where a state was committed via `navigateToState` (bypassing `forwardState`) — if a tracked key is missing or `undefined` in `toState.params`, it removes that key from `#persistentParams`.
+The primary param **injection** happens in the interceptors. `onTransitionSuccess` updates `#persistentParams` to reflect what actually committed. For **removal**, though, it is the primary site (#803): a tracked key that is missing or `undefined` in the committed `toState.params` is deleted from **both** `#persistentParams` and `#paramNamesSet` here — covering the explicit `navigate({ key: undefined })` removal (mergeParams dropped it for this transition) and the defensive `navigateToState` bypass (which skips the `forwardState` injection) with the same branch. Only a key that was really persisted (present with a defined value) is removed; a still-empty tracked key stays tracked so it can persist later.
 
 After updating the snapshot, `onTransitionSuccess` publishes it to `state.context.persistentParams` via `claim.write(toState, #persistentParams)`. This happens before subscriber callbacks fire, so `router.subscribe()` listeners always see the current persistent params snapshot on `state.context.persistentParams`.
 

--- a/packages/persistent-params-plugin/INVARIANTS.md
+++ b/packages/persistent-params-plugin/INVARIANTS.md
@@ -41,8 +41,9 @@
 
 | #   | Invariant                                           | Description                                                                                                                                                                                               |
 | --- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Param set to undefined is absent on next navigation | Passing `undefined` for a tracked param removes it from `#paramNamesSet` and `#persistentParams`. Subsequent navigations do not inject the removed param.                                                 |
+| 1   | Param set to undefined is absent on next navigation | Passing `undefined` for a tracked param removes it from `#paramNamesSet` and `#persistentParams` **once the removal navigation commits** (in `onTransitionSuccess`). Subsequent navigations do not inject the removed param. |
 | 2   | Removal is permanent                                | After removal via `undefined`, re-passing the same param name in a later navigation does NOT restore persistence. The key was deleted from `#paramNamesSet`, so `onTransitionSuccess` never re-tracks it. |
+| 3   | Removal on a rejected/cancelled transition rolls back | The removal is committed only in `onTransitionSuccess`, so a `navigate({ key: undefined })` rejected by a guard or superseded by a concurrent navigate leaves the param persisted — the never-committed transition does not drop it (#803). |
 
 ## Default Values
 
@@ -94,6 +95,6 @@
 
 | File                                            | Invariants | Category                                                                                    |
 | ----------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------- |
-| `tests/property/persistentParams.properties.ts` | 16         | Persistence, Override, No-Clobber, Scope, Idempotency, Removal, Default Values, Multi-Param |
+| `tests/property/persistentParams.properties.ts` | 17         | Persistence, Override, No-Clobber, Scope, Idempotency, Removal, Default Values, Multi-Param |
 | `tests/property/paramUtils.properties.ts`       | 6          | Merge Semantics, Own-Property Extraction                                                    |
 | `tests/property/validation.properties.ts`       | 4          | Validation                                                                                  |

--- a/packages/persistent-params-plugin/README.md
+++ b/packages/persistent-params-plugin/README.md
@@ -68,7 +68,7 @@ router.navigate("page3", { lang: "fr" });      // URL: /page3?lang=fr, saved: la
 router.navigate("page4", { lang: undefined }); // lang removed permanently
 ```
 
-> **Note:** Removal is permanent for the plugin lifetime. Once `undefined` is passed, the param is no longer tracked — even if passed again in a later navigation.
+> **Note:** Removal is permanent for the plugin lifetime — but only once the removal navigation actually commits. Once `undefined` is passed and the navigation succeeds, the param is no longer tracked, even if passed again later. If that navigation is rejected by a guard or superseded by a concurrent navigate, the param stays persisted (the removal rolls back).
 
 ## Use Cases
 

--- a/packages/persistent-params-plugin/src/plugin.ts
+++ b/packages/persistent-params-plugin/src/plugin.ts
@@ -20,6 +20,15 @@ export class PersistentParamsPlugin {
 
   #persistentParams: Readonly<Params>;
 
+  // Per-navigation removal record, valid ONLY within the synchronous
+  // forwardState → buildPath window of core's `buildNavigateState`. forwardState
+  // (which sees the raw `{ key: undefined }` removal marker) records the removed
+  // keys here; the paired buildPath (which receives the already-forwarded params,
+  // where the `undefined` marker is gone) consumes it to drop the same keys from
+  // the built URL, then clears it. Never a source of permanent state — the
+  // permanent removal happens in #onTransitionSuccess against the committed state.
+  readonly #pendingRemovals = new Set<string>();
+
   constructor(
     api: PluginApi,
     persistentParams: Readonly<Params>,
@@ -41,7 +50,7 @@ export class PersistentParamsPlugin {
       removeBuildPath = api.addInterceptor(
         "buildPath",
         (next, route, navParams) =>
-          next(route, this.#withPersistentParams(navParams ?? {})),
+          next(route, this.#buildPathParams(navParams ?? {})),
       );
 
       removeForwardState = api.addInterceptor(
@@ -51,7 +60,7 @@ export class PersistentParamsPlugin {
 
           return {
             ...result,
-            params: this.#withPersistentParams(result.params),
+            params: this.#forwardStateParams(result.params),
           };
         },
       );
@@ -81,25 +90,59 @@ export class PersistentParamsPlugin {
     };
   }
 
-  #withPersistentParams(additionalParams: Params): Params {
+  // forwardState phase (runs first in buildNavigateState). Injects persistent
+  // params into the target state and RECORDS — but does not commit — any removal
+  // requests (`{ key: undefined }`). The removal is NOT applied to the tracked
+  // set/snapshot here: this runs before the deactivation/activation guards, so a
+  // rejected or cancelled transition must leave the param intact (#803). The
+  // permanent removal is committed in #onTransitionSuccess against the state that
+  // actually committed. `mergeParams` honors `undefined` as a delete for the
+  // current transition's params.
+  #forwardStateParams(additionalParams: Params): Params {
     const safeParams = extractOwnParams(additionalParams);
-    let newParams: Params | undefined;
+
+    // Reset the per-navigation record: forwardState opens the synchronous
+    // forwardState → buildPath window that buildPath consumes.
+    this.#pendingRemovals.clear();
 
     for (const [key, value] of Object.entries(safeParams)) {
       if (value === undefined && this.#paramNamesSet.has(key)) {
-        this.#paramNamesSet.delete(key);
-        newParams ??= { ...this.#persistentParams };
-        delete newParams[key];
+        this.#pendingRemovals.add(key);
       } else {
         validateParamValue(key, value);
       }
     }
 
-    if (newParams) {
-      this.#persistentParams = Object.freeze(newParams);
+    return mergeParams(this.#persistentParams, safeParams);
+  }
+
+  // buildPath phase (runs second in buildNavigateState, and standalone for
+  // `router.buildPath()`). Injects persistent params into the URL, then drops the
+  // keys the paired forwardState just removed — otherwise the freshly-removed
+  // param would be re-injected into the built path from the still-unchanged
+  // snapshot (the `undefined` marker is gone by the time params reach buildPath).
+  // Consume-once: a standalone buildPath sees an empty set and injects normally.
+  #buildPathParams(additionalParams: Params): Params {
+    const safeParams = extractOwnParams(additionalParams);
+
+    // A removal marker (`undefined`) is a valid param value, so validating it is
+    // harmless — mergeParams treats it as a delete for the built path. No need to
+    // special-case removal here (unlike forwardState, which must record it).
+    for (const [key, value] of Object.entries(safeParams)) {
+      validateParamValue(key, value);
     }
 
-    return mergeParams(this.#persistentParams, safeParams);
+    const merged = mergeParams(this.#persistentParams, safeParams);
+
+    if (this.#pendingRemovals.size > 0) {
+      for (const key of this.#pendingRemovals) {
+        delete merged[key];
+      }
+
+      this.#pendingRemovals.clear();
+    }
+
+    return merged;
   }
 
   #onTransitionSuccess(toState: State): void {
@@ -109,13 +152,19 @@ export class PersistentParamsPlugin {
       const value = toState.params[key];
 
       if (!Object.hasOwn(toState.params, key) || value === undefined) {
-        // Drop a persisted key absent from a state committed via navigateToState
-        // (which bypasses the forwardState injection) — covered by the "drops a
-        // persisted param when navigateToState bypasses forwardState" test.
+        // A tracked param is absent from the committed state — either an explicit
+        // removal (`navigate({ key: undefined })`, applied as a delete by
+        // mergeParams for this transition) or a state committed via navigateToState
+        // (which bypasses the forwardState injection). The permanent removal is
+        // committed HERE, against the state that actually committed, so a
+        // rejected/cancelled transition never drops the param (#803). Only a param
+        // that was really persisted (present with a defined value) is removed;
+        // a still-empty tracked key stays tracked so it can persist later.
         if (
           Object.hasOwn(this.#persistentParams, key) &&
           this.#persistentParams[key] !== undefined
         ) {
+          this.#paramNamesSet.delete(key);
           newParams ??= { ...this.#persistentParams };
           delete newParams[key];
         }

--- a/packages/persistent-params-plugin/tests/functional/plugin.test.ts
+++ b/packages/persistent-params-plugin/tests/functional/plugin.test.ts
@@ -388,6 +388,84 @@ describe("Persistent params plugin", () => {
       });
     });
 
+    describe("Removal on rejected/cancelled transition (#803)", () => {
+      beforeEach(async () => {
+        router.usePlugin(persistentParamsPlugin({ lang: "en" }));
+        await router.start("/");
+      });
+
+      it("should keep the persistent param when a removal navigation is rejected by a guard", async () => {
+        // route2 activation is always blocked
+        getLifecycleApi(router).addActivateGuard("route2", () => () => false);
+
+        // attempt to remove `lang` on a transition the guard rejects
+        await router
+          .navigate("route2", { id: "2", lang: undefined })
+          .catch(() => {});
+
+        // the transition never committed — the removal must be rolled back
+        const state = await router.navigate("route1", { id: "1" });
+
+        expect(state.params.lang).toBe("en");
+        expect(state.path).toBe("/route1/1?lang=en");
+      });
+
+      it("should keep the persistent param when a removal navigation is cancelled mid-flight", async () => {
+        // route2 activation suspends in an async guard, so the removal navigation
+        // to route2 stays in-flight and can be superseded by another navigate
+        let releaseGuard: (allow: boolean) => void = () => {};
+        let enterGuard: () => void = () => {};
+        const guardEntered = new Promise<void>((resolve) => {
+          enterGuard = resolve;
+        });
+
+        getLifecycleApi(router).addActivateGuard("route2", () => () => {
+          enterGuard();
+
+          return new Promise<boolean>((resolve) => {
+            releaseGuard = resolve;
+          });
+        });
+
+        // removal navigation to route2 suspends inside the async guard
+        const removal = router.navigate("route2", { id: "2", lang: undefined });
+
+        await guardEntered;
+
+        // supersede it with a navigation to route3 → cancels the removal
+        const winner = await router.navigate("route3", { id: "3" });
+
+        // the superseding navigation still carries the (not-yet-removed) param
+        expect(winner.params.lang).toBe("en");
+
+        // release the now-cancelled guard; the removal rejects as cancelled
+        releaseGuard(true);
+        await removal.catch(() => {});
+
+        // the cancelled removal must not have dropped `lang` permanently
+        const state = await router.navigate("route1", { id: "9" });
+
+        expect(state.params.lang).toBe("en");
+      });
+
+      it("should still remove the param permanently once a removal navigation actually commits", async () => {
+        // removal on a committed transition stays permanent (unchanged semantics)
+        await router.navigate("route1", { id: "1", lang: undefined });
+        const reAttempt = await router.navigate("route2", {
+          id: "2",
+          lang: "fr",
+        });
+
+        // `lang` was removed from tracking on the successful removal, so an
+        // explicit re-pass is not re-persisted on the following navigation
+        const state = await router.navigate("route3", { id: "3" });
+
+        expect(reAttempt.path).toBe("/route2/2?lang=fr");
+        expect(state.params.lang).toBeUndefined();
+        expect(state.path).toBe("/route3/3");
+      });
+    });
+
     describe("Parameter Synchronization", () => {
       beforeEach(async () => {
         router.usePlugin(persistentParamsPlugin(["mode", "lang"]));

--- a/packages/persistent-params-plugin/tests/property/persistentParams.properties.ts
+++ b/packages/persistent-params-plugin/tests/property/persistentParams.properties.ts
@@ -1,4 +1,5 @@
 import { test } from "@fast-check/vitest";
+import { getLifecycleApi } from "@real-router/core/api";
 import { describe, expect } from "vitest";
 
 import {
@@ -286,6 +287,33 @@ describe("removal: passing undefined permanently removes a param from persistenc
       await router.navigate("routeA", { id: idD });
 
       expect(router.getState()?.params).not.toHaveProperty(paramName);
+
+      router.stop();
+    },
+  );
+
+  test.prop([arbParamName, arbParamValue], { numRuns: NUM_RUNS.async })(
+    "a removal rejected by a guard does not drop the param (#803)",
+    async (paramName, paramValue) => {
+      const router = await createStartedRouter([paramName]);
+
+      const idA = nextId();
+      const idB = nextId();
+      const idC = nextId();
+
+      // persist the param
+      await router.navigate("routeA", { id: idA, [paramName]: paramValue });
+
+      // block routeB so the removal navigation is rejected by the guard
+      getLifecycleApi(router).addActivateGuard("routeB", () => () => false);
+      await router
+        .navigate("routeB", { id: idB, [paramName]: undefined })
+        .catch(() => {});
+
+      // the rejected removal never committed — the param must still persist
+      await router.navigate("routeC", { id: idC });
+
+      expect(router.getState()?.params[paramName]).toBe(paramValue);
 
       router.stop();
     },


### PR DESCRIPTION
## Summary

Fixes #803. Removing a persistent param via `navigate(name, { key: undefined })` was committed **synchronously inside the `forwardState` interceptor** — during target-state building, **before** the deactivation/activation guards run. A navigation then rejected by a guard (or superseded by a concurrent navigate) dropped the param **permanently anyway**, even though the transition never committed.

## Root cause

`#withPersistentParams` (called from both the `forwardState` and `buildPath` interceptors) mutated `#paramNamesSet` / `#persistentParams` the moment it saw `{ key: undefined }` — a permanent side effect on the pre-guard, pre-commit path.

## Why the fix in the issue was incomplete

The issue proposed deferring the permanent removal to `onTransitionSuccess` and letting `mergeParams` honor `undefined` for the current transition. That is correct for `forwardState`, but core's `buildNavigateState` runs `forwardState` **then** `buildPath` back-to-back, and `buildPath` receives the *already-forwarded* params where the `undefined` marker is gone — so it **re-injects** the just-removed param into `state.path` from the unchanged snapshot. The existing test `should remove param if explicitly set to undefined` (asserts `path === /route2/2`) regresses under the issue's fix.

## Fix

Exploit that `forwardState → buildPath` run in one **synchronous** window:

- **`#forwardStateParams`** (forwardState phase) — records removals into a transient `#pendingRemovals` set; does **not** mutate the tracked set/snapshot (nothing permanent before guards).
- **`#buildPathParams`** (buildPath phase) — injects persistent params, then drops the `#pendingRemovals` keys from the built URL and clears the set (consume-once; a standalone `router.buildPath()` sees an empty set and injects normally).
- **`#onTransitionSuccess`** — the single site of permanent removal, keyed on the committed state (removal branch promoted to primary + `#paramNamesSet.delete(key)`).

Concurrent-safe (the transient set lives only within the synchronous `buildNavigateState` window; the shared snapshot is never mutated before commit). A successful removal stays permanent; a rejected/cancelled one rolls back.

## Tests

- `tests/functional/plugin.test.ts` → `Removal on rejected/cancelled transition (#803)`: guard-rejected, cancelled-mid-flight (async guard), committed-permanent.
- `tests/property/persistentParams.properties.ts` → `a removal rejected by a guard does not drop the param (#803)`.
- Discriminating power verified by injecting the original bug (both key tests fail) and reverting.

## Validation

- `test`: 104 passed, **100% coverage**
- `test:properties`: 27 passed (stable across repeated runs)
- `type-check`, `lint`: clean

## Docs

- Local: `CLAUDE.md`, `ARCHITECTURE.md` (3 diagrams — one literally described the bug as intended), `INVARIANTS.md` (added Removal #3 removal-on-failure), `README.md`.
- Wiki: `persistent-params-plugin.md`.

Closes #803