### PR TITLE
fix(core): refuse a commit superseded mid-flight (#1626) + a revalidation commit on a torn-down router (#1627)

### DIFF
--- a/.changeset/nested-navigation-1626-fix.md
+++ b/.changeset/nested-navigation-1626-fix.md
@@ -1,0 +1,20 @@
+---
+"@real-router/core": patch
+---
+
+Do not commit over a nested navigation that has not finished yet (#1626)
+
+A guard factory recompiled inside `completeTransition` may start a nested
+navigation. When that navigation ran to completion, #1611 already refused the
+outer commit; when it is still **in flight**, the outer navigation committed on
+top of it — `navigate()` resolved with success, `TRANSITION_SUCCESS` was emitted
+for a navigation the FSM had already cancelled, and the nested navigation's
+result was silently lost.
+
+`isTransitioning()` cannot tell the two apart: with a nested navigation parked in
+an async guard the machine *is* in a transition — somebody else's. The commit now
+also asks the supersession token (`inFlight.isCurrent(nav.myId)`), and neither
+half subsumes the other: the token is unmoved when a factory merely `dispose()`s
+the router, and the machine is still transitioning when the supersede is another
+navigation. A superseded navigation now rejects `TRANSITION_CANCELLED` and the
+nested result stands.

--- a/.changeset/replace-revalidation-1627-fix.md
+++ b/.changeset/replace-revalidation-1627-fix.md
@@ -1,0 +1,18 @@
+---
+"@real-router/core": patch
+---
+
+Do not commit `replace()`'s revalidation on a router torn down mid-call (#1627)
+
+`replace()` calls `clearDefinitionGuards()`, which recompiles the compiled guard
+slot from a surviving **external** factory (#1192) — application code, running
+after `replace()`'s entry `throwIfDisposed()`. A `dispose()` or `stop()` from
+there did not stop the swap: it finished, revalidated the URL and committed on a
+dead router, emitting nothing at all (dispose had already cleared the listeners),
+so no subscriber, plugin or adapter ever learned of the state it was left with.
+
+The revalidation commit now re-asks liveness on the same side of that user code
+as the commit itself, and throws `ROUTER_DISPOSED`. This also removes an
+asymmetry: the third revalidation arm (URL no longer matches) was never exposed,
+because it routes through `navigateToNotFound`, whose own liveness gate already
+throws — all three arms now refuse the same way with the same code.

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -384,6 +384,7 @@ export class Router<
       // Cross-namespace state (issue #174)
       getStateName: () => this.#state.get()?.name,
       isTransitioning: () => this.#eventBus.isTransitioning(),
+      isActive: () => this.#eventBus.isActive(),
       clearState: () => {
         this.#state.set(undefined);
       },

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -461,6 +461,23 @@ function commitRevalidated<
   nextState: State,
   fromState: State,
 ): void {
+  // `replace()` runs application code between its entry `throwIfDisposed()` and
+  // this commit: `clearDefinitionGuards()` recompiles the compiled slot from a
+  // surviving EXTERNAL factory (#1192), and a `dispose()` / `stop()` from there
+  // left the swap running — it revalidated and committed on a dead router, with
+  // zero events, because `dispose()` had already cleared the listeners (#1627).
+  //
+  // The third revalidation arm was never exposed: it routes through
+  // `navigateToNotFound`, whose own liveness gate (#1186) throws. This restores
+  // the symmetry — same predicate, same error code, all three arms.
+  //
+  // ⚠ Interim form; absorbed when this commit goes through the machine
+  // (`system-commit`, plan §10 phase 4.1), where a dead router simply has no
+  // edge to take.
+  if (!ctx.isActive()) {
+    throw new RouterError(errorCodes.ROUTER_DISPOSED);
+  }
+
   ctx.setState(nextState);
   ctx.emitTransitionSuccess(nextState, fromState, REVALIDATE_OPTS);
 }

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -203,6 +203,13 @@ export interface RouterInternals<
   // Cross-namespace state (issue #174)
   readonly getStateName: () => string | undefined;
   readonly isTransitioning: () => boolean;
+  /**
+   * Is the router still live (FSM neither IDLE nor DISPOSED)? Asked by
+   * `replace()`'s revalidation commit, which runs application code
+   * (`clearDefinitionGuards` recompiles a surviving external factory) between
+   * its entry `throwIfDisposed()` and the commit itself (#1627).
+   */
+  readonly isActive: () => boolean;
   readonly clearState: () => void;
   readonly setState: (state: State) => void;
   readonly routerExtensions: { keys: string[] }[];

--- a/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
@@ -2,6 +2,7 @@ import { errorCodes, constants } from "../../../constants";
 import { RouterError } from "../../../RouterError";
 
 import type { NavigationOptions, State, TransitionMeta } from "../../../types";
+import type { InFlightNavigation } from "../InFlightNavigation";
 import type { NavigationDependencies, NavigationContext } from "../types";
 
 type MutableTransitionMeta = {
@@ -58,6 +59,7 @@ function stripSignal({
 
 export function completeTransition(
   deps: NavigationDependencies,
+  inFlight: InFlightNavigation,
   nav: NavigationContext,
 ): State {
   const { toState, fromState, opts, toDeactivate, toActivate, intersection } =
@@ -114,13 +116,23 @@ export function completeTransition(
     // `isActive()` the nested case commits the outer state over the inner
     // result; with this, the inner result stands.
     //
+    // NEITHER half subsumes the other, which is why both are asked (#1626):
+    //
+    // - `isTransitioning()` catches a factory that TERMINATED the router
+    //   (`dispose()` → DISPOSED, `stop()` → IDLE) and one whose nested
+    //   navigation already RAN TO COMPLETION (FSM back in READY). The token is
+    //   unmoved in the terminate case, so the token check alone would wave it
+    //   through.
+    // - `isCurrent(myId)` catches the nested navigation still IN FLIGHT: the
+    //   FSM sits in ITS transition, so `isTransitioning()` is true — for
+    //   somebody else — and committing here would silently overwrite a result
+    //   that has not landed yet (measured before the fix: `START:a · CANCEL:a ·
+    //   START:b · SUCCESS:a`, with b's result lost and `navigate()` RESOLVING).
+    //
     // ⚠ Interim form; absorbed when the commit is asked THROUGH the FSM right
-    // before `setState` (RFC-10a §16.7 / §9.9, plan §10 phase 3). Two cells stay
-    // open and are deliberately NOT patched here — both need a token this
-    // function is not given: a nested navigation still IN FLIGHT (the FSM is in
-    // ITS transition, so `isTransitioning()` is true for somebody else), and the
-    // `replace()`-revalidation commit, which is a different commit path.
-    if (cleared && !deps.isTransitioning()) {
+    // before `setState` (RFC-10a §16.7 / §9.9, plan §10 phase 3) — there the
+    // supersede is a table fact (`when`/epoch), not two operational questions.
+    if (cleared && (!deps.isTransitioning() || !inFlight.isCurrent(nav.myId))) {
       throw new RouterError(errorCodes.TRANSITION_CANCELLED);
     }
   }

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -156,11 +156,12 @@ function beginTransition(
  */
 function completeImmediate(
   deps: NavigationDependencies,
+  inFlight: InFlightNavigation,
   plan: NavigationPlan,
 ): State {
   deps.sendLeaveApprove(plan.toState, plan.fromState);
 
-  return completeTransition(deps, plan);
+  return completeTransition(deps, inFlight, plan);
 }
 
 /**
@@ -254,7 +255,7 @@ export function executeNavigation(
     // listener may still register a guard. Hoisting the read would change
     // behaviour, not just shape.
     if (!plan.hasGuards && !plan.suspendable) {
-      return completeImmediate(deps, plan);
+      return completeImmediate(deps, inFlight, plan);
     }
 
     const {
@@ -354,7 +355,7 @@ export function executeNavigation(
       throw new RouterError(errorCodes.TRANSITION_CANCELLED);
     }
 
-    const finalState = completeTransition(deps, plan);
+    const finalState = completeTransition(deps, inFlight, plan);
 
     // A bare `State`, not `Promise.resolve(state)` — the RETURN TYPE is what
     // announces "this navigation already settled, synchronously", which used
@@ -466,7 +467,7 @@ async function finishAsyncNavigation(
       throw new RouterError(errorCodes.TRANSITION_CANCELLED);
     }
 
-    const state = completeTransition(deps, nav);
+    const state = completeTransition(deps, inFlight, nav);
 
     succeeded = true;
 

--- a/packages/core/src/namespaces/NavigationNamespace/types.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/types.ts
@@ -11,6 +11,14 @@ import type {
 } from "../../types";
 
 export interface NavigationContext {
+  /**
+   * Supersession token — `#navigationId` at the moment this navigation began.
+   * Lives HERE and not on {@link NavigationPlan} because `completeTransition`
+   * needs it to tell "the machine is still in MY transition" from "…in somebody
+   * else's" (#1626), and it is handed a `NavigationContext`. Purely a type-level
+   * move: no `NavigationContext` is ever built independently of a plan.
+   */
+  myId: number;
   toState: State;
   fromState: State | undefined;
   opts: NavigationOptions;
@@ -36,8 +44,6 @@ export interface NavigationContext {
  * placeholders.
  */
 export interface NavigationPlan extends NavigationContext {
-  /** Supersession token — `#navigationId` at the moment this one began. */
-  myId: number;
   /** Whether a synchronous supersede is reachable at all (#1169 commit-gate). */
   suspendable: boolean;
   canActivateFunctions: Map<string, GuardFn>;

--- a/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
+++ b/packages/core/tests/functional/api/getRoutesApi/replaceRoutes.test.ts
@@ -1254,3 +1254,119 @@ describe("core/routes/replaceRoutes — failed replace() preserves old definitio
     r.dispose();
   });
 });
+
+describe("replace() revalidation on a router torn down mid-call (#1627)", () => {
+  /**
+   * `replace()` calls `clearDefinitionGuards()`, which — for a name holding BOTH
+   * a definition and an external guard — recompiles the compiled slot from the
+   * surviving EXTERNAL factory (#1192). That factory is application code. A
+   * `dispose()` from it left `replace()` running: it finished the swap,
+   * revalidated the URL and committed, on a dead router, with zero events.
+   *
+   * The entry `throwIfDisposed()` cannot see it — the dispose happens after that
+   * check, inside the guard recompile. Same shape as #1611: the question has to
+   * be re-asked on the same side of the user code as the commit. The third
+   * revalidation arm (no match) was already protected, because it routes through
+   * `navigateToNotFound`, whose own liveness gate (#1186) throws; these two
+   * commit arms were the asymmetry.
+   */
+  const createFixture = (teardown: (router: Router) => void) => {
+    let armed = false;
+    let router!: Router;
+    const events: string[] = [];
+
+    router = createRouter(
+      [
+        { name: "home", path: "/home", canDeactivate: () => () => true },
+        { name: "other", path: "/other" },
+      ],
+      { allowNotFound: true },
+    );
+
+    router.usePlugin(() => ({
+      onTransitionSuccess: (toState) => events.push(`SUCCESS:${toState.name}`),
+    }));
+
+    getLifecycleApi(router).addDeactivateGuard("home", () => {
+      if (armed) {
+        armed = false;
+        teardown(router);
+      }
+
+      return () => true;
+    });
+
+    return { router, events, arm: () => (armed = true) };
+  };
+
+  it("does not commit the SURVIVOR arm on a disposed router", async () => {
+    const { router, events, arm } = createFixture((r) => {
+      r.dispose();
+    });
+
+    await router.start("/home");
+    arm();
+    events.length = 0;
+
+    expect(() => {
+      getRoutesApi(router).replace([
+        { name: "home", path: "/home" },
+        { name: "z", path: "/z" },
+      ]);
+    }).toThrow(
+      expect.objectContaining({ code: errorCodes.ROUTER_DISPOSED }) as Error,
+    );
+
+    expect(events).toStrictEqual([]);
+  });
+
+  it("does not commit the ROUTE-IDENTITY-CHANGE arm on a disposed router", async () => {
+    const { router, events, arm } = createFixture((r) => {
+      r.dispose();
+    });
+
+    await router.start("/home");
+    arm();
+    events.length = 0;
+
+    expect(() => {
+      getRoutesApi(router).replace([{ name: "renamed", path: "/home" }]);
+    }).toThrow(
+      expect.objectContaining({ code: errorCodes.ROUTER_DISPOSED }) as Error,
+    );
+
+    expect(router.getState()?.name).not.toBe("renamed");
+    expect(events).toStrictEqual([]);
+  });
+
+  it("refuses the same way when the factory merely STOPS the router", async () => {
+    const { router, events, arm } = createFixture((r) => r.stop());
+
+    await router.start("/home");
+    arm();
+    events.length = 0;
+
+    expect(() => {
+      getRoutesApi(router).replace([{ name: "renamed", path: "/home" }]);
+    }).toThrow(
+      expect.objectContaining({ code: errorCodes.ROUTER_DISPOSED }) as Error,
+    );
+
+    expect(events).toStrictEqual([]);
+  });
+
+  it("still revalidates normally when the recompiled factory behaves", async () => {
+    const { router, events, arm } = createFixture(() => {
+      /* well-behaved: touches nothing */
+    });
+
+    await router.start("/home");
+    arm();
+    events.length = 0;
+
+    getRoutesApi(router).replace([{ name: "renamed", path: "/home" }]);
+
+    expect(router.getState()?.name).toBe("renamed");
+    expect(events).toStrictEqual(["SUCCESS:renamed"]);
+  });
+});

--- a/packages/core/tests/functional/navigation/commit-after-teardown-1611.test.ts
+++ b/packages/core/tests/functional/navigation/commit-after-teardown-1611.test.ts
@@ -221,6 +221,79 @@ describe("#1611 — a guard factory that tears the router down mid-commit", () =
     expect(log).toStrictEqual(["SUCCESS:b"]);
   });
 
+  it("does not commit over a nested navigation that has NOT finished yet (#1626)", async () => {
+    // The sibling cell of the test above: there the nested navigation runs to
+    // completion (FSM back in READY, caught by `isTransitioning()`); here it is
+    // parked in an async activate guard, so the FSM sits in ITS transition and
+    // `isTransitioning()` is true — for somebody else. Only the supersession
+    // token tells them apart.
+    const log: string[] = [];
+    let armed = false;
+    let router!: Router;
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    router = createRouter([
+      {
+        name: "home",
+        path: "/",
+        canDeactivate: () => {
+          if (armed) {
+            armed = false;
+            router.navigate("b").catch(() => {
+              /* fire-and-forget */
+            });
+          }
+
+          return () => true;
+        },
+      },
+      { name: "a", path: "/a" },
+      {
+        name: "b",
+        path: "/b",
+        canActivate: () => async () => {
+          await held;
+
+          return true;
+        },
+      },
+    ]);
+
+    router.usePlugin(() => ({
+      onTransitionSuccess: (to) => log.push(`SUCCESS:${to.name}`),
+    }));
+
+    getLifecycleApi(router).addDeactivateGuard("home", () => () => true);
+
+    await router.start("/");
+    armed = true;
+    log.length = 0;
+
+    const outcome = await router
+      .navigate("a", {}, undefined, { forceDeactivate: true })
+      .then(
+        (state) => `resolved:${state.name}`,
+        (error: unknown) => `rejected:${codeOf(error)}`,
+      );
+
+    // The outer navigation was superseded — it must not commit, and must not
+    // report success to anyone.
+    expect(outcome).toBe(`rejected:${errorCodes.TRANSITION_CANCELLED}`);
+    expect(router.getState()?.name).not.toBe("a");
+    expect(log).not.toContain("SUCCESS:a");
+
+    // ...and the nested navigation's own result still lands once it settles.
+    release();
+    await vi.waitFor(() => {
+      expect(router.getState()?.name).toBe("b");
+    });
+
+    expect(log).toStrictEqual(["SUCCESS:b"]);
+  });
+
   it("still commits normally when the recompiled factory behaves", async () => {
     const { router, log, arm } = createFixture(() => {
       /* well-behaved factory — side-effect-free with respect to the router */


### PR DESCRIPTION
## Summary

Two sibling defects in the same class: a state commit that lands after the router has moved on. Both are reachable only through a guard factory that breaks its contract, and in both the corruption was **silent** — the state changed and nobody was told.

### #1626 — a superseded navigation still committed

- A navigation that was cancelled mid-flight no longer commits on top of the one that superseded it. It rejects `TRANSITION_CANCELLED`, and the superseding navigation's result stands.
- Before: `navigate()` **resolved with success**, `TRANSITION_SUCCESS` was emitted for a navigation the FSM had already cancelled, and the nested navigation's result was lost (measured: `START:a · CANCEL:a · START:b · SUCCESS:a`).
- **Root cause:** `completeTransition` runs one piece of application code before `setState` — clearing the external `canDeactivate` recompiles the slot from a surviving definition factory. #1611 closed the case where that factory's nested navigation runs to completion (FSM back in `READY`, caught by `isTransitioning()`); when it is still parked in an async guard the machine *is* in a transition — somebody else's — so `isTransitioning()` waves the commit through. The commit now also asks the supersession token. **Neither half subsumes the other:** the token is unmoved when a factory merely `dispose()`s the router, and the machine is still transitioning when the supersede is another navigation.

### #1627 — `replace()`'s revalidation committed on a torn-down router

- A `dispose()` / `stop()` from a guard factory during `replace()` now stops the revalidation from committing; it throws `ROUTER_DISPOSED`.
- Before: `replace()` finished the swap, revalidated the URL and committed on a dead router while emitting **nothing at all** — `dispose()` had already cleared the listeners — so no subscriber, plugin or adapter ever learned of the state the router was left holding.
- **Root cause:** `clearDefinitionGuards()` recompiles the compiled slot from a surviving **external** factory (#1192), i.e. application code running *after* `replace()`'s entry `throwIfDisposed()`. The liveness question has to be re-asked on the same side of that code as the commit — the #1611 shape.
- **Asymmetry removed (found while probing, not in the issue):** the third revalidation arm — URL no longer matches — was never exposed, because it routes through `navigateToNotFound`, whose own liveness gate (#1186) throws. All three arms now refuse identically, with the same code.

### Maintainability

- `myId` moves from `NavigationPlan` to `NavigationContext` — purely type-level: no `NavigationContext` is ever built independently of a plan, so the runtime object and the one-allocation-per-navigation budget are unchanged.
- `RouterInternals` gains `isActive()`, so the revalidation commit asks the same question `navigateToNotFound`'s gate does, rather than inventing a second predicate.

## Test plan

- [x] `tests/functional/navigation/commit-after-teardown-1611.test.ts` — new case for #1626: the nested navigation is held in an async activate guard; asserts the outer navigation rejects `TRANSITION_CANCELLED`, does not commit, emits no `SUCCESS:a`, and that the nested result lands once released. **Verified red before the fix** (`resolved:a`).
- [x] `tests/functional/api/getRoutesApi/replaceRoutes.test.ts` — four new cases for #1627: the survivor arm, the route-identity-change arm, a factory that merely `stop()`s, and the healthy path. The first three **verified red before the fix** (no throw).
- [x] Core suite green: 191 files / 3881 tests, **100% coverage** on all four metrics (statements, branches, functions, lines).
- [x] Property suite green: 44 files / 435 tests.
- [x] `packages/core` type-check and lint clean.
- [x] The five most navigation-heavy dependents green against this branch's core — lifecycle 37, memory 51, browser 356, validation 755, sources 287. Resolution confirmed by a canary (a deliberate break in core reddens the dependent's suite, so the alias resolves to this branch).
- [x] The `completeImmediate` arc stays allocation-free — `controller-allocation.test.ts` green; the fix threads a reference and a number, and allocates nothing.
- [ ] Root-level `pnpm type-check && pnpm lint && pnpm test -- --run` across the full graph — not run locally by convention (full-graph validation is the owner's / CI's); the package-scoped equivalents above were run.
- [x] 100% test coverage maintained

Closes #1626
Closes #1627
