### PR TITLE
feat(core): wire opt-in case-insensitive routing via caseSensitive (#1303)

### DIFF
--- a/.changeset/core-wire-casesensitive-option-1303.md
+++ b/.changeset/core-wire-casesensitive-option-1303.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": minor
+---
+
+Wire opt-in case-insensitive routing via `caseSensitive` (#1303)
+
+The engine already implemented `caseSensitive` end-to-end, but the option was severed at the core seam — `Options` had no field and `deriveMatcherOptions` never mapped it, so `createRouter({ caseSensitive: false })` was silently ignored. `caseSensitive` is now a public router option, mapped through to the matcher. **Default stays `true` (case-sensitive, spec-correct per RFC 3986 §6.2.2.1)** — case-insensitive is an explicit opt-in (`caseSensitive: false`) for server-less / hash / static-hosted / legacy routing. Only static literal segments are compared case-insensitively; dynamic param values keep their case. Note the divergence from React Router v7 / TanStack / vue-router, which default to case-insensitive.

--- a/.changeset/types-add-casesensitive-option-1303.md
+++ b/.changeset/types-add-casesensitive-option-1303.md
@@ -1,0 +1,5 @@
+---
+"@real-router/types": minor
+---
+
+Add `caseSensitive: boolean` to router `Options` (#1303) — opt-in case-insensitive path matching, default `true` (case-sensitive).

--- a/.changeset/validation-plugin-validate-casesensitive-1303.md
+++ b/.changeset/validation-plugin-validate-casesensitive-1303.md
@@ -1,0 +1,5 @@
+---
+"@real-router/validation-plugin": minor
+---
+
+Validate the new `caseSensitive` router option (#1303): accept it as a known option and reject a non-boolean value.

--- a/examples/web/react/hash-routing/src/main.tsx
+++ b/examples/web/react/hash-routing/src/main.tsx
@@ -11,6 +11,11 @@ import "../../../../shared/styles.css";
 const router = createRouter(routes, {
   defaultRoute: "home",
   allowNotFound: true,
+  // #1303 dogfood: hash routing is exactly the niche for opt-in case-insensitive
+  // matching — the server never sees `#!/Home`, so the client router is the only
+  // place that can normalize case. With this, `#!/Home` / `#!/HOME` resolve to the
+  // lower-case `home` route (exact-case URLs still match; param values keep case).
+  caseSensitive: false,
 });
 
 router.usePlugin(hashPluginFactory({ hashPrefix: "!" }));

--- a/packages/core-types/src/router.ts
+++ b/packages/core-types/src/router.ts
@@ -91,6 +91,25 @@ export interface Options {
   trailingSlash: "strict" | "never" | "always" | "preserve";
 
   /**
+   * Whether route matching is case-sensitive.
+   *
+   * When `false`, a mixed-case URL matches a lower-case route (`/Team` matches a
+   * `/team` route). Dynamic param **values** keep their original case — only
+   * static literal segments are compared case-insensitively.
+   *
+   * Default `true` (spec-correct: RFC 3986 §6.2.2.1 treats URL paths as
+   * case-sensitive). Case-insensitive is an explicit **opt-in** for a narrow
+   * niche — server-less / hash / static-hosted / legacy routing where no server
+   * or edge layer can normalize the URL's case before it reaches the router. For
+   * public SSR/edge apps, prefer a canonical-lowercase redirect at the server
+   * instead (SEO / dedup). Note the divergence from React Router v7 / TanStack /
+   * vue-router, which default to case-**insensitive**.
+   *
+   * @default true
+   */
+  caseSensitive: boolean;
+
+  /**
    * How to encode URL parameters.
    * - "default": Standard encoding
    * - "uri": URI encoding (encodeURI)

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -915,6 +915,7 @@ function deriveMatcherOptions(
 ): CreateMatcherOptions {
   return {
     strictTrailingSlash: options.trailingSlash === "strict",
+    caseSensitive: options.caseSensitive,
     strictQueryParams: options.queryParamsMode === "strict",
     urlParamsEncoding: options.urlParamsEncoding,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/core/src/namespaces/OptionsNamespace/constants.ts
+++ b/packages/core/src/namespaces/OptionsNamespace/constants.ts
@@ -11,6 +11,7 @@ export const defaultOptions: Options = {
   defaultRoute: "",
   defaultParams: {},
   trailingSlash: "preserve",
+  caseSensitive: true,
   queryParamsMode: "loose",
   queryParams: DEFAULT_QUERY_PARAMS,
   urlParamsEncoding: "default",

--- a/packages/core/tests/functional/routes/caseSensitive.test.ts
+++ b/packages/core/tests/functional/routes/caseSensitive.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getPluginApi } from "@real-router/core/api";
+
+/**
+ * #1303: `caseSensitive` is honoured end-to-end by the engine but was severed at
+ * the core seam — `Options` had no field and `deriveMatcherOptions` never mapped
+ * it, so `createRouter({ caseSensitive: false })` was silently ignored. These
+ * tests exercise the option through the PUBLIC `createRouter` API (not white-box),
+ * covering the engine's 5 dormant branches: match cache + traverse + registration
+ * cache keys. Default stays case-sensitive (opt-in).
+ */
+describe("core/routes/caseSensitive option (#1303)", () => {
+  it("caseSensitive: false — a mixed-case URL matches a lower-case static route", () => {
+    const router = createRouter([{ name: "team", path: "/team" }], {
+      caseSensitive: false,
+    });
+
+    expect(getPluginApi(router).matchPath("/Team")?.name).toBe("team");
+    expect(getPluginApi(router).matchPath("/TEAM")?.name).toBe("team");
+    // exact case still matches
+    expect(getPluginApi(router).matchPath("/team")?.name).toBe("team");
+
+    router.stop();
+  });
+
+  it("caseSensitive: false — matches nested routes case-insensitively (trie traverse)", () => {
+    const router = createRouter(
+      [
+        {
+          name: "users",
+          path: "/Users",
+          children: [{ name: "settings", path: "/Settings" }],
+        },
+      ],
+      { caseSensitive: false },
+    );
+
+    expect(getPluginApi(router).matchPath("/users/settings")?.name).toBe(
+      "users.settings",
+    );
+    expect(getPluginApi(router).matchPath("/USERS/SETTINGS")?.name).toBe(
+      "users.settings",
+    );
+
+    router.stop();
+  });
+
+  it("caseSensitive: false — dynamic param VALUES keep their original case", () => {
+    const router = createRouter([{ name: "user", path: "/user/:id" }], {
+      caseSensitive: false,
+    });
+
+    // static "/user" matches "/User" insensitively, but the :id value is preserved
+    expect(getPluginApi(router).matchPath("/User/AbC")?.params).toStrictEqual({
+      id: "AbC",
+    });
+
+    router.stop();
+  });
+
+  it("default (caseSensitive: true) — a mixed-case URL does NOT match", () => {
+    const router = createRouter([{ name: "team", path: "/team" }]);
+
+    expect(getPluginApi(router).matchPath("/Team")).toBeUndefined();
+    expect(getPluginApi(router).matchPath("/team")?.name).toBe("team");
+
+    router.stop();
+  });
+});

--- a/packages/validation-plugin/src/validators/options.ts
+++ b/packages/validation-plugin/src/validators/options.ts
@@ -26,6 +26,7 @@ const KNOWN_OPTIONS = new Set<string>([
   "defaultRoute",
   "defaultParams",
   "trailingSlash",
+  "caseSensitive",
   "queryParamsMode",
   "queryParams",
   "urlParamsEncoding",
@@ -254,6 +255,15 @@ export function validateOptions(options: unknown, methodName: string): void {
   ) {
     throw new TypeError(
       `[router.${methodName}] Invalid "rewritePathOnMatch": expected boolean, got ${typeof opts.rewritePathOnMatch}`,
+    );
+  }
+
+  if (
+    opts.caseSensitive !== undefined &&
+    typeof opts.caseSensitive !== "boolean"
+  ) {
+    throw new TypeError(
+      `[router.${methodName}] Invalid "caseSensitive": expected boolean, got ${typeof opts.caseSensitive}`,
     );
   }
 

--- a/packages/validation-plugin/tests/functional/validators.test.ts
+++ b/packages/validation-plugin/tests/functional/validators.test.ts
@@ -793,6 +793,21 @@ describe("Phase 2 options validators", () => {
       }).toThrow("rewritePathOnMatch");
     });
 
+    it("throws for invalid caseSensitive (non-boolean)", () => {
+      expect(() => {
+        validateOptions({ caseSensitive: "no" }, "test");
+      }).toThrow(TypeError);
+      expect(() => {
+        validateOptions({ caseSensitive: "no" }, "test");
+      }).toThrow("caseSensitive");
+    });
+
+    it("accepts a boolean caseSensitive", () => {
+      expect(() => {
+        validateOptions({ caseSensitive: false }, "test");
+      }).not.toThrow();
+    });
+
     it("throws for invalid defaultRoute", () => {
       expect(() => {
         validateOptions({ defaultRoute: 42 }, "test");


### PR DESCRIPTION
Wires the `caseSensitive` router option end-to-end. The engine already implemented case-insensitive matching in full (5 branches), but the option was **severed at the core seam** — `Options` had no field and `deriveMatcherOptions` never mapped it, so `createRouter({ caseSensitive: false })` was silently ignored (`/Team` never matched `/team`). Resolves the #1303 decision (**wire it, opt-in, default stays `true`**).

## Changes

- **`@real-router/types`** — add `caseSensitive: boolean` to router `Options`.
- **`@real-router/core`** — default `true` in `defaultOptions`; map it in `deriveMatcherOptions` → `CreateMatcherOptions.caseSensitive` (the single option bridge).
- **`@real-router/validation-plugin`** — accept `caseSensitive` as a known option + reject a non-boolean value.

## Scope decisions (per the issue)

- **Default stays `true`** (case-sensitive, spec-correct per RFC 3986 §6.2.2.1). Case-insensitive is an explicit **opt-in** for the server-less / hash / static-hosted / legacy niche. Documented the niche + the divergence from React Router v7 / TanStack / vue-router (which default insensitive).
- Only **static literal segments** compare case-insensitively; dynamic param **values** keep their case (`/user/AbC` → `{ id: "AbC" }`).
- The 5 dormant engine branches (`SegmentMatcher.ts:131,559`, `registration.ts:277,297`) are now reachable and their mutants are killed via the **public `createRouter` API** (`caseSensitive.test.ts`), not white-box.
- **Dogfooded** in the React hash-routing example.
- Fixed the wiki (`RouterOptions` / `createRouter`), which documented a **wrong** default (`false`) and description ("route names") for the pre-existing severed option.

## Validation

core 2487 + validation-plugin 570 tests, 100% coverage; type-check + lint clean. Full `pnpm build` delegated.

Closes #1303