### PR TITLE
perf(path-matcher): share frozen empty sentinel for trie staticChildren (~10% table-heap)

### DIFF
--- a/.changeset/path-matcher-static-children-perf.md
+++ b/.changeset/path-matcher-static-children-perf.md
@@ -1,0 +1,14 @@
+---
+"@real-router/core": patch
+---
+
+perf: share a frozen empty sentinel for trie `staticChildren` (#1379)
+
+Every trie node used to allocate its own `Object.create(null)` for
+`staticChildren`, but the leaf-majority (one node per registered route) never
+gains a static child — so each held an empty null-proto object purely to answer
+the match-path `key in node.staticChildren` read. Registration now shares one
+frozen empty sentinel across every fresh node and copies-on-write to a fresh
+mutable map on the first static child; the match path is unchanged. Cross-router
+`table-heap` (react, 10k routes, same-session CDP A/B): 8.59 → 7.71 MB (~10 %
+less retained heap).

--- a/packages/path-matcher/src/pathUtils.ts
+++ b/packages/path-matcher/src/pathUtils.ts
@@ -1,8 +1,22 @@
 import type { SegmentNode } from "./types";
 
+// Every trie node used to allocate its own `Object.create(null)` for
+// `staticChildren`. A null-proto empty object is V8 dictionary-mode from birth
+// (~192 B — own map + backing store, ~3× a plain `{}`), and the leaf-majority
+// (one node per registered route) never gains a static child, so it held that
+// empty object purely to answer the match-path `key in node.staticChildren`
+// read. Share ONE frozen empty null-proto sentinel across every fresh node;
+// `processSegment` (registration/trie.ts) copies-on-write — swaps in a fresh
+// mutable null-proto object — before the first real write. The frozen shell
+// fails loud if a write ever skips that guard. Mirrors the #1009 `EMPTY_*`
+// sentinels in `registration/context.ts`.
+export const EMPTY_STATIC_CHILDREN: Record<string, SegmentNode> = Object.freeze(
+  Object.create(null) as Record<string, SegmentNode>,
+);
+
 export function createSegmentNode(): SegmentNode {
   return {
-    staticChildren: Object.create(null) as Record<string, SegmentNode>,
+    staticChildren: EMPTY_STATIC_CHILDREN,
     // Stryker disable next-line BooleanLiteral: equivalent — for a leaf splat node the `!hasChildren` fast path and the `#traverseFrom` fallback both set `params[name] = slice` and return `sn.route`; nodes that gain children overwrite this flag during registration. Proven: forcing `true` keeps the full suite green (it only un-covers the now-unreachable fast path).
     hasChildren: false,
     paramChild: undefined,

--- a/packages/path-matcher/src/registration/trie.ts
+++ b/packages/path-matcher/src/registration/trie.ts
@@ -2,7 +2,11 @@
 // insertion, per-segment `processSegment`, and the `walkTrie` lookups. Builds the
 // segment trie from the node builders in `./trieNodes`.
 
-import { createSegmentNode, normalizeTrailingSlash } from "../pathUtils";
+import {
+  createSegmentNode,
+  EMPTY_STATIC_CHILDREN,
+  normalizeTrailingSlash,
+} from "../pathUtils";
 import {
   throwDuplicateRoutePath,
   throwNonAsciiStatic,
@@ -305,6 +309,11 @@ function processSegment(
   const key = state.options.caseSensitive ? segment : segment.toLowerCase();
 
   if (!(key in node.staticChildren)) {
+    // Copy-on-write off the shared frozen EMPTY_STATIC_CHILDREN sentinel: the
+    // first static child this node gains earns it a fresh mutable null-proto map.
+    if (node.staticChildren === EMPTY_STATIC_CHILDREN) {
+      node.staticChildren = Object.create(null) as Record<string, SegmentNode>;
+    }
     node.staticChildren[key] = createSegmentNode();
     node.hasChildren = true;
   }

--- a/packages/path-matcher/src/types.ts
+++ b/packages/path-matcher/src/types.ts
@@ -184,7 +184,13 @@ export interface ForkMeta {
 }
 
 export interface SegmentNode {
-  readonly staticChildren: Record<string, SegmentNode>;
+  /**
+   * Starts as the shared frozen `EMPTY_STATIC_CHILDREN` sentinel (pathUtils);
+   * `processSegment` copies-on-write to a fresh mutable null-proto object on the
+   * first static child — hence not `readonly`. Match reads (`key in …` / index)
+   * are correct on the empty sentinel (no key → miss).
+   */
+  staticChildren: Record<string, SegmentNode>;
   hasChildren: boolean;
   paramChild?:
     | { node: SegmentNode; name: string; fork?: ForkMeta | undefined }

--- a/packages/path-matcher/tests/unit/SegmentMatcher.test.ts
+++ b/packages/path-matcher/tests/unit/SegmentMatcher.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildParamMeta } from "../../src/buildParamMeta";
 import { createSegmentNode } from "../../src/SegmentMatcher";
+import { EMPTY_STATIC_CHILDREN } from "../../src/pathUtils";
 import { createMatcher } from "../helpers/buildTree";
 import { createTestMatcher } from "../helpers/createTestMatcher";
 
@@ -133,19 +134,25 @@ describe("createSegmentNode", () => {
     expect(node.slashChildRoute).toBeUndefined();
   });
 
-  it("should use Object.create(null) for staticChildren", () => {
+  it("should initialize staticChildren to the shared frozen empty sentinel", () => {
     const node = createSegmentNode();
 
-    // Object.create(null) has no prototype
+    // Null-proto (Object.create(null)) empty map, frozen so a write that skips
+    // processSegment's copy-on-write fails loud instead of corrupting the shared shell.
     expect(Object.getPrototypeOf(node.staticChildren)).toBeNull();
+    expect(node.staticChildren).toBe(EMPTY_STATIC_CHILDREN);
+    expect(Object.isFrozen(node.staticChildren)).toBe(true);
   });
 
-  it("should create independent instances", () => {
+  it("should share the empty sentinel across fresh nodes (copy-on-write on first static child)", () => {
     const node1 = createSegmentNode();
     const node2 = createSegmentNode();
 
+    // Distinct node objects, but both point at the ONE shared staticChildren
+    // sentinel — until registration adds a static child, which copies-on-write.
     expect(node1).not.toBe(node2);
-    expect(node1.staticChildren).not.toBe(node2.staticChildren);
+    expect(node1.staticChildren).toBe(node2.staticChildren);
+    expect(node1.staticChildren).toBe(EMPTY_STATIC_CHILDREN);
   });
 
   it("should have uniform hidden class shape (all keys present)", () => {


### PR DESCRIPTION
## What

Every segment-trie node used to allocate its own `Object.create(null)` for `staticChildren` (`pathUtils.ts`). A null-proto empty object is V8 dictionary-mode from birth, and the **leaf-majority — one node per registered route — never gains a static child**, so each held an empty map purely to answer the match-path `key in node.staticChildren` read.

This shares **one frozen empty sentinel** (`EMPTY_STATIC_CHILDREN`) across every fresh node; `processSegment` copies-on-write to a fresh mutable null-proto map on the first static child. The match path (`key in …` + index read) is unchanged, and the frozen shell fails loud if a write ever skips the copy-on-write guard.

## Impact

Cross-router `table-heap` benchmark — react cohort, 10k routes, **same-session CDP A/B**, `jsHeapMB@10000` (rme ~0):

| | jsHeapMB@10000 |
|---|---|
| before | 8.585 MB |
| **after** | **7.709 MB** |
| **Δ** | **−0.876 MB (~10 %)** |

Widens real-router's table-heap win over react-router (8.72) and tanstack (11.2); narrows the gap to flat-config minimalists. Pure win — no behavior change.

> A node micro-bench (Node V8) showed ~16 %; the browser number is authoritative — Chrome V8 sizes an empty null-proto object smaller than Node V8, so ~10 % is the real shipped saving.

## Correctness

- **503 path-matcher tests pass, 100 % coverage** (both copy-on-write branches).
- `tsc` clean — the `readonly` drop on `staticChildren` is consistent with the node's other mutable registration-time fields.
- Two `createSegmentNode` factory tests updated to assert the shared-sentinel invariant (fresh nodes share the sentinel; diverge on first static child).

Surfaced by a cross-router perf-vector analysis as the **one genuine addressable memory vector** — the rest of the trie footprint is inherent O(1)-match price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)