### PR TITLE
fix(path-matcher): name-less marker message + INVARIANTS caveat-locks (#1241) + freeze sentinels (#1240 §5)

### DIFF
--- a/.changeset/path-matcher-nameless-marker-message-1241.md
+++ b/.changeset/path-matcher-nameless-marker-message-1241.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Clearer rejection message for a name-less parameter marker or modifier (#1241)
+
+Registering a static segment with a trailing `?` (`/faq?`) — which the optional fork routes through the same name-less check as a bare `:`/`*` — threw `Empty parameter name: a bare ':' marker …`, naming a `:` the segment does not contain. The message is now marker-agnostic (`a parameter marker (':' or '*') or an optional '?' must be followed by a name …`), so it is accurate for the bare `:`/`*`, the modifier-only (`:?`, `:<\d+>`), and the trailing-`?`-on-static cases alike. The rejection itself is unchanged.

--- a/packages/path-matcher/src/registration.ts
+++ b/packages/path-matcher/src/registration.ts
@@ -330,12 +330,18 @@ function throwParamNameConflict(
  * desync of the same class as #736/#738 (#858). Reject it at registration,
  * symmetrically for both markers, instead of corrupting the trie.
  */
-function throwEmptyParamName(marker: ":" | "*"): never {
+function throwEmptyParamName(): never {
+  // Marker-agnostic: this fires for a bare ':'/'*' (`/x/:`, `/x/*`), a marker
+  // carrying only a modifier/constraint (`/x/:?`, `/x/:<\d+>`), AND a static
+  // segment with a trailing '?' (`/faq?`) — which the optional fork routes here
+  // via `extractParamName`. So the message must NOT claim a specific ':' marker
+  // (there isn't one for `/faq?`, #1241).
   throw new Error(
-    `[SegmentMatcher.registerTree] Empty parameter name: a bare '${marker}' ` +
-      `marker must be followed by a name (e.g. '${marker}id'). A name-less ` +
-      `marker would capture under an empty key at match but emit a literal ` +
-      `'${marker}' at build — the two disagree, so it is rejected.`,
+    `[SegmentMatcher.registerTree] Empty parameter name: a parameter marker ` +
+      `(':' or '*') or an optional '?' must be followed by a name (e.g. ':id', ` +
+      `'*rest', ':id?'). A name-less marker or modifier would capture under an ` +
+      `empty key at match but emit a literal at build — the two disagree, so it ` +
+      `is rejected.`,
   );
 }
 
@@ -566,7 +572,7 @@ function extractParamName(segment: string): string {
   const paramName = PARAM_NAME_RGX.exec(segment)?.[1] ?? "";
 
   if (paramName === "") {
-    throwEmptyParamName(":");
+    throwEmptyParamName();
   }
 
   return paramName;
@@ -872,7 +878,7 @@ function processSegment(
     const splatName = segment.slice(1);
 
     if (splatName === "") {
-      throwEmptyParamName("*");
+      throwEmptyParamName();
     }
 
     const child = ensureSplatChild(node, splatName, ownNodes);

--- a/packages/path-matcher/src/registration.ts
+++ b/packages/path-matcher/src/registration.ts
@@ -24,8 +24,14 @@ import type {
 // fresh empty Set/Map/array per route (#1009). All are ReadonlySet/Map/[] and
 // read-only on the match/build hot paths.
 const EMPTY_STRINGS: readonly string[] = Object.freeze([]);
-const EMPTY_STRING_SET: ReadonlySet<string> = new Set();
-const EMPTY_CONSTRAINTS: ReadonlyMap<string, ConstraintPattern> = new Map();
+// #1240 §5: freeze the Set/Map shells too, so the "Shared frozen sentinels" claim
+// above holds for ALL of them and the #1009 sentinels are consistent with route-tree's
+// frozen `EMPTY_CHILDREN_MAP`. `Object.freeze` locks only the shell (not `.add`/`.set`
+// — see route-tree INVARIANTS CC1), but these are `Readonly`-typed and never mutated.
+const EMPTY_STRING_SET: ReadonlySet<string> = Object.freeze(new Set<string>());
+const EMPTY_CONSTRAINTS: ReadonlyMap<string, ConstraintPattern> = Object.freeze(
+  new Map<string, ConstraintPattern>(),
+);
 const EMPTY_PARAM_SLOTS: readonly BuildParamSlot[] = Object.freeze([]);
 const EMPTY_PARAMS: Readonly<Record<string, unknown>> = Object.freeze({});
 

--- a/packages/path-matcher/tests/unit/caveat-locks.test.ts
+++ b/packages/path-matcher/tests/unit/caveat-locks.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { createMatcher } from "../helpers/buildTree";
+
+/**
+ * Locks for the two documented INVARIANTS caveats (#1241). These pin ACCEPTED
+ * (imperfect) behaviour — not bugs — so a future change that silently alters the
+ * documented aliasing / corruption is caught at the test layer, and the caveat
+ * text stays honest. See `INVARIANTS.md` Matching #2 and Roundtrip Extensions #2.
+ */
+
+describe("INVARIANTS Matching #2 — build-side optional aliasing (caveat-lock)", () => {
+  it("a later optional's value binds under the EARLIER omitted optional's name", () => {
+    const m = createMatcher([{ name: "r", path: "/a/:b?/:c?/d" }]);
+
+    // Only the LATER optional (`c`) is supplied — `b` omitted.
+    const url = m.buildPath("r", { c: "x" });
+
+    expect(url).toBe("/a/x/d");
+    // The value comes back under `b`, NOT `c`: the first optional wins the single
+    // filled slot. Supply optionals contiguously to round-trip by name.
+    expect(m.match(url)?.params).toStrictEqual({ b: "x" });
+  });
+});
+
+describe("INVARIANTS Roundtrip #2 — silent value corruption under uri/none (caveat-lock)", () => {
+  const versioned = (encoding: "uri" | "none") =>
+    createMatcher([{ name: "r", path: "/users/:id" }], {
+      urlParamsEncoding: encoding,
+    });
+
+  it.each(["uri", "none"] as const)(
+    "[%s] a '?' in a value silently SPLITS into a query param",
+    (encoding) => {
+      const m = versioned(encoding);
+      const url = m.buildPath("r", { id: "x?tab=1" });
+
+      expect(url).toBe("/users/x?tab=1");
+      expect(m.match(url)?.params).toStrictEqual({ id: "x", tab: "1" });
+    },
+  );
+
+  it.each(["uri", "none"] as const)(
+    "[%s] a '#' in a value silently TRUNCATES at the fragment",
+    (encoding) => {
+      const m = versioned(encoding);
+      const url = m.buildPath("r", { id: "x#sec" });
+
+      expect(url).toBe("/users/x#sec");
+      expect(m.match(url)?.params).toStrictEqual({ id: "x" });
+    },
+  );
+
+  it("[none] a non-ASCII value builds an unmatchable URL", () => {
+    const m = versioned("none");
+    const url = m.buildPath("r", { id: "café" });
+
+    expect(url).toBe("/users/café");
+    expect(m.match(url)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The code tail of the wave-3 audit doc-batch (**#1241**) — its doc caveats already shipped to master (`2145abbd`). Plus **#1240 §5** (a cosmetic sentinel freeze), folded in since it's the same package.

## Commits

- **#1241** `9b99a708`:
  - `throwEmptyParamName`'s message was misleading for `/faq?` — a static segment with a trailing `?` is routed through the same name-less check (via `extractParamName` in the optional fork) as a bare `:`, so it wrongly read `a bare ':' marker …` with no `:` present. Now **marker-agnostic** (`:`/`*`/optional `?`), accurate for the bare-marker, modifier-only, and trailing-`?`-on-static cases alike; the rejection is unchanged.
  - `caveat-locks.test.ts` pins the two documented INVARIANTS caveats so a silent behaviour change is caught: Matching #2 optional aliasing (`/a/:b?/:c?/d`, `buildPath({c:"x"})` → `/a/x/d` → `{b:"x"}`) and Roundtrip #2 uri/none corruption (`?`-split, `#`-truncate, non-ASCII-unmatchable).
- **#1240 §5** `edf6d0ff`: freeze `EMPTY_STRING_SET` + `EMPTY_CONSTRAINTS` so the "Shared frozen sentinels" comment holds for all of them and the #1009 sentinels match route-tree's frozen `EMPTY_CHILDREN_MAP`. Shell-only lock (never `.add`/`.set` — `Readonly`-typed, never mutated) → no behaviour change, no changeset. (The issue's `buildParamMeta.ts:175` reference was stale — no sentinel there; verified against source.)

Audit item 3 (dead `CONSTRAINT_BODY_PATTERN` export) was resolved on master via the keep-option (honest "reserved / no external consumer" comment, `2145abbd`).

## Validation

path-matcher: 405 tests, 100% coverage, type-check + lint (`--no-cache`) clean, zero regression. Changeset `@real-router/core` **patch** (clearer message). Consumer tests verified for the old message wording (no assertion — only a route-tree comment).

Closes #1241
Refs #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)