### PR TITLE
fix(validation-plugin): accept dep store at exactly maxDependencies (#1225)

### DIFF
--- a/.changeset/retrospective-dep-count-boundary-fix.md
+++ b/.changeset/retrospective-dep-count-boundary-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+Fix retrospective dependency-count off-by-one that broke cloneRouter at the limit (#1225)
+
+The retrospective limits pass used `depCount >= maxDependencies`, but the live limiter (`validateDependencyCount`) counts **before** the insert — so a store may legally REACH exactly `maxDependencies`. Because the retrospective re-runs on `usePlugin` and on every `cloneRouter()`, it rejected a state it had itself allowed to be reached, making every SSR per-request clone of an at-limit base throw `RangeError`. Changed `>=` to `>` so an at-limit store passes and only a store that *strictly exceeds* the limit throws; the message now reads "exceeds" instead of "reaches or exceeds".

--- a/packages/validation-plugin/ARCHITECTURE.md
+++ b/packages/validation-plugin/ARCHITECTURE.md
@@ -51,7 +51,7 @@ router.usePlugin(validationPlugin())
     │       ├── retroV.validateRoutePropertiesStore(store)
     │       ├── retroV.validateForwardToTargetsStore(store)
     │       ├── retroV.validateDependenciesStructure(deps)
-    │       ├── retroV.validateLimitsConsistency(options, store, deps)
+    │       ├── retroV.validateLimitsConsistency(options, deps)
     │       ├── validator.options.validateOptions(options)
     │       │       └── cross-field: warnListeners ≤ maxListeners, callbackIgnoresLevel requires callback
     │       └── retroV.validateResolvedDefaultRoute(options.defaultRoute, store)  ← string defaultRoute only

--- a/packages/validation-plugin/INVARIANTS.md
+++ b/packages/validation-plugin/INVARIANTS.md
@@ -153,6 +153,15 @@ Invariants verified by property-based tests (`tests/property/`). Each invariant 
 | 10  | `validateDependencyLimit`: count meeting limit always throws `RangeError`                  | 50   |
 | 11  | `validateDependencyLimit`: `maxDependencies=0` disables limit (never throws)               | —    |
 
+## Retrospective — validateLimitsConsistency
+
+The retrospective pass checks committed **state** (re-run on `usePlugin` and every `cloneRouter()`), so it must accept any count the live limiter lets a store REACH. The live limiter counts before the insert, so reaching exactly `maxDependencies` is legal — the boundary is `>`, not `>=` (#1225).
+
+| #   | Invariant                                                                                   | Runs |
+| --- | ------------------------------------------------------------------------------------------- | ---- |
+| 1   | A store at exactly `maxDependencies` never throws (plugin ⊇ core — #1225)                    | 50   |
+| 2   | A store strictly over `maxDependencies` always throws `RangeError`                           | 50   |
+
 ## Options — validateLimitValue
 
 | #   | Invariant                                                                          | Runs |

--- a/packages/validation-plugin/src/validators/retrospective.ts
+++ b/packages/validation-plugin/src/validators/retrospective.ts
@@ -458,7 +458,8 @@ export function validateDependenciesStructure(deps: unknown): void {
  * Adapted from: validateLimits() in OptionsNamespace/validators.ts
  *
  * @param options - Router options (typed as unknown to avoid core coupling)
- * @throws {RangeError} If dependency count reaches or exceeds maxDependencies limit
+ * @throws {RangeError} If dependency count exceeds maxDependencies limit (#1225:
+ *   `>` not `>=` — an at-limit store is legal, mirroring the live limiter)
  */
 function extractConfiguredLimits(options: unknown): Record<string, unknown> {
   const opts =
@@ -501,9 +502,15 @@ function checkDepCountLimit(
       ? maxDepsFromOptions
       : maxDepsFromStore;
 
-  if (typeof maxDeps === "number" && maxDeps > 0 && depCount >= maxDeps) {
+  // `>`, not `>=` (#1225): the live limiter (`validateDependencyCount`) counts
+  // BEFORE the insert, so a store may legally REACH exactly maxDependencies. This
+  // retrospective pass checks committed STATE (re-run on usePlugin AND every
+  // cloneRouter), so it must accept an at-limit store and reject only one that
+  // STRICTLY exceeds the limit — else every SSR per-request clone of an at-limit
+  // base throws.
+  if (typeof maxDeps === "number" && maxDeps > 0 && depCount > maxDeps) {
     throw new RangeError(
-      `[validation-plugin] validateLimitsConsistency: dependency count (${depCount}) reaches or exceeds maxDependencies limit (${maxDeps})`,
+      `[validation-plugin] validateLimitsConsistency: dependency count (${depCount}) exceeds maxDependencies limit (${maxDeps})`,
     );
   }
 }

--- a/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
+++ b/packages/validation-plugin/tests/functional/integration/retrospective-integration.test.ts
@@ -112,9 +112,11 @@ describe("retrospective validation — triggered at usePlugin() time", () => {
     r.stop();
   });
 
-  it("dependency count at limit triggers RangeError on usePlugin", () => {
+  it("dependency count over limit triggers RangeError on usePlugin", () => {
     const deps: Record<string, number> = {};
 
+    // 5 deps > maxDependencies 3 — strictly over the limit (#1225: an at-limit
+    // store is legal, so the throw case here is over-limit).
     for (let i = 0; i < 5; i++) {
       deps[`dep${i}`] = i;
     }

--- a/packages/validation-plugin/tests/functional/limits.test.ts
+++ b/packages/validation-plugin/tests/functional/limits.test.ts
@@ -404,4 +404,40 @@ describe("core/limits — with validationPlugin", () => {
       expect(errorSpy).not.toHaveBeenCalled();
     });
   });
+
+  // #1225 — a store that legally REACHED maxDependencies (the live limiter
+  // `validateDependencyCount` counts BEFORE the insert, so exactly maxDeps is
+  // reachable) must not be rejected by the retrospective pass, which re-runs on
+  // every usePlugin AND every cloneRouter() → i.e. on every SSR per-request clone.
+  describe("dependency count at exactly maxDependencies (#1225)", () => {
+    it("cloneRouter succeeds when the base is at exactly maxDependencies", () => {
+      const r = createRouter<NumDeps>([], { limits: { maxDependencies: 3 } });
+
+      r.usePlugin(validationPlugin());
+
+      const deps = getDependenciesApi(r);
+
+      deps.set("d1", 1);
+      deps.set("d2", 2);
+      deps.set("d3", 3); // live limiter allows reaching exactly 3
+
+      expect(() => cloneRouter(r)).not.toThrow();
+
+      r.stop();
+    });
+
+    it("usePlugin passes when depCount already equals maxDependencies", () => {
+      // deps seeded via the constructor's 3rd arg — no live limiter runs, so the
+      // store sits at exactly the limit when the plugin's retrospective fires.
+      const r = createRouter<NumDeps>(
+        [],
+        { limits: { maxDependencies: 3 } },
+        { d1: 1, d2: 2, d3: 3 },
+      );
+
+      expect(() => r.usePlugin(validationPlugin())).not.toThrow();
+
+      r.stop();
+    });
+  });
 });

--- a/packages/validation-plugin/tests/functional/retrospective/retrospective.test.ts
+++ b/packages/validation-plugin/tests/functional/retrospective/retrospective.test.ts
@@ -631,9 +631,11 @@ describe("validateLimitsConsistency", () => {
     }).not.toThrow();
   });
 
-  it("throws RangeError when dep count reaches maxDependencies from deps store", () => {
+  it("throws RangeError when dep count exceeds maxDependencies from deps store", () => {
     const deps = makeDeps({
-      dependencies: { dep1: 1, dep2: 2, dep3: 3 },
+      // 4 deps > maxDependencies 3 — strictly over (#1225: at-limit is legal, so
+      // the throw case is now over-limit, not at-limit).
+      dependencies: { dep1: 1, dep2: 2, dep3: 3, dep4: 4 },
       limits: {
         maxDependencies: 3,
         maxPlugins: 50,
@@ -653,7 +655,9 @@ describe("validateLimitsConsistency", () => {
 
   it("prefers maxDependencies from options over deps store limit", () => {
     const deps = makeDeps({
-      dependencies: { dep1: 1, dep2: 2 },
+      // 3 deps: strictly over the OPTIONS limit (2) but well under the STORE
+      // limit (100). The throw proves the options limit is the one applied.
+      dependencies: { dep1: 1, dep2: 2, dep3: 3 },
       limits: {
         maxDependencies: 100,
         maxPlugins: 50,
@@ -671,6 +675,27 @@ describe("validateLimitsConsistency", () => {
   it("passes when deps is null — covers FALSE branch of deps check", () => {
     expect(() => {
       validateLimitsConsistency({}, null);
+    }).not.toThrow();
+  });
+
+  // #1225 — the live limiter (`validateDependencyCount`) counts BEFORE the
+  // insert, so reaching EXACTLY maxDependencies is legal. The retrospective pass
+  // checks state, not room-for-next-insert, so it must accept an at-limit store
+  // (else every cloneRouter on an at-limit base throws — breaking SSR).
+  it("passes when dep count equals maxDependencies (#1225)", () => {
+    const deps = makeDeps({
+      dependencies: { dep1: 1, dep2: 2, dep3: 3 },
+      limits: {
+        maxDependencies: 3,
+        maxPlugins: 50,
+        maxListeners: 10_000,
+        warnListeners: 1000,
+        maxLifecycleHandlers: 200,
+      },
+    });
+
+    expect(() => {
+      validateLimitsConsistency({}, deps);
     }).not.toThrow();
   });
 });

--- a/packages/validation-plugin/tests/property/validation.properties.ts
+++ b/packages/validation-plugin/tests/property/validation.properties.ts
@@ -47,6 +47,7 @@ import {
   validatePluginLimit,
   validateAddInterceptorArgs,
 } from "../../src/validators/plugins";
+import { validateLimitsConsistency } from "../../src/validators/retrospective";
 import {
   validateBuildPathArgs,
   validateMatchPathArgs,
@@ -730,6 +731,51 @@ describe("validateLimitValue — property-based", () => {
       validateLimitValue("maxDependencies", value, "test");
     }).toThrow(RangeError);
   });
+});
+
+// =============================================================================
+// Retrospective: dependency-count boundary (#1225)
+// =============================================================================
+//
+// Class-guard for the false-rejection pair (#1224 / #1225): the opt-in
+// validation layer must never reject a state bare core accepts. The live
+// limiter (`validateDependencyCount`) counts BEFORE the insert, so a store may
+// legally REACH exactly maxDependencies — the retrospective pass must accept
+// that boundary and reject only a store that STRICTLY exceeds it.
+describe("validateLimitsConsistency — dependency-count boundary (#1225)", () => {
+  const depStore = (count: number, max: number) => {
+    const dependencies: Record<string, number> = {};
+
+    for (let i = 0; i < count; i++) {
+      dependencies[`d${i}`] = i;
+    }
+
+    return { dependencies, limits: { maxDependencies: max } };
+  };
+
+  test.prop([fc.integer({ min: 1, max: 100 })], { numRuns: NUM_RUNS.standard })(
+    "a store at exactly maxDependencies never throws (plugin ⊇ core)",
+    (max) => {
+      expect(() => {
+        validateLimitsConsistency(
+          { limits: { maxDependencies: max } },
+          depStore(max, max),
+        );
+      }).not.toThrow();
+    },
+  );
+
+  test.prop([fc.integer({ min: 1, max: 100 })], { numRuns: NUM_RUNS.standard })(
+    "a store strictly over maxDependencies always throws RangeError",
+    (max) => {
+      expect(() => {
+        validateLimitsConsistency(
+          { limits: { maxDependencies: max } },
+          depStore(max + 1, max),
+        );
+      }).toThrow(RangeError);
+    },
+  );
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Fixes a retrospective off-by-one (`>=` → `>`) in `@real-router/validation-plugin`: a dependency store at **exactly** `maxDependencies` was falsely rejected, even though the live limiter (which counts *before* the insert) lets a store legally *reach* the limit.
- The retrospective pass re-runs on `usePlugin` and **every `cloneRouter()`**, so an at-limit base router made every SSR per-request clone throw `RangeError` — the user-visible impact.
- Now an at-limit store passes and only a store that *strictly exceeds* the limit throws; the message reads "exceeds" instead of "reaches or exceeds".
- Adds a class-guard property ("plugin ⊇ core") pinning that the opt-in validation layer never rejects a dependency count that bare core accepts — the invariant behind the #1224/#1225 false-rejection pair.

## Test plan

- [x] Boundary: `validateLimitsConsistency` passes at exactly `maxDependencies` — `retrospective.test.ts`
- [x] Real-world impact: `cloneRouter` + `usePlugin` succeed at exactly `maxDependencies` — `limits.test.ts`
- [x] Class-guard property: at-limit passes / over-limit throws for any M — `validation.properties.ts`
- [x] Two tests that encoded the old at-limit throw updated to over-limit (correct behavior)
- [x] `pnpm -F @real-router/validation-plugin` type-check / lint / test / test:properties pass; 100% coverage (565 functional, 83 property)
- [ ] Full `pnpm build` graph — delegated to CI

Changeset: `@real-router/validation-plugin` patch.

Closes #1225
