### PR TITLE
perf(svelte): event-delegate use:link listeners (#1253)

### DIFF
--- a/.changeset/swift-links-delegate.md
+++ b/.changeset/swift-links-delegate.md
@@ -1,0 +1,8 @@
+---
+"@real-router/svelte": minor
+---
+
+Event-delegate `createLinkAction` (`use:link`) — one shared listener pair per router instead of two per node (#1253)
+
+- `use:link` now registers a single delegated `click` + `keydown` listener on `document` per router (a per-router singleton, ref-counted attach/detach), instead of attaching two listeners to every node. O(1) listeners for any number of links makes the recommended link-heavy path (nav menus, sitemaps, paginated lists) lighter at mount (~5.99 → ~4.3 ms per 1000 links, directional).
+- **Behavior change (edge cases):** a descendant that calls `event.stopPropagation()` before the click reaches `document` now blocks navigation; and an element removed from the DOM without Svelte unmount (`element.remove()`) no longer navigates. Both are irrelevant under the normal `use:` lifecycle. `applyLinkA11y` stays per-node (it sets `role`/`tabindex`, not listeners).

--- a/benchmarks/cross-router/apps/svelte/mateo-router/deep/src/DeepLevel.svelte
+++ b/benchmarks/cross-router/apps/svelte/mateo-router/deep/src/DeepLevel.svelte
@@ -14,16 +14,25 @@
   // table is built once and never needs to react.
   let { k, base }: { k: number; base: string } = $props();
 
+  // Fixed per instance (see above): capture the initial values into plain locals
+  // so the route table is built once from them. The `state_referenced_locally`
+  // suppressions are intentional — these props never change for a given instance,
+  // so reading the initial value is correct, not a missed reaction.
+  // svelte-ignore state_referenced_locally
+  const level = k;
+  // svelte-ignore state_referenced_locally
+  const basePath = base;
+
   const child: RouteConfig[] = [];
-  if (k < DEEP_DEPTH) {
+  if (level < DEEP_DEPTH) {
     child.push({
-      path: `/l${k + 1}`,
+      path: `/l${level + 1}`,
       component: DeepLevel,
-      props: { k: k + 1, base: `${base}/l${k + 1}` },
+      props: { k: level + 1, base: `${basePath}/l${level + 1}` },
     });
   }
-  if (k >= 1) {
-    child.push({ component: CatalogItem, props: { n: String(k) } });
+  if (level >= 1) {
+    child.push({ component: CatalogItem, props: { n: String(level) } });
   }
 </script>
 

--- a/benchmarks/cross-router/run-all.mjs
+++ b/benchmarks/cross-router/run-all.mjs
@@ -38,14 +38,34 @@ const SCENARIOS = [
 // no-router analog. Run after the main matrix of each cohort.
 const BASELINE_SCENARIOS = ["cold-start", "nav-latency", "link-build"];
 
+// Documented competitor limitations — (cohort → scenario → [engines]) cells that
+// CANNOT produce a result because the COMPETING router itself errors on the
+// scenario (not a harness or app bug). These are SKIPPED: not run, not counted as
+// a failure — the per-cohort REPORT documents the N/A. Remove an entry if the
+// competitor fixes the limitation and the cell should measure again.
+const KNOWN_NA = {
+  // @tanstack/solid-router trips its internal error boundary on 60+-segment
+  // deep-nested routes (renders 3/30, errors at 60/90). @tanstack/react-router
+  // renders depth 90 — a solid-port limitation. See REPORT-solid.md.
+  solid: { "deep-config": ["tanstack"] },
+};
+const isKnownNA = (framework, scenario, engine) =>
+  KNOWN_NA[framework]?.[scenario]?.includes(engine) ?? false;
+
 const runs = process.argv[2] ?? "15";
 const fwArg = process.argv[3];
 const frameworks = fwArg ? [fwArg] : Object.keys(COHORT_ENGINES);
 
 let ok = 0;
 let failed = 0;
+let skipped = 0;
 
 const runOne = (scenario, engine, framework) => {
+  if (isKnownNA(framework, scenario, engine)) {
+    skipped += 1;
+    console.error(`⊘ ${framework} · ${scenario} × ${engine}: documented competitor N/A — skipped (see REPORT-${framework}.md)`);
+    return;
+  }
   console.error(`\n=== ${framework} · ${scenario} × ${engine} (runs=${runs}) ===`);
   const result = spawnSync(
     "node",
@@ -73,5 +93,7 @@ for (const framework of frameworks) {
   for (const scenario of BASELINE_SCENARIOS) runOne(scenario, "_baseline", framework);
 }
 
-console.error(`\nmatrix done: ${ok} ok, ${failed} failed`);
+console.error(
+  `\nmatrix done: ${ok} ok, ${failed} failed, ${skipped} n/a (documented)`,
+);
 process.exit(failed > 0 ? 1 : 0);

--- a/packages/svelte/CLAUDE.md
+++ b/packages/svelte/CLAUDE.md
@@ -538,6 +538,34 @@ The factory returns an action function that can be used with the `use:` directiv
 <!-- When userId changes, the action's update() is called automatically -->
 ```
 
+### `use:link` Delegates Events (One Listener Per Router, Not Per Node) — #1253
+
+`createLinkAction` does **not** attach click/keydown listeners to each node. All
+`use:link` nodes for one router share **one** delegated `click` + `keydown`
+listener on `document` (a per-router singleton, `WeakMap<Router, …>`), and each
+node registers its params into a `WeakMap`. The delegated handler walks up from
+`event.target` to the nearest registered node. This gives **O(1) listeners for
+any number of links** (was 2 per node) — matching sv-router's global delegation
+and making `use:link` the light path for nav menus / sitemaps / paginated lists.
+`applyLinkA11y` stays per-node (it sets `role`/`tabindex` attributes, not
+listeners). The two `document` listeners attach on the first registered node and
+detach on the last `destroy()` (ref-counted, like `createActiveNameSelector`'s
+lazy connect/disconnect), so a stopped/disposed router stays GC-able.
+
+Two behavioral consequences of delegation:
+
+- **`stopPropagation()` on a descendant blocks navigation.** A per-node listener
+  fired regardless; the delegated handler only sees events that bubble to
+  `document`. If a child element calls `event.stopPropagation()` on click before
+  the event reaches `document`, the link won't navigate. Rare, but a real change
+  — don't stop propagation inside a `use:link` element (or put an explicit
+  `onclick` on the `<a>` itself).
+- **A manually-detached element no longer navigates.** Removing the element from
+  the DOM *without* Svelte unmount (`element.remove()`) leaves its `WeakMap`
+  entry intact, but a click on a detached node doesn't bubble to `document`, so
+  nothing fires. Under Svelte's normal `use:` lifecycle this is irrelevant —
+  unmount calls `destroy()`, which unregisters the node.
+
 ## SSR
 
 SSR-friendly without a separate entry. The same `RouterProvider`, `RouteView`, `Link`, and composables work under `svelte/server` (`render`) — no SSR-specific imports, no `if (typeof window !== "undefined")` shims, no platform branches in hot paths.
@@ -569,7 +597,8 @@ See also: [Svelte Integration — Server-Side Rendering](https://github.com/grey
 - `useIsActiveRoute` uses cached `createActiveRouteSource` — params hashed via `canonicalJson` (key-order-insensitive)
 - No `memo()` needed — Svelte compiles to fine-grained DOM updates
 - `Link` uses `$derived` for `href` and `class` derivation, `useIsActiveRoute` for active state
-- All WeakMap caches live in `@real-router/sources` — auto-evicted on router GC, no local caches in this adapter
+- Most WeakMap caches live in `@real-router/sources` — auto-evicted on router GC. The one **local** per-router cache is `createLinkAction`'s event-delegation state (`WeakMap<Router, …>`, #1253 — see the `use:link` delegation gotcha) — also GC'd with the router
+- `use:link` (`createLinkAction`) **delegates events** — one `click` + one `keydown` listener per router on `document` (per-router singleton), not two per node → O(1) listeners for any number of links, ref-counted attach/detach (#1253)
 - `EMPTY_PARAMS`, `EMPTY_OPTIONS` (frozen singletons in `src/constants.ts`) are used as default props in `Link` and as fallbacks in `createLinkAction` — avoids `{}` allocation per render / per click
 - `createRouteContext` builds `route`/`previousRoute` getter objects **once** per `RouterProvider` / `useRouteNode` call — avoids the per-access object allocation of a naïve double-getter pattern
 - `createSubscriber` is lazy — no subscription overhead until `.current` is read in a reactive context

--- a/packages/svelte/src/actions/link.svelte.ts
+++ b/packages/svelte/src/actions/link.svelte.ts
@@ -15,6 +15,135 @@ type LinkAction = (
   params: LinkActionParams,
 ) => ActionReturn<LinkActionParams>;
 
+// #1253 — the action delegates events instead of attaching per-node listeners.
+// A per-router singleton registers one `click` + one `keydown` listener at
+// `document`, shared by every `use:link` node; nodes register their params into
+// a `WeakMap`, and the delegated handler walks up from the event target to the
+// nearest registered node. Result: O(1) listeners for any number of links
+// (was 2 per node) — mirroring sv-router's global click delegation and the
+// per-router-singleton pattern of `createActiveNameSelector`.
+//
+// Ref-counted attach/detach (like the selector's lazy connect/disconnect): the
+// two `document` listeners attach on the first registered node and detach on the
+// last `destroy()`, so a stopped/disposed router stays GC-able — the listeners
+// hold a `router` reference, and `delegationByRouter` keys the state weakly. The
+// state itself stays cached for the router's lifetime (never deleted from the
+// map) so every `createLinkAction()` for one router shares ONE delegation root.
+interface DelegationState {
+  register: (node: HTMLElement, params: LinkActionParams) => void;
+  update: (node: HTMLElement, params: LinkActionParams) => void;
+  unregister: (node: HTMLElement) => void;
+}
+
+const delegationByRouter = new WeakMap<Router, DelegationState>();
+
+function findRegisteredNode(
+  nodes: WeakMap<HTMLElement, LinkActionParams>,
+  target: EventTarget | null,
+): HTMLElement | undefined {
+  let el = target instanceof HTMLElement ? target : null;
+
+  while (el) {
+    if (nodes.has(el)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+
+  return undefined;
+}
+
+function getDelegation(router: Router): DelegationState {
+  const cached = delegationByRouter.get(router);
+
+  if (cached) {
+    return cached;
+  }
+
+  const nodes = new WeakMap<HTMLElement, LinkActionParams>();
+  let count = 0;
+
+  function navigate(target: LinkActionParams): void {
+    router
+      .navigate(
+        target.name,
+        target.params ?? EMPTY_PARAMS,
+        target.options ?? EMPTY_OPTIONS,
+      )
+      .catch(NOOP);
+  }
+
+  function handleClick(evt: MouseEvent): void {
+    if (!shouldNavigate(evt)) {
+      return;
+    }
+
+    const node = findRegisteredNode(nodes, evt.target);
+
+    if (!node) {
+      return;
+    }
+
+    // Anchor `target="_blank"` opens a new tab — let the browser handle it.
+    if (
+      node instanceof HTMLAnchorElement &&
+      node.getAttribute("target") === "_blank"
+    ) {
+      return;
+    }
+
+    evt.preventDefault();
+    navigate(nodes.get(node)!);
+  }
+
+  function handleKeyDown(evt: KeyboardEvent): void {
+    if (evt.key !== "Enter") {
+      return;
+    }
+
+    const node = findRegisteredNode(nodes, evt.target);
+
+    // Buttons activate on Enter natively (WAI-ARIA) — don't double-fire.
+    if (!node || node instanceof HTMLButtonElement) {
+      return;
+    }
+
+    navigate(nodes.get(node)!);
+  }
+
+  const state: DelegationState = {
+    register(node, params) {
+      nodes.set(node, params);
+
+      if (count === 0) {
+        document.addEventListener("click", handleClick);
+        document.addEventListener("keydown", handleKeyDown);
+      }
+
+      count++;
+    },
+    update(node, params) {
+      nodes.set(node, params);
+    },
+    unregister(node) {
+      // Svelte calls an action's `destroy()` exactly once per node, so every
+      // `register` is balanced by one `unregister` — no double-decrement guard
+      // needed (mirrors the original per-node `removeEventListener` teardown).
+      nodes.delete(node);
+      count--;
+
+      if (count === 0) {
+        document.removeEventListener("click", handleClick);
+        document.removeEventListener("keydown", handleKeyDown);
+      }
+    },
+  };
+
+  delegationByRouter.set(router, state);
+
+  return state;
+}
+
 /**
  * Factory function that captures router context during component initialization.
  * Must be called during component init (not inside event handlers or effects).
@@ -35,53 +164,21 @@ type LinkAction = (
  */
 export function createLinkAction(): LinkAction {
   const router = getContextOrThrow<Router>(ROUTER_KEY, "createLinkAction");
+  const delegation = getDelegation(router);
 
   return function link(
     node: HTMLElement,
     params: LinkActionParams,
   ): ActionReturn<LinkActionParams> {
-    let currentParams = params;
-
     applyLinkA11y(node);
-
-    function navigate() {
-      router
-        .navigate(
-          currentParams.name,
-          currentParams.params ?? EMPTY_PARAMS,
-          currentParams.options ?? EMPTY_OPTIONS,
-        )
-        .catch(NOOP);
-    }
-
-    function handleClick(evt: MouseEvent) {
-      if (!shouldNavigate(evt)) return;
-      if (
-        node instanceof HTMLAnchorElement &&
-        node.getAttribute("target") === "_blank"
-      ) {
-        return;
-      }
-      evt.preventDefault();
-      navigate();
-    }
-
-    function handleKeyDown(evt: KeyboardEvent) {
-      if (evt.key === "Enter" && !(node instanceof HTMLButtonElement)) {
-        navigate();
-      }
-    }
-
-    node.addEventListener("click", handleClick);
-    node.addEventListener("keydown", handleKeyDown);
+    delegation.register(node, params);
 
     return {
       update(newParams: LinkActionParams) {
-        currentParams = newParams;
+        delegation.update(node, newParams);
       },
       destroy() {
-        node.removeEventListener("click", handleClick);
-        node.removeEventListener("keydown", handleKeyDown);
+        delegation.unregister(node);
       },
     };
   };

--- a/packages/svelte/tests/functional/link-action.test.ts
+++ b/packages/svelte/tests/functional/link-action.test.ts
@@ -10,10 +10,12 @@ import CreateLinkActionInEffect from "../helpers/CreateLinkActionInEffect.svelte
 import CreateLinkActionInTimeout from "../helpers/CreateLinkActionInTimeout.svelte";
 import LinkActionAnchorTest from "../helpers/LinkActionAnchorTest.svelte";
 import LinkActionDoubleTest from "../helpers/LinkActionDoubleTest.svelte";
+import LinkActionNestedChild from "../helpers/LinkActionNestedChild.svelte";
 import LinkActionTest from "../helpers/LinkActionTest.svelte";
 import LinkActionTestNoProvider from "../helpers/LinkActionTestNoProvider.svelte";
 import LinkActionUpdateTest from "../helpers/LinkActionUpdateTest.svelte";
 import LinkActionWithPresetAttributes from "../helpers/LinkActionWithPresetAttrs.svelte";
+import ManyLinkActionsFn from "../helpers/ManyLinkActionsFn.svelte";
 
 import type { Router } from "@real-router/core";
 
@@ -27,6 +29,95 @@ describe("createLinkAction", () => {
 
   afterEach(() => {
     router.stop();
+  });
+
+  it("N use:link nodes register ZERO per-node click/keydown listeners — event delegation (#1253)", () => {
+    // #1253 — the action delegated its click/keydown to a per-router singleton
+    // at `document` instead of attaching 2 listeners per node. Mounting N nodes
+    // must register ZERO per-node click/keydown listeners; the delegated pair
+    // lives on `document` (not an HTMLElement, so the prototype spy misses it).
+    const addSpy = vi.spyOn(HTMLElement.prototype, "addEventListener");
+
+    renderWithRouter(router, ManyLinkActionsFn, { count: 4 });
+
+    const perNode = addSpy.mock.calls.filter(
+      ([type]) => type === "click" || type === "keydown",
+    );
+
+    expect(perNode).toHaveLength(0);
+
+    addSpy.mockRestore();
+  });
+
+  it("delegated handler walks up from a descendant target to the registered link (#1253)", async () => {
+    vi.spyOn(router, "navigate");
+
+    renderWithRouter(router, LinkActionNestedChild, { name: "home" });
+
+    // Click the inner <span> — the delegated `document` handler walks up from
+    // the descendant target to the nearest registered node (the <a>).
+    const child = document.querySelector("[data-testid='child']")!;
+
+    child.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(router.navigate).toHaveBeenCalledWith("home", {}, {});
+  });
+
+  it("delegated click with no registered link ancestor is ignored (#1253)", () => {
+    vi.spyOn(router, "navigate");
+
+    // Mount a link so the per-router `document` delegation listener is attached.
+    renderWithRouter(router, LinkActionTest, {
+      params: { name: "home" },
+      element: "button",
+    });
+
+    // A click bubbling to `document` from an element with no registered
+    // ancestor: findRegisteredNode walks to the root and returns undefined.
+    const stray = document.createElement("div");
+
+    document.body.append(stray);
+
+    stray.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    // And a click whose target is `document` itself (not an HTMLElement) —
+    // exercises the non-HTMLElement guard in findRegisteredNode.
+    document.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(router.navigate).not.toHaveBeenCalled();
+
+    stray.remove();
+  });
+
+  it("delegated Enter with no registered link ancestor is ignored (#1253)", () => {
+    vi.spyOn(router, "navigate");
+
+    renderWithRouter(router, LinkActionTest, {
+      params: { name: "home" },
+      element: "div",
+    });
+
+    const stray = document.createElement("div");
+
+    document.body.append(stray);
+
+    stray.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(router.navigate).not.toHaveBeenCalled();
+
+    stray.remove();
   });
 
   it("should navigate on click", async () => {
@@ -541,14 +632,14 @@ describe("createLinkAction", () => {
     expect(navigateSpy).toHaveBeenLastCalledWith("about", {}, {});
   });
 
-  // Closes review §5.11 row 16: when the element is removed from the DOM
-  // while the action's listeners are still bound, click events naturally
-  // don't fire (no element to receive them). Svelte's `use:` lifecycle
-  // calls `destroy()` on unmount, so the standard path is element removal
-  // BY unmount. Manual `element.remove()` without unmount would leave the
-  // listeners bound — but since the element is detached, no further user
-  // interaction can fire them. Pin this defensive contract.
-  it("element manually removed from DOM → no navigation, no error", async () => {
+  // #1253 — with event delegation the listeners live on `document`, not on the
+  // node. A manually-detached element (removed WITHOUT Svelte unmount, so
+  // `destroy()` never ran and its WeakMap entry survives) no longer fires the
+  // handler: a click on a detached node doesn't bubble up to `document`, so the
+  // delegated handler never sees it. This is a DELIBERATE behavior change from
+  // the per-node-listener era (where a detached node still navigated) — it
+  // matches sv-router's global delegation and is documented in CLAUDE.md.
+  it("element manually removed from DOM → no navigation, no error (delegated)", () => {
     vi.spyOn(router, "navigate");
 
     renderWithRouter(router, LinkActionTest, {
@@ -562,15 +653,12 @@ describe("createLinkAction", () => {
 
     expect(document.body.contains(button)).toBe(false);
 
-    // Dispatching a click on a detached element fires the listener (the
-    // listener was attached directly to the node). The action navigates.
-    // This is documented behavior — Svelte's unmount path is what stops
-    // navigation, not DOM detachment. Locks the contract.
+    // Click on a detached node doesn't reach the `document` delegation root.
     const event = new MouseEvent("click", { bubbles: true, cancelable: true });
 
     button.dispatchEvent(event);
 
-    expect(router.navigate).toHaveBeenCalledWith("home", {}, {});
+    expect(router.navigate).not.toHaveBeenCalled();
   });
 
   // Closes review §5.11 row 17: hash asymmetry pin-test. The action's

--- a/packages/svelte/tests/helpers/LinkActionNestedChild.svelte
+++ b/packages/svelte/tests/helpers/LinkActionNestedChild.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { createLinkAction } from "../../src/actions/link.svelte";
+
+  // A `use:link` anchor wrapping a child element — used to assert the delegated
+  // handler walks up from a descendant target to the registered link (#1253).
+  let { name }: { name: string } = $props();
+
+  const link = createLinkAction();
+</script>
+
+<a use:link={{ name }} data-testid="nested-link">
+  <span data-testid="child">child</span>
+</a>

--- a/packages/svelte/tests/helpers/ManyLinkActionsFn.svelte
+++ b/packages/svelte/tests/helpers/ManyLinkActionsFn.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { createLinkAction } from "../../src/actions/link.svelte";
+
+  // Mounts N `use:link` anchors sharing one createLinkAction factory — used to
+  // assert event delegation (#1253): N nodes register ZERO per-node listeners.
+  let { count }: { count: number } = $props();
+
+  const link = createLinkAction();
+  const items = Array.from({ length: count }, (_, i) => i);
+</script>
+
+{#each items as i (i)}
+  <a use:link={{ name: "home" }} data-testid={`la-${i}`}>Link {i}</a>
+{/each}


### PR DESCRIPTION
## Summary

`use:link` (`createLinkAction`) now **delegates events** instead of attaching two listeners per node — one shared `click` + `keydown` pair per router at `document`, mirroring sv-router's global delegation. Mounting a link-heavy page (nav menu, sitemap, paginated list — exactly what `use:link` is recommended for) is lighter: **O(1) listeners for any number of links** instead of O(2N), ~5.99 → ~4.3 ms per 1000 links (directional).

### #1253 — createLinkAction attaches per-link click/keydown listeners

- `use:link` registers **one** delegated `click` + `keydown` listener on `document` per router (a per-router singleton, `WeakMap<Router, …>`), with each node's params in a `WeakMap<HTMLElement, LinkActionParams>`; the delegated handler walks up from `event.target` to the nearest registered node.
- Ref-counted attach/detach (mirroring `createActiveNameSelector`'s lazy connect/disconnect) keeps a stopped/disposed router GC-able. `applyLinkA11y` stays per-node (it sets `role`/`tabindex` attributes, not listeners).
- **Root cause:** the action ran `node.addEventListener("click")` + `("keydown")` on every `use:link` invocation — 2×N listeners at mount, the excess `use:link` paid over a plain `<a>`.

### Maintainability

- `chore(benchmarks)`: skip documented competitor-N/A cells in the `run-all` matrix; silence benchmark log warnings.

## Breaking changes

Two edge-case behavior changes from the per-node-listener era (documented in `packages/svelte/CLAUDE.md` + the Svelte-Integration wiki). Both are irrelevant under Svelte's normal `use:` lifecycle; bumped **minor** (pre-1.0).

- A descendant calling `event.stopPropagation()` before the click reaches `document` now blocks navigation (a per-node listener fired regardless).
- An element removed from the DOM *without* Svelte unmount (`element.remove()`) no longer navigates — its click doesn't bubble to `document`.

## Test plan

- [x] `packages/svelte/tests/functional/link-action.test.ts` — resource discriminator `N use:link nodes register ZERO per-node click/keydown listeners` (fails before at 8, passes after at 0 for 4 nodes); `delegated handler walks up from a descendant target`; `delegated click/Enter with no registered link ancestor is ignored`
- [x] Existing behavior preserved: modifier-key skip, `target="_blank"` anchor skip, Enter navigation + `HTMLButtonElement` skip, `preventDefault` on same-tab nav, params `update()`, throw-outside-provider. One detached-element pin-test flipped to the new delegation behavior (documented)
- [x] `@real-router/svelte`: 353 unit + 77 stress + 189 property tests pass; 100% coverage on `link.svelte.ts`; type-check + lint clean
- [x] `pnpm build` passes (pre-push: build + lint:types + lint:package + osv-audit + semgrep all green)

Closes #1253
