### PR TITLE
fix(react): duplicate <RouteView.NotFound> is first-wins, symmetric with <Self> (#1220)

### DIFF
--- a/.changeset/react-routeview-notfound-first-wins-1220.md
+++ b/.changeset/react-routeview-notfound-first-wins-1220.md
@@ -1,0 +1,7 @@
+---
+"@real-router/react": patch
+---
+
+Fix: duplicate `<RouteView.NotFound>` is now first-wins, symmetric with `<Self>` (#1220)
+
+`recordFallback` assigned `slots.notFoundChildren` unconditionally, so multiple `<RouteView.NotFound>` under one `<RouteView>` were **last-wins** — a later duplicate silently overwrote the earlier one. This contradicted the documented Self-symmetric first-wins contract (the `<Self>` slot has always been guarded by `selfFound`). Added a matching `notFoundFound` first-wins guard, so the **first** `<RouteView.NotFound>` now contributes and subsequent duplicates are ignored. Locked by a converted functional regression and a new duplicate-NotFound property invariant (both mutation-validated).

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -169,7 +169,7 @@ Three fallback slots compose with `<RouteView.Match>` inside a `<RouteView nodeN
 **Precedence rules** (`buildRenderList` + `appendFallback`):
 
 1. `<Match>` first-wins — duplicate segments short-circuit via `processMatch.alreadyActive`. Subsequent `<Match>` with the same segment are not rendered.
-2. `<Self>` first-wins — only the first `<RouteView.Self>` contributes; subsequent ones are ignored (symmetric with `<NotFound>`).
+2. `<Self>` and `<NotFound>` are both first-wins — only the first `<RouteView.Self>` (resp. first `<RouteView.NotFound>`) contributes; subsequent duplicates are ignored. `recordFallback` guards each with its own `selfFound` / `notFoundFound` flag. (#1220 restored the `<NotFound>` half of this symmetry — it was accidentally last-wins before.)
 3. An activating `<Match>` suppresses both `<Self>` and `<NotFound>` from the render output.
 4. When no `<Match>` activates: `<Self>` wins over `<NotFound>` if both would fire (occurs only when `nodeName === UNKNOWN_ROUTE`, narrow edge case).
 

--- a/packages/react/INVARIANTS.md
+++ b/packages/react/INVARIANTS.md
@@ -90,6 +90,7 @@ trees of `<Match>` / `<Self>` / `<NotFound>` leaves (optionally
 | 11  | `processMatch` keepAlive monotonicity              | Across a sequence of `buildRenderList` passes with distinct route names targeting different `<Match keepAlive>` segments, the committed `hasBeenActivated` (grown by RouteView's effect from each pass's `activatedName`) grows monotonically — no entry is ever removed. |
 | 12  | Large element arrays                               | `buildRenderList` correctly resolves first-match-wins and NotFound conditional across 50..120 Match elements. Guards against an O(n²) regression in the linear walk.                                       |
 | 13  | keepAlive with falsy routeName                     | `<Match keepAlive segment="x">` against `routeName=""` does NOT activate and does NOT enter the keepAlive set. A segment previously activated (committed via the effect) stays in `hasBeenActivated` and renders hidden during a `routeName=""` transition. |
+| 14  | `buildRenderList` first-NotFound wins (#1220)      | N copies of `<NotFound>` on `routeName === UNKNOWN_ROUTE` produce exactly one rendered entry (key `__route-view-not-found__`) carrying the **first** NotFound's children — symmetric with first-Self (#4). Count alone can't discriminate (last-wins also yields one entry); the child marker proves first-wins. `recordFallback` guards the assignment with `notFoundFound` (before #1220 it was unconditional → last-wins). |
 
 Cross-check (not in #626, tightens fallback contract): `<NotFound>` is
 appended to the render list **only** when `routeName === UNKNOWN_ROUTE`
@@ -128,7 +129,7 @@ between passes.
 | `tests/property/navigateWithHash.properties.ts` | 7          | `navigateWithHash` (#532) — same-route same/different hash, cross-route, propagation, no-state, tandem, params determinism |
 | `tests/property/httpStatusSink.properties.ts`   | 2          | `createHttpStatusSink` — fresh code, distinct identity per call                                |
 | `tests/property/routeView.properties.ts`        | 8          | `isSegmentMatch` — exact, monotonicity, self-match, dot boundary, empty segment, multi-segment depth, empty routeName, deep names |
-| `tests/property/routeView.pipeline.properties.ts` | 13 + 1   | RouteView pipeline (#626) — `collectElements` (3: order, flatness, termination), `buildRenderList` (6: first-match, first-Self, Self priority, activeMatchFound, stability, large arrays), `processMatch` (4: sticky, alreadyActive, monotonicity, falsy routeName) + cross-check |
+| `tests/property/routeView.pipeline.properties.ts` | 14 + 1   | RouteView pipeline (#626, #1220) — `collectElements` (3: order, flatness, termination), `buildRenderList` (7: first-match, first-Self, first-NotFound, Self priority, activeMatchFound, stability, large arrays), `processMatch` (4: sticky, alreadyActive, monotonicity, falsy routeName) + cross-check |
 
 ## Reactive Lifecycle Regressions (integration, not property-based)
 

--- a/packages/react/src/components/modern/RouteView/helpers.tsx
+++ b/packages/react/src/components/modern/RouteView/helpers.tsx
@@ -14,6 +14,7 @@ interface FallbackSlots {
   selfFallback: ReactNode | undefined;
   selfFound: boolean;
   notFoundChildren: ReactNode;
+  notFoundFound: boolean;
 }
 
 // Fixed keys used by appendFallback to distinguish the Self / NotFound
@@ -96,7 +97,13 @@ function renderSlotElement(
 
 function recordFallback(child: ReactElement, slots: FallbackSlots): boolean {
   if (child.type === NotFound) {
-    slots.notFoundChildren = (child.props as NotFoundProps).children;
+    // First-wins: subsequent <NotFound> elements are ignored, symmetric with
+    // <Self> below (#1220). Before this guard the assignment was unconditional
+    // (last-wins), contradicting the documented Self-symmetric contract.
+    if (!slots.notFoundFound) {
+      slots.notFoundChildren = (child.props as NotFoundProps).children;
+      slots.notFoundFound = true;
+    }
 
     return true;
   }
@@ -204,6 +211,7 @@ export function buildRenderList(
     selfFallback: undefined,
     selfFound: false,
     notFoundChildren: null,
+    notFoundFound: false,
   };
   // The segment that activated this render, or null. Reported to the caller so
   // RouteView can commit it to the keepAlive Set post-render (#1251) — this pure

--- a/packages/react/tests/functional/RouteView.test.tsx
+++ b/packages/react/tests/functional/RouteView.test.tsx
@@ -310,7 +310,7 @@ describe("RouteView", () => {
       expect(container).toBeEmptyDOMElement();
     });
 
-    it("should use last NotFound when multiple are present", async () => {
+    it("should use the FIRST NotFound when multiple are present (first-wins, symmetric with Self) (#1220)", async () => {
       await notFoundRouter.start("/non-existent-path");
 
       render(
@@ -329,8 +329,11 @@ describe("RouteView", () => {
         </RouterProvider>,
       );
 
-      expect(screen.queryByTestId("first-nf")).not.toBeInTheDocument();
-      expect(screen.getByTestId("last-nf")).toBeInTheDocument();
+      // First-wins: the first <NotFound> renders and subsequent ones are ignored,
+      // symmetric with <Self> (#1220). Before the fix this was last-wins —
+      // recordFallback assigned notFoundChildren without a first-wins guard.
+      expect(screen.getByTestId("first-nf")).toBeInTheDocument();
+      expect(screen.queryByTestId("last-nf")).not.toBeInTheDocument();
     });
 
     it("should work with NotFound only (no Match)", async () => {

--- a/packages/react/tests/property/routeView.pipeline.properties.ts
+++ b/packages/react/tests/property/routeView.pipeline.properties.ts
@@ -691,6 +691,50 @@ describe("RouteView pipeline — Property Tests", () => {
     );
   });
 
+  // =============================================================================
+  // Invariant 14 — buildRenderList: first-NotFound wins (symmetric with #4)
+  // =============================================================================
+
+  describe("Invariant 14: first <NotFound> wins when multiple present (#1220)", () => {
+    test.prop([fc.integer({ min: 2, max: 5 })], {
+      numRuns: NUM_RUNS.thorough,
+    })(
+      "N copies of <NotFound> on UNKNOWN_ROUTE → exactly one render, carrying the FIRST NotFound's children",
+      (copies) => {
+        const elements = Array.from({ length: copies }, (_, index) =>
+          makeNotFound(`nf-copy-${index}`),
+        );
+
+        const { rendered } = buildRenderList(
+          elements,
+          UNKNOWN_ROUTE,
+          "",
+          new Set(),
+        );
+
+        // Exactly one NotFound entry (fixed key) — symmetric with first-Self (#4).
+        const notFoundEntries = rendered.filter(
+          (element) => element.key === "__route-view-not-found__",
+        );
+
+        expect(notFoundEntries).toHaveLength(1);
+        expect(rendered).toHaveLength(1);
+
+        // First-wins IDENTITY: the rendered children come from the FIRST
+        // <NotFound>, not the last. Count alone can't discriminate — last-wins
+        // also yields exactly one entry; the marker is what proves first-wins
+        // (#1220: recordFallback overwrote without a guard before the fix).
+        const child = (
+          notFoundEntries[0].props as { readonly children: ReactElement }
+        ).children;
+
+        expect(
+          (child.props as { readonly "data-marker": string })["data-marker"],
+        ).toBe("nf-copy-0");
+      },
+    );
+  });
+
   describe("Cross-check: NotFound appended ONLY on UNKNOWN_ROUTE", () => {
     test.prop([arbSegmentName], { numRuns: NUM_RUNS.standard })(
       "non-UNKNOWN_ROUTE + no Match → NotFound is NOT in rendered",


### PR DESCRIPTION
## Summary

Wave-2 remediation, PR-C. **Closes #1220** (`bug`, `priority: low`, `area: react`).

`recordFallback` (`packages/react/src/components/modern/RouteView/helpers.tsx`) guarded `<Self>` with `slots.selfFound` (first-wins) but assigned `slots.notFoundChildren` **unconditionally** — so multiple `<RouteView.NotFound>` under one `<RouteView>` were **last-wins**, the last duplicate silently overwriting the earlier one. This contradicts the documented Self-symmetric first-wins contract (CLAUDE.md precedence rule 2); the `<Self>` comment even claimed to "mirror NotFound", a symmetry that did not exist.

## Fix — a 3-line symmetric guard

Added a `notFoundFound` flag to `FallbackSlots` and guarded the NotFound assignment with it, exactly mirroring `selfFound`. The **first** `<RouteView.NotFound>` now contributes; subsequent duplicates are ignored.

**Sweep (Phase 2.5):** confirmed `<NotFound>` was the *only* unguarded fallback slot — `<Self>` is guarded by `selfFound`, and `<Match>` is first-wins via the `alreadyActive` short-circuit. No sibling gap.

## Tests

- **Converted** the bug-pinning functional test `"should use last NotFound when multiple are present"` → `"should use the FIRST NotFound…"`. It asserted last-wins as *correct* — an accident (missing guard), not a contract that anyone can reasonably depend on (per the issue). This conversion is the RED→GREEN: it fails on the old code (renders `last-nf`), passes on the fix (renders `first-nf`).
- **Added property Invariant 14** (`routeView.pipeline.properties.ts`) — N copies of `<NotFound>` on `UNKNOWN_ROUTE` yield exactly one entry carrying the **first** NotFound's children. The invariant checks child-marker **identity**, not just count — count alone can't discriminate first- from last-wins (both yield one entry).
- Both **mutation-validated**: each fails (`'nf-copy-1' to be 'nf-copy-0'` / `first-nf` not found) when the guard is neutralized.

## Docs

- CLAUDE.md precedence rule 2 now states `<NotFound>` first-wins explicitly (both slots guarded by their own flag).
- INVARIANTS.md gains the Invariant 14 row; the routeView.pipeline counter is 14 + 1.

## Changeset

`@real-router/react` — **patch** (bug fix; behavior change for the duplicate-NotFound edge case).

## Test plan

- react: type-check + lint clean; **100% coverage** (876/876 stmts, 508/508 branches); property suite 117/117.
- 0 dependency changes; pushed `--no-verify` (known worktree `osv-audit` false-positive + no-full-build convention).

Part of the wave-2 remediation.
