### PR TITLE
refactor(validation-plugin): reach the engine via core, not a direct route-tree import (#1301)

### DIFF
--- a/.changeset/core-reexport-validate-route-validation-subpath-1301.md
+++ b/.changeset/core-reexport-validate-route-validation-subpath-1301.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Re-export `validateRoute` (+ `Matcher` / `RouteTree` types) from the `@real-router/core/validation` subpath (#1301)
+
+So `@real-router/validation-plugin` reaches the batch route validator through core instead of importing the foundation `route-tree` package directly — keeping core the sole consumer of the routing engine. Plumbing on the plugin-facing subpath (off the main public index); no runtime behaviour change.

--- a/.changeset/validation-plugin-drop-route-tree-import-1301.md
+++ b/.changeset/validation-plugin-drop-route-tree-import-1301.md
@@ -1,0 +1,7 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+Reach the routing engine only through `@real-router/core`, not `route-tree` (#1301)
+
+The plugin no longer imports the foundation package `route-tree`: `validateRoute` now comes from the `@real-router/core/validation` subpath, and forwardTo segment lookup + existence use the matcher's own `getSegmentsByName` / `hasRoute` (the `RouteTree` / `Matcher` types come from core). `route-tree` is dropped from the plugin's devDependencies. Core is now the sole consumer of the routing engine; validation behaviour is unchanged. A package-level guard test prevents re-coupling.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -75,6 +75,8 @@ The `validator` object is namespaced by concern (`routes`, `navigation`, `state`
 
 Structural guards remain in namespace folders (`OptionsNamespace/validators.ts`, `PluginsNamespace/validators.ts`). DX validators live in `@real-router/validation-plugin`, accessed via `RouterValidator` interface in `src/types/RouterValidator.ts`.
 
+**The `@real-router/core/validation` subpath (`src/validation.ts`) is the plugin's ONLY door to the engine (#1301).** Besides `getInternals` / `RouterInternals`, it re-exports `validateRoute` (route-tree's batch validator — no matcher equivalent) plus the `Matcher` / `RouteTree` types, so the validation plugin never imports the foundation `route-tree` package directly (segment lookup + existence go through the matcher's own `getSegmentsByName` / `hasRoute`). Kept on this plugin-facing subpath, off the main public index; a guard test in the plugin blocks re-coupling.
+
 ### Invariant Guards (always active, no plugin required)
 
 Core contains four invariant guards that run regardless of whether validation-plugin is installed:

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -10,3 +10,14 @@ export type { RouterValidator } from "./types/RouterValidator";
 export { getInternals } from "./internals";
 
 export type { RouterInternals } from "./internals";
+
+// Route-tree surface the validation plugin needs, re-exported so the plugin
+// depends only on @real-router/core (not the foundation `route-tree` package) —
+// core stays the sole consumer of the routing engine (#1301). `validateRoute` is
+// a pure batch validator with no equivalent on the runtime matcher; `Matcher` /
+// `RouteTree` are the node/matcher types the plugin's validators operate on
+// (segment lookup + existence come from the matcher itself: getSegmentsByName /
+// hasRoute). Kept on this plugin-facing subpath, off the main public index.
+export { validateRoute } from "route-tree";
+
+export type { Matcher, RouteTree } from "route-tree";

--- a/packages/route-tree/CLAUDE.md
+++ b/packages/route-tree/CLAUDE.md
@@ -1,6 +1,6 @@
 # route-tree
 
-Internal package that builds an immutable routing tree from route definitions, provides URL matching via `createMatcher`, and supports tree queries and validation. Not published to npm — consumed by `@real-router/core`.
+Internal package that builds an immutable routing tree from route definitions, provides URL matching via `createMatcher`, and supports tree queries and validation. Not published to npm — consumed **only** by `@real-router/core`, the sole consumer of the routing engine. `@real-router/validation-plugin` reaches `validateRoute` through core's `@real-router/core/validation` subpath (segment lookup / existence via the matcher), never importing this package directly (#1301, enforced by a plugin-level guard test).
 
 ## Exports
 

--- a/packages/validation-plugin/CLAUDE.md
+++ b/packages/validation-plugin/CLAUDE.md
@@ -71,6 +71,10 @@ Callbacks are intentionally **not** probed at registration time — their return
 
 `navigateToDefault()` is declared `Promise<State>` but is not `async`. Synchronous exceptions from `deps.resolveDefault()` — a callback that throws, or a validator that rejects a callback's return — are caught and converted to `Promise.reject` so callers can uniformly handle errors via `.catch()` / `await`.
 
+### Reaches the engine only through `@real-router/core` (#1301)
+
+The plugin does **not** import the foundation `route-tree` package. `validateRoute` (the batch route/path validator — no matcher equivalent) comes from the `@real-router/core/validation` subpath; forwardTo segment lookup + target existence use the matcher's own `getSegmentsByName` / `hasRoute` (via `store.matcher`, threaded into `validateRoutes` → `validateForwardToTargets`); the `RouteTree` / `Matcher` types come from core. This keeps core the sole consumer of the routing engine. `tests/functional/no-route-tree.test.ts` scans `src/` for any `route-tree` import and fails on a regression — keep it green (and `route-tree` out of `devDependencies`).
+
 ## See Also
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — Source structure, data flow, design decisions

--- a/packages/validation-plugin/package.json
+++ b/packages/validation-plugin/package.json
@@ -57,7 +57,6 @@
     "@real-router/core": "workspace:>=0.1.0"
   },
   "devDependencies": {
-    "route-tree": "workspace:^",
     "type-guards": "workspace:^"
   }
 }

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -90,7 +90,7 @@ import type {
   Plugin,
   Options,
 } from "@real-router/core";
-import type { RouterInternals } from "@real-router/core/validation";
+import type { RouterInternals, Matcher } from "@real-router/core/validation";
 
 function buildValidatorObject(ctx: RouterInternals): RouterValidator {
   return {
@@ -108,12 +108,14 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
       validateRoutes(routes, store) {
         const typedStore = store as {
           tree?: unknown;
+          matcher?: unknown;
           config?: { forwardMap?: Record<string, string> };
         };
 
         validateRoutes(
           routes as Route[],
           typedStore.tree as RouteTree | undefined,
+          typedStore.matcher as Matcher | undefined,
           typedStore.config?.forwardMap,
         );
       },

--- a/packages/validation-plugin/src/validators/forwardTo.ts
+++ b/packages/validation-plugin/src/validators/forwardTo.ts
@@ -1,11 +1,10 @@
 // packages/validation-plugin/src/validators/forwardTo.ts
 
 import { resolveForwardChain } from "@real-router/core";
-import { getSegmentsByName } from "route-tree";
 import { getTypeDescription } from "type-guards";
 
 import type { Route, DefaultDependencies } from "@real-router/core";
-import type { RouteTree } from "route-tree";
+import type { Matcher, RouteTree } from "@real-router/core/validation";
 
 // ============================================================================
 // Route Property Validation
@@ -214,30 +213,18 @@ function getRequiredParams(segments: readonly RouteTree[]): Set<string> {
   return params;
 }
 
-function routeExistsInTree(tree: RouteTree, routeName: string): boolean {
-  const segments = routeName.split(".");
-  let current: RouteTree | undefined = tree;
-
-  for (const segment of segments) {
-    current = current.children.get(segment);
-
-    if (!current) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function getTargetParams<Dependencies extends DefaultDependencies>(
   targetRoute: string,
-  existsInTree: boolean,
-  tree: RouteTree,
+  existsInMatcher: boolean,
+  matcher: Matcher,
   routes: readonly Route<Dependencies>[],
 ): Set<string> {
-  if (existsInTree) {
-    /* v8 ignore next -- @preserve: ?? fallback unreachable — existsInTree guarantees non-null */
-    return getRequiredParams(getSegmentsByName(tree, targetRoute) ?? []);
+  if (existsInMatcher) {
+    /* v8 ignore next -- @preserve: ?? fallback unreachable — existsInMatcher guarantees non-null */
+    return getRequiredParams(
+      (matcher.getSegmentsByName(targetRoute) as
+        readonly RouteTree[] | undefined) ?? [],
+    );
   }
 
   return extractParamsFromPaths(collectPathsToRoute(routes, targetRoute));
@@ -248,12 +235,12 @@ function validateSingleForward<Dependencies extends DefaultDependencies>(
   targetRoute: string,
   routes: readonly Route<Dependencies>[],
   batchNames: Set<string>,
-  tree: RouteTree,
+  matcher: Matcher,
 ): void {
-  const existsInTree = routeExistsInTree(tree, targetRoute);
+  const existsInMatcher = matcher.hasRoute(targetRoute);
   const existsInBatch = batchNames.has(targetRoute);
 
-  if (!existsInTree && !existsInBatch) {
+  if (!existsInMatcher && !existsInBatch) {
     throw new ReferenceError(
       `[router.addRoute] forwardTo target "${targetRoute}" does not exist ` +
         `for route "${fromRoute}"`,
@@ -264,7 +251,12 @@ function validateSingleForward<Dependencies extends DefaultDependencies>(
     collectPathsToRoute(routes, fromRoute),
   );
 
-  const toParams = getTargetParams(targetRoute, existsInTree, tree, routes);
+  const toParams = getTargetParams(
+    targetRoute,
+    existsInMatcher,
+    matcher,
+    routes,
+  );
 
   const missingParams = [...toParams].filter((param) => !fromParams.has(param));
 
@@ -281,7 +273,7 @@ export function validateForwardToTargets<
 >(
   routes: readonly Route<Dependencies>[],
   existingForwardMap: Record<string, string>,
-  tree: RouteTree,
+  matcher: Matcher,
 ): void {
   const batchNames = collectRouteNames(routes);
   const batchForwards = collectForwardMappings(routes);
@@ -293,7 +285,7 @@ export function validateForwardToTargets<
   }
 
   for (const [fromRoute, targetRoute] of batchForwards) {
-    validateSingleForward(fromRoute, targetRoute, routes, batchNames, tree);
+    validateSingleForward(fromRoute, targetRoute, routes, batchNames, matcher);
   }
 
   for (const fromRoute of Object.keys(combinedForwardMap)) {

--- a/packages/validation-plugin/src/validators/routes.ts
+++ b/packages/validation-plugin/src/validators/routes.ts
@@ -7,7 +7,7 @@
  */
 
 import { resolveForwardChain } from "@real-router/core";
-import { validateRoute } from "route-tree";
+import { validateRoute } from "@real-router/core/validation";
 import {
   isString,
   validateRouteName,
@@ -23,7 +23,7 @@ import type {
   DefaultDependencies,
   Params,
 } from "@real-router/core";
-import type { Matcher, RouteTree } from "route-tree";
+import type { Matcher, RouteTree } from "@real-router/core/validation";
 
 // Internal constant (matches core's INTERNAL_ROUTE_PREFIX)
 const INTERNAL_ROUTE_PREFIX = "@@";
@@ -399,12 +399,14 @@ export function validateShouldUpdateNodeArgs(
  *
  * @param routes - Routes to validate
  * @param tree - Current route tree (optional for initial validation)
+ * @param matcher - Current route matcher (segment lookup + existence for forwardTo)
  * @param forwardMap - Current forward map for cycle detection
  * @param parentName - Optional parent route fullName for nesting via addRoute({ parent })
  */
 export function validateRoutes<Dependencies extends DefaultDependencies>(
   routes: Route<Dependencies>[],
   tree?: RouteTree,
+  matcher?: Matcher,
   forwardMap?: Record<string, string>,
   parentName?: string,
 ): void {
@@ -438,8 +440,8 @@ export function validateRoutes<Dependencies extends DefaultDependencies>(
     );
   }
 
-  if (tree && forwardMap) {
-    validateForwardToTargets(routes, forwardMap, tree);
+  if (matcher && forwardMap) {
+    validateForwardToTargets(routes, forwardMap, matcher);
   }
 }
 

--- a/packages/validation-plugin/tests/functional/integration/routes-coverage.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/routes-coverage.test.ts
@@ -307,7 +307,12 @@ describe("validateRoutes — direct calls", () => {
 
   it("passes with undefined tree and forwardMap — skips forwardTo targets check", () => {
     expect(() => {
-      validateRoutes([{ name: "child", path: "/child" }], undefined, {});
+      validateRoutes(
+        [{ name: "child", path: "/child" }],
+        undefined,
+        undefined,
+        {},
+      );
     }).not.toThrow();
   });
 
@@ -321,6 +326,7 @@ describe("validateRoutes — direct calls", () => {
       validateRoutes(
         [{ name: "child", path: "/child" }],
         mockTree as never,
+        undefined,
         {},
         "nonexistent",
       );
@@ -341,6 +347,7 @@ describe("validateRoutes — direct calls", () => {
       validateRoutes(
         [{ name: "child", path: "/child" }],
         store.tree as never,
+        store.matcher as never,
         store.config.forwardMap,
         "home",
       );

--- a/packages/validation-plugin/tests/functional/no-route-tree.test.ts
+++ b/packages/validation-plugin/tests/functional/no-route-tree.test.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+/**
+ * Pkg-level boundary guard (#1301): the validation plugin must reach the routing
+ * engine ONLY through `@real-router/core` (its public / plugin-facing API), never
+ * by importing the foundation package `route-tree` directly. Core is the sole
+ * consumer of the engine; a plugin importing `route-tree` violates the
+ * "integrations use only core's public plugin-api" boundary (see CLAUDE.md
+ * "no private API"). The `validateRoute` value comes from `@real-router/core/validation`,
+ * segment lookup + existence from the matcher (`getSegmentsByName` / `hasRoute`),
+ * and the `RouteTree` type from `@real-router/core`.
+ *
+ * The test scans every `.ts` file under `packages/validation-plugin/src/` for a
+ * static / dynamic `route-tree` import. A regression re-couples the plugin to a
+ * foundation package and would re-add the `route-tree` devDependency.
+ */
+const FORBIDDEN_PATTERNS: readonly RegExp[] = [
+  /from\s+["']route-tree["']/,
+  /from\s+["']@real-router\/route-tree["']/,
+  /require\(["']route-tree["']\)/,
+  /import\(["']route-tree["']\)/,
+];
+
+function collectTsFiles(root: string): string[] {
+  const out: string[] = [];
+
+  function walk(directory: string): void {
+    for (const entry of readdirSync(directory)) {
+      const full = path.join(directory, entry);
+
+      if (statSync(full).isDirectory()) {
+        walk(full);
+
+        continue;
+      }
+
+      if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+        out.push(full);
+      }
+    }
+  }
+
+  walk(root);
+
+  return out;
+}
+
+describe("validation-plugin — no direct route-tree import (#1301)", () => {
+  it("packages/validation-plugin/src/ imports the engine only via @real-router/core", () => {
+    const absRoot = path.join(__dirname, "..", "..", "src");
+    const files = collectTsFiles(absRoot);
+
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: { file: string; line: number; text: string }[] = [];
+
+    for (const file of files) {
+      const lines = readFileSync(file, "utf8").split("\n");
+
+      for (const [i, line] of lines.entries()) {
+        if (FORBIDDEN_PATTERNS.some((pattern) => pattern.test(line))) {
+          offenders.push({
+            file: file.slice(absRoot.length + 1),
+            line: i + 1,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+
+    expect(offenders).toStrictEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6537,9 +6537,6 @@ importers:
         specifier: workspace:^
         version: link:../logger
     devDependencies:
-      route-tree:
-        specifier: workspace:^
-        version: link:../route-tree
       type-guards:
         specifier: workspace:^
         version: link:../type-guards


### PR DESCRIPTION
`@real-router/validation-plugin` imported `validateRoute` + `getSegmentsByName` straight from the foundation package `route-tree` (which was a `workspace:^` devDependency), bypassing core's public plugin-api. This makes **core the sole consumer of the routing engine**.

## Approach — 0 new `RouterInternals` methods

Everything the plugin needs is reached through **existing** surfaces:

- **`validateRoute`** (route-tree's batch route/path validator — no matcher equivalent) is re-exported from the **`@real-router/core/validation`** subpath (which the plugin already imports `getInternals` from). Kept off the main public index.
- **forwardTo** segment lookup + target existence now use the **matcher's own** `getSegmentsByName` / `hasRoute` (via `store.matcher`, threaded into `validateRoutes` → `validateForwardToTargets`). `routes.ts` already did this for param-compat, so it's now consistent; the tree-walk `routeExistsInTree` helper is dropped and `forwardTo.ts` is tree-free.
- **`RouteTree` / `Matcher`** types come from `@real-router/core`.
- `route-tree` removed from the plugin's `devDependencies`.

Boundary / architectural-hygiene fix — **not** a bundle-size one (the route-tree validation layer was already tree-shaken out of core's bundle). Behaviour is unchanged.

## Verification

- New guard test `tests/functional/no-route-tree.test.ts` scans `src/` and fails on any `route-tree` import → prevents re-coupling.
- `@real-router/core` **2483** + `@real-router/validation-plugin` **568** green, 100% coverage; type-check + lint clean.
- Docs (route-tree / core / validation-plugin `CLAUDE.md`) updated to record the sole-consumer boundary.

Bumps `@real-router/core` (patch — plugin-facing re-export) + `@real-router/validation-plugin` (patch — internal refactor).

Closes #1301