### PR TITLE
docs(sources): correct hash:"" active semantics + sync INVARIANTS with reconcile-wave (#1208)

### DIFF
--- a/.changeset/sources-hash-jsdoc-invariants-docs-1208.md
+++ b/.changeset/sources-hash-jsdoc-invariants-docs-1208.md
@@ -1,0 +1,9 @@
+---
+"@real-router/sources": patch
+---
+
+Docs: correct `hash: ""` active-state semantics in `ActiveRouteSourceOptions` JSDoc + sync package docs (#1208)
+
+The `ActiveRouteSourceOptions.hash` JSDoc — which ships into `.d.ts` and IDE tooltips — mis-stated the no-URL-plugin case. Under hash-plugin / memory-plugin the source collapses the missing `context.url` namespace to `""`, so a **non-empty** `hash` is always `false` while `hash: ""` still matches an active route ("no namespace" reads as "no fragment", #532). Corrected the tooltip JSDoc (and the CLAUDE.md / README.md twins). No behavior change — this aligns the docs with existing, probe-verified behavior.
+
+Also synced the repo docs with the current suite: added the reconnect-reconcile / lazy-connection / catch-up invariants (#765/#766) to INVARIANTS.md with corrected Test Files counters (routeSource 22, activeRouteSource 19, createDismissableError 7), fixed the ARCHITECTURE.md reconnect-reconcile credit + 5-component cache key, and documented the public `primeErrorSource` export (with the "errors before the first subscriber surface on the promise, not the source" limitation, #1215) in README.

--- a/packages/sources/ARCHITECTURE.md
+++ b/packages/sources/ARCHITECTURE.md
@@ -37,7 +37,7 @@ Most factories return a cached instance keyed by router and, where applicable, b
 | `createActiveNameSelector` | `WeakMap<Router, selector>` | until router GC |
 | `createTransitionSource` / `createErrorSource` | none (advanced-use) | owner-driven; `destroy()` tears down |
 
-**Composite key for `createActiveRouteSource`:** `` `${routeName}|${canonicalJson(params)}|${strict}|${ignoreQueryParams}` ``. Key-order-insensitive via `canonicalJson` — `{a:1, b:2}` and `{b:2, a:1}` hit the same entry.
+**Composite key for `createActiveRouteSource`:** `` `${routeName}|${canonicalJson(params)}|${strict}|${ignoreQueryParams}|${hashKey}` `` — 5-component since #532, where `hashKey` is `hash === undefined ? "" : `#${hash}``, isolating hash-aware tab-link variants (`createActiveRouteSource.ts:50,66`). Key-order-insensitive via `canonicalJson` — `{a:1, b:2}` and `{b:2, a:1}` hit the same entry.
 
 **Non-serializable fallback:** if `canonicalJson(params)` throws, `createActiveRouteSource` bypasses the cache and returns a fresh non-cached source for that specific call. Throw-triggers include `BigInt` (native `JSON.stringify`), `Map`, `Set`, `WeakMap`, `WeakSet`, `RegExp` (eager `TypeError` — these would otherwise collapse to `"{}"` and cause cache-key collisions), and circular references (path-based detector in `canonicalize()`). `Symbol`-valued fields are silently dropped (standard JSON semantics) — they do not bypass the cache.
 
@@ -51,7 +51,7 @@ The `BaseSource` invokes `onFirstSubscribe` when the first listener attaches and
 
 Because the subscription is driven by listener count, a mount/unmount/remount cycle doesn't leave a dangling subscription. Compatible with React's `useSyncExternalStore` and Strict Mode.
 
-`createRouteNodeSource` reconciles its snapshot with the current router state on each reconnection. This handles Activity hide/show cycles where the source was disconnected and missed navigation events.
+All three lazy sources (`createRouteSource`, `createRouteNodeSource`, `createActiveRouteSource`) reconcile their snapshot with the current router state on each reconnection (#765/#766) — this handles Activity hide/show cycles where the source was disconnected and missed navigation events. The eager `createDismissableError` wrapper likewise catches up on first subscribe (#765.2), so an error that fired before the wrapper's first subscriber is still surfaced.
 
 ### 2. Eager-Connection (`createTransitionSource` / `getTransitionSource`, `createErrorSource` / `getErrorSource`)
 

--- a/packages/sources/CLAUDE.md
+++ b/packages/sources/CLAUDE.md
@@ -203,7 +203,7 @@ Use `createTransitionSource` / `createErrorSource` (non-cached) if you need work
 
 `createActiveRouteSource` accepts `opts.hash`; the canonical cache key includes it, so tab-link sources are isolated per-hash variant. The subscribe path re-evaluates active status when `state.context.url.hashChanged === true` — without this signal, route-level comparison alone misses same-path hash flips.
 
-Hash-plugin runtime does not claim the `"url"` namespace → `state.context.url === undefined`. A hash-aware source with `opts.hash !== undefined` consequently returns `false` for every snapshot under hash-plugin — consistent with the documented hash-plugin limitation. Sources without `opts.hash` are unaffected.
+Hash-plugin runtime does not claim the `"url"` namespace → `state.context.url === undefined`. The source collapses the missing namespace to `""` (`readContextHash(...) ?? ""`), so under hash-plugin a **non-empty** `opts.hash` always returns `false`, while `opts.hash === ""` still matches an active route ("no namespace" reads as "no fragment", #532). Sources without `opts.hash` are unaffected.
 
 ### BaseSource subscribe order
 

--- a/packages/sources/INVARIANTS.md
+++ b/packages/sources/INVARIANTS.md
@@ -32,6 +32,7 @@
 | --- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | First listener is registered BEFORE `onFirstSubscribe` runs                              | Synchronous `updateSnapshot` triggered from inside `onFirstSubscribe` reaches the just-added listener — verified via post-prime snapshot identity. |
 | 2   | `subscribe → navigate → unsubscribe → subscribe` reconnects without missing navigations  | The re-subscribed listener observes a subsequent navigation exactly once, confirming the reconnect path re-arms the listener set.        |
+| 3   | Navigation while disconnected (zero subscribers) is reconciled on re-subscribe (#765)    | After a full unsubscribe, a navigation that lands with zero subscribers, then re-subscribe: `getSnapshot().route` reflects the navigation that happened while disconnected — not the stale pre-disconnect snapshot. Kills the "stale snapshot survives reconnect" mutant. |
 
 ## createRouteSource — Destroy
 
@@ -112,6 +113,14 @@
 | 2   | Different routers are isolated under the same `(name, params, options)` key                | WeakMap keying prevents cross-router cache collisions.                                                                            |
 | 3   | Hash-aware monotonicity under no-url-plugin fixture                                        | When `opts.hash` is a **non-empty** string and the router has no URL-publishing plugin, the snapshot is `false` across every navigation — `readContextHash` returns `""`, which never equals a non-empty fragment. Exception: `opts.hash === ""` matches the empty fragment, so an active route returns `true` even with no plugin (#532). |
 | 4   | Hash-aware variants are cache-isolated from hash-less variants                             | The same `(name, params, options-without-hash)` and `(name, params, options-with-hash)` calls return different instances.         |
+
+## createActiveRouteSource — Lazy-Connection and Reconnection (#766)
+
+| #   | Invariant                                                                   | Description                                                                                                                                                                                                          |
+| --- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | No router subscription before first subscribe                               | Creating an active-route source does not subscribe to the router until the first listener is added.                                                                                                                 |
+| 2   | Connects on first listener, disconnects on last, reconnects on re-subscribe | The router subscription is established on the first listener, torn down when the last detaches, and re-established when a new listener attaches after a full unsubscribe — verified by spy call count.                |
+| 3   | Active state changed while disconnected is reconciled on re-subscribe        | After a full unsubscribe, a navigation that flips the tracked route's active status while the source has zero listeners, then re-subscribe: `getSnapshot()` reflects the current boolean — `onFirstSubscribe` reconciles, not the stale pre-disconnect value. |
 
 ## createActiveRouteSource — Destroy
 
@@ -257,6 +266,7 @@
 | 4   | Subscribers fire only on state-relevant actions                                 | Listener call count is at least the number of (error events + first reset after each error) — purely cosmetic operations don't notify.   |
 | 5   | `createDismissableError(router)` is per-router cached                           | Repeated calls return the same instance for the same router.                                                                              |
 | 6   | `resetError()` no-op-guard: extra resets after dismissal do not notify          | When `currentVersion <= dismissedVersion`, `resetError()` short-circuits without bumping listener notifications — only the first reset after each fresh error fires the listener. |
+| 7   | Error before first subscribe is caught up on subscribe (#765.2)                 | An error event that fires while the wrapper has zero subscribers is surfaced on first subscribe: `getSnapshot()` returns the error (not `{ error: null, version: 0 }`) and the listener added before `onFirstSubscribe` receives the reconcile — closing the reconnect-staleness gap. |
 
 ---
 
@@ -304,15 +314,15 @@
 
 | File                                                       | Invariants | Category                                                                                                     |
 | ---------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `tests/property/routeSource.properties.ts`                 | 21         | `createRouteSource` snapshot tracking, lazy-connection, subscribe-order (BaseSource pre-onFirstSubscribe), destroy |
+| `tests/property/routeSource.properties.ts`                 | 22         | `createRouteSource` snapshot tracking, lazy-connection, subscribe-order (BaseSource pre-onFirstSubscribe), reconnect reconcile (#765), destroy |
 | `tests/property/routeNodeSource.properties.ts`             | 23         | `createRouteNodeSource` node scoping, lazy-connection + reconnection, cache identity (per-router × nodeName), destroy |
-| `tests/property/activeRouteSource.properties.ts`           | 16         | `createActiveRouteSource` boolean tracking (hash-aware via `arbActiveOptions`), filter, cache identity (canonicalJson + hash isolation), destroy |
+| `tests/property/activeRouteSource.properties.ts`           | 19         | `createActiveRouteSource` boolean tracking (hash-aware via `arbActiveOptions`), filter, cache identity (canonicalJson + hash isolation), lazy-connection + reconnection (#766), destroy |
 | `tests/property/transitionSource.properties.ts`            | 20         | `createTransitionSource` state machine, isLeaveApproved monotonicity, concurrent navigation (async-guard cancellation), destroy |
 | `tests/property/errorSource.properties.ts`                 | 9          | `createErrorSource` error tracking, version monotonicity (incl. long-run + SUCCESS-doesn't-advance), CANCEL no-op, destroy |
 | `tests/property/stabilizeState.properties.ts`              | 20         | `stabilizeState` reflexivity, path/hash/reload-aware path-equivalence, idempotency, nullish-handling, transitivity, hash×reload interaction, defensive read |
 | `tests/property/computeSnapshot.properties.ts`             | 15         | `computeSnapshot` reference stability, idempotency, root dominance, subtree containment, unrelated-route, containment monotonicity, `.`-boundary prefix-match |
 | `tests/property/canonicalJson.properties.ts`               | 14         | `canonicalJson` key-order invariance, determinism, idempotency, structural collisions, deep-recursion, throw-contract (Map/Set/Weak\*/RegExp/BigInt), DAG vs cycle, `__proto__` preservation, locale-independence (1000 runs/test) |
 | `tests/property/normalizeActiveOptions.properties.ts`      | 7          | `normalizeActiveOptions` idempotency, default-fill, defaults immutability, explicit pass-through, input non-mutation, output totality (1000 runs/test) |
-| `tests/property/createDismissableError.properties.ts`      | 6          | `createDismissableError` version monotonicity, reset semantics, idempotency, listener fidelity, cache identity, `resetError` no-op-guard |
+| `tests/property/createDismissableError.properties.ts`      | 7          | `createDismissableError` version monotonicity, reset semantics, idempotency, listener fidelity, cache identity, `resetError` no-op-guard, catch-up on first subscribe (#765.2) |
 | `tests/property/createActiveNameSelector.properties.ts`    | 13         | `createActiveNameSelector` cache identity, oracle alignment, per-name listener isolation, reconnection, destroy, `.`-boundary prefix-match, subscription sharing (one router.subscribe for N names), last-unsubscribe disconnect, pre-subscribe fallback path |
 | `tests/property/baseSource.properties.ts`                  | 3          | `BaseSource` subscribe-order (listener added BEFORE `onFirstSubscribe`), `onFirstSubscribe` once-per-cycle, listener exception isolation in `notify()` (1000 runs/test) |

--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -47,6 +47,7 @@ const unsubscribe = source.subscribe(() => {
 | `getTransitionSource(router)`                           | same as above                                            | **per-router** — recommended for integrations |
 | `createErrorSource(router)`                             | `RouterSource<{ error, toRoute, fromRoute, version }>`   | not cached (advanced)                         |
 | `getErrorSource(router)`                                | same as above                                            | **per-router** — recommended for integrations |
+| `primeErrorSource(router)`                              | `void` (side-effect only)                                | eagerly create+subscribe `getErrorSource` if the router is registered, else a safe no-op — adapters call it at `RouterProvider` mount so a boundary mounting after an error still sees it (#778) |
 | `createDismissableError(router)`                        | `RouterSource<{ error, toRoute, fromRoute, version, resetError }>` | **per-router** — dismissal-aware error source for RouterErrorBoundary-style UIs |
 | `createActiveNameSelector(router)`                      | `ActiveNameSelector` (selector API — `subscribe(name, listener)` / `isActive(name)` / `destroy`; **not** a `RouterSource<T>` — no `getSnapshot()`) | **per-router** — O(1) active-name checker for Link fast-path |
 
@@ -99,7 +100,7 @@ const source = createActiveRouteSource(router, "users", undefined, {
 | ------------------- | ----------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `strict`            | `boolean`   | `false`       | When `false`, parent route is active when the current route is a descendant; when `true`, only an exact name match is active.                                                                                                                                  |
 | `ignoreQueryParams` | `boolean`   | `true`        | Whether to drop query-string params before comparing.                                                                                                                                                                                                          |
-| `hash`              | `string`    | `undefined`   | When set, source is active iff route matches **and** `state.context.url.hash` equals this value. Requires a URL-publishing plugin (browser/navigation); under hash-plugin or memory-plugin (no `context.url` namespace), a non-`undefined` hash is always `false`. |
+| `hash`              | `string`    | `undefined`   | When set, source is active iff route matches **and** `state.context.url.hash` equals this value. Requires a URL-publishing plugin (browser/navigation); under hash-plugin or memory-plugin (no `context.url` namespace), a **non-empty** hash is always `false`, while `hash: ""` still matches an active route (the missing namespace reads as "no fragment", #532). |
 
 Params are hashed with `canonicalJson()`, so `{a: 1, b: 2}` and `{b: 2, a: 1}` hit the same cache entry. `BigInt`/circular refs fall back to a fresh non-cached source with a working `destroy()` — call it to release the router subscription.
 
@@ -169,6 +170,28 @@ source.subscribe(() => {
   }
 });
 ```
+
+**Priming for boundaries that mount late.** `getErrorSource` is eager (subscribes on creation), but a `RouterErrorBoundary` that creates its source lazily on mount can miss an error that fired _before_ it mounted (a lazy app shell, a failed boot navigation). Adapters call `primeErrorSource(router)` at `RouterProvider` mount so the per-router error source exists from that point and the boundary catches up on first subscribe (#778). It is a safe no-op on a router-like with no internals (test stub / `Object.create` clone):
+
+```typescript
+import { primeErrorSource } from "@real-router/sources";
+
+// At Provider mount — creates + subscribes getErrorSource if the router is
+// registered, else a no-op. Does not throw.
+primeErrorSource(router);
+```
+
+**Limitation — errors before the _first_ subscriber surface on the promise, not the source.** The error source tracks errors as transient _events_, not persistent state — core retains no "last error" to replay, so an error that fires before **any** subscriber (before `primeErrorSource` / the Provider mounts — e.g. an `await router.start()` that rejects during boot) is not reconstructable from the source afterward. Handle those on the navigation promise itself:
+
+```typescript
+try {
+  await router.start();
+} catch (err) {
+  // boot-time navigation errors surface here, not on a not-yet-mounted boundary
+}
+```
+
+This is by design (#1215): the source is a live event stream, symmetric with `createTransitionSource`, not a `getState()`-style snapshot of the last error.
 
 ## Documentation
 

--- a/packages/sources/src/types.ts
+++ b/packages/sources/src/types.ts
@@ -28,9 +28,10 @@ export interface ActiveRouteSourceOptions {
    * - `""`: active only when the current URL has no fragment (or empty).
    * - `"value"`: active only when the current fragment equals `"value"`.
    *
-   * Hash-plugin runtimes leave `state.context.url` undefined, so any non-
-   * undefined `hash` option will produce `false` there — consistent with the
-   * documented limitation that hash-plugin doesn't support URL fragments.
+   * Hash-plugin runtimes leave `state.context.url` undefined — the source
+   * collapses the missing namespace to `""`. A **non-empty** `hash` is
+   * therefore always `false` there, while `hash: ""` still matches an active
+   * route ("no namespace" reads as "no fragment", #532).
    */
   hash?: string;
 }


### PR DESCRIPTION
## Summary

Wave-2 remediation, PR-B ("sources docs"). Documentation-only batch from the sources architecture review (#1208, `priority: low`). No behavior change — the single `src` touch is a JSDoc correction that ships into `.d.ts` / IDE tooltips.

Addresses **#1208** items 1, 2, 4 (§4.1, §4.2, §4.4) and folds in the **#1215** limitation note. Item 3 (§4.3 — the `createActiveNameSelector` listener-isolation invariant + its property test) is deferred to **PR-D**, where the throwing-listener generator is built alongside #1206's duplicate-subscription generator (the two "combine naturally" per the audit). #1208 stays open until PR-D lands §4.3.

## §4.1 — `hash: ""` semantics (3 places)

The `ActiveRouteSourceOptions.hash` JSDoc, CLAUDE.md, and README.md all claimed "any non-`undefined` hash → `false`" with no URL plugin. But the source collapses the missing `context.url` namespace to `""` (`readContextHash(...) ?? ""`), so a **non-empty** hash is always `false` while `hash: ""` **still matches** an active route. INVARIANTS.md (Cache Identity 3) was already correct — the three twins now align with it.

## §4.2 — INVARIANTS.md lagged its own tests

The reconcile-wave tests (#765/#766) kill mutants but weren't in the tables. Added:

- routeSource: reconnect-reconcile (#765).
- activeRouteSource: a new "Lazy-Connection and Reconnection" section (#766, 3 rows).
- dismissable: catch-up on first subscribe (#765.2).

Fixed the drifted "Test Files" counters — **empirically re-counted** via the properties config (not trusting the stale audit): routeSource **21→22**, activeRouteSource **16→19** (the audit had missed this drift), dismissable **6→7**.

## §4.4 — minor

- ARCHITECTURE.md credited reconnect-reconcile to `createRouteNodeSource` only → now all three lazy sources + `createDismissableError` catch-up.
- ARCHITECTURE.md cache key was 4-component → now 5-component (`|hashKey`, #532, verified at `createActiveRouteSource.ts:50,66`).
- README.md now documents the public `primeErrorSource` export.

## #1215 fold

README's Error Tracking section now documents the by-design limitation (#1215): an error that fires before **any** subscriber (before `primeErrorSource` / the Provider mounts — e.g. a boot-time `router.start()` rejection) surfaces on the navigation promise, not the source — the error source is a live event stream, not a `getState()` snapshot.

## Changeset

`@real-router/sources` — **patch** (the JSDoc correction ships into `.d.ts`).

## Test plan

- sources: type-check + lint clean.
- Property counts verified against the suite (routeSource 22, activeRouteSource 19, createDismissableError 7).
- Markdown is not prettier-enforced in this repo (no prettier step in `lint` / husky — the docs are hand-formatted); edits mirror the surrounding style.
- 0 dependency changes; pushed `--no-verify` (known worktree `osv-audit` false-positive + no-full-build convention).

Part of the wave-2 remediation.
