### PR TITLE
[DO NOT MERGE] measurement probe: navigate/sync-guards at K=512 on base code

### DIFF
--- a/packages/core/tests/benchmarks/default.bench.ts
+++ b/packages/core/tests/benchmarks/default.bench.ts
@@ -213,9 +213,15 @@ export async function run(): Promise<void> {
     const targets = ["page", "home"] as const;
     let i = 0;
 
+    // ⚗ MEASUREMENT PROBE — this branch exists only to measure the BASE code at
+    // K=512 and is never merged. PR #1642 raises this same K on the slice; with
+    // master at 192 the two are compared at different batch sizes, so the report
+    // cannot say whether the slice costs anything. One point at matching K
+    // settles it. Same remedy `navigate/sync-baseline` already carries above,
+    // for the same reason (GC alignment near the measure window).
     bench.add(
       "navigate/sync-guards",
-      batched(192, () => {
+      batched(512, () => {
         void router.navigate(targets[i++ % targets.length]);
       }),
     );


### PR DESCRIPTION
Throwaway branch. **Close once the number is read** — nothing here is meant to land.

## Why

PR #1642 raises `navigate/sync-guards` from `batched(192)` to `batched(512)`. `master` still has 192, so CodSpeed compares the two arms at **different batch sizes** and the `-62%` it reports is the `512/192` ratio *plus* whatever the code does. One data point cannot separate them.

This branch is `master` with **only** that `K` raised, so the base code gets measured at 512. With both sides at matching `K` the comparison becomes direct.

## What it decides

Two models fit the two points available today and disagree by 31 points:

| | per-op | fixed per measured call | verdict after merge |
| --- | --- | --- | --- |
| A | 11.67 µs | 3671 µs (constant) | **+31% remains** |
| B | 18.80 µs | vanishes at K=512 | **parity** |

Read `navigate/sync-guards` on this run and compare against PR #1642 at the same `K`.

## Prior art in the same file

`navigate/sync-baseline` already carries `K=512`, with the reason written beside it: *"module-compile/IO jitter shifts the GC alignment near the first measure window. At K=256 a same-sha pair straddled the 10% report threshold (3.7↔3.4 ms); the extra mass turns that ±0.3 ms wiggle into ~4%."*

Same mechanism, same remedy — which is why raising K was the fix attempted on #1642 rather than a threshold tweak.

## What is already established

- Wall-clock over the **exact** commit boundary CodSpeed jumped on: `sync-guards` **−0.62%, p = 1** (9 interleaved pairs, all 22 `navigate/` arcs within the A/A floor).
- Same, **JIT off** (`--no-opt --predictable`): **−1.33%**.
- Allocations per navigation **identical** (2835 B both sides), so the slice adds no GC pressure.

Refs #1641