### PR TITLE
fix(core): definition canDeactivate survives leave — origin-explicit guard clearing (#1171)

### DIFF
--- a/.changeset/loud-guards-linger.md
+++ b/.changeset/loud-guards-linger.md
@@ -1,0 +1,14 @@
+---
+"@real-router/core": minor
+---
+
+Make guard clearing origin-explicit so a route-config guard is never wiped by an external-guard operation (#1171)
+
+The internal guard-clear primitive defaulted to clearing BOTH origin slots (route-config + external), so several operations silently erased a route-config guard they should have left alone. Guard clearing now names its origin lane explicitly (no origin-blind default), fixing two observable behaviors:
+
+- **Post-leave auto-cleanup is external-only.** A route-config `canDeactivate` was one-shot — the first permitted leave erased it, so re-entry was unguarded (e.g. an unsaved-changes confirmation silently broke on the second visit), `getRoutesApi().get(name).canDeactivate` became `undefined`, and a `cloneRouter` taken after the leave never received it. Now only the external, component-managed guard is auto-cleaned; a config guard lives as long as the route is in the tree, symmetric with `canActivate`.
+- **`removeActivateGuard` / `removeDeactivateGuard` are external-only.** They are the inverse of `addActivateGuard` / `addDeactivateGuard` (which register external guards), so they now clear only the external guard and leave a route-config guard intact. To remove a config guard, use `getRoutesApi(router).update(name, { canActivate: null })` / `{ canDeactivate: null }`.
+
+Route removal and `dispose()` still clear both origins (the route/router is gone).
+
+Note: because a route-config `canDeactivate` now persists, it counts toward the per-type handler tally the way a config `canActivate` always has — so under `@real-router/validation-plugin`'s `maxLifecycleHandlers`, a config `canDeactivate` occupies a slot for the life of the route instead of freeing it on first leave.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -370,7 +370,7 @@ Multiple interceptors per method execute in **LIFO** order (last-registered wrap
 
 ### Segment Cleanup After Deactivation
 
-After successful navigation, deactivated segments with `canDeactivate` guards are automatically cleaned up. Only clears guards for segments that are fully deactivated (not re-activated). Uses `Array.includes()` instead of `Set` — faster for 1-5 elements.
+After successful navigation, a deactivated segment's **external** (component-managed) `canDeactivate` guard is automatically cleaned up — the router5 mount/unmount contract, where a guard added via `getLifecycleApi().addDeactivateGuard()` is dropped once its component leaves. Only segments that are fully deactivated (not re-activated) are cleared, and only the **external** slot: a **definition** guard from route config survives the leave, so re-entry stays guarded — symmetric with definition `canActivate`, which lives as long as the route is in the tree (#1171). Uses `Array.includes()` instead of `Set` — faster for 1-5 elements.
 
 ## Dispose Lifecycle
 

--- a/packages/core/INVARIANTS.md
+++ b/packages/core/INVARIANTS.md
@@ -186,6 +186,7 @@ These invariants cover the FSM-driven lifecycle of the router. Each state transi
 | 13  | update canActivate null                          | After `update(name, { canActivate: null })`, any previously set definition guard is removed and navigation is allowed again.                                                  |
 | 14  | replace during navigation                        | `replace()` called during an active navigation returns silently without modifying routes. It is a silent no-op.                                                               |
 | 15  | replace preserves external                       | `replace()` clears definition guards (from route config) but preserves external guards (from `getLifecycleApi`).                                                              |
+| 16  | removeXGuard clears external only                | After `removeActivateGuard(name)` / `removeDeactivateGuard(name)`, an EXTERNAL guard (from `getLifecycleApi`) is removed but a DEFINITION guard (from route config) survives — the inverse of `addXGuard`; removing a config guard is `update(name, { canX: null })`'s job (#1171).                |
 
 ## Guards + navigate Interaction
 

--- a/packages/core/src/api/getLifecycleApi.ts
+++ b/packages/core/src/api/getLifecycleApi.ts
@@ -38,7 +38,9 @@ export function getLifecycleApi<
 
       ctx.validator?.routes.validateRouteName(name, "removeActivateGuard");
 
-      lifecycleNamespace.clearCanActivate(name);
+      // Inverse of addActivateGuard (external): clears only the external guard;
+      // a route-config (definition) canActivate survives (#1171).
+      lifecycleNamespace.clearCanActivate(name, "external");
     },
 
     removeDeactivateGuard(name) {
@@ -46,7 +48,9 @@ export function getLifecycleApi<
 
       ctx.validator?.routes.validateRouteName(name, "removeDeactivateGuard");
 
-      lifecycleNamespace.clearCanDeactivate(name);
+      // Inverse of addDeactivateGuard (external): clears only the external guard;
+      // a route-config (definition) canDeactivate survives (#1171).
+      lifecycleNamespace.clearCanDeactivate(name, "external");
     },
   };
 }

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -93,13 +93,14 @@ function clearRouteConfigurations<
 
   for (const name of Object.keys(canActivateFactories)) {
     if (shouldClear(name)) {
-      lifecycleNamespace.clearCanActivate(name);
+      // Route removed from the tree — both origin slots go (route no longer exists).
+      lifecycleNamespace.clearCanActivate(name, "both");
     }
   }
 
   for (const name of Object.keys(canDeactivateFactories)) {
     if (shouldClear(name)) {
-      lifecycleNamespace.clearCanDeactivate(name);
+      lifecycleNamespace.clearCanDeactivate(name, "both");
     }
   }
 }

--- a/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
+++ b/packages/core/src/namespaces/RouteLifecycleNamespace/RouteLifecycleNamespace.ts
@@ -26,6 +26,18 @@ function booleanToFactory<Dependencies extends DefaultDependencies>(
 }
 
 /**
+ * Origin lane for a guard clear. Every `clearCanActivate` / `clearCanDeactivate`
+ * caller names its lane — there is no origin-blind default — so a new call site
+ * cannot silently wipe both the route-config and the external guard (#1171):
+ *
+ * - `"definition"` — clear only the route-config guard (`update(name, {…: null})`, #952).
+ * - `"external"` — clear only the external, component-managed guard
+ *   (`removeXGuard()` and post-leave auto-cleanup — the inverse of `addXGuard()`).
+ * - `"both"` — clear both (route removal / router teardown; the route is gone).
+ */
+export type GuardClearScope = "definition" | "external" | "both";
+
+/**
  * Source of truth for `canActivate` / `canDeactivate` guards.
  *
  * Storage is split by origin into four factory Maps (definition vs external,
@@ -247,44 +259,37 @@ export class RouteLifecycleNamespace<
   }
 
   /**
-   * Removes a canActivate guard for a route. By default clears BOTH the
-   * definition and external slots (route removal / `clearAll` cleanup). With
-   * `definitionOnly = true` it clears ONLY the definition slot, leaving an
-   * external guard intact — `update(name, { canActivate: null })` passes this so
-   * clearing a route-config guard does not also wipe a guard registered
-   * independently via `getLifecycleApi().addActivateGuard()` (#952). When the
-   * definition is cleared but an external survives, `#recompileSlot` recompiles
-   * the slot from the external factory (external wins).
+   * Removes a canActivate guard for a route. `scope` names the origin lane
+   * (see {@link GuardClearScope}) — there is no origin-blind default, so every
+   * caller commits to a lane and a new call site cannot silently clear both.
+   * Delegates to {@link #clearGuard} (mirrors the add side's `#registerHandler`).
    *
    * @param name - Route name (already validated by facade)
-   * @param definitionOnly - When true, leave the external slot intact (#952)
+   * @param scope - Which origin(s) to clear: `"definition"` / `"external"` / `"both"`
    */
-  clearCanActivate(name: string, definitionOnly = false): void {
-    const clearedDefinition = this.#definitionActivateFactories.delete(name);
-    const clearedExternal = definitionOnly
-      ? false
-      : this.#externalActivateFactories.delete(name);
-
-    if (clearedDefinition || clearedExternal) {
-      this.#recompileSlot("activate", name);
-    }
+  clearCanActivate(name: string, scope: GuardClearScope): void {
+    this.#clearGuard("activate", name, scope);
   }
 
   /**
-   * Removes a canDeactivate guard for a route.
+   * Removes a canDeactivate guard for a route. Symmetric counterpart to
+   * {@link clearCanActivate}.
    *
-   * Symmetric counterpart to {@link clearCanActivate} — `definitionOnly = true`
-   * clears only the definition slot, preserving an external guard (#952).
+   * The `"external"` lane is what makes a route-config `canDeactivate` durable:
+   * post-leave auto-cleanup (`completeTransition`) and `removeDeactivateGuard()`
+   * unregister only the external, component-managed guard (router5 mount/unmount
+   * heritage), while a definition guard survives for re-entry — symmetric with
+   * definition `canActivate`, which lives as long as the route is in the tree
+   * (#1171). Clearing both by default made a config guard one-shot: the first
+   * permitted leave erased it, so re-entry was unguarded, `getRoutesApi().get()`
+   * lost the field, and a clone taken after the leave never received it
+   * (clone invariant #6).
+   *
+   * @param name - Route name (already validated by facade)
+   * @param scope - Which origin(s) to clear: `"definition"` / `"external"` / `"both"`
    */
-  clearCanDeactivate(name: string, definitionOnly = false): void {
-    const clearedDefinition = this.#definitionDeactivateFactories.delete(name);
-    const clearedExternal = definitionOnly
-      ? false
-      : this.#externalDeactivateFactories.delete(name);
-
-    if (clearedDefinition || clearedExternal) {
-      this.#recompileSlot("deactivate", name);
-    }
+  clearCanDeactivate(name: string, scope: GuardClearScope): void {
+    this.#clearGuard("deactivate", name, scope);
   }
 
   /**
@@ -593,6 +598,29 @@ export class RouteLifecycleNamespace<
       this.#recompileSlot(type, name);
 
       throw error;
+    }
+  }
+
+  /**
+   * Shared implementation for {@link clearCanActivate} / {@link clearCanDeactivate}
+   * — the clear-side counterpart to {@link #registerHandler}. `scope` selects the
+   * origin lane (no origin-blind default, #1171); when one origin is cleared and
+   * the other survives, `#recompileSlot` recompiles the compiled function from
+   * the survivor (external wins, #1174).
+   */
+  #clearGuard(
+    type: "activate" | "deactivate",
+    name: string,
+    scope: GuardClearScope,
+  ): void {
+    const { definition, external } = this.#getFactoryMaps(type);
+    const clearedDefinition =
+      scope === "external" ? false : definition.delete(name);
+    const clearedExternal =
+      scope === "definition" ? false : external.delete(name);
+
+    if (clearedDefinition || clearedExternal) {
+      this.#recompileSlot(type, name);
     }
   }
 

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -1030,12 +1030,12 @@ function commitGuardUpdate<Dependencies extends DefaultDependencies>(
 
   if (kind === "activate") {
     if (value === null) {
-      lifecycle.clearCanActivate(name, true);
+      lifecycle.clearCanActivate(name, "definition");
     } else {
       lifecycle.addCanActivate(name, value, true, precompiledFn);
     }
   } else if (value === null) {
-    lifecycle.clearCanDeactivate(name, true);
+    lifecycle.clearCanDeactivate(name, "definition");
   } else {
     lifecycle.addCanDeactivate(name, value, true, precompiledFn);
   }

--- a/packages/core/src/wiring/wireNamespaces.ts
+++ b/packages/core/src/wiring/wireNamespaces.ts
@@ -236,8 +236,10 @@ function wireNavigation<Dependencies extends DefaultDependencies>(
     getLifecycleFunctions: () => ns.routeLifecycle.getFunctions(),
     isActive: () => ns.router.isActive(),
     isTransitioning: () => ns.eventBus.isTransitioning(),
+    // Post-leave auto-cleanup unregisters only the EXTERNAL (component-managed)
+    // guard; a route-config (definition) guard survives for re-entry (#1171).
     clearCanDeactivate: (name: string) => {
-      ns.routeLifecycle.clearCanDeactivate(name);
+      ns.routeLifecycle.clearCanDeactivate(name, "external");
     },
     hasLeaveListeners: () => ns.eventBus.hasLeaveListeners(),
     hasPreCommitListeners: () => ns.eventBus.hasPreCommitListeners(),

--- a/packages/core/tests/functional/api/cloneRouter.test.ts
+++ b/packages/core/tests/functional/api/cloneRouter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { createRouter } from "@real-router/core";
 import {
@@ -193,6 +193,34 @@ describe("cloneRouter()", () => {
 
     expect(clone.getState()?.name).toBe("away");
 
+    clone.dispose();
+  });
+
+  it("preserves a definition canDeactivate on a clone created AFTER the source left the route (#1171)", async () => {
+    const guard = vi.fn(() => true); // permits, so the source leave completes
+    const router = createRouter([
+      { name: "home", path: "/home", canDeactivate: () => guard },
+      { name: "away", path: "/away" },
+    ]);
+
+    await router.start("/home");
+
+    // Source PERMITS the leave before the clone is taken. On the buggy path this
+    // permitted leave auto-erased the config guard from the source Maps, so the
+    // clone (which replays from those Maps) would never receive it — breaking
+    // cloneRouter invariant #6 (guards preserved in the clone).
+    await router.navigate("away");
+
+    const clone = cloneRouter(router);
+
+    guard.mockClear(); // isolate the clone's own invocation from the source's
+
+    await clone.start("/home");
+    await clone.navigate("away"); // clone leaves home — its config guard must fire
+
+    expect(guard).toHaveBeenCalledTimes(1);
+
+    router.dispose();
     clone.dispose();
   });
 });

--- a/packages/core/tests/functional/api/getLifecycleApi/removeGuard.test.ts
+++ b/packages/core/tests/functional/api/getLifecycleApi/removeGuard.test.ts
@@ -181,4 +181,44 @@ describe("core/route-lifecycle/removeGuard", () => {
       lifecycle.removeActivateGuard("admin");
     }).not.toThrow();
   });
+
+  /**
+   * `removeActivateGuard` / `removeDeactivateGuard` are the inverse of
+   * `addActivateGuard` / `addDeactivateGuard`, which register EXTERNAL
+   * (component-managed) guards. They must clear only the external slot: a
+   * DEFINITION guard from route config survives, exactly as it does through
+   * auto-cleanup (#1171). Removing a route-config guard is the job of
+   * `getRoutesApi().update(name, { canX: null })`, not the external-guard API.
+   */
+  describe("route-config (definition) guard survives removeXGuard (external-only)", () => {
+    it("removeDeactivateGuard leaves a route-config canDeactivate intact", async () => {
+      const guard = () => () => false;
+
+      routesApi.add({ name: "cfg-d", path: "/cfg-d", canDeactivate: guard });
+      await router.navigate("cfg-d");
+
+      // The config guard blocks leaving cfg-d.
+      expect(router.canNavigateTo("home")).toBe(false);
+
+      lifecycle.removeDeactivateGuard("cfg-d"); // external-guard API — no external here
+
+      // The config guard was never external — it must still block, and remain readable.
+      expect(router.canNavigateTo("home")).toBe(false);
+      expect(routesApi.get("cfg-d")?.canDeactivate).toBe(guard);
+    });
+
+    it("removeActivateGuard leaves a route-config canActivate intact", () => {
+      const guard = () => () => false;
+
+      routesApi.add({ name: "cfg-a", path: "/cfg-a", canActivate: guard });
+
+      // The config guard blocks activating cfg-a.
+      expect(router.canNavigateTo("cfg-a")).toBe(false);
+
+      lifecycle.removeActivateGuard("cfg-a"); // external-guard API — no external here
+
+      expect(router.canNavigateTo("cfg-a")).toBe(false);
+      expect(routesApi.get("cfg-a")?.canActivate).toBe(guard);
+    });
+  });
 });

--- a/packages/core/tests/functional/api/getRoutesApi/getRoute.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/getRoute.test.ts
@@ -173,6 +173,24 @@ describe("core/routes/routeTree/getRoute", () => {
       expect(route?.canActivate).toBe(guardFactory);
     });
 
+    it("retains canDeactivate after the route has been left (#1171)", async () => {
+      const guardFactory: GuardFnFactory = () => () => true;
+
+      routesApi.add({
+        name: "gr-form",
+        path: "/gr-form",
+        canDeactivate: guardFactory,
+      });
+
+      // Enter then leave the route (a permitted leave that would auto-clean it).
+      await router.navigate("gr-form");
+      await router.navigate("home");
+
+      // The route-config guard must survive the leave — like canActivate, it
+      // lives as long as the route is in the tree, not one cycle.
+      expect(routesApi.get("gr-form")?.canDeactivate).toBe(guardFactory);
+    });
+
     it("should return route with all properties", () => {
       const decoder = (params: Params): Params => ({
         ...params,

--- a/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
@@ -518,17 +518,16 @@ describe("core/routes/replaceRoutes", () => {
     });
 
     it("should have no stale entries after removeActivateGuard + replace", async () => {
-      // Add route with definition guard
-      routesApi.add({
-        name: "removable",
-        path: "/removable",
-        canActivate: () => () => false,
-      });
+      // Route with an EXTERNAL activate guard — `addActivateGuard` registers the
+      // external slot, which is exactly what `removeActivateGuard` clears
+      // (external-only, #1171).
+      routesApi.add({ name: "removable", path: "/removable" });
+      lifecycle.addActivateGuard("removable", () => () => false);
 
-      // Remove the guard externally — clears the entry from #definitionActivateFactories
+      // Remove the external guard — clears the entry from #externalActivateFactories.
       lifecycle.removeActivateGuard("removable");
 
-      // Navigation works now (guard removed)
+      // Navigation works now (external guard removed)
       await router.navigate("removable");
 
       expect(router.getState()?.name).toBe("removable");
@@ -539,7 +538,7 @@ describe("core/routes/replaceRoutes", () => {
         { name: "removable", path: "/removable" }, // no guard
       ]);
 
-      // Navigation still works — no stale definition guard entry
+      // Navigation still works — no stale guard entry
       await router.navigate("home");
       await router.navigate("removable");
 

--- a/packages/core/tests/functional/navigation/navigate/auto-cleanup.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/auto-cleanup.test.ts
@@ -211,4 +211,35 @@ describe("router.navigate() - auto cleanup", () => {
       expect(router.getState()?.name).toBe("orders");
     });
   });
+
+  /**
+   * A route-config (definition) `canDeactivate` is registered once at
+   * construction and nothing re-registers it on re-entry — so auto-cleanup must
+   * NOT erase it. It lives as long as the route is in the tree, symmetric with
+   * definition `canActivate` (#1171). Only external, component-managed guards
+   * (`addDeactivateGuard`) are auto-cleaned on leave.
+   */
+  describe("route-config (definition) canDeactivate is retained (#1171)", () => {
+    it("fires again on re-entry — a config guard is not one-shot", async () => {
+      const guard = vi.fn(() => true);
+      const local = createRouter([
+        { name: "a", path: "/a" },
+        { name: "form", path: "/form", canDeactivate: () => guard },
+      ]);
+
+      await local.start("/a");
+
+      await local.navigate("form");
+      await local.navigate("a"); // leave #1 — permitted, guard fires
+
+      expect(guard).toHaveBeenCalledTimes(1);
+
+      await local.navigate("form"); // re-enter
+      await local.navigate("a"); // leave #2 — guard must fire again
+
+      expect(guard).toHaveBeenCalledTimes(2);
+
+      local.stop();
+    });
+  });
 });

--- a/packages/core/tests/property/route-lifecycle-storage.properties.ts
+++ b/packages/core/tests/property/route-lifecycle-storage.properties.ts
@@ -13,7 +13,7 @@ import { createFixtureRouter, ROUTES, NUM_RUNS } from "./helpers";
 //   - external  → getLifecycleApi(router).addActivateGuard / addDeactivateGuard
 //   - definition→ getRoutesApi(router).update(name, { canActivate })  (true)
 //   - clear definition-only → getRoutesApi(router).replace(routes)
-//   - clear both slots      → getLifecycleApi(router).removeActivateGuard
+//   - clear external-only   → getLifecycleApi(router).removeActivateGuard (#1171)
 // Effect is observed via router.canNavigateTo(name).
 // =============================================================================
 
@@ -159,7 +159,7 @@ describe("RouteLifecycleNamespace storage invariants (public API)", () => {
   test.prop([arbTarget, fc.boolean(), fc.boolean()], {
     numRuns: NUM_RUNS.standard,
   })(
-    "REMOVE_CLEARS_REGARDLESS_OF_ORIGIN: removeActivateGuard drops the guard whether definition, external, or both",
+    "REMOVE_CLEARS_EXTERNAL_ONLY: removeActivateGuard drops the external guard but preserves a definition (config) one (#1171)",
     async (target, useDefinition, useExternal) => {
       fc.pre(useDefinition || useExternal);
 
@@ -179,9 +179,14 @@ describe("RouteLifecycleNamespace storage invariants (public API)", () => {
       // Whatever the origin mix, the route is blocked before removal.
       expect(router.canNavigateTo(target)).toBe(false);
 
-      lifecycle.removeActivateGuard(target); // origin-blind: clears both slots
+      // removeActivateGuard is the inverse of addActivateGuard: it clears only
+      // the EXTERNAL slot. A definition (config) guard survives — removing it is
+      // update(name, { canActivate: null })'s job, not the external-guard API's.
+      lifecycle.removeActivateGuard(target);
 
-      expect(router.canNavigateTo(target)).toBe(true);
+      // Blocked afterwards iff a definition guard was set (it survived); a purely
+      // external guard is gone, so canNavigateTo is allowed (true) only then.
+      expect(router.canNavigateTo(target)).toBe(!useDefinition);
 
       router.stop();
     },


### PR DESCRIPTION
## Summary

- A route-config `canDeactivate` used to be **one-shot** — the first permitted leave erased it, so re-entry was unguarded (an unsaved-changes confirmation silently broke on the second visit), `getRoutesApi().get(name).canDeactivate` became `undefined`, and a `cloneRouter` taken after the leave never received it. Config `canDeactivate` now lives as long as the route is in the tree, symmetric with config `canActivate`.
- `removeActivateGuard` / `removeDeactivateGuard` no longer wipe a route-config guard — they are the inverse of `addXGuard` (external) and clear only the external guard. Removing a config guard is `getRoutesApi().update(name, { canX: null })`'s job.

### #1171 — definition canDeactivate is one-shot

- **Root cause:** the guard-clear primitive defaulted to clearing **both** origin slots (route-config + external). Post-leave auto-cleanup (the router5 mount/unmount contract for external, component-managed guards) used that origin-blind default, so it also erased a route-config guard that nothing re-registers. The same origin-blindness sat in `removeActivateGuard`/`removeDeactivateGuard`. This was the mirror image of #952 (`update(null)` erasing an external guard), each historically patched with a one-off flag.
- **Fix:** make the origin lane explicit. `clearCanActivate` / `clearCanDeactivate` take a required `scope: "definition" | "external" | "both"` (no origin-blind default) and delegate to a shared `#clearGuard(type, name, scope)`, mirroring the add side's `#registerHandler`. Call sites are routed by lane: auto-cleanup and `removeXGuard` → `"external"`; `update(name, { canX: null })` → `"definition"`; route removal / `dispose()` → `"both"`. `#recompileSlot` re-derives the effective guard from the surviving origin (external wins, #1174).

### Behavior change

- **`removeActivateGuard` / `removeDeactivateGuard` are external-only.** A route with a config guard keeps it after an external-guard removal.
- Because a config `canDeactivate` now persists, it counts toward the per-type handler tally as a config `canActivate` always has — under `@real-router/validation-plugin`'s `maxLifecycleHandlers` it occupies a slot for the life of the route instead of freeing it on first leave. This is the correct symmetric accounting.

### Maintainability

- `clearCanActivate` / `clearCanDeactivate` collapsed into one shared `#clearGuard` delegate (removes byte-identical duplication; symmetric with `addCan*` → `#registerHandler`).

## Test plan

- [x] `navigate/auto-cleanup`: a config `canDeactivate` fires again on re-entry (not one-shot)
- [x] `getRoutesApi/getRoute`: `get(name).canDeactivate` retained after the route has been left
- [x] `api/cloneRouter`: a clone created after the source left the route carries the config guard
- [x] `getLifecycleApi/removeGuard`: `removeActivateGuard` / `removeDeactivateGuard` preserve a route-config guard (activate + deactivate)
- [x] Property `REMOVE_CLEARS_REGARDLESS_OF_ORIGIN` → `REMOVE_CLEARS_EXTERNAL_ONLY`; `INVARIANTS.md` #16 added
- [x] Core suite green (2522 tests), 100% coverage; property (311) + stress (113) green; `type-check` + `lint` clean
- [ ] Full `pnpm build` (turbo graph) — verified by CI

Closes #1171
