### PR TITLE
docs(search-schema-plugin): document defaultParams runtime contract (#802)

### DIFF
--- a/.changeset/search-schema-defaultparams-contract-802.md
+++ b/.changeset/search-schema-defaultparams-contract-802.md
@@ -1,0 +1,13 @@
+---
+"@real-router/search-schema-plugin": patch
+---
+
+Document the `defaultParams` runtime contract and sharpen the dev warning (#802)
+
+The plugin's runtime guarantee ("invalid params never reach `state`") is scoped to
+user **input**. `defaultParams` are trusted developer config injected by the router
+core _below_ the interceptor seam the plugin hooks, so a `defaultParams` value that
+violates its own `searchSchema` still reaches `state` and the URL at runtime — in every
+`mode`, including `production`. This is now documented as a contract in the README and
+wiki, and the dev-time warning states the consequence (the value still reaches state)
+plus the fix (make `defaultParams` satisfy `searchSchema`). No behavior change.

--- a/packages/search-schema-plugin/CLAUDE.md
+++ b/packages/search-schema-plugin/CLAUDE.md
@@ -81,6 +81,14 @@ Zod strip mode (default) removes unknown keys from output. With `strict: true`, 
 
 At `usePlugin()` time, validates all existing routes' `defaultParams` against their `searchSchema`. Runtime tree mutations are then re-validated via the `TREE_CHANGED` subscription: `add`/`replace` validate the whole added subtree (flat, full dotted names), and `update` re-validates the route when its `defaultParams` change. `remove`/`clear` are no-ops (routes gone). Production mode skips all of this (no subscription registered).
 
+### Invalid `defaultParams` reach state at runtime — core-injected, plugin cannot gate (#802)
+
+The runtime guarantee ("invalid params never reach `state`") holds for **user input** only. `defaultParams` are **developer config** merged in by **core**, at layers _below_ the `forwardState` interceptor this plugin hooks — so an invalid default reaches `state.params`, `state.path`, `router.buildPath()`, and `isActiveRoute()` comparisons, on every navigation, in every `mode`. The plugin **cannot** strip it from `forwardState`: whatever it returns, core re-merges `{ ...defaultParams, ...params }` afterwards in three uninterceptable spots — `StateNamespace.makeState`, `RoutesNamespace.buildPath`, `RoutesNamespace.isActiveRoute` (`InterceptableMethodMap` = `start` / `buildPath` / `forwardState`; only `forwardState` is hooked). The `{ ...defaults, ...params }` merges always put `params` on top, so an interceptor can add or replace a key but cannot **remove** one core will re-fill from config.
+
+Consequence: the restore branch `{ ...defaults, ...stripped }` in `#validateState` is **redundant with `makeState`'s merge** on the navigate/start paths — but it still matters for `PluginApi.buildState` / `forwardState` consumers (which skip `makeState`), so **do not delete it**. The dev-time check above is a **config lint**, not a runtime gate. Documented limitation, not a plugin bug — a runtime fix would require core changes (single-merge-point refactor; see the #802 analysis). Priority-low, no user report; the plugin's honest contract is "invalid _input_ never reaches state".
+
+Known gap (#802 side-finding): swapping `searchSchema` via `getRoutesApi(router).update(name, { searchSchema })` emits **no** `TREE_CHANGED` (custom fields aren't in `buildStructuralPatch` — only `forwardTo` / `defaultParams` / `encodeParams` / `decodeParams`), so the dev check does **not** re-validate existing `defaultParams` against a newly-swapped schema.
+
 ## See Also
 
 - [RFC](../core/.claude/rfc/rfc-search-schema-validation.md) — Full design document

--- a/packages/search-schema-plugin/README.md
+++ b/packages/search-schema-plugin/README.md
@@ -107,6 +107,26 @@ When schema validation fails, the plugin strips only the keys with validation is
 
 In `mode: "development"`, a `console.error` is emitted with the route name and validation issues before the recovery happens.
 
+### `defaultParams` must satisfy the schema (contract)
+
+The plugin's runtime guarantee is scoped to **user input**: an invalid _incoming_ param (from the URL or a `navigate()` call) never reaches `state`. It does **not** validate `defaultParams` at runtime — those are **trusted developer config**, injected by the router core _below_ the layer this plugin intercepts. So a `defaultParams` value that violates its own `searchSchema` **will reach `state.params` and the URL** (`state.path`), on every navigation, in **every** `mode` — including `mode: "production"`:
+
+```typescript
+{
+  name: "products",
+  path: "/products?page",
+  defaultParams: { page: -5 },              // ← violates the schema below
+  searchSchema: z.object({ page: z.number().positive() }),
+}
+await router.navigate("products");          // no input supplied by the caller
+router.getState().params;                   // { page: -5 }  ← invalid default reaches state
+router.getState().path;                     // "/products?page=-5"  ← and the URL
+```
+
+In `mode: "development"` the plugin **warns** about a schema-violating `defaultParams` at authoring time (at `usePlugin()`, and when routes are added / replaced / updated) — a config lint, not a runtime block. `mode: "production"` skips that warning. Either way the value is **not** blocked at runtime, and `onError` does not change this (core injects the default independently of the callback).
+
+**Fix:** keep each route's `defaultParams` consistent with its `searchSchema`. Treat the dev warning as a config error to resolve, not a recoverable runtime condition. To _fill_ absent params from within the schema instead, use the schema's own `.default()` (e.g. Zod `z.number().default(1)`) — those values are validated by construction.
+
 ### Strict mode
 
 ```typescript

--- a/packages/search-schema-plugin/src/plugin.ts
+++ b/packages/search-schema-plugin/src/plugin.ts
@@ -205,8 +205,14 @@ export class SearchSchemaPlugin {
     }
 
     if ("issues" in validation) {
+      // The plugin gates invalid user *input*, not developer *config*: core
+      // injects `defaultParams` into `state.params` / `state.path` below the
+      // interceptor seam this plugin hooks, so an invalid default reaches state
+      // and the URL at runtime regardless of this warning (documented contract,
+      // #802). Hence the message states the consequence + the fix, rather than
+      // implying the value was blocked.
       console.warn(
-        `${ERROR_PREFIX} Route "${routeName}": defaultParams do not pass searchSchema`,
+        `${ERROR_PREFIX} Route "${routeName}": defaultParams do not pass searchSchema — they are trusted config and will still reach state and the URL at runtime (the plugin validates user input, not config). Fix the route's defaultParams to satisfy its searchSchema.`,
         validation.issues,
       );
     }

--- a/packages/search-schema-plugin/tests/functional/integration.test.ts
+++ b/packages/search-schema-plugin/tests/functional/integration.test.ts
@@ -356,4 +356,78 @@ describe("Search schema plugin", () => {
       consoleSpy.mockRestore();
     });
   });
+
+  // Documented contract boundary for #802. The plugin gates invalid user INPUT
+  // (see the stripping tests above); `defaultParams` are trusted config injected
+  // by core BELOW the interceptor seam the plugin hooks, so an invalid default
+  // reaches state and the URL at runtime. These tests PIN that documented
+  // limitation deliberately — a tripwire: if core ever starts stripping invalid
+  // defaults (e.g. a single-merge-point refactor), they fail and flag that the
+  // README / wiki / CLAUDE contract must be revisited.
+  describe("Documented limitation: invalid defaultParams reach state (#802)", () => {
+    /** `page` must be a positive number when present; no defaults, no coercion. */
+    function positivePageSchema() {
+      return createMockSchema({
+        validate: (value) => {
+          const params = value as Record<string, unknown>;
+
+          if (
+            "page" in params &&
+            !(typeof params.page === "number" && params.page > 0)
+          ) {
+            return {
+              issues: [{ message: "page must be positive", path: ["page"] }],
+            };
+          }
+
+          return { value: params };
+        },
+      });
+    }
+
+    it("guarantee HOLDS for user input: invalid input is stripped, nothing revives it", async () => {
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "clean",
+            path: "/clean?page",
+            searchSchema: positivePageSchema(),
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(searchSchemaPlugin({ mode: "production" }));
+      await router.start("/");
+
+      await router.navigate("clean", { page: -3 });
+
+      expect(router.getState()?.params).toStrictEqual({});
+    });
+
+    it("limitation: an invalid defaultParams value reaches state.params AND state.path (mode: production)", async () => {
+      router = createRouter(
+        [
+          { name: "home", path: "/" },
+          {
+            name: "bad",
+            path: "/bad?page",
+            defaultParams: { page: -5 },
+            searchSchema: positivePageSchema(),
+          },
+        ],
+        { defaultRoute: "home" },
+      );
+      router.usePlugin(searchSchemaPlugin({ mode: "production" }));
+      await router.start("/");
+
+      // No input supplied by the caller — the invalid default is injected by core.
+      await router.navigate("bad");
+
+      const state = router.getState();
+
+      expect(state?.params).toStrictEqual({ page: -5 });
+      expect(state?.path).toBe("/bad?page=-5");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #802 as a **documented by-design limitation** (Option A from the [analysis](https://github.com/greydragon888/real-router/issues/802#issuecomment)).

An invalid `defaultParams` value (one that violates its own route `searchSchema`) reaches `state.params`, `state.path`, and `isActiveRoute()` comparisons at runtime — in every `mode`, including `production`. The plugin **cannot** gate this: `defaultParams` are injected by the router **core**, in three uninterceptable spots (`StateNamespace.makeState`, `RoutesNamespace.buildPath`, `RoutesNamespace.isActiveRoute`), *below* the `forwardState` interceptor seam the plugin hooks. Every `{ ...defaults, ...params }` merge puts `params` on top, so an interceptor can add or replace a key but cannot **remove** one core re-fills from config.

The plugin's honest, verified contract is therefore: **invalid user _input_ never reaches state** (holds); `defaultParams` are **trusted developer config**, validated at authoring time (dev warning), not at runtime. This PR codifies that contract and sharpens the warning — no behavior change.

## What changed

- **`src/plugin.ts`** — the dev-time `defaultParams` warning now states the **consequence** (the value still reaches state/the URL) and the **fix** (make `defaultParams` satisfy the schema), instead of implying it was blocked. Added an explanatory comment.
- **`README.md`** — new "`defaultParams` must satisfy the schema (contract)" section with a runnable example and the input-vs-config distinction.
- **`CLAUDE.md`** (package) — gotcha documenting the core-injection map, why the restore branch must not be deleted, and the `update({ searchSchema })` → no-`TREE_CHANGED` gap.
- **`tests/functional/integration.test.ts`** — two executable-doc tests pinning the contract boundary as a **tripwire**: user input stays gated; an invalid default reaches state. If core ever starts stripping invalid defaults, these fail and flag that the docs must be revisited.
- **Changeset** — `patch` for `@real-router/search-schema-plugin`.

> Wiki (`search-schema-plugin.md`) has a matching update (contract section + fix of stale "add interceptor" wording → `subscribeChanges`/`TREE_CHANGED`), pushed separately to the wiki repo.

## Why not a "real" fix

- **Issue option 1** (re-validate the restore branch) was implemented and empirically disproven — core re-injects the default after the plugin returns `{}`.
- **Plugin-side enforcement** (sanitize/reject config at registration): only plugin-side way to keep the value out of core-injected state, but it mutates/rejects user config, must run in production (SSR clone cost), and leaves a microtask window for runtime CRUD. Rejected.
- **Core fix** (single-merge-point): disproportionate blast radius for a priority-low issue, and does not cover `isActiveRoute`. Recorded as an architectural-debt note, to revisit only on a real request for plugin-managed defaults.
- **Always-on production warning** (add a config-lint warning in prod too): considered and **declined** — the dev-mode default already surfaces the bad config at authoring time; a prod warning adds per-request SSR cost, module-level state, and a behavior change for existing `mode: "production"` users, for a priority-low issue with no user report.

## Verification

Package gates green: `lint`, `type-check`, `test` (61 passed, 100% coverage), `test:properties` (21). `lint:changeset` valid. Full pre-push build (`turbo run build lint:types lint:package`, 172 tasks) + `knip` + `syncpack` + `semgrep` all green; `osv-scanner` re-verified clean from the main checkout (the pre-push run tripped the known worktree-path false positive).

Closes #802.
