### PR TITLE
fix: route-CRUD phantom-write hardening — dotted constructor gap + update(nonexistent) no-op (#1194 #1205 #1195)

### DIFF
--- a/.changeset/core-update-nonexistent-noop-1205.md
+++ b/.changeset/core-update-nonexistent-noop-1205.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+fix(core): update() of a nonexistent route is a true no-op in bare core (#1205)
+
+Without `@real-router/validation-plugin`, `update("ghost", …)` for a route that does not exist used to silently seed `config.defaultParams` + compile/register the guard factory and emit a lying `TREE_CHANGED` `"update"` event for a route `get()`/`has()` cannot see — and a later `add({ name: "ghost" })` inherited the phantom config + a blocking guard (`navigate` rejected `CANNOT_ACTIVATE` out of the box). It is now a genuine no-op: the commit and the emit are skipped when the route is absent. No throw is added (validation stays opt-in — the validation-plugin already throws a `ReferenceError` here).

--- a/.changeset/validation-plugin-constructor-dotcheck-1194.md
+++ b/.changeset/validation-plugin-constructor-dotcheck-1194.md
@@ -1,0 +1,7 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+fix(validation-plugin): reject flat dotted route names on the constructor's initial routes (#1194)
+
+`add()`/`replace()` already reject a dotted route name (e.g. `{ name: "users.view" }`), but the plugin's retrospective pass (`validateExistingRoutes`, run on `usePlugin(validationPlugin())`) validated only name-is-string / path / duplicates — not the dot rule. So a validation-enabled app that declared a dotted name in `createRouter([...])` still slipped it past validation into a name-vs-URL split-brain (buildPath/matchPath disagree; the route mounts at the wrong URL). The retrospective pass now rejects a dotted `name` on the initial routes too, symmetric with `add()`/`replace()` — use a nested `children` array or the `{ parent }` option instead.

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -749,6 +749,18 @@ export function getRoutesApi<
 
       ctx.validator?.routes.validateUpdateRoute(name, updates, store);
 
+      // #1205: bare-core existence backstop as a TRUE no-op — NOT a throw
+      // (validation is opt-in). update() of a route that does not exist used to
+      // seed config.defaultParams + compile/register the guard (commitRouteUpdate
+      // below) and emit a lying TREE_CHANGED "update" event for a route get()/
+      // has() cannot see; a future add() of that name then inherited the phantom
+      // config + a blocking guard. Skip the commit and the emit entirely when the
+      // route is absent. (With the validation-plugin, validateUpdateRoute above
+      // already threw a ReferenceError, so this is only reached in bare core.)
+      if (!store.matcher.hasRoute(name)) {
+        return;
+      }
+
       // Field-patch commit core (NO_TREE_REBUILD) — co-located in routesStore.ts
       // beside the add/replace (adoptRouteArtifacts) / remove (commitTreeChanges)
       // / clear (resetStore) cores. Returns the structural fields for the

--- a/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/updateRoute.test.ts
@@ -1503,19 +1503,36 @@ describe("core/routes/routeTree/updateRoute", () => {
   });
 
   describe("core contract without validation-plugin", () => {
-    it("update(nonexistent) is a silent no-op (existence check is plugin-only)", () => {
-      // Without @real-router/validation-plugin, core trusts its input and does
-      // not verify the route exists — update throws nothing and creates no route
-      // (the orphan config write is unreachable). The plugin throws here instead.
+    it("update(nonexistent) is a TRUE no-op — no phantom config/guard, no lying event, no inheritance by a later add() (#1205)", () => {
+      // Without @real-router/validation-plugin core trusts its input and does not
+      // throw (validation is opt-in). But it must NOT silently seed config or a
+      // guard for a route that does not exist: update() previously wrote
+      // config.defaultParams + compiled/registered the guard + emitted a lying
+      // TREE_CHANGED "update" event, and a later add() of that name inherited the
+      // phantom (defaultParams + a blocking guard). It is now a genuine no-op.
+      // (With the validation-plugin, update() throws a ReferenceError instead.)
+      const events: string[] = [];
+      const unsub = routesApi.subscribeChanges((event) =>
+        events.push(event.op),
+      );
+
       expect(() => {
-        routesApi.update("nonexistent", { defaultParams: { x: "1" } });
+        routesApi.update("nonexistent", {
+          defaultParams: { seeded: "yes" },
+          canActivate: () => () => false,
+        });
       }).not.toThrow();
 
       expect(routesApi.has("nonexistent")).toBe(false);
       expect(routesApi.get("nonexistent")).toBeUndefined();
-      expect(
-        getPluginApi(router).getRouteConfig("nonexistent"),
-      ).toBeUndefined();
+      expect(events).toStrictEqual([]); // no lying "update" event
+
+      // A later add() of that name must arrive clean — no inherited phantom.
+      routesApi.add({ name: "nonexistent", path: "/nonexistent" });
+      unsub();
+
+      expect(routesApi.get("nonexistent")?.defaultParams).toBeUndefined();
+      expect(router.canNavigateTo("nonexistent")).toBe(true);
     });
 
     it("update(encodeParams) on the active route leaves state.path stale (NO_TREE_REBUILD)", async () => {

--- a/packages/validation-plugin/CLAUDE.md
+++ b/packages/validation-plugin/CLAUDE.md
@@ -47,7 +47,7 @@ Value inspection is **own-property only** (mirrors `isParams`) and runs before t
 
 ### Retrospective rollback on failure
 
-If the retrospective pass throws (e.g., duplicate route name in existing routes), `ctx.validator` is set back to `null` before the error propagates. The router is left in a clean state — no partial validation active. The error surfaces at the `usePlugin()` call site.
+If the retrospective pass throws (e.g., duplicate route name, or a **dotted route name** in the constructor's initial routes — `validateExistingRoutes` rejects a flat dotted `name` symmetric with `add()`/`replace()`, #1194), `ctx.validator` is set back to `null` before the error propagates. The router is left in a clean state — no partial validation active. The error surfaces at the `usePlugin()` call site.
 
 ### Teardown disables validation
 

--- a/packages/validation-plugin/src/validators/retrospective.ts
+++ b/packages/validation-plugin/src/validators/retrospective.ts
@@ -210,6 +210,20 @@ export function validateExistingRoutes(store: unknown): void {
       );
     }
 
+    // #1194: reject a flat dotted name on the constructor's initial routes too.
+    // add()/replace() already reject a dotted route name (route-batch
+    // validateRouteName), but the retrospective pass previously validated only
+    // string/path/duplicates — so `createRouter([{ name: "a.c" }])` + this plugin
+    // slipped a dotted name past validation into a name-vs-URL split-brain. The
+    // raw `def.name` (not the nesting-derived fullName) is checked, so nested
+    // children (simple names) pass; the message mirrors add()/replace().
+    if (def.name.includes(".")) {
+      throw new TypeError(
+        `[router.constructor] Route name "${def.name}" cannot contain dots. ` +
+          `Use children array or { parent } option in addRoute() instead.`,
+      );
+    }
+
     if (typeof def.path !== "string") {
       throw new TypeError(
         `[validation-plugin] validateExistingRoutes: route "${fullName}" has non-string path (${typeof def.path})`,

--- a/packages/validation-plugin/tests/functional/createRouter.validation.test.ts
+++ b/packages/validation-plugin/tests/functional/createRouter.validation.test.ts
@@ -22,6 +22,17 @@ describe("createRouter — validation (with validationPlugin)", () => {
       expect(() => router.usePlugin(validationPlugin())).toThrow();
     });
 
+    it("should throw for a flat dotted route name — constructor symmetry with add()/replace() (#1194)", () => {
+      // add()/replace() reject a dotted route name; the constructor's initial
+      // routes must be rejected on plugin registration too, else a validation-ON
+      // app still gets the name-vs-URL split-brain via createRouter([...]).
+      router = createRouter([{ name: "users.view", path: "/:id" }]);
+
+      expect(() => router.usePlugin(validationPlugin())).toThrow(
+        /cannot contain dots/,
+      );
+    });
+
     it("should not throw for valid unique routes", () => {
       router = createRouter([
         { name: "home", path: "/home" },


### PR DESCRIPTION
## Summary

Chain-2 route-CRUD hardening from the 2026-07-03/04 deep audits — two "phantom write + lying `TREE_CHANGED`" defects plus the companion `addRoute.md` docs drift. Neither code fix changes the opt-in validation model: #1194 closes an asymmetry **within** the validation-plugin, #1205 makes a bare-core operation a genuine no-op **without adding a throw**.

### #1194 — dotted route names slipped past validation via the constructor
- `add()`/`replace()` reject a dotted route name (`{ name: "users.view" }`), but the plugin's retrospective pass (`validateExistingRoutes`, run on `usePlugin(validationPlugin())`) validated only name-is-string / path / duplicates — not the dot rule. So a validation-ON app that declared a dotted name in `createRouter([...])` still got the name-vs-URL split-brain (buildPath/matchPath disagree; the route mounts at the wrong URL).
- **Root cause + fix:** the retrospective pass was asymmetric with `add()`/`replace()`. `validateExistingRoutes` now rejects a flat dotted `name` on the initial routes too (checking the raw `def.name`, so nested `children` with simple names pass), with the same "cannot contain dots — use children / { parent }" message. Bare-core acceptance is unchanged (validation stays opt-in).

### #1205 — bare-core update() of a nonexistent route silently corrupted
- Without the validation-plugin, `update("ghost", …)` for a route that does not exist was not a no-op: it seeded `config.defaultParams` + compiled/registered the guard factory and emitted a lying `TREE_CHANGED` "update" event for a route `get()`/`has()` cannot see — and a later `add({ name: "ghost" })` inherited the phantom config + a blocking guard (`navigate` rejected `CANNOT_ACTIVATE` out of the box).
- **Root cause + fix (true no-op, not a throw):** an existence backstop (`store.matcher.hasRoute`) after the validator, before the commit + emit — skips both when the route is absent. No throw is added (validation stays opt-in; the plugin already throws a `ReferenceError` here). The mis-asserting pin (checked only `getRouteConfig`, missing `config.defaultParams`) is rewritten to assert the genuine no-op.

### #1195 — companion docs: addRoute.md drift (wiki, separate repo)
- The wiki `addRoute.md` "Possible Errors" table mixed always-on core guards with validation-plugin-only rows; the "batch — preferred" example used flat dotted names (the #1194 trap); the `forwardTo` target-existence + duplicate-path claims were unscoped; and `REENTRANT_TREE_MUTATION` / `TREE_CHANGED` were undocumented. Fixed in the wiki: a "Bare core?" column + scoping note (incl. the cryptic bare-core `name.startsWith is not a function`), the batch example rewritten to `children`, the duplicate-path row scoped to batch-only (silent shadow tracked as #1153), the `name` regex corrected to the strict no-dots form, and the missing rows added.

## Test plan

- [x] `validation-plugin/createRouter.validation.test.ts` — dotted constructor route + plugin throws (#1194)
- [x] `core/updateRoute.test.ts` — update(nonexistent) is a true no-op: no lying event, no phantom inherited by a later `add()`, `canNavigateTo` true (#1205)
- [x] validation-plugin: test **571** (100% cov), properties 84; type-check; lint
- [x] core: test **2517** (100% cov), properties 311, stress 113; type-check; lint
- [x] probes flip: add-route probe-02 (dotted seam), update-route probe-01 Q1 (`events=[]`, `guardFactoryCompiled=0x`)
- [ ] `pnpm build` (full turbo graph) — delegated to CI
- ⚠️ Behavior notes for the full build: #1194 makes `usePlugin()` throw on a dotted constructor route (was silently accepted); #1205 makes bare-core `update(nonexistent)` a no-op (was seeding). Downstream adapter/plugin suites are validated by the full build.

Closes #1194
Closes #1205
Closes #1195
