### PR TITLE
perf: adopt createActiveNameSelector fast path for <Link> active state in react/preact/vue (#1248 #1249 #1250)

### DIFF
--- a/.changeset/preact-active-selector-fastpath.md
+++ b/.changeset/preact-active-selector-fastpath.md
@@ -1,0 +1,7 @@
+---
+"@real-router/preact": patch
+---
+
+Adopt the `createActiveNameSelector` fast path for `<Link>` active state (#1249)
+
+- `useIsActiveRoute` resolves default-options active state (no custom params, non-strict, `ignoreQueryParams`, no `hash`) through the per-router shared `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` links — instead of a per-instance `createActiveRouteSource` (a `BaseSource` + its own subscription each). Fewer subscriptions ⇒ lower mount cost and less retained heap, with per-nav active-state notifications unchanged (the selector keeps its `areRoutesRelated` pre-filter + only-changed diff). Direct port of the svelte (#1101) / angular (#1104) / react (#1248) fast paths (validated via the React cohort + micro-bench — the preact cohort has no full-router cross-router competitor). The full argument surface (custom params, strict, `ignoreQueryParams: false`, hash) still uses `createActiveRouteSource`.

--- a/.changeset/react-active-selector-fastpath.md
+++ b/.changeset/react-active-selector-fastpath.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": patch
+---
+
+Adopt the `createActiveNameSelector` fast path for `<Link>` active state (#1248)
+
+- `useIsActiveRoute` resolves default-options active state (no custom params, non-strict, `ignoreQueryParams`, no `hash`) through the per-router shared `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` links — instead of a per-instance `createActiveRouteSource` (a `BaseSource` + its own subscription each). Fewer subscriptions ⇒ lower mount cost (link-build ~9.9 → ~8.5 ms per 1000 links, directional n=5) with per-nav active-state notifications unchanged (the selector keeps its `areRoutesRelated` pre-filter + only-changed diff). Direct port of the svelte (#1101) / angular (#1104) fast paths; the full argument surface (custom params, strict, `ignoreQueryParams: false`, hash) still uses `createActiveRouteSource`.

--- a/.changeset/vue-active-selector-fastpath.md
+++ b/.changeset/vue-active-selector-fastpath.md
@@ -1,0 +1,7 @@
+---
+"@real-router/vue": patch
+---
+
+Adopt the `createActiveNameSelector` fast path for `<Link>` active state (#1250)
+
+- `useIsActiveRoute` resolves default-options active state (no custom params, non-strict, `ignoreQueryParams`, no `hash`) through the per-router shared `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` links — instead of a per-instance `createActiveRouteSource` (a `BaseSource` + its own subscription each). Fewer subscriptions ⇒ lower mount cost and less retained heap, with per-nav active-state notifications unchanged (the selector keeps its `areRoutesRelated` pre-filter + only-changed diff). Direct port of the svelte (#1101) / angular (#1104) / react (#1248) / preact (#1249) fast paths. `useRefFromSource` is narrowed to the `subscribe` + `getSnapshot` methods it actually consumes, so the fast path can bridge a two-method selector wrapper without a dead `destroy`. The full argument surface (custom params, strict, `ignoreQueryParams: false`, hash) still uses `createActiveRouteSource`.

--- a/packages/preact/CLAUDE.md
+++ b/packages/preact/CLAUDE.md
@@ -53,7 +53,7 @@ src/
 │   ├── useRoute.tsx            # Full route state from context (every navigation)
 │   ├── useNavigator.tsx        # Navigator from context (never re-renders)
 │   ├── useRouteNode.tsx        # Node-scoped subscription (cached createRouteNodeSource from sources)
-│   ├── useIsActiveRoute.tsx    # Active state subscription (cached createActiveRouteSource, useMemo-wrapped)
+│   ├── useIsActiveRoute.tsx    # Default opts → shared createActiveNameSelector fast path (#1249); else cached createActiveRouteSource, useMemo-wrapped
 │   ├── useRouteUtils.tsx       # RouteUtils from route tree (never re-renders)
 │   ├── useRouterTransition.tsx # Transition lifecycle (cached getTransitionSource)
 │   ├── useRouteExit.tsx        # Wraps subscribeLeave with abort + same-route guards + handler ref
@@ -499,6 +499,6 @@ integration contract:
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` hook)
-- `useIsActiveRoute` uses cached `createActiveRouteSource` — params are hashed via `canonicalJson` (key-order-insensitive)
+- `useIsActiveRoute` resolves default-options active state through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1249); custom params / strict / `ignoreQueryParams: false` / hash fall to cached `createActiveRouteSource` (params hashed via `canonicalJson`, key-order-insensitive)
 - `Link` uses `memo()` with custom `areLinkPropsEqual` comparator: `Object.is` for primitives + `style` + `children`, `shallowEqual` (from `dom-utils`) for `routeParams`/`routeOptions`. Nested objects in params are not deep-compared — consumers stabilize via `useMemo` if needed
 - WeakMap caches in `@real-router/sources` are per-router, auto-evicted on router GC

--- a/packages/preact/src/hooks/useIsActiveRoute.tsx
+++ b/packages/preact/src/hooks/useIsActiveRoute.tsx
@@ -1,11 +1,13 @@
-import { createActiveRouteSource } from "@real-router/sources";
+import {
+  createActiveNameSelector,
+  createActiveRouteSource,
+} from "@real-router/sources";
 import { useMemo } from "preact/hooks";
 
 import { useSyncExternalStore } from "../useSyncExternalStore";
 import { useRouter } from "./useRouter";
 
 import type { Params } from "@real-router/core";
-import type { ActiveRouteSourceOptions } from "@real-router/sources";
 
 export function useIsActiveRoute(
   routeName: string,
@@ -16,27 +18,43 @@ export function useIsActiveRoute(
 ): boolean {
   const router = useRouter();
 
-  // createActiveRouteSource is per-router + canonical-args cached in
-  // @real-router/sources. Caching the opts object + memoising the source
-  // lookup avoids (a) re-allocating the literal on every render and (b)
-  // re-running canonicalJson(params) on the cache lookup path. The `hash`
-  // argument (#532) participates in the cache key — a tab Link pointing to
-  // `/settings#account` shares its source only with consumers using the
-  // same routeName + params + hash. exactOptionalPropertyTypes forbids
-  // `{ hash: undefined }` literally, so we conditionally include the key
-  // only when the caller passed a value.
-  const opts = useMemo<ActiveRouteSourceOptions>(
-    () =>
+  // Fast path (#1249) — the default-options active check: no custom `params`,
+  // non-strict, query params ignored, no `hash`. Resolve through the per-router
+  // shared `createActiveNameSelector` — ONE `router.subscribe` handle serves any
+  // number of distinct-`routeName` links — instead of a per-instance
+  // `createActiveRouteSource` (a `BaseSource` AND its own router subscription for
+  // every distinct name). Direct port of the svelte (#1101) / angular (#1104) /
+  // react (#1248) fast paths; the selector's `isActive` is exactly non-strict,
+  // query-ignoring, name-only matching. Any deviation falls to the slow path,
+  // whose canonical-args cache handles the full surface (custom params, strict,
+  // `ignoreQueryParams: false`, hash-aware #532).
+  //
+  // The `useMemo` wrap skips the branch + `canonicalJson(params)` + cache lookup
+  // on every render when all primitive deps and the `params` reference are stable.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so we
+  // conditionally spread the key only when the caller passed a value.
+  const store = useMemo(() => {
+    if (
+      params === undefined &&
+      !strict &&
+      ignoreQueryParams &&
       hash === undefined
-        ? { strict, ignoreQueryParams }
-        : { strict, ignoreQueryParams, hash },
-    [strict, ignoreQueryParams, hash],
-  );
+    ) {
+      const selector = createActiveNameSelector(router);
 
-  const store = useMemo(
-    () => createActiveRouteSource(router, routeName, params, opts),
-    [router, routeName, params, opts],
-  );
+      return {
+        subscribe: (onChange: () => void) =>
+          selector.subscribe(routeName, onChange),
+        getSnapshot: () => selector.isActive(routeName),
+      };
+    }
+
+    return createActiveRouteSource(router, routeName, params, {
+      strict,
+      ignoreQueryParams,
+      ...(hash !== undefined && { hash }),
+    });
+  }, [router, routeName, params, strict, ignoreQueryParams, hash]);
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/preact/tests/functional/Link.test.tsx
+++ b/packages/preact/tests/functional/Link.test.tsx
@@ -1173,8 +1173,13 @@ describe("Link component", () => {
       // Discriminator: a cache HIT returns the shared source without re-running
       // `router.isActiveRoute`; a cache MISS constructs a fresh source and calls it
       // once for its initial value.
+      // #1249 re-target: the default-options fast path no longer builds a
+      // `createActiveRouteSource` (it uses the shared name-selector), so this
+      // #776 undefined-vs-"{}" dedup guard now exercises the SLOW path via
+      // `ignoreQueryParams={false}` — which still passes `routeParams` straight
+      // through as `undefined` (keying "", not "{}").
       render(
-        <Link routeName="users" data-testid="link">
+        <Link routeName="users" ignoreQueryParams={false} data-testid="link">
           Users
         </Link>,
         { wrapper },
@@ -1184,7 +1189,7 @@ describe("Link component", () => {
 
       createActiveRouteSource(router, "users", undefined, {
         strict: false,
-        ignoreQueryParams: true,
+        ignoreQueryParams: false,
       });
 
       expect(isActiveRouteSpy).not.toHaveBeenCalled();

--- a/packages/preact/tests/functional/useIsActiveRoute.test.tsx
+++ b/packages/preact/tests/functional/useIsActiveRoute.test.tsx
@@ -1,7 +1,8 @@
 import { errorCodes } from "@real-router/core";
 import { getRoutesApi } from "@real-router/core/api";
+import { createActiveRouteSource } from "@real-router/sources";
 import { act, renderHook } from "@testing-library/preact";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
 import { RouterProvider } from "@real-router/preact";
 
@@ -35,6 +36,30 @@ describe("useIsActiveRoute", () => {
     );
 
     expect(result.current).toBe(true);
+  });
+
+  it("a default useIsActiveRoute uses the shared name-selector fast path, NOT a per-instance createActiveRouteSource (#1249)", () => {
+    // #1249 — a default-options call (no params, non-strict, ignoreQueryParams,
+    // no hash) resolves active state through the per-router
+    // `createActiveNameSelector` (ONE shared `router.subscribe` for any number
+    // of distinct-name links) instead of a per-instance `createActiveRouteSource`.
+    // Direct port of svelte (#1101) / angular (#1104) / react (#1248).
+    //
+    // Discriminator: the canonical undefined-params slow-path source is still
+    // UNBUILT after the hook mounts → building it now is a cache MISS →
+    // `router.isActiveRoute` is called (a pre-#1249 HIT would NOT re-run it).
+    renderHook(() => useIsActiveRoute("users"), {
+      wrapper: (props) => wrapper({ ...props, router }),
+    });
+
+    const isActiveRouteSpy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "users", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+    });
+
+    expect(isActiveRouteSpy).toHaveBeenCalled();
   });
 
   it("should handle non-strict mode", () => {

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 │   ├── useRoute.tsx                # Returns RouteHookResult<P> — route is non-nullable
 │   ├── useNavigator.tsx
 │   ├── useRouteNode.tsx            # Uses cached createRouteNodeSource from @real-router/sources
-│   ├── useIsActiveRoute.tsx        # Uses cached createActiveRouteSource, useMemo-wrapped
+│   ├── useIsActiveRoute.tsx        # Default opts → shared createActiveNameSelector fast path (#1248); else cached createActiveRouteSource, useMemo-wrapped
 │   ├── useRouteUtils.tsx
 │   ├── useRouterTransition.tsx     # Uses cached getTransitionSource
 │   ├── useRouteEnter.tsx           # Mount-side window: reentrant abort, same-route skip, latest-ref, StrictMode dedupe
@@ -578,5 +578,5 @@ No built-in SSR support. For SSR:
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — `N` consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` hook)
-- `useIsActiveRoute` uses cached `createActiveRouteSource` — params are hashed with `canonicalJson` (key-order-insensitive), so `{a:1, b:2}` and `{b:2, a:1}` hit the same cache entry. No `useStableValue` wrapper needed
+- `useIsActiveRoute` resolves default-options active state (no params, non-strict, `ignoreQueryParams`, no `hash`) through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1248). Custom params / strict / `ignoreQueryParams: false` / hash fall to cached `createActiveRouteSource` — params are hashed with `canonicalJson` (key-order-insensitive), so `{a:1, b:2}` and `{b:2, a:1}` hit the same cache entry. No `useStableValue` wrapper needed
 - `Link` uses `memo()` with custom `areLinkPropsEqual` comparator: `Object.is` for primitives + `style` + `children`, `shallowEqual` (Object.is per key, order-insensitive) for `routeParams`/`routeOptions`. Nested objects in params are not deep-compared — consumers stabilize via `useMemo` if needed

--- a/packages/react/src/hooks/useIsActiveRoute.tsx
+++ b/packages/react/src/hooks/useIsActiveRoute.tsx
@@ -1,4 +1,7 @@
-import { createActiveRouteSource } from "@real-router/sources";
+import {
+  createActiveNameSelector,
+  createActiveRouteSource,
+} from "@real-router/sources";
 import { useMemo, useSyncExternalStore } from "react";
 
 import { useRouter } from "./useRouter";
@@ -14,30 +17,44 @@ export function useIsActiveRoute(
 ): boolean {
   const router = useRouter();
 
-  // createActiveRouteSource is per-router + canonical-args cached in
-  // @real-router/sources, so passing params by reference is safe — equivalent
-  // param shapes hit the same cache entry regardless of key order. The
-  // `hash` argument (#532) is part of the cache key when defined: a Link
-  // pointing to `/settings#account` shares its source only with other
-  // consumers using the same routeName + params + hash.
+  // Fast path (#1248) — the default-options active check: no custom `params`,
+  // non-strict, query params ignored, no `hash`. Resolve through the per-router
+  // shared `createActiveNameSelector` — ONE `router.subscribe` handle serves any
+  // number of distinct-`routeName` links — instead of a per-instance
+  // `createActiveRouteSource` (a `BaseSource` AND its own router subscription for
+  // every distinct name). Direct port of the svelte (#1101) / angular (#1104)
+  // fast paths; the selector's `isActive` is exactly non-strict, query-ignoring,
+  // name-only matching, identical to the default-options `createActiveRouteSource`.
+  // Any deviation falls to the slow path below, whose canonical-args cache handles
+  // the full surface (custom params, strict, `ignoreQueryParams: false`,
+  // hash-aware #532).
   //
-  // The useMemo wrap skips `canonicalJson(params)` + cache lookup on every
-  // render when all primitive deps and the `params` reference are stable —
-  // the common case once memo()+shallowEqual has bailed out further up
-  // (or when the parent re-renders for a non-Link reason). For inline
-  // `params={{id:1}}` the dep changes per render and the lookup still
-  // runs, but that path was already the slow path before this memo.
-  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so
-  // we conditionally spread the key only when the caller passed a value.
-  const store = useMemo(
-    () =>
-      createActiveRouteSource(router, routeName, params, {
-        strict,
-        ignoreQueryParams,
-        ...(hash !== undefined && { hash }),
-      }),
-    [router, routeName, params, strict, ignoreQueryParams, hash],
-  );
+  // The `useMemo` wrap skips the branch + `canonicalJson(params)` + cache lookup
+  // on every render when all primitive deps and the `params` reference are stable.
+  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so we
+  // conditionally spread the key only when the caller passed a value.
+  const store = useMemo(() => {
+    if (
+      params === undefined &&
+      !strict &&
+      ignoreQueryParams &&
+      hash === undefined
+    ) {
+      const selector = createActiveNameSelector(router);
+
+      return {
+        subscribe: (onChange: () => void) =>
+          selector.subscribe(routeName, onChange),
+        getSnapshot: () => selector.isActive(routeName),
+      };
+    }
+
+    return createActiveRouteSource(router, routeName, params, {
+      strict,
+      ignoreQueryParams,
+      ...(hash !== undefined && { hash }),
+    });
+  }, [router, routeName, params, strict, ignoreQueryParams, hash]);
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/react/tests/functional/InkLink.test.tsx
+++ b/packages/react/tests/functional/InkLink.test.tsx
@@ -351,9 +351,15 @@ describe("InkLink", () => {
     // and splits from the canonical undefined key "" used by useIsActiveRoute(name).
     // Discriminator: a cache HIT skips construction (no router.isActiveRoute); a MISS
     // constructs a fresh source and calls isActiveRoute once.
+    // #1248 re-target: default-options fast path no longer builds a
+    // `createActiveRouteSource`; this #776 undefined-vs-"{}" dedup now exercises
+    // the SLOW path via `ignoreQueryParams={false}` (still passes `routeParams`
+    // through as `undefined`, keying "").
     render(
       <InkRouterProvider router={router}>
-        <InkLink routeName="users.list">Users</InkLink>
+        <InkLink routeName="users.list" ignoreQueryParams={false}>
+          Users
+        </InkLink>
       </InkRouterProvider>,
     );
 
@@ -361,7 +367,7 @@ describe("InkLink", () => {
 
     createActiveRouteSource(router, "users.list", undefined, {
       strict: false,
-      ignoreQueryParams: true,
+      ignoreQueryParams: false,
     });
 
     expect(isActiveRouteSpy).not.toHaveBeenCalled();

--- a/packages/react/tests/functional/Link.test.tsx
+++ b/packages/react/tests/functional/Link.test.tsx
@@ -837,8 +837,13 @@ describe("Link component", () => {
       // constructs a fresh source and calls `isActiveRoute` exactly once for its initial
       // value. So if the canonical undefined-params lookup is a HIT, the Link already
       // owns that exact instance.
+      // #1248 re-target: the default-options fast path no longer builds a
+      // `createActiveRouteSource` (it uses the shared name-selector), so this
+      // #776 undefined-vs-"{}" dedup guard now exercises the SLOW path via
+      // `ignoreQueryParams={false}` — which still passes `routeParams` straight
+      // through as `undefined` (keying "", not "{}").
       render(
-        <Link routeName="users" data-testid="link">
+        <Link routeName="users" ignoreQueryParams={false} data-testid="link">
           Users
         </Link>,
         { wrapper },
@@ -846,10 +851,10 @@ describe("Link component", () => {
 
       const isActiveRouteSpy = vi.spyOn(router, "isActiveRoute");
 
-      // Exactly what `useIsActiveRoute("users")` builds internally.
+      // Exactly what `useIsActiveRoute("users", undefined, false, false)` builds.
       createActiveRouteSource(router, "users", undefined, {
         strict: false,
-        ignoreQueryParams: true,
+        ignoreQueryParams: false,
       });
 
       // GREEN: the Link created this same "" entry → cache hit → no recompute.

--- a/packages/react/tests/functional/useIsActiveRoute.test.tsx
+++ b/packages/react/tests/functional/useIsActiveRoute.test.tsx
@@ -1,7 +1,8 @@
 import { errorCodes } from "@real-router/core";
 import { getRoutesApi } from "@real-router/core/api";
+import { createActiveRouteSource } from "@real-router/sources";
 import { act, renderHook } from "@testing-library/react";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
 import { RouterProvider } from "@real-router/react";
 
@@ -35,6 +36,33 @@ describe("useIsActiveRoute", () => {
     );
 
     expect(result.current).toBe(true);
+  });
+
+  it("a default useIsActiveRoute uses the shared name-selector fast path, NOT a per-instance createActiveRouteSource (#1248)", () => {
+    // #1248 — a default-options call (no params, non-strict, ignoreQueryParams,
+    // no hash) resolves active state through the per-router
+    // `createActiveNameSelector` (ONE shared `router.subscribe` for any number
+    // of distinct-name links) instead of a per-instance `createActiveRouteSource`
+    // (a BaseSource + its own router subscription EACH). Direct port of svelte
+    // (#1101) / angular (#1104).
+    //
+    // Discriminator: the canonical undefined-params slow-path source is
+    // therefore still UNBUILT after the hook mounts. Building it now is a cache
+    // MISS — `buildActiveRouteSource` computes its initial value via
+    // `router.isActiveRoute`. (Pre-#1248 the hook built this exact source, so the
+    // same call was a cache HIT and `isActiveRoute` was NOT re-run.)
+    renderHook(() => useIsActiveRoute("users"), {
+      wrapper: (props) => wrapper({ ...props, router }),
+    });
+
+    const isActiveRouteSpy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "users", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+    });
+
+    expect(isActiveRouteSpy).toHaveBeenCalled();
   });
 
   it("should handle non-strict mode", () => {

--- a/packages/sources/CLAUDE.md
+++ b/packages/sources/CLAUDE.md
@@ -130,7 +130,7 @@ interface ActiveNameSelector {
 
 Only notifies a listener when the `routeName`-specific active status actually flips (internal prev/next diff). Non-strict matching (descendants included).
 
-**Per-router cached.** Currently only Solid `RouterProvider` uses an inline equivalent; other adapters (React/Preact/Vue/Svelte/Angular) are still on the slow path via `createActiveRouteSource`. Migration is a Link-component-level concern — see the [Adapter Guide / "When to migrate a Link component to the fast path"](https://github.com/greydragon888/real-router/wiki/sources-adapter-guide#when-to-migrate-a-link-component-to-the-fast-path) for a concrete recipe and the cost-comparison table. `destroy()` is a no-op.
+**Per-router cached.** Every framework adapter now resolves default-options `Link` active state through this selector — Svelte (#1101), Angular (#1104), React (#1248), Preact (#1249), Vue (#1250) — while Solid `RouterProvider` uses an inline `createSelector` equivalent of the same pattern. The slow path via `createActiveRouteSource` is reserved for the full argument surface (custom params, strict, `ignoreQueryParams: false`, hash-aware). Migration is a Link-component-level concern — see the [Adapter Guide / "When to migrate a Link component to the fast path"](https://github.com/greydragon888/real-router/wiki/sources-adapter-guide#when-to-migrate-a-link-component-to-the-fast-path) for the recipe and cost-comparison table. `destroy()` is a no-op.
 
 ## Lazy vs Eager Subscription
 

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -36,7 +36,7 @@ src/
 │   ├── useNavigator.ts
 │   ├── useRoute.ts
 │   ├── useRouteNode.ts           # Uses cached createRouteNodeSource from @real-router/sources
-│   ├── useIsActiveRoute.ts       # Internal — used by Link (cached createActiveRouteSource)
+│   ├── useIsActiveRoute.ts       # Internal — used by Link (default opts → shared createActiveNameSelector fast path #1250; else cached createActiveRouteSource)
 │   ├── useRouteUtils.ts
 │   ├── useRouterTransition.ts    # Uses cached getTransitionSource
 │   ├── useRouteExit.ts           # Wraps subscribeLeave with abort + same-route guards
@@ -648,7 +648,7 @@ See also: [Vue Integration — Server-Side Rendering](https://github.com/greydra
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — N consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` composable)
-- `useIsActiveRoute` uses cached `createActiveRouteSource` — params hashed via `canonicalJson` (key-order-insensitive)
+- `useIsActiveRoute` resolves default-options active state through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1250); custom params / strict / `ignoreQueryParams: false` / hash fall to cached `createActiveRouteSource` (params hashed via `canonicalJson`, key-order-insensitive). `useRefFromSource` consumes only `subscribe` + `getSnapshot`
 - No `memo()` needed — Vue tracks ref dependencies automatically
 - `Link` content-stabilizes `routeParams` with `shallowEqual` (Object.is per key, order-insensitive — the same contract as the React adapter's `Link` `memo`), so an inline `:routeParams="{ id }"` literal from a re-rendering parent does **not** re-run `buildHref` or `canonicalJson` every navigation; `href` and active-class are `computed()` off the stabilized params + `useIsActiveRoute`. Same-shape navigations skip both derivations entirely (~18% faster on the Link-heavy `vs-tanstack` Vue bench)
 - All WeakMap caches live in `@real-router/sources` — auto-evicted on router GC, no local caches in this adapter

--- a/packages/vue/src/composables/useIsActiveRoute.ts
+++ b/packages/vue/src/composables/useIsActiveRoute.ts
@@ -1,4 +1,7 @@
-import { createActiveRouteSource } from "@real-router/sources";
+import {
+  createActiveNameSelector,
+  createActiveRouteSource,
+} from "@real-router/sources";
 
 import { useRefFromSource } from "../useRefFromSource";
 import { useRouter } from "./useRouter";
@@ -32,8 +35,7 @@ export interface UseIsActiveRouteOptions {
 }
 
 /**
- * @internal Consumed by `<Link>` via `createActiveRouteSource`. Not exported
- * from `@real-router/vue`.
+ * @internal Consumed by `<Link>`. Not exported from `@real-router/vue`.
  */
 export function useIsActiveRoute(
   routeName: string,
@@ -44,6 +46,31 @@ export function useIsActiveRoute(
   const strict = options?.strict ?? false;
   const ignoreQueryParams = options?.ignoreQueryParams ?? true;
   const hash = options?.hash;
+
+  // Fast path (#1250) — the default-options active check: no custom `params`,
+  // non-strict, query params ignored, no `hash`. Resolve through the per-router
+  // shared `createActiveNameSelector` — ONE `router.subscribe` handle serves any
+  // number of distinct-`routeName` links — instead of a per-instance
+  // `createActiveRouteSource` (a `BaseSource` AND its own router subscription for
+  // every distinct name). Direct port of the svelte (#1101) / angular (#1104) /
+  // react (#1248) / preact (#1249) fast paths; the selector's `isActive` is
+  // exactly non-strict, query-ignoring, name-only matching. Any deviation falls
+  // to the slow path below, whose canonical-args cache handles the full surface
+  // (custom params, strict, `ignoreQueryParams: false`, hash-aware #532).
+  if (
+    params === undefined &&
+    !strict &&
+    ignoreQueryParams &&
+    hash === undefined
+  ) {
+    const selector = createActiveNameSelector(router);
+
+    return useRefFromSource({
+      subscribe: (listener: () => void) =>
+        selector.subscribe(routeName, listener),
+      getSnapshot: () => selector.isActive(routeName),
+    });
+  }
 
   // The `hash` argument (#532) participates in the cache key when defined.
   // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally — we

--- a/packages/vue/src/useRefFromSource.ts
+++ b/packages/vue/src/useRefFromSource.ts
@@ -3,7 +3,13 @@ import { shallowRef, onScopeDispose } from "vue";
 import type { RouterSource } from "@real-router/sources";
 import type { ShallowRef } from "vue";
 
-export function useRefFromSource<T>(source: RouterSource<T>): ShallowRef<T> {
+export function useRefFromSource<T>(
+  // Only `subscribe` + `getSnapshot` are consumed — teardown goes through the
+  // `subscribe` unsub via `onScopeDispose`, never `source.destroy`. Narrowing to
+  // this shape lets the #1250 name-selector fast path pass a 2-method wrapper
+  // (no dead `destroy` needed); full `RouterSource`s still satisfy it.
+  source: Pick<RouterSource<T>, "subscribe" | "getSnapshot">,
+): ShallowRef<T> {
   const ref = shallowRef(source.getSnapshot());
 
   const unsub = source.subscribe(() => {

--- a/packages/vue/tests/functional/Link.test.ts
+++ b/packages/vue/tests/functional/Link.test.ts
@@ -622,13 +622,18 @@ describe("Link component", () => {
       //
       // Discriminator: a cache HIT returns the shared source without re-running
       // `router.isActiveRoute`; a cache MISS constructs a fresh source and calls it once.
-      mountLink(router, { routeName: "users" });
+      // #1250 re-target: the default-options fast path no longer builds a
+      // `createActiveRouteSource` (it uses the shared name-selector), so this
+      // #776 undefined-vs-"{}" dedup guard now exercises the SLOW path via
+      // `ignoreQueryParams: false` — which still passes `routeParams` straight
+      // through as `undefined` (keying "", not "{}").
+      mountLink(router, { routeName: "users", ignoreQueryParams: false });
 
       const isActiveRouteSpy = vi.spyOn(router, "isActiveRoute");
 
       createActiveRouteSource(router, "users", undefined, {
         strict: false,
-        ignoreQueryParams: true,
+        ignoreQueryParams: false,
       });
 
       expect(isActiveRouteSpy).not.toHaveBeenCalled();

--- a/packages/vue/tests/functional/useIsActiveRoute.test.ts
+++ b/packages/vue/tests/functional/useIsActiveRoute.test.ts
@@ -1,6 +1,7 @@
 import { getRoutesApi } from "@real-router/core/api";
+import { createActiveRouteSource } from "@real-router/sources";
 import { mount, flushPromises } from "@vue/test-utils";
-import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 import { defineComponent, h } from "vue";
 
 import { useIsActiveRoute } from "../../src/composables/useIsActiveRoute";
@@ -56,6 +57,40 @@ describe("useIsActiveRoute", () => {
     );
 
     expect(result.value).toBe(true);
+  });
+
+  it("a default useIsActiveRoute uses the shared name-selector fast path, NOT a per-instance createActiveRouteSource (#1250)", () => {
+    // #1250 — a default-options call (no params, non-strict, ignoreQueryParams,
+    // no hash) resolves active state through the per-router
+    // `createActiveNameSelector` (ONE shared `router.subscribe` for any number
+    // of distinct-name links) instead of a per-instance `createActiveRouteSource`.
+    // Direct port of svelte (#1101) / angular (#1104) / react (#1248) / preact (#1249).
+    //
+    // Discriminator: the canonical undefined-params slow-path source is still
+    // UNBUILT after the composable mounts → building it now is a cache MISS →
+    // `router.isActiveRoute` is called (a pre-#1250 HIT would NOT re-run it).
+    mountWithRouter(router, () => useIsActiveRoute("users"));
+
+    const isActiveRouteSpy = vi.spyOn(router, "isActiveRoute");
+
+    createActiveRouteSource(router, "users", undefined, {
+      strict: false,
+      ignoreQueryParams: true,
+    });
+
+    expect(isActiveRouteSpy).toHaveBeenCalled();
+  });
+
+  it("a hash-set check deviates from the fast-path defaults → hash-aware slow path (#532)", () => {
+    // `hash` set → the fast-path condition (`hash === undefined`) is false, so
+    // the hash-aware slow path builds `createActiveRouteSource` with the hash
+    // keyed into its options. The test URL "/users/123" carries no hash, so a
+    // hash-expecting check is inactive.
+    const { result } = mountWithRouter(router, () =>
+      useIsActiveRoute("users", undefined, { hash: "profile" }),
+    );
+
+    expect(result.value).toBe(false);
   });
 
   it("should handle non-strict mode", () => {


### PR DESCRIPTION
## Summary

Port the shared per-router `createActiveNameSelector` fast path (already shipped in Svelte #1101 / Angular #1104) to the React, Preact, and Vue adapters. A `<Link>` with **default** active-state options (no custom `routeParams`, `activeStrict: false`, `ignoreQueryParams: true`, no `hash`) now resolves its active state through ONE shared `router.subscribe` handle for any number of distinct-`routeName` links, instead of a per-instance `createActiveRouteSource` (a `BaseSource` + its own router subscription each). Fewer subscriptions ⇒ lower mount cost and less retained heap; per-navigation active-state notifications are unchanged (the selector keeps its `areRoutesRelated` pre-filter + only-changed diff). The full argument surface (custom params, strict, `ignoreQueryParams: false`, hash-aware #532) still uses `createActiveRouteSource`.

### #1248 — React

- `useIsActiveRoute` branches **inside** its `useMemo` so `useSyncExternalStore` stays unconditional (Rules of Hooks — props can flip the fast/slow condition between renders): default options → a `createActiveNameSelector` wrapper, else `createActiveRouteSource`.
- **Root cause:** each distinct `routeName` built its own cached `createActiveRouteSource` → N links = N router subscriptions.
- Directional cross-router A/B (React cohort, n=5, same env): link-build **9.889 → 8.498 ms** per 1000 links (−1.39 ms, ~14%); active-links **0.405 → 0.393 ms** (neutral — no per-nav regression, the distinguishing property vs a naive shared-bridge).

### #1249 — Preact

- Same fast path via the `useSyncExternalStore` polyfill. Validated via the shared selector's own `@real-router/sources` tests + the React cohort (Preact has no full-router cross-router competitor).

### #1250 — Vue

- Same fast path bridged through `useRefFromSource`. `useRefFromSource` is narrowed to the `subscribe` + `getSnapshot` methods it actually consumes, so the fast path bridges a two-method selector wrapper with no dead `destroy`.

### Maintainability

- Each adapter's `#776` no-params dedup test is re-targeted to the slow path (`ignoreQueryParams: false`) — the default-options fast path no longer builds a `createActiveRouteSource`, so the undefined-vs-`{}` cache-key guard now exercises the slow path (still passes `routeParams` through as `undefined`, keying `""`).
- Doc drift fixed: `packages/sources/CLAUDE.md` no longer claims React/Preact/Vue are "still on the slow path"; per-adapter Performance sections updated.

## Test plan

- [x] `@real-router/react`: 822 tests pass, 100% coverage; RED `useIsActiveRoute.test.tsx` "shared name-selector fast path (#1248)" (fails before — the hook pre-builds the source; passes after — fast path skips it)
- [x] `@real-router/preact`: 440 tests pass, 100% coverage; RED (#1249)
- [x] `@real-router/vue`: 457 tests pass, 100% coverage (`useIsActiveRoute.ts` + `useRefFromSource.ts` at 100%); RED (#1250) + hash slow-path branch test
- [x] type-check + lint clean (react / preact / vue)
- [ ] `pnpm build` (full graph) — delegated to reviewer

Closes #1248
Closes #1249
Closes #1250
