### PR TITLE
perf(route-utils): segment testers match via flat string comparisons — no RegExp engine (#1432)

### DIFF
--- a/.changeset/segment-testers-flat-perf.md
+++ b/.changeset/segment-testers-flat-perf.md
@@ -1,0 +1,7 @@
+---
+"@real-router/route-utils": patch
+---
+
+Segment testers match via flat string comparisons — no RegExp engine (#1432)
+
+`startsWithSegment` / `endsWithSegment` / `includesSegment` no longer build and execute cached RegExps: matching reduces to prefix/suffix/occurrence checks with a dot-or-edge boundary, exactly equivalent to the historical patterns (property-locked against an inline regex reference). Validation is unchanged and still once-per-segment. Cuts the cold-path cost every adapter's `RouteView` pays per navigation — react deep-config@90: **−31 % totalMs** (conservative ABAB browser A/B).

--- a/packages/route-utils/CLAUDE.md
+++ b/packages/route-utils/CLAUDE.md
@@ -20,7 +20,7 @@ Cached read-only query API for route tree structure. **Published** to npm — co
 src/
 ├── RouteUtils.ts        — RouteUtils class (chain/siblings caches, isDescendantOf)
 ├── getRouteUtils.ts     — WeakMap-cached factory for RouteUtils
-├── segmentTesters.ts    — startsWithSegment, endsWithSegment, includesSegment (regex-cached)
+├── segmentTesters.ts    — startsWithSegment, endsWithSegment, includesSegment (flat comparisons, Set-validated)
 ├── routeRelation.ts     — areRoutesRelated (string prefix comparison)
 ├── constants.ts         — MAX_SEGMENT_LENGTH, ROUTE_SEGMENT_SEPARATOR, SAFE_SEGMENT_PATTERN
 ├── types.ts             — RouteTreeNode (structural interface), SegmentTestFunction
@@ -33,7 +33,7 @@ src/
 - **Replace the root, don't mutate it in place** — the cache is keyed by root **identity**. Mutating a root object in place (e.g. pushing a child into its `nonAbsoluteChildren`) keeps the same key, so `getRouteUtils(root)` returns the **prior cached** `RouteUtils` — the new child is invisible (`getChain("newChild") → undefined`). This is **unreachable through core** (both route-CRUD paths rebuild the tree via `adoptRouteArtifacts`, so the root identity changes → WeakMap miss → fresh `RouteUtils`), but if you build trees by hand, construct a **new** root instead of mutating the old one.
 - **All caches are pre-computed and frozen** — `getChain()` and `getSiblings()` return `Object.freeze`-d arrays built at construction time. No lazy computation.
 - **`isDescendantOf` does not handle root** — `isDescendantOf(child, "")` returns `false` because `"users".startsWith(".")` is false. Root is a special case; every route is trivially a descendant of root.
-- **Segment testers use regex caching** — Each segment string builds a `RegExp` once and caches it in a `Map`. Validated for length (`MAX_SEGMENT_LENGTH`) and character safety.
+- **Segment testers match via flat string comparisons** — no RegExp engine: prefix/suffix/occurrence checks with a dot-or-edge boundary (`codePointAt === 46`), exactly equivalent to the historical `^seg(?:\\.|$)`-style patterns (locked by `tests/property/segmentTesters.regex-equivalence.properties.ts`). Validation (length `MAX_SEGMENT_LENGTH` + character safety) runs once per segment via a `Set` cache; an invalid segment throws on every call.
 - **Segment testers accept `State` objects** — When passed a `State`, the `.name` property is extracted automatically.
 - **`areRoutesRelated` is pure string comparison** — No tree lookup; O(k) where k is name length. Checks `===`, `startsWith(a + ".")`, or `startsWith(b + ".")`.
 - **Structural `RouteTreeNode` type** — Defined locally to avoid runtime dependency on `route-tree`. Structurally compatible with `RouteTree`.

--- a/packages/route-utils/INVARIANTS.md
+++ b/packages/route-utils/INVARIANTS.md
@@ -50,8 +50,17 @@
 | 1   | Character pattern partition | Segments matching `SAFE_SEGMENT_PATTERN` (`/^[\w.-]+$/`) are accepted without throwing. Segments containing any other character throw `TypeError`. All three testers enforce the same validation. |
 | 2   | Length partition            | Segments with length ≤ `MAX_SEGMENT_LENGTH` (10,000) are accepted. Segments exceeding the limit throw `RangeError`. All three testers enforce the same length validation.                         |
 
+## Implementation Equivalence
+
+| #   | Invariant                        | Description                                                                                                                                                                                                                                                                                            |
+| --- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Flat ≡ reference regex semantics | Each tester's flat string-comparison implementation returns exactly what the historical cached-RegExp form (`^seg(?:\.|$)`, `(?:^|\.)seg$`, `(?:^|\.)seg(?:\.|$)` over the escaped segment) returns, for any route name (incl. arbitrary unicode) and any `SAFE_SEGMENT_PATTERN`-valid segment — dots/dashes in any position. |
+| 2   | Curried form preserved           | The curried form equals both the direct form and the regex reference (Inv 5 restated against the reference).                                                                                                                                                                                            |
+| 3   | Throw parity, validation uncached for invalid input | An invalid-character segment throws `TypeError` on EVERY call (never enters the validated-segments cache); an over-length segment throws `RangeError` — same classes and trigger points as the regex-cache implementation.                                                                  |
+
 ## Test Files
 
-| File                                      | Invariants | Category                                                    |
-| ----------------------------------------- | ---------- | ----------------------------------------------------------- |
-| `tests/property/routeUtils.properties.ts` | 21         | Segment testers, route relation, isDescendantOf, validation |
+| File                                                          | Invariants | Category                                                    |
+| ------------------------------------------------------------- | ---------- | ----------------------------------------------------------- |
+| `tests/property/routeUtils.properties.ts`                     | 21         | Segment testers, route relation, isDescendantOf, validation |
+| `tests/property/segmentTesters.regex-equivalence.properties.ts` | 3          | Implementation equivalence (flat ≡ reference regex)         |

--- a/packages/route-utils/src/segmentTesters.ts
+++ b/packages/route-utils/src/segmentTesters.ts
@@ -10,46 +10,82 @@ import type { SegmentTestFunction } from "./types";
 import type { State } from "@real-router/types";
 
 /**
- * Escapes special RegExp characters in a string.
- * Handles all RegExp metacharacters including dash in character classes.
- *
- * @param str - String to escape
- * @returns Escaped string safe for RegExp construction
- * @internal
+ * `.` as a char code — the boundary the flat comparisons test for. Matching is
+ * exactly the historical regex semantics (`^seg(?:\.|$)` etc. over the escaped
+ * segment) without entering the RegExp engine: for a validated segment the
+ * escaped pattern is a literal, so prefix/suffix/substring checks with a
+ * dot-or-edge boundary are equivalent — locked by
+ * `tests/property/segmentTesters.regex-equivalence.properties.ts` (INVARIANTS: Implementation Equivalence).
  */
-const escapeRegExp = (str: string): string =>
-  str.replaceAll(/[$()*+.?[\\\]^{|}-]/g, String.raw`\$&`);
+const DOT = ROUTE_SEGMENT_SEPARATOR.codePointAt(0);
+
+/** `^seg(?:\.|$)` — prefix hit whose end lands on a dot or the string end. */
+const matchesStart = (name: string, segment: string): boolean =>
+  name.startsWith(segment) &&
+  (name.length === segment.length || name.codePointAt(segment.length) === DOT);
+
+/** `(?:^|\.)seg$` — suffix hit whose start lands on a dot or the string start. */
+const matchesEnd = (name: string, segment: string): boolean =>
+  name.endsWith(segment) &&
+  (name.length === segment.length ||
+    name.codePointAt(name.length - segment.length - 1) === DOT);
 
 /**
- * Creates a segment tester function with specified start and end patterns.
+ * `(?:^|\.)seg(?:\.|$)` — SOME occurrence bounded by dot-or-edge on both
+ * sides. Scans every occurrence (like the regex engine): an unbounded earlier
+ * hit must not mask a bounded later one (`x.b.c` in `ax.b.c.x.b.c`).
+ */
+const matchesAnywhere = (name: string, segment: string): boolean => {
+  let index = name.indexOf(segment);
+
+  while (index !== -1) {
+    const end = index + segment.length;
+
+    if (
+      (index === 0 || name.codePointAt(index - 1) === DOT) &&
+      (end === name.length || name.codePointAt(end) === DOT)
+    ) {
+      return true;
+    }
+
+    index = name.indexOf(segment, index + 1);
+  }
+
+  return false;
+};
+
+/**
+ * Creates a segment tester function around a flat boundary predicate.
  * This is a factory function that produces the actual test functions.
  *
- * @param start - RegExp pattern for start (e.g., "^" for startsWith)
- * @param end - RegExp pattern for end (e.g., "$" or dotOrEnd for specific matching)
+ * @param matches - Boundary predicate over (routeName, validated segment)
  * @returns A test function that can check if routes match the segment pattern
  * @internal
  */
-const makeSegmentTester = (start: string, end: string) => {
-  const regexCache = new Map<string, RegExp>();
+const makeSegmentTester = (
+  matches: (name: string, segment: string) => boolean,
+) => {
+  // Once-per-segment validation: a segment that passed the length + character
+  // checks never re-pays them. An INVALID segment is never cached — it throws
+  // on every call (same contract as the pre-flat regex cache, which also only
+  // stored successfully-built patterns).
+  const validatedSegments = new Set<string>();
 
   /**
-   * Builds a RegExp for testing segment matches.
-   * Validates length and character pattern. Type and empty checks are done by caller.
+   * Validates length and character pattern. Type and empty checks are done by
+   * caller.
    *
    * This optimizes performance by avoiding redundant checks - callers verify
    * type and empty before calling this function.
    *
-   * @param segment - The segment to build a regex for (non-empty string, pre-validated)
-   * @returns RegExp for testing
+   * @param segment - The segment to validate (non-empty string)
    * @throws {RangeError} If segment exceeds maximum length
    * @throws {TypeError} If segment contains invalid characters
    * @internal
    */
-  const buildRegex = (segment: string): RegExp => {
-    const cached = regexCache.get(segment);
-
-    if (cached) {
-      return cached;
+  const validateSegment = (segment: string): void => {
+    if (validatedSegments.has(segment)) {
+      return;
     }
 
     // Type and empty checks are SKIPPED - caller already verified these
@@ -68,11 +104,7 @@ const makeSegmentTester = (start: string, end: string) => {
       );
     }
 
-    const regex = new RegExp(start + escapeRegExp(segment) + end);
-
-    regexCache.set(segment, regex);
-
-    return regex;
+    validatedSegments.add(segment);
   };
 
   // TypeScript cannot infer conditional return type for curried function with union return.
@@ -121,8 +153,10 @@ const makeSegmentTester = (start: string, end: string) => {
           return false;
         }
 
-        // Use buildRegex (type and empty checks already done above)
-        return buildRegex(localSegment).test(name);
+        // Validate once per segment (type and empty checks already done above)
+        validateSegment(localSegment);
+
+        return matches(name, localSegment);
       };
     }
 
@@ -144,17 +178,13 @@ const makeSegmentTester = (start: string, end: string) => {
       return false;
     }
 
-    // Perform the actual regex test
-    // buildRegex skips type and empty checks (already validated above)
-    return buildRegex(segment).test(name);
+    // Perform the actual boundary test
+    // validateSegment skips type and empty checks (already validated above)
+    validateSegment(segment);
+
+    return matches(name, segment);
   };
 };
-
-/**
- * Pattern that matches either a dot separator or end of string.
- * Used for prefix/suffix matching that respects segment boundaries.
- */
-const dotOrEnd = `(?:${escapeRegExp(ROUTE_SEGMENT_SEPARATOR)}|$)`;
 
 /**
  * Tests if a route name starts with the given segment.
@@ -193,8 +223,7 @@ const dotOrEnd = `(?:${escapeRegExp(ROUTE_SEGMENT_SEPARATOR)}|$)`;
  * @see includesSegment for anywhere matching
  */
 export const startsWithSegment = makeSegmentTester(
-  "^",
-  dotOrEnd,
+  matchesStart,
 ) as SegmentTestFunction;
 
 /**
@@ -229,8 +258,7 @@ export const startsWithSegment = makeSegmentTester(
  * @see includesSegment for anywhere matching
  */
 export const endsWithSegment = makeSegmentTester(
-  `(?:^|${escapeRegExp(ROUTE_SEGMENT_SEPARATOR)})`,
-  "$",
+  matchesEnd,
 ) as SegmentTestFunction;
 
 /**
@@ -263,6 +291,5 @@ export const endsWithSegment = makeSegmentTester(
  * @see endsWithSegment for suffix matching
  */
 export const includesSegment = makeSegmentTester(
-  `(?:^|${escapeRegExp(ROUTE_SEGMENT_SEPARATOR)})`,
-  dotOrEnd,
+  matchesAnywhere,
 ) as SegmentTestFunction;

--- a/packages/route-utils/tests/property/segmentTesters.regex-equivalence.properties.ts
+++ b/packages/route-utils/tests/property/segmentTesters.regex-equivalence.properties.ts
@@ -1,0 +1,129 @@
+// packages/route-utils/tests/property/segmentTesters.regex-equivalence.properties.ts
+//
+// Equivalence lock for the segment testers' matching semantics (Implementation Equivalence).
+//
+// The testers historically matched via cached RegExps (`^seg(?:\.|$)`,
+// `(?:^|\.)seg$`, `(?:^|\.)seg(?:\.|$)` over the escaped segment). The
+// implementation now uses allocation-free flat string comparisons; this suite
+// pins that the OBSERVABLE semantics are exactly the regex ones by comparing
+// every tester against an inline reference built from those very patterns.
+// If a future edit drifts the flat form (a boundary check, a multi-occurrence
+// scan), this lock fails with a concrete counterexample.
+
+import { fc, test } from "@fast-check/vitest";
+
+import { NUM_RUNS } from "./helpers";
+import {
+  endsWithSegment,
+  includesSegment,
+  startsWithSegment,
+} from "../../src/segmentTesters";
+
+// =============================================================================
+// Reference: the pre-flat regex semantics, reproduced verbatim (no cache).
+// =============================================================================
+
+const escapeRegExp = (str: string): string =>
+  str.replaceAll(/[$()*+.?[\\\]^{|}-]/g, String.raw`\$&`);
+
+const refStarts = (name: string, segment: string): boolean =>
+  new RegExp(String.raw`^${escapeRegExp(segment)}(?:\.|$)`).test(name);
+
+const refEnds = (name: string, segment: string): boolean =>
+  new RegExp(String.raw`(?:^|\.)${escapeRegExp(segment)}$`).test(name);
+
+const refIncludes = (name: string, segment: string): boolean =>
+  new RegExp(String.raw`(?:^|\.)${escapeRegExp(segment)}(?:\.|$)`).test(name);
+
+const TESTERS = [
+  ["startsWithSegment", startsWithSegment, refStarts],
+  ["endsWithSegment", endsWithSegment, refEnds],
+  ["includesSegment", includesSegment, refIncludes],
+] as const;
+
+// =============================================================================
+// Generators — deliberately WIDER than helpers.arbSegment: dots and dashes in
+// any position (leading/trailing/consecutive) are valid per SAFE_SEGMENT_PATTERN
+// and are exactly the RegExp metacharacters the escape path had to neutralize.
+// =============================================================================
+
+const arbValidSegment: fc.Arbitrary<string> =
+  fc.stringMatching(/^[\w.-]{1,24}$/);
+
+// Names: same-alphabet strings (empty included), arbitrary unicode noise, and
+// targeted compositions around the segment (exact hit, dot-bounded hit,
+// prefix/suffix collisions that must NOT match).
+const arbNameFor = (segment: string): fc.Arbitrary<string> =>
+  fc.oneof(
+    fc.stringMatching(/^[\w.-]{0,40}$/),
+    fc.string({ maxLength: 30 }),
+    fc.constantFrom(
+      segment,
+      `${segment}.tail`,
+      `head.${segment}`,
+      `head.${segment}.tail`,
+      `${segment}x`,
+      `x${segment}`,
+      `x.${segment}x.y`,
+      `${segment}.${segment}`,
+      "",
+    ),
+  );
+
+const arbPair: fc.Arbitrary<[string, string]> = arbValidSegment.chain(
+  (segment) => fc.tuple(arbNameFor(segment), fc.constant(segment)),
+);
+
+// =============================================================================
+// Inv 9: flat implementation ≡ reference regex semantics
+// =============================================================================
+
+describe("segmentTesters ≡ reference regex semantics (Implementation Equivalence)", () => {
+  describe.each(TESTERS)("%s", (_label, tester, ref) => {
+    test.prop([arbPair], { numRuns: NUM_RUNS.standard })(
+      "direct form matches the reference for any (name, valid segment)",
+      ([name, segment]: [string, string]) => {
+        expect(tester(name, segment)).toBe(ref(name, segment));
+      },
+    );
+
+    test.prop([arbPair], { numRuns: NUM_RUNS.standard })(
+      "curried form matches the direct form and the reference (Inv 5 preserved)",
+      ([name, segment]: [string, string]) => {
+        const curried = tester(name);
+
+        expect(curried(segment)).toBe(tester(name, segment));
+        expect(curried(segment)).toBe(ref(name, segment));
+      },
+    );
+  });
+
+  test.prop(
+    [
+      // Non-empty name: with an invalid (empty) route name both forms return
+      // `false` BEFORE segment validation (#769) — no throw to observe.
+      fc.stringMatching(/^[\w.-]{1,10}$/),
+      fc
+        .string({ minLength: 1, maxLength: 20 })
+        .filter((s) => !/^[\w.-]+$/.test(s)),
+    ],
+    { numRuns: NUM_RUNS.standard },
+  )(
+    "an invalid-character segment still throws TypeError on every call (validation not cached away)",
+    (name: string, badSegment: string) => {
+      for (const [, tester] of TESTERS) {
+        expect(() => tester(name, badSegment)).toThrow(TypeError);
+        // Repeat call: an invalid segment must never enter the validated cache.
+        expect(() => tester(name, badSegment)).toThrow(TypeError);
+      }
+    },
+  );
+
+  it("an over-length segment still throws RangeError", () => {
+    const long = "a".repeat(10_001);
+
+    for (const [, tester] of TESTERS) {
+      expect(() => tester("route.name", long)).toThrow(RangeError);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The segment testers — the matching primitive every adapter's `RouteView` calls per navigation, and part of the public `route-utils` API — no longer enter the RegExp engine.

### #1432 — cold RegExp compilation in the testers' hot path

- `startsWithSegment` / `endsWithSegment` / `includesSegment` now match via flat string comparisons (prefix/suffix/occurrence with a dot-or-edge boundary), exactly equivalent to the historical `^seg(?:\.|$)`-style cached-RegExp patterns. `includesSegment` scans every occurrence, like the regex engine, so an unbounded earlier hit cannot mask a bounded later one.
- **Waste cause:** each cache-miss segment paid `escapeRegExp` + `new RegExp` + a first-exec compile (~7 µs/segment measured), and deep nesting pays it per navigation on any fresh page — the deep-config scenario reloads before every measured nav, so depth 90 compiled ~90 patterns inside every measured window.
- Validation is untouched in behavior: length + character checks run once per segment via a `Set` cache; an invalid segment throws `TypeError`/`RangeError` on every call (never cached), the `#769` deferred-invalid-name semantics and the currying overloads are preserved.
- Browser A/B (react deep-config sweep, n=30, **ABAB**: base 2.027/1.773 vs fix 1.226/1.199 @90): conservative Δ (min base − max fix) = **−0.547 ms @90 (−31 %)**, −25 % @60, −12 % @30 — the pre-registered kill-criterion (>2×rme ≈ 50-86 µs) exceeded 6-11×. Per-depth slope drops ~12 → ~4.7 µs/segment. All five cohorts' RouteView helpers share the primitive, so the win is cross-cohort; react deep@90 vs react-router flips from a 26 µs near-tie to a ~30 % lead.

## Test plan

- [x] New permanent property lock `tests/property/segmentTesters.regex-equivalence.properties.ts` (registered in INVARIANTS.md "Implementation Equivalence"): every tester ≡ an inline reference built from the exact historical regex patterns — over segments with dots/dashes in any position × names incl. arbitrary unicode; curried ≡ direct (Inv 5) restated against the reference; throw-parity (invalid segment throws on EVERY call, over-length → RangeError). Green on BOTH the old regex implementation (pre-change) and the flat one.
- [x] route-utils suite green at 100 % coverage (98 functional + 33 property)
- [x] Full turbo test across all 32 packages green (all six adapter consumers unchanged)
- [x] Same-session ABAB browser A/B (react deep-config, n=30 × 4 runs)
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes (pre-push full validation)
- [x] 100% test coverage maintained

Closes #1432
