### PR TITLE
fix(logger): isolate async callback rejection + close configure() TOCTOU (#1161 #1162)

### DIFF
--- a/.changeset/logger-1161-async-callback-isolation.md
+++ b/.changeset/logger-1161-async-callback-isolation.md
@@ -1,0 +1,16 @@
+---
+"@real-router/logger": patch
+---
+
+fix(logger): isolate an async callback rejection instead of leaking a Node unhandledRejection (#1161)
+
+`#invokeCallback` wrapped the user callback in a `try/catch` that isolated only
+**synchronous** throws. An async callback (a `(...) => Promise<void>` is assignable
+to the void-typed `LogCallback`, no cast) had its returned Promise discarded, so a
+rejection surfaced as a Node `unhandledRejection` — process-fatal under
+`--unhandled-rejections=strict` (Node 22+ default), reachable on the documented
+async-analytics callback and via `createRouter(routes, { logger: { callback: asyncFn } })`.
+
+The callback's runtime return is now read, duck-checked for a thenable, and its
+rejection routed to the same `console.error` sink a sync throw uses (`[Logger] Error
+in async callback:`) — mirroring core's `subscribe` isolation (#944). No API change.

--- a/.changeset/logger-1162-configure-level-toctou.md
+++ b/.changeset/logger-1162-configure-level-toctou.md
@@ -1,0 +1,13 @@
+---
+"@real-router/logger": patch
+---
+
+fix(logger): read config.level once in configure() — close the unstable-getter TOCTOU (#1162)
+
+`configure()` read `config.level` as a value up to four times (validate `!== undefined`,
+`Object.hasOwn(LEVEL_CONFIGS, ·)`, store, threshold lookup). A config with an unstable
+`level` getter that returns different values across reads passed validation with a valid
+level and then stored a later, unvalidated one — disabling the threshold filter. `level`
+and `callbackIgnoresLevel` are now read once into a local before validation and storage,
+so the getter fires once and the validated value is what gets stored. No change for a
+normal value config.

--- a/packages/logger/CLAUDE.md
+++ b/packages/logger/CLAUDE.md
@@ -37,7 +37,7 @@ src/
 ## Gotchas
 
 - **Singleton** -- `logger` is a module-level instance; all imports share the same config state
-- **Callback errors are swallowed** -- if `callback` throws, the error is caught and reported via `console.error` directly (avoids recursive logger calls)
+- **Callback errors are swallowed — synchronous throws AND async rejections** -- a synchronous `throw` is caught and reported as `[Logger] Error in callback:`; an async callback (a `(...) => Promise<void>` is assignable to the `void`-typed `LogCallback`) whose returned Promise rejects is isolated too (`[Logger] Error in async callback:`), so it is **not** leaked as a Node `unhandledRejection` — process-fatal under `--unhandled-rejections=strict`, Node 22+ default (#1161). Both report via `console.error` directly (avoids recursive logger calls), mirroring core's `subscribe` isolation (#944)
 - **Re-entrant callbacks are a safe no-op** -- if `callback` calls `logger.*`, an `#inCallback` re-entrancy guard skips the nested callback invocation (the nested message still reaches the console once). Without it the call would recurse ~5.9k deep to a swallowed `RangeError` (#791)
 - **`callbackIgnoresLevel`** -- when true, callback receives ALL messages even if console output is filtered; when false (default), callback follows the same threshold as console
 - **Level `"none"` early exit** -- when level is `"none"` and `callbackIgnoresLevel` is false, `#writeLog` returns immediately without any processing

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -82,22 +82,31 @@ class Logger {
    * ```
    */
   configure(config: Partial<LoggerConfig>): void {
-    if (config.level !== undefined) {
+    // Read each field ONCE into a local — an unstable getter must not be re-read
+    // between validation and storage: re-reading could pass validation with a
+    // valid level and then store a later, unvalidated one, disabling the
+    // threshold filter (a TOCTOU, #1162).
+    const level = config.level;
+
+    if (level !== undefined) {
       // Validate that the provided level is a valid configuration level
-      if (!Object.hasOwn(LEVEL_CONFIGS, config.level)) {
+      if (!Object.hasOwn(LEVEL_CONFIGS, level)) {
         throw new Error(
-          `Invalid log level: "${config.level}". Valid levels are: ${Object.keys(LEVEL_CONFIGS).join(", ")}`,
+          `Invalid log level: "${level}". Valid levels are: ${Object.keys(LEVEL_CONFIGS).join(", ")}`,
         );
       }
 
-      this.#config.level = config.level;
-      this.#currentThreshold = LEVEL_CONFIGS[config.level];
+      this.#config.level = level;
+      this.#currentThreshold = LEVEL_CONFIGS[level];
     }
     if (Object.hasOwn(config, "callback")) {
       this.#config.callback = config.callback;
     }
-    if (config.callbackIgnoresLevel !== undefined) {
-      this.#config.callbackIgnoresLevel = config.callbackIgnoresLevel;
+
+    const callbackIgnoresLevel = config.callbackIgnoresLevel;
+
+    if (callbackIgnoresLevel !== undefined) {
+      this.#config.callbackIgnoresLevel = callbackIgnoresLevel;
     }
   }
 

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -308,18 +308,46 @@ class Logger {
     // from breaking the logger or causing cascading failures
     this.#inCallback = true;
     try {
-      this.#config.callback(level, context, message, ...args);
-    } catch (error) {
-      // Fallback error reporting if callback throws
-      // Use console.error directly (don't call logger to avoid infinite loops)
+      // An async callback (`(...) => Promise<void>` is assignable to the
+      // void-typed LogCallback) returns a Promise whose rejection would otherwise
+      // leak as a Node `unhandledRejection` — process-fatal under
+      // `--unhandled-rejections=strict` (Node 22+ default). Read the runtime
+      // return and isolate it like core's subscribe (#944): duck-check the
+      // thenable + `.catch` into the same console.error sink a sync throw uses
+      // (#1161).
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -- read the runtime Promise of a void-typed async callback (#1161)
+      const result: unknown = this.#config.callback(
+        level,
+        context,
+        message,
+        ...args,
+      );
+
       if (
-        typeof console !== "undefined" &&
-        typeof console.error === "function"
+        result !== null &&
+        result !== undefined &&
+        typeof (result as PromiseLike<unknown>).then === "function"
       ) {
-        console.error("[Logger] Error in callback:", error);
+        Promise.resolve(result as PromiseLike<unknown>).catch(
+          (error: unknown) => {
+            this.#reportError("[Logger] Error in async callback:", error);
+          },
+        );
       }
+    } catch (error) {
+      // Fallback error reporting if the callback throws synchronously
+      this.#reportError("[Logger] Error in callback:", error);
     } finally {
       this.#inCallback = false;
+    }
+  }
+
+  // Report a callback error via console.error directly — never call the logger
+  // (would recurse). Shared by the sync-throw catch and the async-rejection
+  // `.catch` (#1161). Console-safety guard mirrors #writeToConsole.
+  #reportError(message: string, error: unknown): void {
+    if (typeof console !== "undefined" && typeof console.error === "function") {
+      console.error(message, error);
     }
   }
 }

--- a/packages/logger/tests/functional/logger.test.ts
+++ b/packages/logger/tests/functional/logger.test.ts
@@ -483,6 +483,41 @@ describe("Logger", () => {
 
       expect(console.warn).toHaveBeenCalledWith("[Router] Warning");
     });
+
+    it("isolates an async callback rejection instead of leaking a Node unhandledRejection (#1161)", async () => {
+      // An async callback (`(...) => Promise<void>` is assignable to the void-typed
+      // LogCallback) returns a Promise; before the fix its rejection was discarded
+      // and surfaced as a Node `unhandledRejection` — process-fatal under
+      // `--unhandled-rejections=strict` (Node 22+ default). It must be isolated
+      // into console.error like core's subscribe (#944 → #1161).
+      const leaked: unknown[] = [];
+      const onUnhandled = (reason: unknown): void => {
+        leaked.push(reason);
+      };
+
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        logger.configure({
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises -- #1161: a Promise-returning callback IS assignable to the void-typed LogCallback; that assignability is exactly the misuse under test
+          callback: () => Promise.reject(new Error("async boom")),
+        });
+
+        expect(() => {
+          logger.error("Router", "Test");
+        }).not.toThrow();
+
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(console.error).toHaveBeenCalledWith(
+          "[Logger] Error in async callback:",
+          expect.any(Error),
+        );
+        expect(leaked).toHaveLength(0);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+    });
   });
 
   describe("console fallback", () => {

--- a/packages/logger/tests/functional/logger.test.ts
+++ b/packages/logger/tests/functional/logger.test.ts
@@ -195,6 +195,31 @@ describe("Logger", () => {
       }).toThrow(/Invalid log level/);
     });
 
+    it("reads config.level once — immune to an unstable getter TOCTOU (#1162)", () => {
+      // A well-typed getter (returns LogLevelConfig) that changes value between
+      // reads passed validation with a valid level, then the code stored a later
+      // unvalidated one — disabling the threshold filter. Read-once closes it.
+      let reads = 0;
+      const evil: Partial<LoggerConfig> = {
+        get level(): LogLevelConfig {
+          reads++;
+
+          return reads <= 2 ? ERROR_ONLY : ("toString" as LogLevelConfig);
+        },
+      };
+
+      logger.configure(evil);
+
+      // The validated "error-only" is stored (not a later "toString")…
+      expect(logger.getConfig().level).toBe(ERROR_ONLY);
+
+      // …and the threshold filter stays valid: a "toString" level → NaN threshold
+      // would disable it, letting a filtered "log" message through.
+      logger.log("Probe", "x");
+
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
     it("should verify default callbackIgnoresLevel is false in internal config", () => {
       // Reset to defaults to verify internal state
       logger.configure({


### PR DESCRIPTION
Closes #1161
Closes #1162

Two findings from the `@real-router/logger` audit (2026-07-03; companions with #1163). Both in `Logger.ts`, different regions.

## #1161 — async callback rejection leaks as a Node unhandledRejection (bug, medium)

`#invokeCallback`'s `try/catch` isolated only **synchronous** throws. An async callback (a `(...) => Promise<void>` is assignable to the void-typed `LogCallback`, no cast) had its returned Promise discarded, so a rejection surfaced as a Node `unhandledRejection` — **process-fatal under `--unhandled-rejections=strict` (Node 22+ default)**, reachable on the documented async-analytics callback and via `createRouter(routes, { logger: { callback: asyncFn } })`.

Fix (option **(a)**, owner-chosen): read the callback's runtime return, duck-check the thenable, and route its rejection to the same `console.error` sink a sync throw uses (`[Logger] Error in async callback:`) — mirroring core's `subscribe` isolation (#944). Extracted a shared `#reportError` helper. No API change.

Test: "isolates an async callback rejection instead of leaking a Node unhandledRejection" (RED before — rejection leaked, console.error not called).

## #1162 — configure() re-reads config.level up to 4× (TOCTOU, low)

`configure()` read `config.level` as a value up to four times (validate `!== undefined`, `Object.hasOwn(LEVEL_CONFIGS, ·)`, store, threshold lookup). A config with an **unstable `level` getter** (returning different values across reads — well-typed, no cast) passed validation with a valid level, then stored a later, unvalidated one — **disabling the threshold filter**.

Fix: read `level` (and `callbackIgnoresLevel`) **once** into a local before validation + storage — the getter fires once, so the validated value is what's stored.

Test: "reads config.level once — immune to an unstable getter TOCTOU" (RED before — stored `"toString"`, filter disabled).

Scope note: the parallel *proto-read* residual (an **inherited** `config.level` being applied — own-property discipline adjacent to #792) is left as-is; an `Object.hasOwn(config, "level")` gate would introduce a `level !== undefined` guard unreachable under `exactOptionalPropertyTypes` (`{ level: undefined }` is a type error), which the codebase discourages. #1162's actual defect — the TOCTOU — is closed.

## Validation

logger **82** functional + **31** property tests pass · **100 % coverage** · type-check + lint clean. 2 patch changesets. The CLAUDE.md "callback errors are swallowed" gotcha now documents sync + async isolation. #1163 (JSDoc/comment drift) remains the third audit companion. Full `pnpm build` delegated to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
