### PR TITLE
fix(react,preact,svelte,solid): empty routeName matches router.isActiveRoute("") (#1427)

### DIFF
--- a/.changeset/preact-useisactiveroute-1427-fix.md
+++ b/.changeset/preact-useisactiveroute-1427-fix.md
@@ -1,0 +1,15 @@
+---
+"@real-router/preact": patch
+---
+
+fix(preact): `useIsActiveRoute("")` is inactive, matching `router.isActiveRoute("")` (#1427)
+
+`useIsActiveRoute` kept an inline copy of the fast/slow active-source decision
+whose predicate lacked the `routeName !== ""` guard, so an empty `routeName` took
+the name-selector fast path — where `isActive("") === true` (the root is every
+route's ancestor) — and wrongly reported active, diverging from the canonical
+`router.isActiveRoute("") === false`. The hook now delegates to the shared
+`createActiveSource` builder from `@real-router/sources`, whose guard routes an
+empty name to the slow path. No change for any non-empty name — the fast/slow
+decision and behaviour are otherwise identical (the `#1249` fast path is now the
+one in the shared builder).

--- a/.changeset/react-useisactiveroute-1427-fix.md
+++ b/.changeset/react-useisactiveroute-1427-fix.md
@@ -1,0 +1,15 @@
+---
+"@real-router/react": patch
+---
+
+fix(react): `useIsActiveRoute("")` is inactive, matching `router.isActiveRoute("")` (#1427)
+
+`useIsActiveRoute` kept an inline copy of the fast/slow active-source decision
+whose predicate lacked the `routeName !== ""` guard, so an empty `routeName` took
+the name-selector fast path — where `isActive("") === true` (the root is every
+route's ancestor) — and wrongly reported active, diverging from the canonical
+`router.isActiveRoute("") === false`. The hook now delegates to the shared
+`createActiveSource` builder from `@real-router/sources`, whose guard routes an
+empty name to the slow path. No change for any non-empty name — the fast/slow
+decision and behaviour are otherwise identical (the `#1248` fast path is now the
+one in the shared builder).

--- a/.changeset/solid-empty-routename-1427-fix.md
+++ b/.changeset/solid-empty-routename-1427-fix.md
@@ -1,0 +1,17 @@
+---
+"@real-router/solid": patch
+---
+
+fix(solid): `<Link routeName="">` is inactive, matching `router.isActiveRoute("")` (#1427)
+
+Solid's `<Link>` resolved default-options active state through the per-router
+`routeSelector` (`createSelector` + `isRouteActive`), whose unstarted sentinel
+(`routeSignal().route?.name ?? ""`) makes `isRouteActive("", "") === true` — so a
+misused empty-name Link lit up **before `router.start()`**, diverging from the
+canonical `router.isActiveRoute("") === false`. (A started router was already
+correct — `isRouteActive("", "<route>")` is `false` — so this closes only the
+unstarted/stopped window.) `useFastPath` now guards `routeName !== ""`, routing an
+empty name to the slow `createActiveRouteSource`, which reads
+`router.isActiveRoute("")` in every router state. This aligns solid with the other
+five adapters (#1416/#1424 · #1427). The `isRouteActive` helper and its property
+locks are unchanged. No change for any non-empty name.

--- a/.changeset/svelte-useisactiveroute-1427-fix.md
+++ b/.changeset/svelte-useisactiveroute-1427-fix.md
@@ -1,0 +1,15 @@
+---
+"@real-router/svelte": patch
+---
+
+fix(svelte): `useIsActiveRoute("")` is inactive, matching `router.isActiveRoute("")` (#1427)
+
+`useIsActiveRoute` kept an inline copy of the fast/slow active-source decision
+whose predicate lacked the `routeName !== ""` guard, so an empty `routeName` took
+the name-selector fast path — where `isActive("") === true` (the root is every
+route's ancestor) — and wrongly reported active, diverging from the canonical
+`router.isActiveRoute("") === false`. The composable now delegates to the shared
+`createActiveSource` builder from `@real-router/sources` (bridged through
+`createReactiveSource`), whose guard routes an empty name to the slow path. No
+change for any non-empty name — the fast/slow decision and behaviour are
+otherwise identical (the `#1099` fast path is now the one in the shared builder).

--- a/packages/preact/ARCHITECTURE.md
+++ b/packages/preact/ARCHITECTURE.md
@@ -67,7 +67,7 @@ src/
 │   ├── useRoute.tsx            # Full route state from context (every navigation)
 │   ├── useNavigator.tsx        # Navigator from context (never re-renders)
 │   ├── useRouteNode.tsx        # Node-scoped subscription (cached createRouteNodeSource from sources)
-│   ├── useIsActiveRoute.tsx    # Active state subscription (cached createActiveRouteSource, useMemo-wrapped opts + source)
+│   ├── useIsActiveRoute.tsx    # Active state subscription — delegates to shared createActiveSource (#1427); useMemo-wrapped
 │   ├── useRouteUtils.tsx       # RouteUtils from route tree (never re-renders)
 │   ├── useRouterTransition.tsx # Transition lifecycle (cached getTransitionSource)
 │   ├── useRouteExit.tsx        # Wrap subscribeLeave with abort + same-route + latest-handler guards

--- a/packages/preact/CLAUDE.md
+++ b/packages/preact/CLAUDE.md
@@ -53,7 +53,7 @@ src/
 │   ├── useRoute.tsx            # Full route state from context (every navigation)
 │   ├── useNavigator.tsx        # Navigator from context (never re-renders)
 │   ├── useRouteNode.tsx        # Node-scoped subscription (cached createRouteNodeSource from sources)
-│   ├── useIsActiveRoute.tsx    # Default opts → shared createActiveNameSelector fast path (#1249); else cached createActiveRouteSource, useMemo-wrapped
+│   ├── useIsActiveRoute.tsx    # Delegates to shared createActiveSource builder (#1427): default opts + non-empty name → createActiveNameSelector fast path (#1249), else cached createActiveRouteSource; useMemo-wrapped
 │   ├── useRouteUtils.tsx       # RouteUtils from route tree (never re-renders)
 │   ├── useRouterTransition.tsx # Transition lifecycle (cached getTransitionSource)
 │   ├── useRouteExit.tsx        # Wraps subscribeLeave with abort + same-route guards + handler ref
@@ -499,6 +499,6 @@ integration contract:
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` hook)
-- `useIsActiveRoute` resolves default-options active state through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1249); custom params / strict / `ignoreQueryParams: false` / hash fall to cached `createActiveRouteSource` (params hashed via `canonicalJson`, key-order-insensitive)
+- `useIsActiveRoute` delegates to the shared `createActiveSource` builder from `@real-router/sources` (#1427) — the fast/slow decision, and the `routeName !== ""` guard that keeps `useIsActiveRoute("")` in sync with `router.isActiveRoute("") === false`, live in one place for every adapter. Default options + a **non-empty** name resolve through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1249); custom params / strict / `ignoreQueryParams: false` / hash / empty name fall to cached `createActiveRouteSource` (params hashed via `canonicalJson`, key-order-insensitive)
 - `Link` uses `memo()` with custom `areLinkPropsEqual` comparator: `Object.is` for primitives + `style` + `children`, `shallowEqual` (from `dom-utils`) for `routeParams`/`routeOptions`. Nested objects in params are not deep-compared — consumers stabilize via `useMemo` if needed
 - WeakMap caches in `@real-router/sources` are per-router, auto-evicted on router GC

--- a/packages/preact/src/hooks/useIsActiveRoute.tsx
+++ b/packages/preact/src/hooks/useIsActiveRoute.tsx
@@ -1,7 +1,4 @@
-import {
-  createActiveNameSelector,
-  createActiveRouteSource,
-} from "@real-router/sources";
+import { createActiveSource } from "@real-router/sources";
 import { useMemo } from "preact/hooks";
 
 import { useSyncExternalStore } from "../useSyncExternalStore";
@@ -18,43 +15,25 @@ export function useIsActiveRoute(
 ): boolean {
   const router = useRouter();
 
-  // Fast path (#1249) — the default-options active check: no custom `params`,
-  // non-strict, query params ignored, no `hash`. Resolve through the per-router
-  // shared `createActiveNameSelector` — ONE `router.subscribe` handle serves any
-  // number of distinct-`routeName` links — instead of a per-instance
-  // `createActiveRouteSource` (a `BaseSource` AND its own router subscription for
-  // every distinct name). Direct port of the svelte (#1101) / angular (#1104) /
-  // react (#1248) fast paths; the selector's `isActive` is exactly non-strict,
-  // query-ignoring, name-only matching. Any deviation falls to the slow path,
-  // whose canonical-args cache handles the full surface (custom params, strict,
-  // `ignoreQueryParams: false`, hash-aware #532).
-  //
-  // The `useMemo` wrap skips the branch + `canonicalJson(params)` + cache lookup
-  // on every render when all primitive deps and the `params` reference are stable.
-  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so we
-  // conditionally spread the key only when the caller passed a value.
-  const store = useMemo(() => {
-    if (
-      params === undefined &&
-      !strict &&
-      ignoreQueryParams &&
-      hash === undefined
-    ) {
-      const selector = createActiveNameSelector(router);
-
-      return {
-        subscribe: (onChange: () => void) =>
-          selector.subscribe(routeName, onChange),
-        getSnapshot: () => selector.isActive(routeName),
-      };
-    }
-
-    return createActiveRouteSource(router, routeName, params, {
-      strict,
-      ignoreQueryParams,
-      ...(hash !== undefined && { hash }),
-    });
-  }, [router, routeName, params, strict, ignoreQueryParams, hash]);
+  // The fast/slow decision — and the `routeName !== ""` guard that keeps
+  // `useIsActiveRoute("")` in sync with `router.isActiveRoute("")` (a misused
+  // empty name matches nothing, #1427) — lives in the shared `createActiveSource`
+  // builder, so every adapter resolves active state identically (#1249 landed the
+  // fast path inline here; #1427 folded it into the shared builder). The `useMemo`
+  // wrap skips the branch + `canonicalJson(params)` + cache lookup on every render
+  // when all deps (including the `params` reference) are stable.
+  const store = useMemo(
+    () =>
+      createActiveSource(
+        router,
+        routeName,
+        params,
+        strict,
+        ignoreQueryParams,
+        hash,
+      ),
+    [router, routeName, params, strict, ignoreQueryParams, hash],
+  );
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/preact/tests/functional/useIsActiveRoute.test.tsx
+++ b/packages/preact/tests/functional/useIsActiveRoute.test.tsx
@@ -62,6 +62,23 @@ describe("useIsActiveRoute", () => {
     expect(isActiveRouteSpy).toHaveBeenCalled();
   });
 
+  it("an empty routeName is inactive — agrees with router.isActiveRoute('') (#1427)", () => {
+    // #1427 — an empty `routeName` is a misuse (matches no route). The canonical
+    // answer is `router.isActiveRoute("") === false`, and the hook must agree.
+    // The default-options fast-path predicate lacked the `routeName !== ""` guard,
+    // so "" took the name-selector fast path where `selector.isActive("") === true`
+    // (the root is every route's ancestor) and the hook wrongly reported active.
+    // The shared `createActiveSource` builder carries the guard, routing "" to the
+    // slow path whose snapshot is `router.isActiveRoute("")`.
+    expect(router.isActiveRoute("")).toBe(false);
+
+    const { result } = renderHook(() => useIsActiveRoute(""), {
+      wrapper: (props) => wrapper({ ...props, router }),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
   it("should handle non-strict mode", () => {
     const { result } = renderHook(() => useIsActiveRoute("users", {}, false), {
       wrapper: (props) => wrapper({ ...props, router }),

--- a/packages/react/ARCHITECTURE.md
+++ b/packages/react/ARCHITECTURE.md
@@ -78,7 +78,7 @@ src/
 │   ├── useRoute.tsx               # Full route state — RouteHookResult<P> with non-nullable route (throws if undefined)
 │   ├── useNavigator.tsx           # Navigator from context (never re-renders)
 │   ├── useRouteNode.tsx           # Node-scoped subscription (cached createRouteNodeSource)
-│   ├── useIsActiveRoute.tsx       # Active state subscription (useMemo-wrapped createActiveRouteSource)
+│   ├── useIsActiveRoute.tsx       # Active state subscription — delegates to shared createActiveSource (#1427); useMemo-wrapped
 │   ├── useRouteUtils.tsx          # RouteUtils from route tree (never re-renders)
 │   ├── useRouterTransition.tsx    # Transition lifecycle (cached getTransitionSource)
 │   ├── useRouteExit.tsx           # Wrap subscribeLeave with reentrant abort + same-route skip + latest-handler ref + StrictMode dedupe

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 │   ├── useRoute.tsx                # Returns RouteHookResult<P> — route is non-nullable
 │   ├── useNavigator.tsx
 │   ├── useRouteNode.tsx            # Uses cached createRouteNodeSource from @real-router/sources
-│   ├── useIsActiveRoute.tsx        # Default opts → shared createActiveNameSelector fast path (#1248); else cached createActiveRouteSource, useMemo-wrapped
+│   ├── useIsActiveRoute.tsx        # Delegates to shared createActiveSource builder (#1427): default opts + non-empty name → createActiveNameSelector fast path (#1248), else cached createActiveRouteSource; useMemo-wrapped
 │   ├── useRouteUtils.tsx
 │   ├── useRouterTransition.tsx     # Uses cached getTransitionSource
 │   ├── useRouteEnter.tsx           # Mount-side window: reentrant abort, same-route skip, latest-ref, StrictMode dedupe
@@ -585,5 +585,5 @@ No built-in SSR support. For SSR:
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — `N` consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` hook)
-- `useIsActiveRoute` resolves default-options active state (no params, non-strict, `ignoreQueryParams`, no `hash`) through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1248). Custom params / strict / `ignoreQueryParams: false` / hash fall to cached `createActiveRouteSource` — params are hashed with `canonicalJson` (key-order-insensitive), so `{a:1, b:2}` and `{b:2, a:1}` hit the same cache entry. No `useStableValue` wrapper needed
+- `useIsActiveRoute` delegates to the shared `createActiveSource` builder from `@real-router/sources` (#1427) — the fast/slow decision, and the `routeName !== ""` guard that keeps `useIsActiveRoute("")` in sync with `router.isActiveRoute("") === false`, live in one place for every adapter. Default options (no params, non-strict, `ignoreQueryParams`, no `hash`, **non-empty** name) resolve through the shared per-router `createActiveNameSelector` — one `router.subscribe` for any number of distinct-`routeName` Links (#1248). Custom params / strict / `ignoreQueryParams: false` / hash / empty name fall to cached `createActiveRouteSource` — params hashed with `canonicalJson` (key-order-insensitive), so `{a:1, b:2}` and `{b:2, a:1}` hit the same cache entry. `useMemo`-wrapped; no `useStableValue` wrapper needed
 - `Link` uses `memo()` with custom `areLinkPropsEqual` comparator: `Object.is` for primitives + `style` + `children`, `shallowEqual` (Object.is per key, order-insensitive) for `routeParams`/`routeOptions`. Nested objects in params are not deep-compared — consumers stabilize via `useMemo` if needed

--- a/packages/react/src/hooks/useIsActiveRoute.tsx
+++ b/packages/react/src/hooks/useIsActiveRoute.tsx
@@ -1,7 +1,4 @@
-import {
-  createActiveNameSelector,
-  createActiveRouteSource,
-} from "@real-router/sources";
+import { createActiveSource } from "@real-router/sources";
 import { useMemo, useSyncExternalStore } from "react";
 
 import { useRouter } from "./useRouter";
@@ -17,44 +14,25 @@ export function useIsActiveRoute(
 ): boolean {
   const router = useRouter();
 
-  // Fast path (#1248) — the default-options active check: no custom `params`,
-  // non-strict, query params ignored, no `hash`. Resolve through the per-router
-  // shared `createActiveNameSelector` — ONE `router.subscribe` handle serves any
-  // number of distinct-`routeName` links — instead of a per-instance
-  // `createActiveRouteSource` (a `BaseSource` AND its own router subscription for
-  // every distinct name). Direct port of the svelte (#1101) / angular (#1104)
-  // fast paths; the selector's `isActive` is exactly non-strict, query-ignoring,
-  // name-only matching, identical to the default-options `createActiveRouteSource`.
-  // Any deviation falls to the slow path below, whose canonical-args cache handles
-  // the full surface (custom params, strict, `ignoreQueryParams: false`,
-  // hash-aware #532).
-  //
-  // The `useMemo` wrap skips the branch + `canonicalJson(params)` + cache lookup
-  // on every render when all primitive deps and the `params` reference are stable.
-  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally, so we
-  // conditionally spread the key only when the caller passed a value.
-  const store = useMemo(() => {
-    if (
-      params === undefined &&
-      !strict &&
-      ignoreQueryParams &&
-      hash === undefined
-    ) {
-      const selector = createActiveNameSelector(router);
-
-      return {
-        subscribe: (onChange: () => void) =>
-          selector.subscribe(routeName, onChange),
-        getSnapshot: () => selector.isActive(routeName),
-      };
-    }
-
-    return createActiveRouteSource(router, routeName, params, {
-      strict,
-      ignoreQueryParams,
-      ...(hash !== undefined && { hash }),
-    });
-  }, [router, routeName, params, strict, ignoreQueryParams, hash]);
+  // The fast/slow decision — and the `routeName !== ""` guard that keeps
+  // `useIsActiveRoute("")` in sync with `router.isActiveRoute("")` (a misused
+  // empty name matches nothing, #1427) — lives in the shared `createActiveSource`
+  // builder, so every adapter resolves active state identically (#1248 landed the
+  // fast path inline here; #1427 folded it into the shared builder). The `useMemo`
+  // wrap skips the branch + `canonicalJson(params)` + cache lookup on every render
+  // when all deps (including the `params` reference) are stable.
+  const store = useMemo(
+    () =>
+      createActiveSource(
+        router,
+        routeName,
+        params,
+        strict,
+        ignoreQueryParams,
+        hash,
+      ),
+    [router, routeName, params, strict, ignoreQueryParams, hash],
+  );
 
   return useSyncExternalStore(
     store.subscribe,

--- a/packages/react/tests/functional/useIsActiveRoute.test.tsx
+++ b/packages/react/tests/functional/useIsActiveRoute.test.tsx
@@ -65,6 +65,23 @@ describe("useIsActiveRoute", () => {
     expect(isActiveRouteSpy).toHaveBeenCalled();
   });
 
+  it("an empty routeName is inactive — agrees with router.isActiveRoute('') (#1427)", () => {
+    // #1427 — an empty `routeName` is a misuse (matches no route). The canonical
+    // answer is `router.isActiveRoute("") === false`, and the hook must agree.
+    // The default-options fast-path predicate lacked the `routeName !== ""` guard,
+    // so "" took the name-selector fast path where `selector.isActive("") === true`
+    // (the root is every route's ancestor) and the hook wrongly reported active.
+    // The shared `createActiveSource` builder carries the guard, routing "" to the
+    // slow path whose snapshot is `router.isActiveRoute("")`.
+    expect(router.isActiveRoute("")).toBe(false);
+
+    const { result } = renderHook(() => useIsActiveRoute(""), {
+      wrapper: (props) => wrapper({ ...props, router }),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
   it("should handle non-strict mode", () => {
     const { result } = renderHook(() => useIsActiveRoute("users", {}, false), {
       wrapper: (props) => wrapper({ ...props, router }),

--- a/packages/solid/CLAUDE.md
+++ b/packages/solid/CLAUDE.md
@@ -443,31 +443,33 @@ RouteView renders only the active match. On navigation, the previous component d
 <Link routeName="users" /> // Active even if ?page=2 differs
 ```
 
-### Empty `routeName` Link is always active in unstarted state
+### Empty `routeName` Link is inactive in every router state (#1427)
 
-`<Link routeName="">` is a misuse pattern, but the helper does not validate
-against it. RouterProvider's `routeSelector` uses an empty-string sentinel
-(`routeSignal().route?.name ?? ""`) when the router has no active state
-(unstarted / stopped / disposed). The underlying `isRouteActive("", "")`
-returns `true` via the equality branch — so a Link with `routeName=""`
-ends up matching the sentinel and renders as **always active** until the
-router commits a real route.
+`<Link routeName="">` is a misuse pattern (an empty name matches no route). The
+canonical answer is `router.isActiveRoute("") === false`, and the Link honors it
+in **every** state. The `useFastPath` predicate (`components/Link.tsx`) guards
+`routeName !== ""`, so an empty name skips the `routeSelector` fast path — whose
+unstarted sentinel (`routeSignal().route?.name ?? ""`) would otherwise make
+`isRouteActive("", "") === true` and light the Link up before `router.start()` —
+and falls to the slow `createActiveRouteSource`, which reads
+`router.isActiveRoute("") === false` whether the router is unstarted, stopped, or
+on a real route.
 
 ```tsx
-// WRONG — empty routeName matches the sentinel; this Link is "active"
-// before the router starts, which is rarely what the consumer wants.
-<Link routeName="" activeClassName="active">Home</Link>
+// A misused empty-name Link is never active (tracks router.isActiveRoute("")):
+<Link routeName="" activeClassName="active">Home</Link>  // never "active"
 
-// CORRECT — pass a real route name; helper is safe by construction.
+// CORRECT — pass a real route name.
 <Link routeName="home" activeClassName="active">Home</Link>
 ```
 
-Every `isRouteActive` edge case (incl. `""`, trailing dots, dot-only
-inputs) is regression-locked via property tests — search for
-`isRouteActive` in `tests/property/routerProvider.properties.ts` to
-find the pin-tests when investigating a regression. Validation may
-reject `routeName=""` at register time, but raw helper invocation
-through a custom plugin / `routeSelector("")` is still observable.
+The `isRouteActive` helper itself is **unchanged** — `isRouteActive("", "")` still
+returns `true` (its edge cases stay property-locked in
+`tests/property/routerProvider.properties.ts`, whose Invariant 7 pins only the
+non-empty arms). The guard lives at the Link level (`useFastPath`), routing the
+misuse to the canonical slow path. Locked by `tests/functional/Link.test.tsx`
+(unstarted empty-name inactive) + `tests/integration/Link.test.tsx` (inactive
+before **and** after start).
 
 ### Link Props Are Captured at Init (Slow Path)
 

--- a/packages/solid/src/components/Link.tsx
+++ b/packages/solid/src/components/Link.tsx
@@ -57,6 +57,12 @@ export function Link<P extends Params = Params>(
   // sentinel identity when consumer omits the field). The new check is
   // explicit: "fast path kicks in when consumer did not supply routeParams".
   const useFastPath =
+    // An empty `routeName` is a misuse (matches no route). It must NOT take the
+    // routeSelector fast path, whose unstarted sentinel (`route?.name ?? ""`)
+    // makes `isRouteActive("", "") === true` — a misused empty-name Link would
+    // light up before `router.start()`. Route it to the slow path instead, which
+    // reads `router.isActiveRoute("") === false` in every router state (#1427).
+    local.routeName !== "" &&
     local.hash === undefined &&
     !local.activeStrict &&
     local.ignoreQueryParams &&

--- a/packages/solid/tests/functional/Link.test.tsx
+++ b/packages/solid/tests/functional/Link.test.tsx
@@ -87,6 +87,32 @@ describe("Link component", () => {
       expect(screen.getByTestId("link")).toHaveClass("active");
     });
 
+    it("empty routeName is inactive on an unstarted router — agrees with router.isActiveRoute('') (#1427)", () => {
+      // #1427 — an empty routeName is a misuse (matches no route); the canonical
+      // answer is router.isActiveRoute("") === false. Solid's Link fast path went
+      // through the routeSelector, whose unstarted sentinel (route?.name ?? "")
+      // makes isRouteActive("", "") === true → a misused empty-name Link lit up
+      // before router.start(). The routeName !== "" guard in useFastPath routes an
+      // empty name to the slow createActiveRouteSource (reads router.isActiveRoute("")).
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const unstarted = createTestRouterWithADefaultRouter();
+
+      // NOT started — no active route → the sentinel coerces the current name to "".
+      expect(unstarted.isActiveRoute("")).toBe(false);
+
+      render(() => (
+        <RouterProvider router={unstarted}>
+          <Link routeName="" activeClassName="active" data-testid="empty-link">
+            Empty
+          </Link>
+        </RouterProvider>
+      ));
+
+      expect(screen.getByTestId("empty-link")).not.toHaveClass("active");
+
+      errorSpy.mockRestore();
+    });
+
     it("should set active class with route params", async () => {
       const linkRouteName = "items.item";
       const linkRouteParams = { id: 6 };

--- a/packages/solid/tests/integration/Link.test.tsx
+++ b/packages/solid/tests/integration/Link.test.tsx
@@ -350,10 +350,15 @@ describe("Link - Integration Tests", () => {
   // RouterProvider → routeSelector pipeline so a regression in any
   // layer (selector wrapping, sentinel value change, Link-side
   // short-circuit) becomes visible at the UI boundary.
-  describe("Empty routeName sentinel (Gotcha #16)", () => {
-    it("Link routeName='' is active BEFORE router.start() (sentinel `''` matches)", () => {
-      // Use a router that hasn't been started — override the wrapper's
-      // implicit start from beforeEach by stopping immediately.
+  describe("Empty routeName is inactive in every router state (#1427)", () => {
+    // An empty routeName is a misuse (matches no route). Before #1427 the Link
+    // fast path went through the routeSelector, whose unstarted sentinel
+    // (`route?.name ?? ""`) made `isRouteActive("", "") === true` — the Link lit
+    // up before `router.start()`. The `routeName !== ""` guard in `useFastPath`
+    // now routes an empty name to the slow `createActiveRouteSource`, so the Link
+    // tracks the canonical `router.isActiveRoute("") === false` in EVERY state.
+    it("Link routeName='' is INACTIVE before router.start()", () => {
+      // Stop the router so it has no active route (the sentinel state).
       router.stop();
 
       render(
@@ -365,14 +370,10 @@ describe("Link - Integration Tests", () => {
         { wrapper },
       );
 
-      // Sentinel: with no active route, routeSelector falls back to
-      // the empty string. Link with routeName='' compares equal to
-      // the sentinel and renders as active.
-      expect(screen.getByTestId("empty-link")).toHaveClass("active");
+      expect(screen.getByTestId("empty-link")).not.toHaveClass("active");
     });
 
-    it("Link routeName='' becomes INACTIVE after router commits a real route", async () => {
-      // Stop and re-mount; then start to commit a non-empty route name.
+    it("Link routeName='' stays INACTIVE after router commits a real route", async () => {
       router.stop();
 
       render(
@@ -384,14 +385,12 @@ describe("Link - Integration Tests", () => {
         { wrapper },
       );
 
-      // Before start — active (sentinel match).
-      expect(screen.getByTestId("empty-link")).toHaveClass("active");
+      // Inactive before start (aligned with isActiveRoute("") === false)…
+      expect(screen.getByTestId("empty-link")).not.toHaveClass("active");
 
       await router.start("/");
 
-      // After start the route name is non-empty (default route
-      // resolved). Sentinel no longer matches → link flips to
-      // inactive.
+      // …and still inactive once a real route resolves.
       expect(screen.getByTestId("empty-link")).not.toHaveClass("active");
     });
   });

--- a/packages/svelte/CLAUDE.md
+++ b/packages/svelte/CLAUDE.md
@@ -622,7 +622,7 @@ See also: [Svelte Integration — Server-Side Rendering](https://github.com/grey
 - `useRouteNode` uses cached `createRouteNodeSource` from `@real-router/sources` — N consumers of the same `nodeName` share one router subscription
 - `useRouterTransition` uses `getTransitionSource` — shared eager source per router
 - `RouterErrorBoundary` uses `createDismissableError` — shared error source with integrated dismissal state (no local `useRouterError` composable)
-- `useIsActiveRoute` uses cached `createActiveRouteSource` — params hashed via `canonicalJson` (key-order-insensitive)
+- `useIsActiveRoute` delegates to the shared `createActiveSource` builder from `@real-router/sources` (#1427), bridged via `createReactiveSource`. Default options + a **non-empty** name take the per-router `createActiveNameSelector` fast path (#1099 — one `router.subscribe` for any number of distinct-`routeName` Links); custom params / strict / `ignoreQueryParams: false` / hash / empty name fall to cached `createActiveRouteSource` (params hashed via `canonicalJson`, key-order-insensitive). The `routeName !== ""` guard keeps `useIsActiveRoute("")` in sync with `router.isActiveRoute("") === false`
 - No `memo()` needed — Svelte compiles to fine-grained DOM updates
 - `Link` uses `$derived` for `href` and `class` derivation, `useIsActiveRoute` for active state
 - Most WeakMap caches live in `@real-router/sources` — auto-evicted on router GC. The one **local** per-router cache is `createLinkAction`'s event-delegation state (`WeakMap<Router, …>`, #1253 — see the `use:link` delegation gotcha) — also GC'd with the router

--- a/packages/svelte/src/composables/useIsActiveRoute.svelte.ts
+++ b/packages/svelte/src/composables/useIsActiveRoute.svelte.ts
@@ -1,8 +1,4 @@
-import {
-  createActiveNameSelector,
-  createActiveRouteSource,
-} from "@real-router/sources";
-import { createSubscriber } from "svelte/reactivity";
+import { createActiveSource } from "@real-router/sources";
 
 import { createReactiveSource } from "../createReactiveSource.svelte";
 import { useRouter } from "./useRouter.svelte";
@@ -18,53 +14,20 @@ export function useIsActiveRoute(
 ): { readonly current: boolean } {
   const router = useRouter();
 
-  // Fast path (#1099) — the default-options `<Link>`: non-strict matching,
-  // query params ignored, no custom `params`, no `hash`. Use the per-router
-  // shared `ActiveNameSelector`: ONE `router.subscribe` handle serves any
-  // number of distinct-`routeName` links, instead of a per-link
-  // `createActiveRouteSource` (which allocates a `BaseSource` AND opens its own
-  // router subscription for every link). This mirrors the Solid adapter's
-  // `routeSelector` fast path and removes ~4 ms / 1000 links from the
-  // link-build mount — the per-link source setup was the bulk of the Svelte
-  // `<Link>`'s extra cost over the Solid adapter.
-  //
-  // Equivalence: the selector's `isActive` is exactly non-strict,
-  // query-ignoring, name-only matching — identical to
-  // `createActiveRouteSource(router, name, undefined, { strict: false,
-  // ignoreQueryParams: true })`. Any deviation from these defaults falls to the
-  // slow path below, whose cache handles the full argument surface (custom
-  // params, strict, `ignoreQueryParams: false`, hash-aware #532).
-  if (
-    params === undefined &&
-    !strict &&
-    ignoreQueryParams &&
-    hash === undefined
-  ) {
-    const selector = createActiveNameSelector(router);
-    const subscribe = createSubscriber((update) =>
-      selector.subscribe(routeName, update),
-    );
-
-    return {
-      get current(): boolean {
-        subscribe();
-
-        return selector.isActive(routeName);
-      },
-    };
-  }
-
-  // The `hash` argument (#532) participates in the cache key when defined.
-  // exactOptionalPropertyTypes forbids `{ hash: undefined }` literally — we
-  // conditionally include the key only when a value is provided.
-  const source = createActiveRouteSource(
-    router,
-    routeName,
-    params,
-    hash === undefined
-      ? { strict, ignoreQueryParams }
-      : { strict, ignoreQueryParams, hash },
+  // The fast/slow decision — and the `routeName !== ""` guard that keeps
+  // `useIsActiveRoute("")` in sync with `router.isActiveRoute("")` (a misused
+  // empty name matches nothing, #1427) — lives in the shared `createActiveSource`
+  // builder (#1099 landed the fast path inline here; #1427 folded it into the
+  // shared builder). `createReactiveSource` bridges either path — the selector-
+  // backed fast source or the per-link slow source — to Svelte reactivity.
+  return createReactiveSource(
+    createActiveSource(
+      router,
+      routeName,
+      params,
+      strict,
+      ignoreQueryParams,
+      hash,
+    ),
   );
-
-  return createReactiveSource(source);
 }

--- a/packages/svelte/tests/functional/useIsActiveRoute.test.ts
+++ b/packages/svelte/tests/functional/useIsActiveRoute.test.ts
@@ -201,6 +201,26 @@ describe("useIsActiveRoute", () => {
     expect(strictResult.current).toBe(false);
   });
 
+  it("an empty routeName is inactive — agrees with router.isActiveRoute('') (#1427)", () => {
+    // #1427 — an empty routeName is a misuse (matches no route). The canonical
+    // answer is router.isActiveRoute("") === false; the hook must agree. Before
+    // the guard, "" took the name-selector fast path where isActive("") === true
+    // (root is every route's ancestor). createActiveSource's routeName !== ""
+    // guard routes "" to the slow path (snapshot = router.isActiveRoute("")).
+    expect(router.isActiveRoute("")).toBe(false);
+
+    let result!: { readonly current: boolean };
+
+    renderWithRouter(router, ActiveRouteCapture, {
+      routeName: "",
+      onCapture: (r: { readonly current: boolean }) => {
+        result = r;
+      },
+    });
+
+    expect(result.current).toBe(false);
+  });
+
   describe("fast path (#1099 — default options, no params)", () => {
     // A no-params call with defaults (strict=false, ignoreQueryParams=true, no
     // hash) takes the `createActiveNameSelector` fast path — one shared router


### PR DESCRIPTION
Closes #1427.

## Root
`react` / `preact` / `svelte` `useIsActiveRoute` each kept an **inline** copy of the fast/slow active-source decision, and all three predicates lacked the `routeName !== ""` guard that `vue` / `angular` gained when the builder moved to `@real-router/sources` (#1416, #1424). An empty `routeName` therefore took the name-selector fast path — where `createActiveNameSelector.isActive("") === true` (the root is every route's ancestor) — so the hook reported **active**, diverging from the canonical `router.isActiveRoute("") === false`. RED-confirmed per adapter (`expected true to be false`, router started at `/users/123`).

**solid** has the same *class* of divergence via a **different mechanism**: its Link fast path uses the `routeSelector` (`createSelector` + `isRouteActive`), not `createActiveNameSelector`. A *started* router is already correct (`isRouteActive("", "<route>")` is `false`), but the **unstarted** sentinel (`route?.name ?? ""`) makes `isRouteActive("", "") === true`, so a misused empty-name Link lit up **before `router.start()`**.

## Fix
- **react / preact / svelte:** each hook now calls the shared `createActiveSource(...)` from `@real-router/sources` (bridged via `useSyncExternalStore` / `createReactiveSource`); its `routeName !== ""` guard routes an empty name to the slow path.
- **solid:** the `useFastPath` predicate now guards `routeName !== ""`, routing an empty name to the slow `createActiveRouteSource` (which reads `router.isActiveRoute("")`) in **every** router state. `isRouteActive` and its property locks are untouched — the guard lives at the Link level.

The drift class #1416 was created to close is now closed for **all six adapters** — every one tracks `router.isActiveRoute("")` for an empty name. No behaviour change for any non-empty name.

## Per-adapter
| adapter | active-state mechanism | change |
|---|---|---|
| react / preact / svelte | shared `createActiveSource` (`createActiveNameSelector` fast / `createActiveRouteSource` slow) | hooks delegate to the builder; guard for free |
| vue / angular | shared `createActiveSource` | already done in #1424 |
| **solid** | own `routeSelector` (`createSelector` + `isRouteActive`) | `routeName !== ""` guard in `useFastPath` → slow path; closes the unstarted-sentinel window |

## Tests / class-guard
- react/preact/svelte: `"empty routeName is inactive — agrees with router.isActiveRoute('')"` per adapter (started).
- solid: `"empty routeName is inactive on an unstarted router"` (functional) + `"inactive before/after start"` (integration — the prior *Gotcha #16* pins, which asserted the old sentinel-active behavior, rewritten to the aligned contract).
- Builder-level: the `@real-router/sources` `"empty routeName → slow path"` test guards the five createActiveSource adapters.

## Docs
Updated react/preact/svelte CLAUDE.md + react/preact ARCHITECTURE.md; fixed svelte's inaccurate "uses cached createActiveRouteSource" line; rewrote solid's "Empty routeName Link is always active in unstarted state" gotcha to the aligned behavior.

## Validation
react 829 / preact 441 / svelte 356 / solid 448 tests · strict-100 % (react/preact) + 100 %-file (svelte/solid) · type-check + lint clean. 4 patch changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
