### PR TITLE
fix(svelte): isolate a synchronously-throwing Lazy loader (#1476)

### DIFF
--- a/.changeset/svelte-lazy-sync-throw-fix.md
+++ b/.changeset/svelte-lazy-sync-throw-fix.md
@@ -1,0 +1,7 @@
+---
+"@real-router/svelte": patch
+---
+
+Fix `Lazy`: a synchronously-throwing loader now renders the error UI instead of escaping (#1476)
+
+`<Lazy>` invoked `loader()` outside any try, so its `.catch` — which only covers the returned promise — missed a loader that throws **synchronously** (init work before the dynamic import, before the promise is returned). The sync throw escaped the `$effect` to `<svelte:boundary>` / uncaught, bypassing the component's own `{status: "error"}` UI. `loader()` is now wrapped in a `try/catch` that routes a sync throw into the same rejection path as an async failure, so both surface consistently in the error UI. The loader is still invoked synchronously on mount; the async path is unchanged.

--- a/packages/svelte/src/components/Lazy.svelte
+++ b/packages/svelte/src/components/Lazy.svelte
@@ -20,7 +20,21 @@
     state = { status: "loading" };
     let active = true;
 
-    loader()
+    // Isolate a synchronously-throwing loader (#1476): a loader that throws
+    // *before* returning its promise (init work before the dynamic import) would
+    // otherwise escape the `.catch` below — the async channel only covers the
+    // returned promise — and bypass the error UI. The try/catch routes a sync
+    // throw into the same rejection path as an async failure, while still
+    // invoking the loader synchronously on mount (throw-isolation class, #806).
+    let pending: Promise<{ default: Component }>;
+
+    try {
+      pending = loader();
+    } catch (err) {
+      pending = Promise.reject(err);
+    }
+
+    pending
       .then((module) => {
         if (!active) return;
         if (!module || typeof module.default === "undefined") {

--- a/packages/svelte/tests/functional/Lazy.test.ts
+++ b/packages/svelte/tests/functional/Lazy.test.ts
@@ -97,6 +97,38 @@ describe("Lazy component", () => {
     );
   });
 
+  it("should show the error UI when the loader throws synchronously (#1476)", async () => {
+    const testError = new Error("sync loader boom");
+    // A loader that throws *before* returning a promise (init work before the
+    // dynamic import). The async `.catch` only covers the returned promise, so
+    // pre-fix the sync throw escapes the $effect and the component's own error
+    // UI is bypassed — same throw-isolation class as #806.
+    const loader: LazyLoader = vi.fn(() => {
+      throw testError;
+    });
+
+    render(LazyTest, {
+      props: {
+        router,
+        loader,
+        fallback: MockFallbackComponent,
+      },
+    });
+
+    await vi.waitFor(() => {
+      flushSync();
+
+      expect(screen.getByText(/Error loading component: /)).toBeInTheDocument();
+    });
+
+    const errorLine = screen.getByText(/Error loading component: /);
+
+    expect(errorLine.textContent).toBe(
+      "Error loading component: sync loader boom",
+    );
+    expect(screen.queryByTestId("loaded")).not.toBeInTheDocument();
+  });
+
   it("should call loader function on mount", () => {
     const loader: LazyLoader = vi.fn(() =>
       Promise.resolve({ default: MockLoadedComponent }),


### PR DESCRIPTION
## Summary

- Fixes a throw-isolation gap in `<Lazy>` (`@real-router/svelte`): the component invoked `loader()` outside any `try`, so its `.catch` — which only covers the returned promise — missed a loader that throws **synchronously** (init work before the dynamic import). The sync throw escaped the `$effect` to `<svelte:boundary>` / uncaught, **bypassing the component's own error UI**.
- `loader()` is now wrapped in a `try/catch` that routes a sync throw into the same rejection path as an async failure — both surface consistently in `{status: "error"}`.
- Minimal behavioral change: the loader is still invoked **synchronously on mount** and the async path is unchanged; only a sync throw now shows the error UI instead of escaping.
- The one live descendant of the throw-isolation class (#767 → #798 → #806 → #1222) found by the post-#1222 codebase-wide sweep; same shape as #806's preload sync-throw guard. `<Lazy>` is unique to the Svelte adapter (React/Vue/Solid/Preact use native lazy primitives), so there is no sibling to fix.

## Test plan

- [x] `should show the error UI when the loader throws synchronously (#1476)` — `Lazy.test.ts` (RED before, GREEN after)
- [x] `pnpm -F @real-router/svelte` type-check / lint / test / test:stress pass; `Lazy.svelte` new code 100% covered (async + sync-throw paths)
- [ ] Full `pnpm build` graph — delegated to CI

Changeset: `@real-router/svelte` patch. Wiki `Lazy.md` updated (the error state now documents sync throws).

Closes #1476
