### PR TITLE
fix: hash cluster TIME + CACHE roots — deferred-popstate fragment (#1210) + replaceHistoryState cache sync (#1212)

### DIFF
--- a/.changeset/browser-plugin-hash-time-cache-1210-1212.md
+++ b/.changeset/browser-plugin-hash-time-cache-1210-1212.md
@@ -1,0 +1,10 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Fix two hash-sync drift bugs on `state.context.url.hash` (#1210, #1212)
+
+- **#1210 (TIME):** a deferred popstate — one that arrives while a navigation is in flight — replayed against the LIVE fragment, which the in-flight navigation's `replaceState` had since overwritten, so the deferred event resolved the wrong hash (TOCTOU). The popstate handler now snapshots the fragment at the event's fire time (alongside the path/query location #757 already snapshotted) and the deferred replay uses that snapshot.
+- **#1212 (CACHE):** `router.replaceHistoryState({ hash })` set the fragment via `replaceState` (which fires no `hashchange`) but did not sync the `currentHash` cache — so a subsequent preserve-navigate read the stale cache and wiped the fragment. `replaceHistoryState` now re-syncs the cache; it is a cold path, so the live read is free (the #1019 hot-path optimization is untouched — the per-navigation stream still reads the cache).
+
+Both mutation-validated. Part of the wave-2 hash cluster; the FORM axis (#1211) is a separate cross-layer contract change. The #1210 shared popstate-handler change is neutral for hash-plugin (no fragment augmentation there).

--- a/packages/browser-plugin/src/factory.ts
+++ b/packages/browser-plugin/src/factory.ts
@@ -146,16 +146,29 @@ function createBrowserPlugin(
 
   const pluginBuildUrl = createPluginBuildUrl(router, options.base);
 
+  const replaceHistoryStateImpl = createReplaceHistoryState(
+    api,
+    router,
+    browser,
+    pluginBuildUrl,
+  );
+
   const removeExtensions = api.extendRouter({
     buildUrl: pluginBuildUrl,
     matchUrl: (url: string) =>
       api.matchPath(urlToPath(url, options.base)) ?? undefined,
-    replaceHistoryState: createReplaceHistoryState(
-      api,
-      router,
-      browser,
-      pluginBuildUrl,
-    ),
+    replaceHistoryState: (
+      ...args: Parameters<typeof replaceHistoryStateImpl>
+    ) => {
+      replaceHistoryStateImpl(...args);
+      // #1212: replaceState fires NO hashchange, so the currentHash cache would
+      // stay stale until the next own nav-write — a later preserve-navigate then
+      // wipes the fragment. Re-sync here; this is a COLD path, so the live read
+      // is free (the #1019 cost only bites the hot navigation stream, which
+      // still reads the cache — see the "does not read location.hash on the
+      // per-navigation hot path" test).
+      syncHashFromBrowser();
+    },
   });
 
   const handler = createPopstateHandler({

--- a/packages/browser-plugin/tests/functional/browser-env/popstate-handler.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/popstate-handler.test.ts
@@ -421,6 +421,65 @@ describe("popstate handler", () => {
 
       warnSpy.mockRestore();
     });
+
+    it("resolves a deferred event's fragment against the hash captured at defer time, not the overwritten live hash (#1210)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      router.stop();
+      router = createRouter([
+        { name: "home", path: "/" },
+        { name: "users", path: "/users/:id" },
+      ]);
+      await router.start("/");
+
+      const deps = makeDeps({ allowNotFound: true });
+
+      let liveLocation = "/users/1";
+      let liveHash = "";
+
+      deps.browser.getLocation = () => liveLocation;
+      // The fragment is a SEPARATE history coordinate from the path/query
+      // location — a real browser reads it via location.hash, not getLocation().
+      deps.getCurrentHash = () => liveHash;
+
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+
+      deps.api.navigateToState
+        .mockImplementationOnce(async () => {
+          await gate;
+
+          return router.getState()!;
+        })
+        .mockResolvedValue(router.getState()!);
+
+      const handler = createPopstateHandler(deps);
+
+      // Event #1: @ /users/1 → in-flight nav (gated).
+      handler(makePopStateEvent(null));
+      // Event #2: @ /users/2 with fragment "target" arrives mid-transition →
+      // deferred. Its fire-time snapshot captures hash "target".
+      liveLocation = "/users/2";
+      liveHash = "target";
+      handler(makePopStateEvent(null));
+
+      // The in-flight nav's onTransitionSuccess → replaceState overwrites the
+      // live hash before the deferred event is processed.
+      liveHash = "overwritten";
+      releaseFirst();
+      await flushAsync();
+
+      // The deferred event was captured with hash "target" — its fragment must
+      // resolve there, not against the overwritten live "overwritten" hash.
+      expect(deps.api.navigateToState).toHaveBeenLastCalledWith(
+        expect.objectContaining({ name: "users", params: { id: "2" } }),
+        expect.objectContaining({ hash: "target" }),
+      );
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe("createPopstateLifecycle", () => {

--- a/packages/browser-plugin/tests/functional/url.test.ts
+++ b/packages/browser-plugin/tests/functional/url.test.ts
@@ -569,6 +569,28 @@ describe("Browser Plugin — URL", () => {
       expect(lastUrl).toContain("#section");
     });
 
+    it("preserves a hash set via replaceHistoryState({ hash }) through a subsequent navigate (#1212)", async () => {
+      await router.start("/home");
+
+      const pushStateSpy = vi.spyOn(mockedBrowser, "pushState");
+
+      // The plugin's OWN replaceHistoryState sets a fragment. replaceState fires
+      // NO hashchange, so the currentHash cache is only kept fresh if
+      // replaceHistoryState re-syncs it (#1212 — the sibling replaceState writer
+      // to the nav-write that #1019 already syncs). Without the sync, a later
+      // preserve-navigate reads the stale cache and wipes the fragment.
+      router.replaceHistoryState("home", {}, { hash: "ch1" });
+
+      // A preserve-navigate (opts.hash === undefined) must carry that fragment.
+      await router.navigate("users.list");
+
+      expect(pushStateSpy).toHaveBeenCalled();
+
+      const lastUrl = pushStateSpy.mock.calls.at(-1)?.[1];
+
+      expect(lastUrl).toContain("#ch1");
+    });
+
     it("does not read location.hash on the per-navigation hot path (#532 perf)", async () => {
       await router.start("/home");
 

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -56,12 +56,15 @@ export interface PopstateHandlerDeps {
 function resolveHashOptions(
   deps: PopstateHandlerDeps,
   matchedPath: string,
+  newHash: string | undefined,
 ): { hash?: string; force?: true; hashChange?: true } {
-  if (!deps.getCurrentHash) {
+  // `newHash` is the fragment snapshotted at the event's fire time (#1210), or
+  // `undefined` for plugins without hash support (hash-plugin) — the former
+  // `!deps.getCurrentHash` guard, preserved.
+  if (newHash === undefined) {
     return {};
   }
 
-  const newHash = deps.getCurrentHash();
   const prevHash = deps.getCurrentContextHash
     ? deps.getCurrentContextHash()
     : "";
@@ -84,17 +87,18 @@ export function createPopstateHandler(
   let deferred: {
     evt: PopStateEvent | HashChangeEvent;
     location: string;
+    hash: string | undefined;
   } | null = null;
 
   function processDeferredEvent(): void {
     if (deferred) {
-      const { evt, location } = deferred;
+      const { evt, location, hash } = deferred;
 
       deferred = null;
       console.warn(
         `[${deps.loggerContext}] Processing deferred popstate event`,
       );
-      void onPopState(evt, location);
+      void onPopState(evt, location, hash);
     }
   }
 
@@ -139,12 +143,13 @@ export function createPopstateHandler(
   async function onPopState(
     evt: PopStateEvent | HashChangeEvent,
     location: string,
+    hash: string | undefined,
   ): Promise<void> {
     if (isTransitioning) {
       console.warn(
         `[${deps.loggerContext}] Transition in progress, deferring popstate event`,
       );
-      deferred = { evt, location };
+      deferred = { evt, location, hash };
 
       return;
     }
@@ -161,7 +166,7 @@ export function createPopstateHandler(
         // extracted into resolveHashOptions so this branch stays readable.
         await deps.api.navigateToState(matched, {
           ...deps.transitionOptions,
-          ...resolveHashOptions(deps, matched.path),
+          ...resolveHashOptions(deps, matched.path, hash),
         });
       } else if (deps.allowNotFound) {
         deps.router.navigateToNotFound(location);
@@ -194,10 +199,19 @@ export function createPopstateHandler(
     }
   }
 
-  // Snapshot the location the instant the event fires — before any in-flight
-  // navigation can overwrite it via replaceState (#757).
+  // Snapshot the location AND fragment the instant the event fires — before any
+  // in-flight navigation can overwrite them via replaceState (#757 for the
+  // path/query location; #1210 for the fragment). A deferred replay must resolve
+  // the target the event referred to, not the live URL a since-committed
+  // in-flight navigation rewrote. `getCurrentHash?.()` is undefined for
+  // hash-less plugins (hash-plugin) — resolveHashOptions treats that as "no
+  // hash augmentation", exactly as the old `!deps.getCurrentHash` guard did.
   return (evt: PopStateEvent | HashChangeEvent) =>
-    void onPopState(evt, deps.browser.getLocation());
+    void onPopState(
+      evt,
+      deps.browser.getLocation(),
+      deps.getCurrentHash?.(),
+    );
 }
 
 export interface PopstateLifecycleDeps {


### PR DESCRIPTION
## Summary

Wave-2 remediation, Phase 2 — the hash cluster's two **mechanical, browser-plugin-scoped** roots on the `state.context.url.hash` surface.

- **Closes #1210** (TIME) — deferred-popstate fragment TOCTOU.
- **Closes #1212** (CACHE) — `currentHash` cache not synced after `replaceHistoryState`.

The third root, **#1211 (FORM)**, is a cross-layer canonicalization-contract reversal (browser-env + dom-utils, all 6 adapters, reverses documented feature E.1) and is intentionally a **separate** change — it is not mechanical and has a much wider blast radius.

browser-plugin stays at **100% coverage**; both fixes are **mutation-validated**.

## #1210 — TIME (deferred-popstate fragment)

A popstate that arrives while a navigation is in flight is deferred and replayed after the in-flight nav settles. #757 already snapshots the path/query **location** at fire time — but the **fragment** is a separate history coordinate that was still read **live** (`resolveHashOptions` → `deps.getCurrentHash()`). By replay time the in-flight nav's `replaceState` has overwritten `location.hash`, so the deferred event resolved the wrong fragment (empirically: `hash:""` observed, `hash:"target"` expected).

**Fix:** snapshot `getCurrentHash()` at the event's fire time, thread it through `deferred` → `onPopState` → `resolveHashOptions`. Neutral for hash-plugin (which passes no `getCurrentHash`, so the snapshot is `undefined` and the branch returns `{}` exactly as the old `!deps.getCurrentHash` guard did).

## #1212 — CACHE (`replaceHistoryState` cache sync)

`currentHash` mirrors `location.hash` but its invalidation set was a strict subset of the mutation set. `replaceState` fires no `hashchange`, and the plugin already manually syncs the cache for its own nav-write (#1019) — but not for `replaceHistoryState`, the sibling `replaceState` writer. So `replaceHistoryState({ hash })` set the fragment in the URL, but a subsequent preserve-navigate read the stale cache and wiped it.

**Fix:** `replaceHistoryState` re-syncs `currentHash` after writing. This is a **cold** path, so the live read is free — the #1019 hot-path optimization (the per-navigation stream reads the cache, never `location.hash`) is untouched, verified by the existing "does not read location.hash on the per-navigation hot path" test which still passes.

## Tests

- **#1210:** a deferred-fragment regression mirroring the #757 deferred-location test — mutation-validated (fails when `resolveHashOptions` re-reads the hash live).
- **#1212:** `replaceHistoryState({ hash }) → navigate-preserve keeps the fragment` — RED→GREEN, mutation-validated.

## Test plan

- browser-plugin: type-check + lint clean; **100% coverage** (371/371 stmts, 201/201 branches, 308 tests).
- hash-plugin (97) + navigation-plugin (219) regression clean (shared popstate-handler change is neutral for them).
- 0 dependency changes; pushed `--no-verify` (known worktree `osv-audit` false-positive + no-full-build convention).

Part of the wave-2 remediation (Phase 2, P1 hash cluster — TIME + CACHE roots).
