### PR TITLE
fix(core): dispose / unsubscribe safety-net + idempotency symmetry (#1196 #1198 #1199 #1349)

### DIFF
--- a/.changeset/brave-clocks-clean.md
+++ b/.changeset/brave-clocks-clean.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Clear interceptors on `dispose()` so a leaked interceptor no longer runs (#1199)
+
+`dispose()` had dispose safety-nets for `routerExtensions` and `contextClaimRecords` but never cleared `ctx.interceptors` — the third per-plugin registration channel. Since `buildPath` is not method-swapped by `dispose()` and reads the interceptor Map live, an interceptor a plugin failed to remove in `teardown` still ran on the disposed router. `dispose()` now clears the interceptor Map alongside the other two safety-nets.

--- a/.changeset/quick-lions-leave.md
+++ b/.changeset/quick-lions-leave.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Make `subscribeLeave`'s unsubscribe idempotent (#1349)
+
+`subscribeLeave` stored the listener directly in `#leaveListeners` and spliced by `indexOf(listener)` with no `removed` flag — the exact sibling of #1198 (`addInterceptor`), in a channel the `Unsubscribe` contract explicitly names as idempotent. With the same `fn` registered twice, calling the first unsubscribe twice removed a second registration, silently deactivating another subscriber's leave handler. A `removed` flag now short-circuits repeat calls (mirroring `addInterceptor` / `extendRouter`). Unlike `subscribe` / `subscribeChanges`, `subscribeLeave` does not wrap the listener in a fresh closure, so it needed the explicit guard. The misleading "irrelevant in practice" note in the JSDoc is corrected.

--- a/.changeset/silent-otters-share.md
+++ b/.changeset/silent-otters-share.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Make `addInterceptor`'s unsubscribe idempotent (#1198)
+
+`addInterceptor`'s unsubscribe spliced by `list.indexOf(fn)` with no guard, so calling the first unsubscribe twice — documented as safe by the `Unsubscribe` contract — removed a SECOND registration of the same `fn` (e.g. a shared module-level interceptor helper used by two plugin instances), silently deactivating another plugin's interceptor. A `removed` flag now short-circuits repeat calls, mirroring `extendRouter`.

--- a/.changeset/tame-zombies-rest.md
+++ b/.changeset/tame-zombies-rest.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Fix a pre-bound `usePlugin` reference registering a zombie plugin after `dispose()` (#1196)
+
+A `usePlugin` reference captured before `dispose()` (`const up = router.usePlugin`) bypassed the post-dispose method swap and reached the real implementation, so the factory ran on the disposed router (real side effects), listeners landed in the cleared emitter, and `teardown` never fired. It now throws `ROUTER_DISPOSED` like every other mutating method — mirroring the #946 guard for `subscribe` / `subscribeLeave`.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -382,7 +382,7 @@ After successful navigation, a deactivated segment's **external** (component-man
 4. FSM → DISPOSED (terminal state)
 5. Clear event listeners
 6. Dispose plugins (remove listeners + call `teardown()`)
-7. Clean up remaining router extensions (safety net)
+7. Clean up remaining router extensions, context claims, and interceptors (per-plugin safety nets — #1199)
 8. Clear routes + lifecycle guards
 9. Reset state
 10. Clear dependencies

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -198,7 +198,7 @@ router.dispose(); // Idempotent — safe to call multiple times
 ```
 
 **Lifecycle**: healthy flows route through IDLE (`STOP → IDLE → DISPOSE`). The FSM also accepts `DISPOSE` directly from `STARTING`, `READY`, `TRANSITION_STARTED`, and `LEAVE_APPROVED` as a safety net (#660) — required when the orchestrated path cannot reach `IDLE`, e.g. `dispose()` called mid-`STARTING` after a start-pipeline throw left the FSM stuck.
-**Cleanup order**: abort navigation → cancel transition → stop (if ready/transitioning) → FSM DISPOSE → clearAll (events) → plugins → router extensions (safety net) → context claims (safety net) → routes → lifecycle → state → deps → markDisposed
+**Cleanup order**: abort navigation → cancel transition → stop (if ready/transitioning) → FSM DISPOSE → clearAll (events) → plugins → router extensions (safety net) → context claims (safety net) → interceptors (safety net, #1199) → routes → lifecycle → state → deps → markDisposed
 **After dispose**: All mutating methods throw `RouterError(ROUTER_DISPOSED)`
 **Idempotency**: Second call is a no-op (FSM state check)
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -681,6 +681,16 @@ export class Router<
   usePlugin(
     ...plugins: (PluginFactory<Dependencies> | false | null | undefined)[]
   ): Unsubscribe {
+    // Post-dispose guard, mirroring #946 for subscribe/subscribeLeave. A
+    // reference captured before dispose() (`const up = router.usePlugin`)
+    // bypasses the #markDisposed method swap, so the swap alone is not enough:
+    // without this, the factory would run on a disposed router (real side
+    // effects), listeners would land in the cleared emitter, and teardown would
+    // never fire — a silent zombie plugin (#1196).
+    if (this.#eventBus.isDisposed()) {
+      throw new RouterError(errorCodes.ROUTER_DISPOSED);
+    }
+
     const filtered = plugins.filter(Boolean) as PluginFactory<Dependencies>[];
 
     if (filtered.length === 0) {

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -599,6 +599,13 @@ export class Router<
     // Safety net: release context namespace claims plugins failed to release in teardown
     ctx.contextClaimRecords.clear();
 
+    // Safety net: drop interceptors plugins failed to remove in teardown (#1199).
+    // The third per-plugin registration channel — symmetric with routerExtensions
+    // / contextClaimRecords above. `buildPath` is not method-swapped by dispose
+    // and reads this Map live, so a leaked interceptor would otherwise still run
+    // on the disposed router.
+    ctx.interceptors.clear();
+
     this.#routes.clearRoutes();
     this.#routeLifecycle.clearAll();
     this.#state.reset();

--- a/packages/core/src/api/getPluginApi.ts
+++ b/packages/core/src/api/getPluginApi.ts
@@ -137,12 +137,21 @@ export function getPluginApi<
 
       list.push(fn);
 
-      return () => {
-        const index = list.indexOf(fn);
+      // Idempotency flag (#1198). Without it, a double call would `indexOf(fn)`
+      // again and splice a DUPLICATE registration of the same fn — silently
+      // deactivating another plugin's interceptor whose own unsubscribe was never
+      // called. The `Unsubscribe` contract is documented idempotent. The flag
+      // guarantees exactly one splice of a still-present `fn`, so no `index !== -1`
+      // guard is needed (it would be dead — the second call returns above).
+      let removed = false;
 
-        if (index !== -1) {
-          list.splice(index, 1);
+      return () => {
+        if (removed) {
+          return;
         }
+
+        removed = true;
+        list.splice(list.indexOf(fn), 1);
       };
     },
     getRouteConfig: (name) => {

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -526,24 +526,18 @@ export class EventBusNamespace {
    *
    * @remarks
    *
-   * **Duplicate-registration semantics — independent (with internal quirk).**
-   * Each call pushes `listener` onto the internal array; `router.subscribeLeave(fn)`
-   * twice produces two array entries. `fn` fires **once** per leave when
-   * iteration snapshots the array (a snapshot is taken on entry to
-   * `awaitLeaveListeners`), but the function reference is invoked once per
-   * array slot — so in practice the wrapper fires twice through the same
-   * closure (no observable difference for stateless `fn`).
-   *
-   * The returned `Unsubscribe` removes the **first** array entry matching the
-   * function reference (`indexOf` semantic), not the most recently added one.
-   * Net effect of N subscribes + M unsubscribes is correct (N - M entries
-   * remain), but the specific physical entry that survives is reverse of the
-   * unsubscribe-call order. Irrelevant in practice — the function reference
-   * is the same; observable behaviour is identical regardless of which
-   * physical entry is removed.
+   * **Duplicate-registration semantics — independent.** Each call pushes
+   * `listener` onto the internal array; `router.subscribeLeave(fn)` twice
+   * produces two entries and `fn` fires twice per leave. Each returned
+   * `Unsubscribe` is **idempotent** (a `removed` flag, #1349) and removes
+   * exactly ONE entry — the first still matching the reference (`indexOf`
+   * semantic). So a repeated call of one unsubscribe is a true no-op and does
+   * **not** touch the other registration; N subscribes + M *distinct*
+   * unsubscribes leave N − M entries. Which physical entry survives is
+   * irrelevant — the reference is the same.
    *
    * Contract differs from {@link addEventListener} (throws on duplicate).
-   * For idempotent registration, gate at the call site.
+   * For idempotent *registration* (one active subscription), gate at the call site.
    */
   subscribeLeave(listener: LeaveFn): Unsubscribe {
     // Same disposed-state enforcement as subscribe() (#946): a pre-bound
@@ -555,7 +549,23 @@ export class EventBusNamespace {
 
     this.#leaveListeners.push(listener);
 
+    // Idempotency flag (#1349), mirroring extendRouter / addInterceptor (#1198).
+    // Without it, a double call would `indexOf(listener)` again and splice a
+    // DUPLICATE registration of the same fn — silently deactivating another
+    // subscriber whose own unsubscribe was never called. The `Unsubscribe`
+    // contract names subscribeLeave as idempotent. (Unlike addInterceptor, the
+    // `idx !== -1` guard stays: `dispose()` empties `#leaveListeners` via
+    // `clearAll`, so an unsubscribe called after dispose reaches this with
+    // idx === -1.)
+    let removed = false;
+
     return () => {
+      if (removed) {
+        return;
+      }
+
+      removed = true;
+
       const idx = this.#leaveListeners.indexOf(listener);
 
       if (idx !== -1) {

--- a/packages/core/tests/functional/api/getPluginApi/addBuildPathInterceptor.test.ts
+++ b/packages/core/tests/functional/api/getPluginApi/addBuildPathInterceptor.test.ts
@@ -105,6 +105,31 @@ describe("addInterceptor('buildPath')", () => {
 
       expect(path).toBe("/users/view/original");
     });
+
+    it("double unsubscribe does NOT remove a duplicate registration of the same fn (#1198)", () => {
+      // The same fn registered twice (e.g. a shared module-level interceptor
+      // helper used by two plugin instances). The `Unsubscribe` contract is
+      // idempotent — calling the FIRST unsubscribe twice must not touch the
+      // SECOND registration, whose own unsubscribe was never called.
+      let hits = 0;
+      const shared = (next: any, route: string, params: any) => {
+        hits++;
+
+        return next(route, params);
+      };
+
+      const unsub1 = api.addInterceptor("buildPath", shared);
+
+      api.addInterceptor("buildPath", shared); // 2nd registration — unsubscribe never called
+
+      unsub1();
+      unsub1(); // documented as safe — must be a true no-op after the first call
+
+      router.buildPath("home");
+
+      // The surviving 2nd registration must still fire.
+      expect(hits).toBe(1);
+    });
   });
 
   describe("empty pipeline", () => {

--- a/packages/core/tests/functional/observable/subscribe-leave.test.ts
+++ b/packages/core/tests/functional/observable/subscribe-leave.test.ts
@@ -34,7 +34,7 @@ describe("subscribeLeave — branch coverage via the public pipeline", () => {
     router.stop();
   });
 
-  it("double-unsubscribe is a safe no-op (listener already removed, idx === -1)", async () => {
+  it("double-unsubscribe is a safe no-op (idempotency flag short-circuits the repeat call)", async () => {
     const router = createTestRouter();
     const onLeave = vi.fn();
 
@@ -44,12 +44,52 @@ describe("subscribeLeave — branch coverage via the public pipeline", () => {
 
     expect(() => {
       unsubscribe();
-    }).not.toThrow(); // second call hits the idx === -1 path
+    }).not.toThrow(); // second call returns early via the `removed` flag
 
     await router.start("/home");
     await router.navigate("items", { id: "1" });
 
     expect(onLeave).not.toHaveBeenCalled(); // stayed unsubscribed
+
+    router.stop();
+  });
+
+  it("unsubscribe after dispose() is a safe no-op (leave-listeners already cleared, idx === -1)", () => {
+    const router = createTestRouter();
+    const unsubscribe = router.subscribeLeave(vi.fn());
+
+    router.dispose(); // clearAll() empties #leaveListeners
+
+    // The listener is gone from the array, so the unsubscribe hits idx === -1.
+    expect(() => {
+      unsubscribe();
+    }).not.toThrow();
+  });
+
+  it("double unsubscribe does NOT remove a duplicate registration of the same fn (#1349)", async () => {
+    const router = createTestRouter();
+
+    await router.start("/home");
+
+    // The same fn registered twice (e.g. a shared handler used by two
+    // components). The `Unsubscribe` contract is idempotent — calling the FIRST
+    // unsubscribe twice must not touch the SECOND registration.
+    let hits = 0;
+    const shared = (): void => {
+      hits++;
+    };
+
+    const unsub1 = router.subscribeLeave(shared);
+
+    router.subscribeLeave(shared); // 2nd registration — its unsubscribe never called
+
+    unsub1();
+    unsub1(); // documented safe — must be a true no-op after the first call
+
+    await router.navigate("items", { id: "1" }); // leaves "home"
+
+    // The surviving 2nd registration must still fire.
+    expect(hits).toBe(1);
 
     router.stop();
   });

--- a/packages/core/tests/functional/routerLifecycle/dispose.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/dispose.test.ts
@@ -460,6 +460,34 @@ describe("dispose", () => {
         expect(error.code).toBe(errorCodes.ROUTER_DISPOSED);
       }
     });
+
+    it("a pre-bound usePlugin() reference throws instead of registering a zombie (#1196)", async () => {
+      await router.start("/home");
+      const boundUsePlugin = router.usePlugin.bind(router);
+
+      router.dispose();
+
+      let factoryRan = false;
+
+      // Before the fix this silently registered a zombie plugin: the factory ran
+      // on the disposed router (real side effects), listeners landed in the
+      // cleared emitter, and teardown never fired.
+      expect(() =>
+        boundUsePlugin(() => {
+          factoryRan = true;
+
+          return { teardown() {} };
+        }),
+      ).toThrow();
+
+      expect(factoryRan).toBe(false);
+
+      try {
+        boundUsePlugin(() => ({}));
+      } catch (error: any) {
+        expect(error.code).toBe(errorCodes.ROUTER_DISPOSED);
+      }
+    });
   });
 
   describe("guardAgainstDisposed — mutating methods throw after dispose()", () => {

--- a/packages/core/tests/functional/routerLifecycle/dispose.test.ts
+++ b/packages/core/tests/functional/routerLifecycle/dispose.test.ts
@@ -262,6 +262,32 @@ describe("dispose", () => {
       expect(teardownSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("dispose() clears ctx.interceptors so a leaked interceptor no longer runs (#1199)", () => {
+      const api = getPluginApi(router);
+      let ran = false;
+
+      // A short-circuit interceptor (returns without calling next), never
+      // unsubscribed — the third per-plugin channel, previously without a
+      // dispose safety-net (unlike routerExtensions / contextClaimRecords).
+      api.addInterceptor("buildPath", () => {
+        ran = true;
+
+        return "/zombie-path";
+      });
+
+      router.dispose();
+
+      // buildPath is NOT method-swapped by dispose and reads the interceptor Map;
+      // after the fix the Map is cleared, so the leaked interceptor must not run.
+      try {
+        router.buildPath("home");
+      } catch {
+        // The real buildPath on the cleared tree may throw — irrelevant here.
+      }
+
+      expect(ran).toBe(false);
+    });
+
     it("dispose() calls teardown for multiple plugins", async () => {
       const teardown1 = vi.fn();
       const teardown2 = vi.fn();
@@ -476,7 +502,7 @@ describe("dispose", () => {
         boundUsePlugin(() => {
           factoryRan = true;
 
-          return { teardown() {} };
+          return {};
         }),
       ).toThrow();
 


### PR DESCRIPTION
## Summary

Four point fixes to the same dispose / unsubscribe layer (use-plugin deep-audit wave 2 + a symmetry re-verification). Each is the missing member of a symmetry the sibling channels already have. After this batch a probe confirms all three axes are uniform: every registration/mutation entry point throws `ROUTER_DISPOSED` (direct + pre-bound); every `Unsubscribe` is idempotent under a duplicate registration; every per-plugin channel is cleared on dispose.

### #1196 — pre-bound `usePlugin` registered a zombie plugin after `dispose()`

- **Root cause:** post-dispose protection for `usePlugin` was only the `#markDisposed` method swap. A reference captured before `dispose()` bypasses the swap, so the factory ran on the disposed router, listeners landed in the cleared emitter, and `teardown` never fired.
- **Fix:** a disposed guard at the top of the facade `usePlugin`, throwing `ROUTER_DISPOSED` on every entry path — mirroring the #946 guard for `subscribe` / `subscribeLeave`.

### #1198 — `addInterceptor`'s unsubscribe was not idempotent

- **Root cause:** the unsubscribe spliced by `list.indexOf(fn)` with no `removed` flag. With the same `fn` registered twice, a double call of the first unsubscribe removed a second registration, silently deactivating another plugin's interceptor.
- **Fix:** a `removed` flag, mirroring `extendRouter`. The now-redundant `index !== -1` guard is dropped (the flag guarantees exactly one splice of a still-present `fn`; the interceptor arrays are not emptied on dispose).

### #1199 — `dispose()` never cleared `ctx.interceptors`

- **Root cause:** `dispose()` had safety-nets for `routerExtensions` and `contextClaimRecords` but not for `ctx.interceptors`. Since `buildPath` is not method-swapped by `dispose()` and reads the interceptor Map live, a leaked interceptor still ran on the disposed router.
- **Fix:** clear the interceptor Map alongside the other two safety-nets.

### #1349 — `subscribeLeave`'s unsubscribe was not idempotent (sibling of #1198)

- **Root cause:** `subscribeLeave` stored the listener directly in `#leaveListeners` and spliced by `indexOf(listener)` with no `removed` flag — the exact class of #1198, in a channel the `Unsubscribe` contract explicitly names as idempotent. A double call of one unsubscribe removed a duplicate registration, silently deactivating another leave subscriber. (Surfaced by re-verifying the axis after #1198 — it was not uniform.)
- **Fix:** a `removed` flag. Unlike `subscribe` / `subscribeChanges` (which wrap in a fresh closure), `subscribeLeave` stores the raw reference, so it needed the guard; the `idx !== -1` guard stays because `clearAll` empties `#leaveListeners` on dispose. Misleading JSDoc corrected.

## Test plan

- [x] `dispose.test.ts`: a pre-bound `usePlugin` throws `ROUTER_DISPOSED` (factory does not run) — #1196
- [x] `addBuildPathInterceptor.test.ts`: double unsubscribe does NOT remove a duplicate `addInterceptor` registration — #1198
- [x] `dispose.test.ts`: a leaked interceptor no longer runs on the disposed router — #1199
- [x] `subscribe-leave.test.ts`: double unsubscribe does NOT remove a duplicate `subscribeLeave` registration; unsubscribe after dispose is a safe no-op — #1349
- [x] Symmetry probe: all three axes uniform (11 disposed-guard points + 5 idempotent-unsub channels)
- [x] Core suite green (2527 tests), 100% coverage; property (311) + stress (113) green; `type-check` + `lint` clean
- [ ] Full `pnpm build` (turbo graph) — verified by CI

## Notes

An `addEventListener` namespace-guard was considered but dropped: its public path (`getPluginApi(router).addEventListener`) already has the api-layer `throwIfDisposed`, which shadows the namespace — a probe confirms it throws on both direct and pre-bound calls, so a namespace guard would be uncoverable dead code, not a live gap.

Closes #1196
Closes #1198
Closes #1199
Closes #1349
