### PR TITLE
test(core): navigate-input test-gap batch — nullish name, NaN/Infinity params, cached-rejection identity (#1180 #1182 #1184)

### DIFF
--- a/packages/core/tests/functional/navigation/fire-and-forget.test.ts
+++ b/packages/core/tests/functional/navigation/fire-and-forget.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { errorCodes } from "@real-router/core";
 import { getLifecycleApi } from "@real-router/core/api";
 
 import { captureUnhandledRejections, createTestRouter } from "../../helpers";
@@ -79,5 +80,79 @@ describe("#721 fire-and-forget — no unhandledRejection leaks", () => {
     });
 
     expect(leaked).toStrictEqual([]);
+  });
+});
+
+// #1184: the zero-allocation cached-rejection fast path
+// (CACHED_SAME_STATES_REJECTION / CACHED_NOT_STARTED_REJECTION /
+// CACHED_ROUTE_NOT_FOUND_REJECTION, NavigationNamespace/constants.ts) returns a
+// SHARED singleton promise + error per rejection class. Every other test compares
+// by VALUE (.rejects.toMatchObject({ code })), so silently replacing a singleton
+// with a per-call `Promise.reject(new RouterError(...))` — losing BOTH the
+// optimization AND the #721 pre-suppression contract (lastSyncRejected → the
+// facade skips its .catch()) — passes the whole suite. Pin IDENTITY through the
+// public API: two triggering navigations return the SAME promise + error ref.
+describe("cached-rejection identity (#1184 — zero-alloc fast path)", () => {
+  it("SAME_STATES: two same-state navigations return the SAME promise + error instance", async () => {
+    const router = createTestRouter();
+
+    await router.start("/home");
+
+    const r1 = router.navigate("home");
+    const r2 = router.navigate("home");
+
+    expect(r1).toBe(r2); // CACHED_SAME_STATES_REJECTION singleton
+
+    const [error1, error2] = await Promise.all([
+      r1.catch((error: unknown) => error),
+      r2.catch((error: unknown) => error),
+    ]);
+
+    expect(error1).toBe(error2); // CACHED_SAME_STATES_ERROR singleton
+    expect((error1 as { code?: string }).code).toBe(errorCodes.SAME_STATES);
+
+    router.stop();
+  });
+
+  it("ROUTER_NOT_STARTED: two pre-start navigations return the SAME promise + error instance", async () => {
+    const router = createTestRouter();
+
+    const r1 = router.navigate("users");
+    const r2 = router.navigate("users");
+
+    expect(r1).toBe(r2); // CACHED_NOT_STARTED_REJECTION singleton
+
+    const [error1, error2] = await Promise.all([
+      r1.catch((error: unknown) => error),
+      r2.catch((error: unknown) => error),
+    ]);
+
+    expect(error1).toBe(error2); // CACHED_NOT_STARTED_ERROR singleton
+    expect((error1 as { code?: string }).code).toBe(
+      errorCodes.ROUTER_NOT_STARTED,
+    );
+
+    router.dispose();
+  });
+
+  it("ROUTE_NOT_FOUND: two unknown-route navigations return the SAME promise + error instance", async () => {
+    const router = createTestRouter({ allowNotFound: false });
+
+    await router.start("/home");
+
+    const r1 = router.navigate("nonexistent.route");
+    const r2 = router.navigate("nonexistent.route");
+
+    expect(r1).toBe(r2); // CACHED_ROUTE_NOT_FOUND_REJECTION singleton
+
+    const [error1, error2] = await Promise.all([
+      r1.catch((error: unknown) => error),
+      r2.catch((error: unknown) => error),
+    ]);
+
+    expect(error1).toBe(error2); // CACHED_ROUTE_NOT_FOUND_ERROR singleton
+    expect((error1 as { code?: string }).code).toBe(errorCodes.ROUTE_NOT_FOUND);
+
+    router.stop();
   });
 });

--- a/packages/core/tests/functional/navigation/navigate/edge-cases-input-validation.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/edge-cases-input-validation.test.ts
@@ -52,6 +52,30 @@ describe("router.navigate() - edge cases input validation", () => {
       // Router should still be operational
       expect(router.isActive()).toBe(true);
     });
+
+    // #1180: a nullish route NAME rejects GRACEFULLY with ROUTE_NOT_FOUND on bare
+    // core — no crash, no cryptic deep TypeError (the class of #939's
+    // start(undefined) → codePointAt throw in path-matcher). Pinned so a refactor
+    // of buildNavigateState / forwardState cannot regress this input class into a
+    // deep throw and ship green. `.rejects` also guards the crash-regression: a
+    // synchronous throw from navigate(null) would fail this assertion too.
+    it("rejects navigate(null) with ROUTE_NOT_FOUND (graceful, not a cryptic throw)", async () => {
+      // @ts-expect-error — null is not a valid route name; bare-core hardening pin
+      await expect(router.navigate(null)).rejects.toMatchObject({
+        code: errorCodes.ROUTE_NOT_FOUND,
+      });
+
+      expect(router.isActive()).toBe(true);
+    });
+
+    it("rejects navigate(undefined) with ROUTE_NOT_FOUND (graceful, not a cryptic throw)", async () => {
+      // @ts-expect-error — undefined is not a valid route name; bare-core pin
+      await expect(router.navigate(undefined)).rejects.toMatchObject({
+        code: errorCodes.ROUTE_NOT_FOUND,
+      });
+
+      expect(router.isActive()).toBe(true);
+    });
   });
 
   // ============================================================================
@@ -83,6 +107,39 @@ describe("router.navigate() - edge cases input validation", () => {
       );
 
       expect(router.isActive()).toBe(true);
+    });
+
+    // #1182: NaN / Infinity as a PATH-param value flow through the full navigate
+    // pipeline untouched — bare core does NOT validate param values (that is
+    // opt-in via @real-router/validation-plugin; CLAUDE.md "Param-value type
+    // validation stays opt-in"). Previously exercised only through buildPath()
+    // unit tests — the committed state.params / state.path was unpinned.
+    it("accepts NaN as a path-param value — params keep raw NaN, path stringifies to /items/NaN", async () => {
+      const state = await router.navigate("items", { id: Number.NaN });
+
+      expect(state.name).toBe("items");
+      // Raw NaN preserved in params (typeof number) — not coerced, not dropped.
+      expect(Number.isNaN(state.params.id)).toBe(true);
+      // String(NaN) folded into the URL segment.
+      expect(state.path).toBe("/items/NaN");
+
+      expect(router.isActive()).toBe(true);
+    });
+
+    it("accepts Infinity / -Infinity as a path-param value — params keep raw value, path stringifies", async () => {
+      const inf = await router.navigate("items", {
+        id: Number.POSITIVE_INFINITY,
+      });
+
+      expect(inf.params.id).toBe(Number.POSITIVE_INFINITY);
+      expect(inf.path).toBe("/items/Infinity");
+
+      const negInf = await router.navigate("items", {
+        id: Number.NEGATIVE_INFINITY,
+      });
+
+      expect(negInf.params.id).toBe(Number.NEGATIVE_INFINITY);
+      expect(negInf.path).toBe("/items/-Infinity");
     });
 
     it("rejects a Symbol param VALUE with a TypeError (Symbol→string is illegal)", async () => {


### PR DESCRIPTION
Closes #1180
Closes #1182
Closes #1184

navigate-input test-gap batch. Every test mutation-proven discriminating; tests-only — no `src/`, no changeset.

## #1180 — nullish route name rejects gracefully (MISSING)
`navigate(null)` / `navigate(undefined)` reject with **ROUTE_NOT_FOUND** — graceful, no crash, no cryptic deep TypeError (the class of #939's `start(undefined)` → `codePointAt` throw). Pinned so a refactor of `buildNavigateState` / `forwardState` cannot regress this input class into a deep throw and ship green. `.rejects` also guards the crash-regression (a sync throw would fail the assertion).
- **Discrimination:** re-coding `CACHED_ROUTE_NOT_FOUND` reds both tests.

## #1182 — NaN/Infinity param values (MISSING)
`NaN` / `Infinity` / `-Infinity` as a PATH-param value flow through the full navigate pipeline untouched: `state.params` keeps the RAW numeric value (typeof number, not coerced/dropped), `state.path` stringifies (`/items/NaN`, `/items/Infinity`, `/items/-Infinity`). Bare core does not validate param values (opt-in via `@real-router/validation-plugin`). Previously exercised only through `buildPath()` unit tests.
- **Discrimination:** coercing `normalizeParams` (value→`String`) reds both tests.

## #1184 — cached-rejection identity (perf-invariant pin)
The zero-alloc cached-rejection fast path (`CACHED_SAME_STATES_REJECTION` / `CACHED_NOT_STARTED_REJECTION` / `CACHED_ROUTE_NOT_FOUND_REJECTION`) returns a SHARED singleton promise + error per class. Every other test compares by VALUE, so replacing a singleton with a per-call `Promise.reject(...)` — losing the optimization AND the #721 pre-suppression contract — passed the whole suite. Pinned by IDENTITY: two triggering navigations return the SAME promise + error ref (`r1 === r2`, `error1 === error2`).
- **Discrimination:** replacing the singletons with a per-call derived promise (`.then()`) reds every identity assertion (and the sibling #721 leak tests) — exactly the silent regression the issue describes.

## Validation
Full core functional suite: 130 files / 2537 tests, **100% coverage**. `tsc`, eslint, prettier clean.