### PR TITLE
fix(validation-plugin): make the factory generic over the dependency map (#1621)

### DIFF
--- a/.changeset/validation-plugin-1621-fix.md
+++ b/.changeset/validation-plugin-1621-fix.md
@@ -1,0 +1,17 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+Make `validationPlugin()` generic over the router's dependency map (#1621)
+
+The factory returned `PluginFactory` with the `DefaultDependencies` (= `object`)
+default. `keyof object` is `never`, so `getDependency` was typed
+`(key: never) => never`, and TypeScript 7 — which performs a variance check
+TypeScript 6 skipped — refuses to assign that where `PluginFactory<D>` is
+expected for any `D` with an index signature. Consumers on `typescript@7` (now
+`latest`) typing their dependencies as `Record<string, T>` could not register the
+plugin at all: `router.usePlugin(validationPlugin())` failed with TS2345.
+
+`validationPlugin<D>()` now carries the caller's map, inferred from the router in
+the usual case. No runtime change, and no source change is required — the type
+parameter defaults exactly as before.

--- a/packages/validation-plugin/CLAUDE.md
+++ b/packages/validation-plugin/CLAUDE.md
@@ -6,7 +6,7 @@
 
 | Export              | Kind      | Description                                                                 |
 | ------------------- | --------- | --------------------------------------------------------------------------- |
-| `validationPlugin`  | function  | Plugin factory — pass to `router.usePlugin()`. Takes no arguments.          |
+| `validationPlugin`  | function  | Plugin factory — pass to `router.usePlugin()`. No runtime arguments; generic over the router's dependency map, normally inferred (#1621) |
 | `RouterValidator`   | type      | Full validator interface that core calls into via `ctx.validator?.ns.fn()`. |
 
 ## Validator Namespaces
@@ -25,6 +25,26 @@ The `RouterValidator` interface is organized into 8 namespaces, matching core's 
 | `eventBus`     | `validateListenerArgs` — validates event names: `$start`, `$stop`, `$$start`, `$$leaveApprove`, `$$cancel`, `$$success`, `$$error`; `validateCountThresholds` — proactive `warn@20% / error@50%` on the per-event listener count for `subscribe` / `addEventListener` (#1188), mirroring the plugins / lifecycle / dependencies counters |
 
 ## Gotchas
+
+### The factory is generic over the dependency map (#1621)
+
+`validationPlugin<D>()` carries the CALLER's dependency map instead of the
+`DefaultDependencies` (= `object`) default. `keyof object` is `never`, so a bare
+`PluginFactory` types `getDependency` as `(key: never) => never`, and TypeScript
+7 — which runs a variance check TS 6 skipped — refuses to assign that where
+`PluginFactory<D>` is expected for any `D` with an **index signature**. In
+practice `usePlugin(validationPlugin())` stopped compiling for a consumer typing
+dependencies as `Record<string, T>`; a map with concrete keys was always fine.
+
+`PluginFactory<never>` is NOT the shorthand here, even though core uses exactly
+that for `AnyOptions = Options<never>`: measured, it fails on BOTH compilers,
+because this plugin actually reads dependencies. `buildValidatorObject` is
+generic for the same reason — otherwise `RouterInternals<D>` does not fit its
+`RouterInternals<object>` parameter.
+
+⚠ The same `(): PluginFactory` default is still on the other nine plugin
+factories — see #1621 for the list. Anything added here should take the type
+parameter from the start.
 
 ### Register before start()
 

--- a/packages/validation-plugin/README.md
+++ b/packages/validation-plugin/README.md
@@ -54,10 +54,28 @@ Core's crash guards always run, regardless of whether this plugin is installed. 
 ### `validationPlugin()`
 
 ```typescript
-function validationPlugin(): PluginFactory;
+function validationPlugin<
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+>(): PluginFactory<Dependencies>;
 ```
 
-Returns a `PluginFactory` to pass to `router.usePlugin()`. Takes no arguments.
+Returns a `PluginFactory` to pass to `router.usePlugin()`. Takes no runtime
+arguments; the dependency map is a type parameter, normally inferred from the
+router you register it on (#1621). Spell it explicitly only when inference has
+nothing to work from:
+
+```typescript
+type Deps = Record<string, number>;
+
+const router = createRouter<Deps>(routes);
+
+router.usePlugin(validationPlugin()); // inferred
+const factory = validationPlugin<Deps>(); // explicit
+```
+
+Without the parameter the factory would default to `object`, whose `keyof` is
+`never` — and TypeScript 7 refuses to assign that where `PluginFactory<Deps>` is
+expected for any `Deps` carrying an index signature.
 
 Throws `RouterError("VALIDATION_PLUGIN_AFTER_START")` if the router is already active. Always register before `router.start()`.
 

--- a/packages/validation-plugin/src/validationPlugin.ts
+++ b/packages/validation-plugin/src/validationPlugin.ts
@@ -86,6 +86,7 @@ import {
 
 import type { EventName, EventMethodMap } from "./validators/eventBus";
 import type {
+  DefaultDependencies,
   PluginFactory,
   RouterValidator,
   Route,
@@ -94,7 +95,9 @@ import type {
 } from "@real-router/core";
 import type { RouterInternals, Matcher } from "@real-router/core/validation";
 
-function buildValidatorObject(ctx: RouterInternals): RouterValidator {
+function buildValidatorObject<
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+>(ctx: RouterInternals<Dependencies>): RouterValidator {
   return {
     routes: {
       validateBuildPathArgs,
@@ -323,7 +326,22 @@ function buildValidatorObject(ctx: RouterInternals): RouterValidator {
   };
 }
 
-export function validationPlugin(): PluginFactory {
+/**
+ * The dependency map is a type parameter so the factory carries the CALLER's
+ * `D` rather than the `object` default (#1621). `keyof object` is `never`, so a
+ * bare `PluginFactory` types `getDependency` as `(key: never) => never`, which
+ * TypeScript 7 refuses to assign where `PluginFactory<D>` is expected for any
+ * `D` with an index signature — `usePlugin(validationPlugin())` stops compiling
+ * for a consumer whose dependencies are `Record<string, T>`. TS 6 skipped that
+ * variance check, so the imprecision was always there and simply invisible.
+ *
+ * `PluginFactory<never>` does NOT work as a shorthand here (unlike
+ * `AnyOptions = Options<never>` in core): it fails on both compilers, because
+ * this plugin actually reads dependencies.
+ */
+export function validationPlugin<
+  Dependencies extends DefaultDependencies = DefaultDependencies,
+>(): PluginFactory<Dependencies> {
   // eslint-disable-next-line unicorn/consistent-function-scoping
   return (router) => {
     const ctx = getInternals(router);

--- a/packages/validation-plugin/tests/functional/plugin-factory-variance.test.ts
+++ b/packages/validation-plugin/tests/functional/plugin-factory-variance.test.ts
@@ -1,0 +1,54 @@
+import { createRouter } from "@real-router/core";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { validationPlugin } from "../../src/validationPlugin";
+
+import type { PluginFactory } from "@real-router/core";
+
+/**
+ * #1621 — the factory must carry the caller's dependency map, not the
+ * `object` default.
+ *
+ * `DefaultDependencies` is `object`, whose `keyof` is `never`, so a bare
+ * `PluginFactory` types `getDependency` as `(key: never) => never`. TypeScript 7
+ * runs a variance check TypeScript 6 skips, and rejects that value where
+ * `PluginFactory<D>` is expected for any `D` with an index signature — i.e.
+ * `usePlugin(validationPlugin())` stops compiling for a consumer who types
+ * dependencies as `Record<string, T>`.
+ *
+ * These are compile-time assertions: `vitest` transpiles without checking, so
+ * the pin is enforced by `tsc --noEmit` (which `turbo test` depends on), and
+ * the runtime bodies only prove the typed forms are real registrations.
+ */
+describe("validationPlugin — dependency-map variance (#1621)", () => {
+  it("accepts the caller's dependency map as a type argument", () => {
+    type Deps = Record<string, number>;
+
+    // Fails to compile while the factory is non-generic: TS2558, "Expected 0
+    // type arguments, but got 1". This is the pin that goes red on TS 6 too —
+    // the variance rejection itself only surfaces on TS 7.
+    const factory: PluginFactory<Deps> = validationPlugin<Deps>();
+
+    expectTypeOf(factory).toEqualTypeOf<PluginFactory<Deps>>();
+
+    const router = createRouter<Deps>([{ name: "home", path: "/" }]);
+
+    expect(() => router.usePlugin(factory)).not.toThrow();
+  });
+
+  it("registers on a router whose dependency map has an index signature", () => {
+    type Deps = Record<string, number>;
+
+    const router = createRouter<Deps>([{ name: "home", path: "/" }]);
+
+    // The consumer-facing shape from the issue. Inference must land on `Deps`;
+    // on TS 7 the bare `PluginFactory` is not assignable here at all.
+    expect(() => router.usePlugin(validationPlugin())).not.toThrow();
+  });
+
+  it("still registers with no type argument and untyped dependencies", () => {
+    const router = createRouter([{ name: "home", path: "/" }]);
+
+    expect(() => router.usePlugin(validationPlugin())).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- `router.usePlugin(validationPlugin())` compiles again for consumers on `typescript@7` (currently `latest`) whose dependency map carries an index signature — e.g. `createRouter<Record<string, number>>(...)`. Before this, it failed with TS2345 and the plugin could not be registered at all.
- `validationPlugin<D>()` now carries the caller's dependency map. It is inferred in the normal case, so **no consumer source change is required**; the type parameter defaults exactly as before.
- No runtime change, no behaviour change, no bundle-shape change.

**Root cause.** The factory returned a bare `PluginFactory`, i.e. `PluginFactory<object>` via the `DefaultDependencies` default. `keyof object` is `never`, so `getDependency` was typed `(key: never) => never`. TypeScript 7 runs a variance check that TypeScript 6 skipped, and rejects that value where `PluginFactory<D>` is expected for any `D` with an index signature — the parameter is contravariant, and `number` is not assignable to `never`. A dependency map with concrete keys (`{ db: number }`) was fine on both compilers, which is why the imprecision went unnoticed. `buildValidatorObject` is generic for the same reason: otherwise `RouterInternals<D>` does not fit its `RouterInternals<object>` parameter.

**Two shorthands were measured and rejected.** `PluginFactory<never>` — core's own trick for `AnyOptions = Options<never>` — fails on **both** compilers here, because this plugin actually reads dependencies. Changing `DefaultDependencies` itself from `object` to `never` breaks all 23 packages, since the alias doubles as the `extends` constraint. The generic form is the only one clean on 6 and 7 alike.

### Scope

This closes the `validation-plugin` instance only. The same `(): PluginFactory` default is still on the other nine plugin factories — #1621 tracks the class and stays open.

## Test plan

- [x] `tests/functional/plugin-factory-variance.test.ts` — pins that the factory **accepts a type argument** (`TS2558: Expected 0 type arguments, but got 1` before the fix, clean after). The variance rejection itself is invisible until TS 7, so the pin is written to go red on TS 6 as well; verified red before and green after on both compilers.
- [x] `tsc --noEmit` clean on TypeScript 6.0.3 **and** 7.0.2 for this package; all 23 packages now type-check clean under TS 7 — `validation-plugin` was the only red one (8 errors, all in tests).
- [x] Reproduced and re-verified through the **published `dist` types from an external project** (`node16` resolution, not the workspace `internal-source` condition): `validationPlugin()` no longer errors, while `browserPluginFactory()` still does — confirming the fix boundary.
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes (`turbo run test` — 69/69 tasks)
- [x] 100% test coverage maintained (736/736 statements, 652/652 branches, 150/150 functions)

Part of #1621