### PR TITLE
perf(core): derive route definitions from the tree on demand — drop the third retained copy (#1426)

### DIFF
--- a/.changeset/definitions-derive-on-demand-perf.md
+++ b/.changeset/definitions-derive-on-demand-perf.md
@@ -1,0 +1,7 @@
+---
+"@real-router/core": patch
+---
+
+Derive route definitions from the tree on demand — drop the third retained copy of the route table (#1426)
+
+`RoutesStore.definitions` is now a getter over `routeTreeToDefinitions(store.tree)` (the lossless inverse `cloneRouter` already relies on) instead of a permanently-retained parallel array. Browser CDP A/B on the 10k-route table: **−0.229 MB (−3.6 %) retained heap** — cumulatively −30 % with #1379/#1414/#1415. The derived array is a fresh snapshot per access (cold CRUD/plugin-registration paths only); behavior is unchanged and the internals surface consumed by `@real-router/validation-plugin` is preserved.

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -580,7 +580,10 @@ function replaceRoutes<
 function removeRoute<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(store: RoutesStore<Dependencies>, name: string): boolean {
-  const wasRemoved = removeFromDefinitions(store.definitions, name);
+  // `store.definitions` is a fresh tree-derived snapshot — mutate it locally,
+  // then commit the mutated table as the new tree.
+  const definitions = store.definitions;
+  const wasRemoved = removeFromDefinitions(definitions, name);
 
   if (!wasRemoved) {
     return false;
@@ -594,7 +597,7 @@ function removeRoute<
     store.lifecycleNamespace!,
   );
 
-  commitTreeChanges(store);
+  commitTreeChanges(store, definitions);
 
   return true;
 }

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -1,7 +1,11 @@
 // packages/core/src/namespaces/RoutesNamespace/routesStore.ts
 
 import { logger } from "@real-router/logger";
-import { createMatcher, createRouteTree } from "route-tree";
+import {
+  createMatcher,
+  createRouteTree,
+  routeTreeToDefinitions,
+} from "route-tree";
 
 import { DEFAULT_ROUTE_NAME, STANDARD_ROUTE_KEYS } from "./constants";
 import { resolveForwardChain } from "./forwardChain";
@@ -35,6 +39,18 @@ import type {
 export interface RoutesStore<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 > {
+  /**
+   * DERIVED VIEW, not stored state: reconstructed from `tree` on every access
+   * via `routeTreeToDefinitions` (the lossless inverse cloneRouter already
+   * relies on — the `~` absolute marker is restored, child order is the
+   * definition order). The tree is the single source of truth, so a third
+   * retained copy of the route table (~30 B/route) is not kept. Every reader
+   * is a cold CRUD/plugin-registration path; the derive is O(N).
+   *
+   * The returned array is a FRESH snapshot each time — mutating it never
+   * affects the store (pass an explicitly-mutated snapshot to
+   * `commitTreeChanges` instead, as `remove` does).
+   */
   readonly definitions: RouteDefinition[];
   readonly config: RouteConfig;
   tree: RouteTree;
@@ -61,7 +77,7 @@ export interface RoutesStore<
 // =============================================================================
 
 function rebuildTree(
-  definitions: RouteDefinition[],
+  definitions: readonly RouteDefinition[],
   rootPath: string,
   matcherOptions: CreateMatcherOptions | undefined,
 ): { tree: RouteTree; matcher: Matcher } {
@@ -73,14 +89,18 @@ function rebuildTree(
   return { tree, matcher };
 }
 
+/**
+ * Rebuilds tree+matcher in place from `definitions` (defaults to the current
+ * tree's own derived definitions — the same-table case, e.g. a rootPath
+ * change).
+ */
 export function rebuildTreeInPlace<
   Dependencies extends DefaultDependencies = DefaultDependencies,
->(store: RoutesStore<Dependencies>): void {
-  const result = rebuildTree(
-    store.definitions,
-    store.rootPath,
-    store.matcherOptions,
-  );
+>(
+  store: RoutesStore<Dependencies>,
+  definitions: readonly RouteDefinition[] = store.definitions,
+): void {
+  const result = rebuildTree(definitions, store.rootPath, store.matcherOptions);
 
   store.tree = result.tree;
   store.matcher = result.matcher;
@@ -89,8 +109,11 @@ export function rebuildTreeInPlace<
 
 export function commitTreeChanges<
   Dependencies extends DefaultDependencies = DefaultDependencies,
->(store: RoutesStore<Dependencies>): void {
-  rebuildTreeInPlace(store);
+>(
+  store: RoutesStore<Dependencies>,
+  definitions: readonly RouteDefinition[],
+): void {
+  rebuildTreeInPlace(store, definitions);
   store.resolvedForwardMap = refreshForwardMap(store.config);
 }
 
@@ -106,18 +129,18 @@ export function resetStore<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(store: RoutesStore<Dependencies>): void {
   clearRouteData(store);
-  rebuildTreeInPlace(store);
+  rebuildTreeInPlace(store, []);
 }
 
 /**
  * Clears route data without rebuilding the tree.
  * Used by replace() to avoid double rebuild (clearRouteData + commitTreeChanges).
+ * `definitions` needs no clearing — it is derived from the tree, which the
+ * caller rebuilds (resetStore → empty, replace → the new artifacts).
  */
 export function clearRouteData<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 >(store: RoutesStore<Dependencies>): void {
-  store.definitions.length = 0;
-
   Object.assign(store.config, createEmptyConfig());
 
   store.resolvedForwardMap = Object.create(null) as Record<string, string>;
@@ -322,7 +345,6 @@ function registerAllRouteHandlers<Dependencies extends DefaultDependencies>(
 interface RouteArtifacts<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 > {
-  readonly definitions: RouteDefinition[];
   readonly config: RouteConfig;
   readonly routeCustomFields: Record<string, Record<string, unknown>>;
   readonly pendingCanActivate: Map<string, GuardFnFactory<Dependencies>>;
@@ -554,7 +576,7 @@ export function assertAddable<Dependencies extends DefaultDependencies>(
  * forwardTo and invalid path constraint — before the caller mutates the store.
  */
 function buildArtifacts<Dependencies extends DefaultDependencies>(
-  definitions: RouteDefinition[],
+  definitions: readonly RouteDefinition[],
   routesForHandlers: readonly Route<Dependencies>[],
   config: RouteConfig,
   routeCustomFields: Record<string, Record<string, unknown>>,
@@ -578,7 +600,6 @@ function buildArtifacts<Dependencies extends DefaultDependencies>(
   const { tree, matcher } = rebuildTree(definitions, rootPath, matcherOptions);
 
   return {
-    definitions,
     config,
     routeCustomFields,
     pendingCanActivate,
@@ -718,13 +739,8 @@ export function adoptRouteArtifacts<Dependencies extends DefaultDependencies>(
   const { activate: compiledActivate, deactivate: compiledDeactivate } =
     precompiled ?? compileArtifactGuards(artifacts, deps);
 
-  // Atomic swap — pure assignments, cannot throw.
-  store.definitions.length = 0;
-
-  for (const def of artifacts.definitions) {
-    store.definitions.push(def);
-  }
-
+  // Atomic swap — pure assignments, cannot throw. (`definitions` is derived
+  // from `tree`, so swapping the tree IS the definitions swap.)
   Object.assign(store.config, artifacts.config);
   store.routeCustomFields = artifacts.routeCustomFields;
   store.tree = artifacts.tree;
@@ -1070,8 +1086,11 @@ export function createRoutesStore<
 
   const artifacts = buildReplaceArtifacts(routes, "", matcherOptions);
 
-  return {
-    definitions: artifacts.definitions,
+  const store: RoutesStore<Dependencies> = {
+    // Deferred access: the getter runs only after `store` is initialized.
+    get definitions() {
+      return routeTreeToDefinitions(store.tree);
+    },
     config: artifacts.config,
     tree: artifacts.tree,
     matcher: artifacts.matcher,
@@ -1085,4 +1104,6 @@ export function createRoutesStore<
     pendingCanActivate: artifacts.pendingCanActivate,
     pendingCanDeactivate: artifacts.pendingCanDeactivate,
   };
+
+  return store;
 }


### PR DESCRIPTION
## Summary

`RoutesStore` no longer keeps a third permanently-retained copy of the route table — `definitions` is derived from the tree on demand.

### #1426 — third retained copy of the route table

- `store.definitions` is now a getter over `routeTreeToDefinitions(store.tree)` — the documented lossless inverse `cloneRouter` already relies on (`~` absolute marker restored, child order = definition order). The tree is the single source of truth; behavior is unchanged.
- **Waste cause:** ~23 B/route of `{name, path, children?}` objects plus array slots, retained for the router's lifetime yet read only by cold paths — CRUD rebuilds (`add`/`remove`/`replace`/`clear`/`setRootPath`), the `subscribeChanges` diff walk, and validation-plugin's registration-time retrospective.
- Browser CDP A/B (cross-router `table-heap`, react cohort, n=6, rme ≤ 0.001; base reproduced **bit-for-bit before and after** the fix run, matching the committed full-matrix cell): **6.279 → 6.050 MB @10k = −0.229 MB (−3.6 %)**; @1k −23 KB. The pre-registered kill-criterion (Δ ≥ 0.15 MB) passed. Fourth rung of the #1379 → #1414 → #1415 ladder — cumulatively **−30 %** vs the 07-09 snapshot; narrows the solid cohort's gap to solid-router to ~0.44 MB.
- Mutating paths now hand an explicit table to the rebuild instead of mutating stored state: `remove` derives → splices locally → `commitTreeChanges(store, definitions)`; `clear` rebuilds from `[]`; `adoptRouteArtifacts` no longer stores definitions at all (swapping the tree IS the definitions swap; the `RouteArtifacts.definitions` field is gone).
- The internals surface consumed by `@real-router/validation-plugin` (`routesStore.definitions`, including its structural `Array.isArray` check) is preserved by the getter — the plugin is untouched and its suite passes unchanged.

## Test plan

- [x] Inverse is property-locked (pre-existing lock, unchanged): `route-tree/tests/property/tree.properties.ts` — `routeTreeToDefinitions ∘ createRouteTree` is a faithful, idempotent roundtrip over arbitrary nested forests (names, paths incl. `~`/params/query/splat, child order); 63 route-tree property tests green
- [x] Mutation-validated discrimination: breaking the getter (`return []`) fails **117 tests across 22 core files** — the existing suites pin the derive, no new pinning tests required
- [x] core suite green at **100 % coverage** (2221/2221 statements); route-tree (244), validation-plugin (569), core property (316) and core stress (116) suites green
- [x] Browser CDP A/B with bit-for-bit base control runs before and after the fix measurement
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes (pre-push full validation)
- [x] 100% test coverage maintained

Closes #1426
