### PR TITLE
perf(browser-plugin, hash-plugin): skip no-op popstate replaceState on back/forward (#1353)

### DIFF
--- a/.changeset/browser-plugin-popstate-perf.md
+++ b/.changeset/browser-plugin-popstate-perf.md
@@ -1,0 +1,7 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Skip the redundant popstate-success `replaceState` on back/forward when it is provably a no-op (#1353)
+
+On a browser back/forward the engine has already restored the target entry's `{name, params, path}` and URL before firing `popstate`, so re-writing them via `replaceState` was a value-level no-op that still fired a second `updateForSameDocumentNavigation` Blink event per navigation. The plugin now skips the write when the resolved target deep-equals the live `history.state` (same path + `areStatesEqual`). Every load-bearing case keeps the write: redirect/normalization (path or params differ), corrupted or missing `history.state`, and custom `Browser` implementations without a state reader. The optional `Browser.getState` reader added for this is non-breaking (absent → the write is preserved).

--- a/.changeset/hash-plugin-popstate-perf.md
+++ b/.changeset/hash-plugin-popstate-perf.md
@@ -1,0 +1,7 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Skip the redundant popstate-success `replaceState` on back/forward when it is provably a no-op (#1353)
+
+On a browser back/forward the engine has already restored the target entry's `{name, params, path}` and URL before firing `popstate`, so re-writing them via `replaceState` was a value-level no-op that still fired a second `updateForSameDocumentNavigation` Blink event per navigation. The plugin now skips the write when the resolved target deep-equals the live `history.state` (same path + `areStatesEqual`). Every load-bearing case keeps the write: redirect/normalization (path or params differ), corrupted or missing `history.state`, and custom `Browser` implementations without a state reader.

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -130,7 +130,7 @@ The `Browser` interface, `createSafeBrowser()`, `createHistoryFallbackBrowser()`
 - `shared/browser-env/safe-browser.ts` — `createSafeBrowser` (real History API binding)
 - `shared/browser-env/ssr-fallback.ts` — `createHistoryFallbackBrowser` (no-op fallback for SSR/Node)
 - `shared/browser-env/detect.ts` — `isBrowserEnvironment()`
-- `shared/browser-env/history-api.ts` — `pushState`, `replaceState`, `addPopstateListener`, `getHash`
+- `shared/browser-env/history-api.ts` — `pushState`, `replaceState`, `addPopstateListener`, `getHash`, `getState` (`getState` reads `history.state` so `onTransitionSuccess` can skip a no-op popstate `replaceState`, #1353)
 
 **Key points for browser-plugin:**
 

--- a/packages/browser-plugin/CLAUDE.md
+++ b/packages/browser-plugin/CLAUDE.md
@@ -76,6 +76,9 @@ See [IMPLEMENTATION_NOTES.md](../../IMPLEMENTATION_NOTES.md) section "URL Fragme
 ### State Validation
 External code can corrupt `history.state`. Plugin validates structure via `isStateStrict` (from browser-env) and ignores invalid states gracefully.
 
+### Popstate history-write skip (#1353)
+On back/forward the browser has **already** restored the target entry's `{name, params, path}` and URL before firing `popstate`, so `onTransitionSuccess`'s `replaceState` re-writes identical values — a value-level no-op that still fires a **second** `updateForSameDocumentNavigation` Blink event per nav (lean native routers emit one; real-router emitted two). The write is skipped when `canSkipPopstateHistoryWrite` (browser-env) proves it a no-op: `source === "popstate"`, `replace` is true, and the resolved target deep-equals the live `history.state` (`Browser.getState` reader + same `path` + `router.areStatesEqual` with query params compared). Every **load-bearing** write is kept — redirect/normalization (path or params differ), corrupted/missing `history.state` (fails `isStateStrict`), or a custom `Browser` without `getState` (opt-in, non-breaking). The guard runs **after** `claim.write`/`urlClaim.write`, so subscribers still receive the transition; only the redundant native write is elided. `getState` is a rare popstate-path read (not the per-nav hot path — cf. #1019). The deferred-popstate replay (#757) is unaffected: it reads the event's own snapshot, not the live entry this write would commit. Shared via `browser-env`, so hash-plugin gets the same skip.
+
 ### SSR Safety
 ```typescript
 // createSafeBrowser() from browser-env detects environment:

--- a/packages/browser-plugin/src/factory.ts
+++ b/packages/browser-plugin/src/factory.ts
@@ -2,6 +2,7 @@ import { getPluginApi } from "@real-router/core/api";
 
 import {
   buildUrl,
+  canSkipPopstateHistoryWrite,
   createPluginBuildUrl,
   createPopstateHandler,
   createPopstateLifecycle,
@@ -256,9 +257,22 @@ function createBrowserPlugin(
       const url = buildUrl(toState.path, options.base);
       const finalUrl = hash ? `${url}#${encodeHashFragment(hash)}` : url;
 
-      updateState(toState, finalUrl, replaceHistory, browser);
-
       const isPopstate = navOptions.source === POPSTATE_SOURCE;
+
+      // On back/forward the browser has already restored the target entry's
+      // {name,params,path} + URL, so the plugin's replaceState re-writes the
+      // same values — a value-level no-op that still fires a second
+      // updateForSameDocumentNavigation Blink event. Skip it when provably a
+      // no-op; every load-bearing case (redirect, normalization, corrupted
+      // history.state) keeps the write. (#1353)
+      const skipHistoryWrite =
+        isPopstate &&
+        replaceHistory &&
+        canSkipPopstateHistoryWrite(toState, browser, router.areStatesEqual);
+
+      if (!skipHistoryWrite) {
+        updateState(toState, finalUrl, replaceHistory, browser);
+      }
 
       claim.write(toState, isPopstate ? FROZEN_POPSTATE : FROZEN_NAVIGATE);
     },

--- a/packages/browser-plugin/tests/functional/popstate.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate.test.ts
@@ -632,4 +632,200 @@ describe("Browser Plugin — Popstate", () => {
       expect(currentState?.path).toBe("/home");
     });
   });
+
+  describe("Popstate history-write skip (#1353)", () => {
+    beforeEach(async () => {
+      router.usePlugin(browserPluginFactory({}, mockedBrowser));
+      await router.start();
+    });
+
+    it("does NOT re-replaceState when the restored entry already equals the resolved target", async () => {
+      await router.navigate("users.view", { id: "1" });
+
+      // Real browsers set history.state + location for the restored entry,
+      // THEN fire popstate. Emulate a back to the index entry ("/").
+      const restored = { name: "index", params: {}, path: "/" };
+
+      globalThis.history.replaceState(restored, "", "/");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: restored }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("index");
+      // The browser already restored the identical {name,params,path} + URL,
+      // so the plugin's replaceState would be a value-level no-op firing a
+      // redundant updateForSameDocumentNavigation Blink event (#1353). Skip it.
+      expect(replaceSpy).not.toHaveBeenCalled();
+    });
+
+    it("KEEPS replaceState when the recorded history.state has a valid shape but a stale path (external edit)", async () => {
+      await router.navigate("users.view", { id: "1" });
+      await router.navigate("users.list");
+
+      // The recorded history.state was externally edited to a valid-shape but
+      // stale path (path drift). getState() returns the stale entry, while the
+      // event carries the canonical entry the browser navigated back to.
+      const staleLive = {
+        name: "users.view",
+        params: { id: "1" },
+        path: "/stale",
+      };
+
+      globalThis.history.replaceState(staleLive, "", "/users/view/1");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", {
+          state: {
+            name: "users.view",
+            params: { id: "1" },
+            path: "/users/view/1",
+          },
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.view");
+      // Resolved path /users/view/1 ≠ recorded stale path → guard cannot prove
+      // a no-op → write re-canonicalizes the recorded history.state.
+      expect(replaceSpy).toHaveBeenCalled();
+    });
+
+    it("KEEPS replaceState when history.state is corrupted (invalid shape)", async () => {
+      await router.navigate("users.view", { id: "1" });
+
+      // External code corrupts history.state; the browser restores a /home
+      // entry whose recorded state is garbage but whose URL still matches.
+      globalThis.history.replaceState({ garbage: true }, "", "/home");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: { garbage: true } }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("home");
+      // Live history.state fails isState → guard cannot prove a no-op → the
+      // write restores the canonical { name, params, path } shape.
+      expect(replaceSpy).toHaveBeenCalled();
+    });
+
+    it("KEEPS replaceState when restored params differ from resolved (defaultParams injected, same path)", async () => {
+      router.stop();
+      const dpRouter = createRouter(
+        [
+          ...routerConfig,
+          { name: "def", path: "/def", defaultParams: { tab: "home" } },
+        ],
+        { defaultRoute: "home", queryParamsMode: "default" },
+      );
+
+      dpRouter.usePlugin(browserPluginFactory({}, mockedBrowser));
+      await dpRouter.start();
+      await dpRouter.navigate("users.view", { id: "1" });
+
+      // Restored entry lacks the default param (e.g. recorded before it
+      // existed); the resolved target injects { tab: "home" }. Same path,
+      // different params — path check passes but areStatesEqual fails.
+      const restored = { name: "def", params: {}, path: "/def" };
+
+      globalThis.history.replaceState(restored, "", "/def");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: restored }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(dpRouter.getState()?.name).toBe("def");
+      expect(dpRouter.getState()?.params).toStrictEqual({ tab: "home" });
+      // Params drifted from the restored entry → write re-canonicalizes.
+      expect(replaceSpy).toHaveBeenCalled();
+
+      dpRouter.stop();
+    });
+
+    it("KEEPS replaceState when the Browser exposes no getState (custom/legacy browser)", async () => {
+      router.stop();
+      const legacyBrowser = createMockedBrowser(noop);
+
+      // Custom Browser predating getState — the opt-in reader is absent.
+      delete (legacyBrowser as { getState?: unknown }).getState;
+
+      const legacyRouter = createRouter(routerConfig, {
+        defaultRoute: "home",
+        queryParamsMode: "default",
+      });
+
+      legacyRouter.usePlugin(browserPluginFactory({}, legacyBrowser));
+      await legacyRouter.start();
+      await legacyRouter.navigate("users.view", { id: "1" });
+
+      const restored = { name: "index", params: {}, path: "/" };
+
+      globalThis.history.replaceState(restored, "", "/");
+
+      const replaceSpy = vi.spyOn(legacyBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: restored }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(legacyRouter.getState()?.name).toBe("index");
+      // No state reader → guard cannot prove a no-op → legacy write preserved.
+      expect(replaceSpy).toHaveBeenCalled();
+
+      legacyRouter.stop();
+    });
+
+    it("does not skip a forward navigation (pushState still fires)", async () => {
+      const pushSpy = vi.spyOn(mockedBrowser, "pushState");
+
+      await router.navigate("users.view", { id: "1" });
+
+      // Forward navigation is a push, not a popstate replace — untouched by the
+      // skip guard.
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("replays a deferred popstate correctly even when the first write is skipped (#757 unaffected)", async () => {
+      await router.navigate("users.view", { id: "1" });
+      await router.navigate("users.list");
+
+      // First back → users.view/1 (a skippable no-op write). Fire it, then
+      // synchronously fire a second back → home while the first is in flight,
+      // so the second is deferred and replayed from its own snapshot.
+      const entryA = {
+        name: "users.view",
+        params: { id: "1" },
+        path: "/users/view/1",
+      };
+
+      globalThis.history.replaceState(entryA, "", "/users/view/1");
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: entryA }),
+      );
+
+      const entryB = { name: "home", params: {}, path: "/home" };
+
+      globalThis.history.replaceState(entryB, "", "/home");
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: entryB }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      // The deferred B replays from its snapshot regardless of A's skipped
+      // write — final state is home, proving #757 is unaffected.
+      expect(router.getState()?.name).toBe("home");
+    });
+  });
 });

--- a/packages/browser-plugin/tests/property/browser-env/canSkipPopstateHistoryWrite.properties.ts
+++ b/packages/browser-plugin/tests/property/browser-env/canSkipPopstateHistoryWrite.properties.ts
@@ -1,0 +1,163 @@
+import { fc, test } from "@fast-check/vitest";
+import { createRouter } from "@real-router/core";
+
+import { NUM_RUNS, arbFullState } from "./helpers";
+import { canSkipPopstateHistoryWrite } from "../../../src/browser-env";
+
+import type { Browser } from "../../../src/browser-env";
+import type { State } from "@real-router/core";
+
+// areStatesEqual with ignoreQueryParams=false compares name + all params and
+// never touches the route tree, so any router instance works as the reference.
+// Wrapped in an arrow (not destructured) to avoid vitest/unbound-method.
+const router = createRouter([{ name: "x", path: "/x" }]);
+const areStatesEqual = (
+  a: State,
+  b: State,
+  ignoreQueryParams: boolean,
+): boolean => router.areStatesEqual(a, b, ignoreQueryParams);
+
+// Minimal Browser exposing only the field the guard reads (`getState`); the
+// cast is sound because the guard never touches any other Browser method.
+const browserWithState = (getState: () => unknown): Browser =>
+  ({ getState }) as unknown as Browser;
+
+const triplet = (
+  s: State,
+): { name: string; params: State["params"]; path: string } => ({
+  name: s.name,
+  params: { ...s.params },
+  path: s.path,
+});
+
+describe("canSkipPopstateHistoryWrite Properties", () => {
+  describe("no getState reader — never skips (opt-in, non-breaking)", () => {
+    test.prop([arbFullState], { numRuns: NUM_RUNS.standard })(
+      "a Browser without getState always keeps the write",
+      (toState: State) => {
+        expect(
+          canSkipPopstateHistoryWrite(toState, {} as Browser, areStatesEqual),
+        ).toBe(false);
+      },
+    );
+  });
+
+  describe("corrupted / missing history.state — never skips", () => {
+    test.prop(
+      [
+        arbFullState,
+        fc.oneof(
+          fc.constant(null),
+          fc.constant(undefined),
+          fc.record({ foo: fc.integer() }),
+          fc.string(),
+          fc.integer(),
+        ),
+      ],
+      { numRuns: NUM_RUNS.standard },
+    )(
+      "an invalid-shape live history.state always keeps the write",
+      (toState: State, garbage: unknown) => {
+        expect(
+          canSkipPopstateHistoryWrite(
+            toState,
+            browserWithState(() => garbage),
+            areStatesEqual,
+          ),
+        ).toBe(false);
+      },
+    );
+  });
+
+  describe("restored entry identical to resolved — skips", () => {
+    test.prop([arbFullState], { numRuns: NUM_RUNS.standard })(
+      "an identical {name,params,path} live entry allows the skip",
+      (toState: State) => {
+        expect(
+          canSkipPopstateHistoryWrite(
+            toState,
+            browserWithState(() => triplet(toState)),
+            areStatesEqual,
+          ),
+        ).toBe(true);
+      },
+    );
+  });
+
+  describe("path differs — never skips (normalization / redirect)", () => {
+    test.prop([arbFullState], { numRuns: NUM_RUNS.standard })(
+      "a live entry with the same name/params but a different path keeps the write",
+      (toState: State) => {
+        const live = { ...triplet(toState), path: `${toState.path}/extra` };
+
+        expect(
+          canSkipPopstateHistoryWrite(
+            toState,
+            browserWithState(() => live),
+            areStatesEqual,
+          ),
+        ).toBe(false);
+      },
+    );
+  });
+
+  describe("params differ, same path — never skips (defaultParams / drift)", () => {
+    test.prop([arbFullState], { numRuns: NUM_RUNS.standard })(
+      "a live entry with an extra param but identical path keeps the write",
+      (toState: State) => {
+        const live = {
+          ...triplet(toState),
+          params: { ...toState.params, __drift: "z" },
+        };
+
+        expect(
+          canSkipPopstateHistoryWrite(
+            toState,
+            browserWithState(() => live),
+            areStatesEqual,
+          ),
+        ).toBe(false);
+      },
+    );
+  });
+
+  describe("SAFETY — a skip implies the write would be a value-level no-op", () => {
+    // Correlate `live` with `toState` so the skip branch is actually reached:
+    // sometimes an exact clone (→ skip), sometimes a mutation or garbage (→ keep).
+    const arbCase = arbFullState.chain((toState) =>
+      fc.tuple(
+        fc.constant(toState),
+        fc.oneof(
+          fc.constant(triplet(toState)),
+          fc.constant({ ...triplet(toState), path: `${toState.path}/x` }),
+          fc.constant({
+            ...triplet(toState),
+            params: { ...toState.params, __x: "1" },
+          }),
+          fc.constant(null),
+          fc.record({ garbage: fc.boolean() }),
+        ),
+      ),
+    );
+
+    test.prop([arbCase], { numRuns: NUM_RUNS.thorough })(
+      "skip === true ⟹ live path equals resolved path and areStatesEqual holds; result is always boolean",
+      ([toState, live]: [State, unknown]) => {
+        const skip = canSkipPopstateHistoryWrite(
+          toState,
+          browserWithState(() => live),
+          areStatesEqual,
+        );
+
+        expect(typeof skip).toBe("boolean");
+
+        if (skip) {
+          const committed = live as State;
+
+          expect(committed.path).toBe(toState.path);
+          expect(areStatesEqual(toState, committed, false)).toBe(true);
+        }
+      },
+    );
+  });
+});

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -300,7 +300,11 @@ router.navigate(name, params, opts)
         ├── shouldReplaceHistory(navOptions, toState, fromState)
         │     (from browser-env: replace ?? !fromState || reload && path match)
         │
-        ├── url = router.buildUrl(toState.name, toState.params)
+        ├── skip? popstate + shouldReplace + canSkipPopstateHistoryWrite
+        │     (browser already restored the identical entry — #1353)
+        │     └── yes → no write (avoids a redundant Blink history event)
+        │
+        ├── url = router.buildUrl(toState.name, toState.params)   [only when writing]
         │         └── pre-computed urlPrefix + router.buildPath()
         │
         └── updateBrowserState(toState, url, shouldReplace, browser)

--- a/packages/hash-plugin/CLAUDE.md
+++ b/packages/hash-plugin/CLAUDE.md
@@ -99,6 +99,9 @@ See [IMPLEMENTATION_NOTES.md](../../IMPLEMENTATION_NOTES.md) section "URL Fragme
 ### State Validation
 External code can corrupt `history.state`. Plugin validates structure via `isStateStrict` (from browser-env) and ignores invalid states gracefully.
 
+### Popstate history-write skip (#1353)
+On back/forward the browser has **already** restored the target entry's `{name, params, path}` and URL before firing `popstate`, so `onTransitionSuccess`'s `replaceState` re-writes identical values — a value-level no-op that still fires a **second** `updateForSameDocumentNavigation` Blink event per nav. The write is skipped when `canSkipPopstateHistoryWrite` (browser-env) proves it a no-op: `source === "popstate"` (via the `source` NavigationOptions augmentation), `replace` is true, and the resolved target deep-equals the live `history.state` (`Browser.getState` reader + same `path` + `router.areStatesEqual`). Every **load-bearing** write is kept — redirect/normalization (path or params differ), corrupted/missing `history.state` (fails `isStateStrict`), or a custom `Browser` without `getState`. `url` is only built when the write actually happens. Same guard as browser-plugin — the logic lives in shared `browser-env`.
+
 ### SSR Safety
 ```typescript
 // createSafeBrowser() from browser-env detects environment:

--- a/packages/hash-plugin/src/index.ts
+++ b/packages/hash-plugin/src/index.ts
@@ -33,6 +33,13 @@ declare module "@real-router/types" {
     hash?: string;
     /** @internal — not used by hash-plugin. */
     hashChange?: boolean;
+    /**
+     * @internal — transition origin tag. Set to `"popstate"` by the popstate
+     * handler so `onTransitionSuccess` can gate the back/forward history-write
+     * skip (#1353). Identical optional shape to browser-plugin's augmentation,
+     * so the two merge cleanly when both are imported for typing.
+     */
+    source?: string;
   }
 }
 

--- a/packages/hash-plugin/src/plugin.ts
+++ b/packages/hash-plugin/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+  canSkipPopstateHistoryWrite,
   createPopstateHandler,
   createHashSyncLifecycle,
   createStartInterceptor,
@@ -6,7 +7,7 @@ import {
   shouldReplaceHistory,
   updateBrowserState,
 } from "./browser-env";
-import { LOGGER_CONTEXT } from "./constants";
+import { LOGGER_CONTEXT, source as POPSTATE_SOURCE } from "./constants";
 import { hashUrlToPath } from "./hash-utils";
 
 import type { Browser, SharedFactoryState } from "./browser-env";
@@ -136,9 +137,28 @@ export class HashPlugin {
           fromState,
         );
 
-        const url = this.#router.buildUrl(toState.name, toState.params);
+        const isPopstate = navOptions.source === POPSTATE_SOURCE;
 
-        updateBrowserState(toState, url, replaceHistory, this.#browser);
+        // On back/forward the browser has already restored the target entry's
+        // {name,params,path} + URL, so hash-plugin's replaceState re-writes the
+        // same values — a value-level no-op that still fires a second
+        // updateForSameDocumentNavigation Blink event. Skip it when provably a
+        // no-op; every load-bearing case (redirect, normalization, corrupted
+        // history.state) keeps the write. (#1353)
+        const skipHistoryWrite =
+          isPopstate &&
+          replaceHistory &&
+          canSkipPopstateHistoryWrite(
+            toState,
+            this.#browser,
+            this.#router.areStatesEqual,
+          );
+
+        if (!skipHistoryWrite) {
+          const url = this.#router.buildUrl(toState.name, toState.params);
+
+          updateBrowserState(toState, url, replaceHistory, this.#browser);
+        }
       },
     };
   }

--- a/packages/hash-plugin/tests/functional/popstate.test.ts
+++ b/packages/hash-plugin/tests/functional/popstate.test.ts
@@ -623,4 +623,54 @@ describe("Hash Plugin — Popstate & Error Recovery", async () => {
       addEventSpy.mockRestore();
     });
   });
+
+  describe("Popstate history-write skip (#1353)", () => {
+    beforeEach(async () => {
+      router.usePlugin(hashPluginFactory({}, mockedBrowser));
+      await router.start();
+    });
+
+    it("does NOT re-replaceState when the restored entry already equals the resolved target", async () => {
+      await router.navigate("users.view", { id: "1" });
+
+      // Browser restores the users.list entry on back: sets history.state +
+      // hash location, THEN fires popstate.
+      const restored = { name: "users.list", params: {}, path: "/users/list" };
+
+      globalThis.history.replaceState(restored, "", "/#/users/list");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: restored }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("users.list");
+      // The browser already restored the identical {name,params,path} + URL, so
+      // the plugin's replaceState is a value-level no-op firing a redundant
+      // updateForSameDocumentNavigation Blink event (#1353). Skip it.
+      expect(replaceSpy).not.toHaveBeenCalled();
+    });
+
+    it("KEEPS replaceState when history.state is corrupted (invalid shape)", async () => {
+      await router.navigate("users.view", { id: "1" });
+
+      // Browser restores a /home entry whose recorded state is garbage but
+      // whose hash URL still resolves.
+      globalThis.history.replaceState({ garbage: true }, "", "/#/home");
+
+      const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+      globalThis.dispatchEvent(
+        new PopStateEvent("popstate", { state: { garbage: true } }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(router.getState()?.name).toBe("home");
+      // Live history.state fails isState → guard cannot prove a no-op → the
+      // write restores the canonical shape.
+      expect(replaceSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/shared/browser-env/history-api.ts
+++ b/shared/browser-env/history-api.ts
@@ -29,3 +29,6 @@ export const addHashChangeListener: HistoryBrowser["addHashChangeListener"] = (
 };
 
 export const getHash = (): string => globalThis.location.hash;
+
+export const getState: NonNullable<HistoryBrowser["getState"]> = () =>
+  globalThis.history.state;

--- a/shared/browser-env/index.ts
+++ b/shared/browser-env/index.ts
@@ -21,6 +21,7 @@ export {
   getRouteFromEvent,
   updateBrowserState,
   createUpdateBrowserState,
+  canSkipPopstateHistoryWrite,
 } from "./popstate-utils.js";
 
 export {

--- a/shared/browser-env/popstate-utils.ts
+++ b/shared/browser-env/popstate-utils.ts
@@ -115,3 +115,48 @@ export function createUpdateBrowserState(): (
     }
   };
 }
+
+/**
+ * True when a popstate-success `replaceState` would be a value-level no-op and
+ * can be skipped to avoid a redundant `updateForSameDocumentNavigation` Blink
+ * event on back/forward (#1353).
+ *
+ * On a back/forward to an entry the plugin itself recorded, the browser has
+ * ALREADY restored the identical `{name, params, path}` into `history.state`
+ * and the matching URL before firing popstate — re-writing them costs a full
+ * Blink history event for zero value change.
+ *
+ * Returns `false` (→ keep the write) for every divergence that makes the write
+ * load-bearing, so the correctness cases stay covered:
+ *   - redirect            → resolved name/params differ from the restored entry
+ *   - path normalization  → resolved path differs (e.g. trailing slash)
+ *   - corrupted / missing `history.state` → fails `isState`
+ *   - custom `Browser` without a state reader → `getState` absent (opt-in)
+ *
+ * URL equality is not re-checked: the resolved path is compared directly, and
+ * the popstate fragment is sampled FROM the live location, so the committed URL
+ * already matches by construction. The deferred-popstate replay (#757) is
+ * unaffected too — it reads the event's own snapshotted state/location, never
+ * the live entry this write would commit.
+ */
+export function canSkipPopstateHistoryWrite(
+  toState: State,
+  browser: Browser,
+  areStatesEqual: (
+    state1: State,
+    state2: State,
+    ignoreQueryParams: boolean,
+  ) => boolean,
+): boolean {
+  if (!browser.getState) {
+    return false;
+  }
+
+  const live = browser.getState();
+
+  return (
+    isState(live) &&
+    live.path === toState.path &&
+    areStatesEqual(toState, live as unknown as State, false)
+  );
+}

--- a/shared/browser-env/safe-browser.ts
+++ b/shared/browser-env/safe-browser.ts
@@ -5,6 +5,7 @@ import {
   addPopstateListener,
   addHashChangeListener,
   getHash,
+  getState,
 } from "./history-api.js";
 import {
   createWarnOnce,
@@ -25,6 +26,7 @@ export function createSafeBrowser(
       addHashChangeListener,
       getLocation,
       getHash,
+      getState,
     };
   }
 

--- a/shared/browser-env/types.ts
+++ b/shared/browser-env/types.ts
@@ -14,6 +14,18 @@ export interface HistoryBrowser {
    */
   addHashChangeListener: (fn: (evt: HashChangeEvent) => void) => () => void;
   getHash: () => string;
+  /**
+   * Reads the current `history.state`. Used on popstate success to detect when
+   * the browser has already restored the exact `{name, params, path}` the
+   * transition resolved to — in which case the plugin's own `replaceState` is a
+   * value-level no-op and can be skipped, avoiding a redundant
+   * `updateForSameDocumentNavigation` Blink event on back/forward (#1353).
+   *
+   * Optional so a custom `Browser` predating this method still type-checks; when
+   * absent the plugin keeps the unconditional write (no skip, legacy behavior).
+   * The default browser (`createSafeBrowser`) always provides it.
+   */
+  getState?: () => unknown;
 }
 
 export interface Browser extends HistoryBrowser {


### PR DESCRIPTION
## Summary

- On browser **back/forward**, `browser-plugin` and `hash-plugin` no longer fire a redundant second same-document navigation. Previously every popstate success re-wrote the history entry with `replaceState`, emitting **2** `updateForSameDocumentNavigation` Blink events per nav where lean native routers emit **1**.
- The write is skipped **only when provably a no-op** — the browser has already restored the identical `{name, params, path}` and URL — so router state, the visible URL, and all subscriber notifications are unchanged.
- Every load-bearing write is preserved: redirect / path normalization, corrupted or missing `history.state`, and custom `Browser` implementations without a state reader.

### #1353 — popstate-success always replaceStates (2× same-document nav on back/forward)

- **Root cause:** on back/forward the browser restores `history.state` + URL *before* firing `popstate`, but `onTransitionSuccess` unconditionally called `updateBrowserState(..., replace=true)` (popstate navigates with `replace: true` → `shouldReplaceHistory` → `true`), re-writing byte-identical values — a value-level no-op that still costs a full Blink history event.
- **Fix:** a shared guard `canSkipPopstateHistoryWrite` (`shared/browser-env/popstate-utils.ts`) skips the write when `source === "popstate"`, `replace` is true, and the resolved target deep-equals the live `history.state` (`path` equality + `router.areStatesEqual` comparing all params). Because `browser-env` is shared, one guard fixes both URL plugins.
- **Scope decisions vs the issue's proposal:** the extra URL-equality check is unnecessary (the popstate fragment is sampled *from* `location`, so the URL matches by construction), and the "no deferred popstate pending" precondition (#757) was dropped — the deferred replay reads the event's own snapshot, not the live entry this write commits, so a skip cannot affect it (verified by a rapid double-back test). The four correctness cases collapse to a single state-equality check.
- `navigation-plugin` was checked and is **not** affected — it already avoids the extra event on `traverse` via `updateCurrentEntry`.

### Maintainability

- New optional `Browser.getState` reader (reads `history.state`); absent → the write is preserved, so this is **non-breaking** for custom browsers and the SSR fallback.
- `hash-plugin` `NavigationOptions` gains the `source` field (parity with `browser-plugin`) to gate the skip.
- Docs synced: both plugins' `CLAUDE.md` (new gotcha) + `ARCHITECTURE.md`, and the wiki (`browser-plugin.md` corrected the stale "No `getState()` method" note).

## Test plan

- [x] `browser-plugin/tests/functional/popstate.test.ts` — skip on happy-path (fails before / passes after); keeps write on stale-path, corrupted state, defaultParams drift, and no-`getState` browsers; forward `pushState` unaffected; deferred replay after a skipped write (#757)
- [x] `hash-plugin/tests/functional/popstate.test.ts` — skip on happy-path; keeps write on corrupted state
- [x] `browser-plugin/tests/property/browser-env/canSkipPopstateHistoryWrite.properties.ts` — safety invariant **skip ⟹ (path equal ∧ areStatesEqual)**; mutation-validated (forcing always-skip fails 5/6)
- [x] 100% coverage maintained (browser-plugin, hash-plugin)
- [x] Per-package validation green: unit + property + type-check + lint (browser-plugin, hash-plugin, navigation-plugin regression); pre-commit full-graph passed (117 tasks). Full `pnpm build` runs in CI

Closes #1353
