### PR TITLE
perf(react): decouple RouteView keepAlive tracking to memoize the render walk (#1251)

### DIFF
--- a/.changeset/react-routeview-memoize-walk.md
+++ b/.changeset/react-routeview-memoize-walk.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": patch
+---
+
+Decouple `RouteView` keepAlive tracking to memoize the render walk (#1251)
+
+- `<RouteView>`'s `buildRenderList` no longer re-walks its `<Match>` children on every render. Previously `processMatch` mutated the keepAlive `hasBeenActivated` Set inline, coupling the pure winner/`rendered` computation to a side effect — so a parent (or ancestor) re-render with no route change re-walked every Match and re-diffed the identical output (preact, whose `buildRenderList` is a 3-arg pure function, already memoized here). The walk is now a pure function memoized on `[elements, routeName, nodeName]`, and the activation is committed to the Set in a post-render effect. This also makes keepAlive tracking safe under concurrent rendering: a render React discards no longer records a phantom activation that would later render an un-committed match as a hidden keepAlive subtree. Existing precedence and keepAlive behavior is unchanged (covered by the RouteView functional + pipeline property tests).

--- a/packages/react/INVARIANTS.md
+++ b/packages/react/INVARIANTS.md
@@ -83,17 +83,27 @@ trees of `<Match>` / `<Self>` / `<NotFound>` leaves (optionally
 | 4   | `buildRenderList` first-Self wins                  | N copies of `<Self>` with `routeName === nodeName` produce exactly one rendered entry with key `__route-view-self__`. Subsequent `<Self>` elements update no state in `recordFallback`.                       |
 | 5   | `buildRenderList` Self priority over NotFound      | When `<Self>` matches (`routeName === nodeName`), `<NotFound>` is never appended even if the route also satisfies `UNKNOWN_ROUTE`. Self has priority in `appendFallback`.                                    |
 | 6   | `buildRenderList` activeMatchFound precludes fallback | Any activating `<Match>` suppresses both `<Self>` and `<NotFound>` from the render list. `appendFallback` is gated by `!activeMatchFound`.                                                                  |
-| 7   | `processMatch` keepAlive sticky activation         | Once a `keepAlive=true` segment becomes visible, it stays in `hasBeenActivated` for the RouteView's lifetime. Subsequent navigations to a different route still render it (in hidden mode).                  |
+| 7   | `processMatch` keepAlive sticky activation         | Once a `keepAlive=true` segment activates, `buildRenderList` reports it via `activatedName`; RouteView commits it to `hasBeenActivated` in a post-render effect (#1251), keeping it sticky for the RouteView's lifetime. Subsequent navigations to a different route still render it (in hidden mode). |
 | 8   | `processMatch` alreadyActive short-circuit         | After the first `<Match>` activates within a `buildRenderList` pass, subsequent matches with overlapping segments are short-circuited via the `alreadyActive` flag — exactly one entry rendered per pass.    |
 | 9   | `collectElements` recursion termination            | Depth-N Fragment wrapping (N up to 10) terminates and returns the inner Match element. Defends against an iterator regression that loses the terminating case.                                              |
 | 10  | `buildRenderList` stability                        | Two consecutive calls with identical `(elements, routeName, freshSet)` produce render lists of equal length, identical `activeMatchFound`, and identical per-index `type` + `key`. No hidden state.         |
-| 11  | `processMatch` keepAlive monotonicity              | Across a sequence of `buildRenderList` passes with distinct route names targeting different `<Match keepAlive>` segments, `hasBeenActivated` grows monotonically — no entry is ever removed.                |
+| 11  | `processMatch` keepAlive monotonicity              | Across a sequence of `buildRenderList` passes with distinct route names targeting different `<Match keepAlive>` segments, the committed `hasBeenActivated` (grown by RouteView's effect from each pass's `activatedName`) grows monotonically — no entry is ever removed. |
 | 12  | Large element arrays                               | `buildRenderList` correctly resolves first-match-wins and NotFound conditional across 50..120 Match elements. Guards against an O(n²) regression in the linear walk.                                       |
-| 13  | keepAlive with falsy routeName                     | `<Match keepAlive segment="x">` against `routeName=""` does NOT activate and does NOT enter the keepAlive set. A segment previously activated stays in `hasBeenActivated` and renders hidden during a `routeName=""` transition. |
+| 13  | keepAlive with falsy routeName                     | `<Match keepAlive segment="x">` against `routeName=""` does NOT activate and does NOT enter the keepAlive set. A segment previously activated (committed via the effect) stays in `hasBeenActivated` and renders hidden during a `routeName=""` transition. |
 
 Cross-check (not in #626, tightens fallback contract): `<NotFound>` is
 appended to the render list **only** when `routeName === UNKNOWN_ROUTE`
 AND no `<Match>` activated AND no `<Self>` consumed the slot.
+
+**#1251 — `buildRenderList` is a pure walk:** it no longer mutates
+`hasBeenActivated` inline (which coupled the pure winner computation to a side
+effect — blocking memoization — and was unsafe under concurrent rendering, where
+a discarded render would leave a phantom entry that later renders an un-committed
+match as a hidden keepAlive subtree). It READS the Set (a `ReadonlySet`) for the
+hidden-render decision and RETURNS `activatedName`; RouteView commits it to the
+Set in a post-render `useEffect`, so only committed renders record an activation.
+Invariants 7 / 11 / 13 simulate that effect (adding `activatedName` to the Set)
+between passes.
 
 ## Segment Matching (isSegmentMatch)
 

--- a/packages/react/src/components/modern/RouteView/RouteView.tsx
+++ b/packages/react/src/components/modern/RouteView/RouteView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { Match, NotFound, Self } from "./components";
 import { buildRenderList, collectElements } from "./helpers";
@@ -16,6 +16,8 @@ function RouteViewRoot({
 
   // eslint-disable-next-line @eslint-react/refs -- lazy init: assign once when null to avoid `new Set()` allocation on every render
   hasBeenActivatedRef.current ??= new Set();
+  // eslint-disable-next-line @eslint-react/refs -- stable render cache; the ref is never reassigned after lazy init
+  const hasBeenActivated = hasBeenActivatedRef.current;
 
   // Skip the Children.forEach + collectElements traversal when the children
   // reference is unchanged. The common SPA case is a stable JSX tree across
@@ -34,17 +36,40 @@ function RouteViewRoot({
     return collected;
   }, [children]);
 
-  if (!route) {
-    return null;
-  }
+  const routeName = route?.name ?? null;
 
-  const { rendered } = buildRenderList(
-    elements,
-    route.name,
-    nodeName,
-    // eslint-disable-next-line @eslint-react/refs -- stable Set ref read for keepAlive tracking (never reassigned)
-    hasBeenActivatedRef.current,
-  );
+  // Memoize the render walk by its pure inputs. Previously `buildRenderList` ran
+  // on EVERY render because `processMatch` mutated the keepAlive Set inline —
+  // coupling the pure winner/`rendered` computation to a side effect, so a
+  // parent re-render with no route change re-walked every Match and re-diffed
+  // the identical output (preact, whose `buildRenderList` is a 3-arg pure
+  // function, already memoizes here). The Set mutation now lives in the effect
+  // below, so the walk memoizes on `[elements, routeName, nodeName]` too. #1251.
+  const { rendered, activatedName } = useMemo(() => {
+    if (routeName === null) {
+      return { rendered: [] as ReactElement[], activatedName: null };
+    }
+
+    const result = buildRenderList(
+      elements,
+      routeName,
+      nodeName,
+      hasBeenActivated,
+    );
+
+    return { rendered: result.rendered, activatedName: result.activatedName };
+  }, [elements, routeName, nodeName, hasBeenActivated]);
+
+  // Commit the keepAlive activation AFTER render, not during it. A render that
+  // React discards under concurrent rendering must not record an activation
+  // that never committed — otherwise a later render would show that
+  // never-mounted match as a hidden keepAlive subtree. Adding the same name
+  // twice is a no-op, so the effect is safe to re-run.
+  useEffect(() => {
+    if (activatedName !== null) {
+      hasBeenActivated.add(activatedName);
+    }
+  }, [activatedName, hasBeenActivated]);
 
   if (rendered.length > 0) {
     return <>{rendered}</>;

--- a/packages/react/src/components/modern/RouteView/helpers.tsx
+++ b/packages/react/src/components/modern/RouteView/helpers.tsx
@@ -119,9 +119,9 @@ function processMatch(
   child: ReactElement,
   routeName: string,
   nodeName: string,
-  hasBeenActivated: Set<string>,
+  hasBeenActivated: ReadonlySet<string>,
   alreadyActive: boolean,
-): { rendered: ReactElement | null; matched: boolean } {
+): { rendered: ReactElement | null; activatedName: string | null } {
   const matchProps = child.props as MatchProps;
   const { segment, exact = false, keepAlive = false, fallback } = matchProps;
   const fullSegmentName = nodeName ? `${nodeName}.${segment}` : segment;
@@ -129,8 +129,11 @@ function processMatch(
     !alreadyActive && isSegmentMatch(routeName, fullSegmentName, exact);
 
   if (isActive) {
-    hasBeenActivated.add(fullSegmentName);
-
+    // The keepAlive Set is NOT mutated here — RouteView commits the activation
+    // in a post-render effect (#1251). Mutating during render coupled the pure
+    // winner computation to a side effect (blocking memoization) and, under
+    // concurrent rendering, a discarded render would leave a phantom entry that
+    // later renders an un-committed match as a hidden keepAlive subtree.
     return {
       rendered: renderSlotElement(
         matchProps.children,
@@ -139,7 +142,7 @@ function processMatch(
         "visible",
         fallback,
       ),
-      matched: true,
+      activatedName: fullSegmentName,
     };
   }
 
@@ -152,11 +155,11 @@ function processMatch(
         "hidden",
         fallback,
       ),
-      matched: false,
+      activatedName: null,
     };
   }
 
-  return { rendered: null, matched: false };
+  return { rendered: null, activatedName: null };
 }
 
 function appendFallback(
@@ -190,15 +193,23 @@ export function buildRenderList(
   elements: ReactElement[],
   routeName: string,
   nodeName: string,
-  hasBeenActivated: Set<string>,
-): { rendered: ReactElement[]; activeMatchFound: boolean } {
+  hasBeenActivated: ReadonlySet<string>,
+): {
+  rendered: ReactElement[];
+  activeMatchFound: boolean;
+  activatedName: string | null;
+} {
   const slots: FallbackSlots = {
     selfChildren: null,
     selfFallback: undefined,
     selfFound: false,
     notFoundChildren: null,
   };
-  let activeMatchFound = false;
+  // The segment that activated this render, or null. Reported to the caller so
+  // RouteView can commit it to the keepAlive Set post-render (#1251) — this pure
+  // walk no longer mutates the Set. At most one match activates (first-wins via
+  // the `alreadyActive` short-circuit), so a single name suffices.
+  let activatedName: string | null = null;
   const rendered: ReactElement[] = [];
 
   for (const child of elements) {
@@ -211,11 +222,11 @@ export function buildRenderList(
       routeName,
       nodeName,
       hasBeenActivated,
-      activeMatchFound,
+      activatedName !== null,
     );
 
-    if (result.matched) {
-      activeMatchFound = true;
+    if (result.activatedName !== null) {
+      activatedName = result.activatedName;
     }
 
     if (result.rendered !== null) {
@@ -223,9 +234,9 @@ export function buildRenderList(
     }
   }
 
-  if (!activeMatchFound) {
+  if (activatedName === null) {
     appendFallback(rendered, routeName, nodeName, slots);
   }
 
-  return { rendered, activeMatchFound };
+  return { rendered, activeMatchFound: activatedName !== null, activatedName };
 }

--- a/packages/react/tests/functional/RouteView.test.tsx
+++ b/packages/react/tests/functional/RouteView.test.tsx
@@ -2,11 +2,12 @@ import { browserPluginFactory } from "@real-router/browser-plugin";
 import { createRouter } from "@real-router/core";
 import { getRoutesApi } from "@real-router/core/api";
 import { render, screen, act } from "@testing-library/react";
-import { lazy, memo, useEffect, useRef } from "react";
+import { lazy, memo, useEffect, useReducer, useRef } from "react";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 
 import { RouteView, RouterProvider } from "@real-router/react";
 
+import * as routeViewHelpers from "../../src/components/modern/RouteView/helpers";
 import { createTestRouterWithADefaultRouter } from "../helpers";
 
 import type { Router } from "@real-router/core";
@@ -21,6 +22,47 @@ describe("RouteView", () => {
 
   afterEach(() => {
     router.stop();
+  });
+
+  describe("Render-list memoization (#1251)", () => {
+    it("does not re-walk buildRenderList on a non-route parent re-render", async () => {
+      await router.start("/users/list");
+
+      let forceParent: () => void = () => {};
+      // Stable `children` reference → the `elements` memo stays hit across the
+      // parent re-render, which is the precondition for the buildRenderList memo
+      // to hit as well (elements + routeName + nodeName all unchanged).
+      const routeViewChildren = (
+        <RouteView.Match segment="users">
+          <div>users</div>
+        </RouteView.Match>
+      );
+      const Parent: FC = () => {
+        const [, force] = useReducer((n: number) => n + 1, 0);
+
+        forceParent = force;
+
+        return <RouteView nodeName="">{routeViewChildren}</RouteView>;
+      };
+
+      render(
+        <RouterProvider router={router}>
+          <Parent />
+        </RouterProvider>,
+      );
+
+      const buildRenderListSpy = vi.spyOn(routeViewHelpers, "buildRenderList");
+
+      act(() => {
+        forceParent();
+      });
+
+      // #1251 — with elements / routeName / nodeName all unchanged, the render
+      // walk is memoized and must NOT re-run. Before the fix, buildRenderList
+      // re-walked on every render because it mutated the keepAlive Set inline,
+      // coupling the pure winner computation to a side effect and blocking memo.
+      expect(buildRenderListSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("Segment matching", () => {

--- a/packages/react/tests/property/routeView.pipeline.properties.ts
+++ b/packages/react/tests/property/routeView.pipeline.properties.ts
@@ -13,8 +13,11 @@
  *   matches. Invariants: first-match wins, first-Self wins, Self priority
  *   over NotFound, activeMatchFound precludes fallback.
  * - `processMatch` (private; reached via `buildRenderList`) — handles the
- *   keepAlive sticky-activation and `alreadyActive` short-circuit. The
- *   shared `hasBeenActivated: Set<string>` is the persistence vehicle.
+ *   keepAlive sticky-activation and `alreadyActive` short-circuit. Since #1251
+ *   the walk is pure: it READS `hasBeenActivated` (a `ReadonlySet`) for the
+ *   hidden-render decision and REPORTS the activated segment via `activatedName`
+ *   rather than mutating the Set — RouteView commits it in a post-render effect,
+ *   so the keepAlive tests below simulate that commit between passes.
  *
  * The React-element generators here build well-formed trees without JSX
  * (vitest config is `environment: "node"` for property tests). Each
@@ -326,7 +329,9 @@ describe("RouteView pipeline — Property Tests", () => {
         const elements = [makeMatch(matchSegment, { keepAlive: true })];
         const hasBeenActivated = new Set<string>();
 
-        // Pass 1: route activates the Match.
+        // Pass 1: route activates the Match. buildRenderList is now a pure walk
+        // (#1251) — it REPORTS the activation via `activatedName` instead of
+        // mutating the Set; RouteView commits it in a post-render effect.
         const first = buildRenderList(
           elements,
           matchSegment,
@@ -335,10 +340,15 @@ describe("RouteView pipeline — Property Tests", () => {
         );
 
         expect(first.activeMatchFound).toBe(true);
+        expect(first.activatedName).toBe(matchSegment);
         expect(first.rendered).toHaveLength(1);
-        expect(hasBeenActivated.has(matchSegment)).toBe(true);
+        // Pure: the walk did NOT mutate the Set.
+        expect(hasBeenActivated.has(matchSegment)).toBe(false);
 
-        // Pass 2: different route, keepAlive must keep it in the render list.
+        // Simulate RouteView's post-render effect committing the activation.
+        hasBeenActivated.add(first.activatedName!);
+
+        // Pass 2: different route; keepAlive reads the committed Set → hidden.
         const second = buildRenderList(
           elements,
           otherSegment,
@@ -347,6 +357,7 @@ describe("RouteView pipeline — Property Tests", () => {
         );
 
         expect(second.activeMatchFound).toBe(false);
+        expect(second.activatedName).toBeNull();
         expect(second.rendered).toHaveLength(1);
         // Sticky: still in the activated set.
         expect(hasBeenActivated.has(matchSegment)).toBe(true);
@@ -529,7 +540,18 @@ describe("RouteView pipeline — Property Tests", () => {
         let previousSize = 0;
 
         for (const seg of uniqueSegments) {
-          buildRenderList(elements, seg, "", hasBeenActivated);
+          const { activatedName } = buildRenderList(
+            elements,
+            seg,
+            "",
+            hasBeenActivated,
+          );
+
+          // Simulate RouteView's post-render effect committing the activation
+          // (#1251 — the pure walk reports it, the effect grows the Set).
+          if (activatedName !== null) {
+            hasBeenActivated.add(activatedName);
+          }
 
           // After visiting `seg`, every previously-visited segment must
           // still be in the set.
@@ -647,10 +669,15 @@ describe("RouteView pipeline — Property Tests", () => {
         const elements = [makeMatch(segment, { keepAlive: true })];
         const hasBeenActivated = new Set<string>();
 
-        // Pass 1: activate.
+        // Pass 1: activate. buildRenderList reports the activation (#1251);
+        // simulate RouteView's effect committing it to the Set.
         const first = buildRenderList(elements, segment, "", hasBeenActivated);
 
         expect(first.activeMatchFound).toBe(true);
+        expect(first.activatedName).toBe(segment);
+
+        hasBeenActivated.add(first.activatedName!);
+
         expect(hasBeenActivated.has(segment)).toBe(true);
 
         // Pass 2: transition through empty route name. The segment stays


### PR DESCRIPTION
## Summary

`<RouteView>`'s `buildRenderList` no longer re-walks its `<Match>` children on every render. Previously `processMatch` mutated the keepAlive `hasBeenActivated` Set inline, coupling the pure winner/`rendered` computation to a side effect — so a parent (or ancestor) re-render with no route change re-walked every Match and re-diffed the identical output, where preact (whose `buildRenderList` is a 3-arg pure function) returns a memoized list. The walk is now pure and memoized on `[elements, routeName, nodeName]`, and the activation is committed in a post-render effect.

### #1251 — RouteView render-walk memoization

- **Root cause:** `buildRenderList` → `processMatch` called `hasBeenActivated.add(...)` during render. A side effect in the render path can't be memoized (the walk re-ran every render) and is unsafe under concurrent rendering — a render React discards would leave a phantom activation that a later render shows as a hidden keepAlive subtree.
- **Fix (decouple):** `buildRenderList` is now a pure walk — it reads the Set (a `ReadonlySet`) for the hidden-render decision and returns the activated segment via `activatedName`. `RouteView` memoizes the walk on `[elements, routeName, nodeName]` and commits the activation to the Set in a post-render `useEffect`, so only committed renders record an activation. A naive `useMemo` of the old 4-arg walk would not have sufficed — the Set side effect had to leave the render path for concurrent-rendering correctness, not just for memoization.
- Existing precedence + keepAlive behavior is unchanged (covered by the RouteView functional + pipeline property tests).

## Test plan

- [x] `@real-router/react`: 822 functional tests pass, 100% coverage; RED `RouteView.test.tsx` "does not re-walk buildRenderList on a non-route parent re-render" (before: the `buildRenderList` spy fires on a forced re-render; after: 0 — memoized)
- [x] 116 pipeline property tests pass; invariants 7 / 11 / 13 (keepAlive sticky / monotonic / falsy-routeName) reworked to the decoupled contract (`buildRenderList` reports `activatedName`; the tests simulate RouteView's effect committing it)
- [x] type-check + lint clean
- [ ] `pnpm build` (full graph) — delegated to reviewer

Closes #1251
