### PR TITLE
perf(core): the navigation plan is born in its final shape (#1693)

### DIFF
--- a/.changeset/navigation-plan-final-shape-1693.md
+++ b/.changeset/navigation-plan-final-shape-1693.md
@@ -8,16 +8,23 @@ Restore navigate hot-path performance: the navigation plan is born in its final 
 
 A write to an absent property transitions the object's hidden class. The plan is allocated per navigation, so this happened on every one of them, and every reader downstream — `planPhases`, `completeImmediate`, `completeTransition`, `buildTransitionMeta` — saw two shapes instead of one. Declaring both fields in the literal is behaviour-neutral and removes the transition.
 
-**Measured** on the benchmark runner with one variable — the same tree, the same harness, the same hour — before and after this two-field change:
+**Measured** on the benchmark runner against the tree this lands on — **12 improvements, 0 regressions, 78 benchmarks unchanged**:
 
-| benchmark                                                |  before |              after |
-| -------------------------------------------------------- | ------: | -----------------: |
-| `navigate/sync-baseline`                                 | 11.3 ms | **8 ms** (+42.5 %) |
-| `navigate/sync-deactivate-guards`                        |  4.6 ms |   3.7 ms (+25.2 %) |
-| `navigate/deep-10`                                       |  5.8 ms |   4.7 ms (+23.5 %) |
-| `navigate/sync-guards`                                   | 11.7 ms |   9.6 ms (+22.1 %) |
-| `navigate/sync-guards-both-phases`                       |  5.5 ms |   4.5 ms (+21.2 %) |
-| `navigate/forwardTo` · `params` · `plugins-1` · `deep-5` |         |           +14–15 % |
-| `navigate/leave-1` · `leave-3`                           |         |              +12 % |
+| benchmark                          |  before |                after |
+| ---------------------------------- | ------: | -------------------: |
+| `navigate/sync-baseline`           | 11.3 ms | **7.9 ms** (+42.7 %) |
+| `navigate/sync-deactivate-guards`  |  4.6 ms |     3.7 ms (+25.3 %) |
+| `navigate/deep-10`                 |  5.8 ms |     4.7 ms (+23.6 %) |
+| `navigate/sync-guards`             | 11.7 ms |     9.6 ms (+22.1 %) |
+| `navigate/sync-guards-both-phases` |  5.5 ms |     4.5 ms (+21.2 %) |
+| `navigate/forwardTo`               |  7.2 ms |       6 ms (+19.1 %) |
+| `navigate/params`                  |  3.6 ms |     3.1 ms (+15.1 %) |
+| `navigate/plugins-1`               |  6.7 ms |     5.8 ms (+14.9 %) |
+| `navigate/deep-5`                  |    5 ms |     4.4 ms (+13.7 %) |
+| `navigate/leave-1`                 |  3.6 ms |     3.2 ms (+12.1 %) |
+| `navigate/leave-3`                 |  3.6 ms |     3.2 ms (+12.1 %) |
+| `navigate/external-signal`         |  9.9 ms |       9 ms (+10.8 %) |
 
-Eleven improvements, no regressions, and 79 benchmarks unchanged. Against the pre-#1684 base the whole suite now reads _unchanged_ except `navigate/external-signal`, whose separate cost is [#1690](https://github.com/greydragon888/real-router/issues/1690).
+Nothing outside the navigate family moves — `matchPath/*`, `buildPath/*` and `state/*` never touch a plan.
+
+`navigate/external-signal` is the one arm that does not return to its pre-#1684 value: it also pays for the external-signal bridge itself, ≈330 ns per navigation, which is [#1690](https://github.com/greydragon888/real-router/issues/1690). Every other navigate benchmark now reads _unchanged_ against the pre-#1684 base.

--- a/.changeset/navigation-plan-final-shape-1693.md
+++ b/.changeset/navigation-plan-final-shape-1693.md
@@ -1,0 +1,23 @@
+---
+"@real-router/core": patch
+---
+
+Restore navigate hot-path performance: the navigation plan is born in its final shape ([#1693](https://github.com/greydragon888/real-router/issues/1693))
+
+`NavigationPlan`'s two optional fields — `controller` and `detachExternalBridge`, both introduced with the AbortController-ownership fix ([#1684](https://github.com/greydragon888/real-router/issues/1684)) — were left out of the object literal that builds the plan and written afterwards. `detachExternalBridge` is cleared unconditionally on every settle, so **every** navigation paid that write, including the ones carrying no `signal` and therefore never attaching a bridge at all.
+
+A write to an absent property transitions the object's hidden class. The plan is allocated per navigation, so this happened on every one of them, and every reader downstream — `planPhases`, `completeImmediate`, `completeTransition`, `buildTransitionMeta` — saw two shapes instead of one. Declaring both fields in the literal is behaviour-neutral and removes the transition.
+
+**Measured** on the benchmark runner with one variable — the same tree, the same harness, the same hour — before and after this two-field change:
+
+| benchmark                                                |  before |              after |
+| -------------------------------------------------------- | ------: | -----------------: |
+| `navigate/sync-baseline`                                 | 11.3 ms | **8 ms** (+42.5 %) |
+| `navigate/sync-deactivate-guards`                        |  4.6 ms |   3.7 ms (+25.2 %) |
+| `navigate/deep-10`                                       |  5.8 ms |   4.7 ms (+23.5 %) |
+| `navigate/sync-guards`                                   | 11.7 ms |   9.6 ms (+22.1 %) |
+| `navigate/sync-guards-both-phases`                       |  5.5 ms |   4.5 ms (+21.2 %) |
+| `navigate/forwardTo` · `params` · `plugins-1` · `deep-5` |         |           +14–15 % |
+| `navigate/leave-1` · `leave-3`                           |         |              +12 % |
+
+Eleven improvements, no regressions, and 79 benchmarks unchanged. Against the pre-#1684 base the whole suite now reads _unchanged_ except `navigate/external-signal`, whose separate cost is [#1690](https://github.com/greydragon888/real-router/issues/1690).

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -216,6 +216,19 @@ function beginTransition(
     shouldDeactivate: false,
     shouldActivate: false,
     hasGuards: false,
+    // The two OPTIONAL fields, declared rather than left to their first write,
+    // so the plan is born in its final shape. Both are written after the
+    // literal — `controller` on the async arc, `detachExternalBridge` on every
+    // settle (it is cleared unconditionally, so a navigation carrying no signal
+    // pays for a bridge it never attached). A write to an absent property
+    // transitions the object's hidden class, and the plan is per-navigation, so
+    // that happened on EVERY navigation and made every downstream `plan.*` read
+    // — `planPhases`, `completeImmediate`, `completeTransition`,
+    // `buildTransitionMeta` — polymorphic. Measured on the runner: leaving them
+    // out cost 10–27% across every `navigate/*` benchmark (#1693), and 42% on
+    // `navigate/sync-baseline` alone. `plan-born-in-final-shape.test.ts` pins it.
+    controller: undefined,
+    detachExternalBridge: undefined,
   };
 
   // The bridge stands from here: after the already-aborted pre-check above,

--- a/packages/core/tests/functional/plan-born-in-final-shape.test.ts
+++ b/packages/core/tests/functional/plan-born-in-final-shape.test.ts
@@ -1,0 +1,124 @@
+// The navigation plan is born in its final shape — every field of its type is
+// in the literal, including the optional ones.
+//
+// This is a PERFORMANCE invariant with no functional symptom, which is why it
+// needs a test at all: `plan.controller = c` and `plan.detachExternalBridge =
+// undefined` behave identically whether or not the field was declared, so
+// nothing in the functional suite can tell the two apart. What differs is the
+// object's hidden class. A write to an absent property transitions it, the plan
+// is allocated per navigation, and every reader downstream — `planPhases`,
+// `completeImmediate`, `completeTransition`, `buildTransitionMeta` — then sees
+// two maps instead of one.
+//
+// The cost was measured on the CodSpeed runner with one variable (#1693):
+// omitting the two optional fields cost 10–27% on every `navigate/*` benchmark
+// and 42% on `navigate/sync-baseline`, while `matchPath/*`, `buildPath/*` and
+// `state/*` — which never touch a plan — did not move at all.
+//
+// ⚠ The assertion is CLOSED-SET over the TYPE, not a check for the two names
+// that happen to be optional today. A third optional field added to
+// `NavigationContext` and assigned after construction would re-open exactly the
+// same hole, silently; keying on the interface is what makes this test notice.
+//
+// The scan keys on the type ANNOTATION at an object literal (`: NavigationPlan
+// = {…}`), the same discipline as `state-freeze-authority.test.ts`: property
+// names alone would match reads and spreads that build no plan.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const NS_DIR = path.resolve(
+  __dirname,
+  "../../src/namespaces/NavigationNamespace",
+);
+const TYPES_FILE = path.join(NS_DIR, "types.ts");
+const EXECUTE_FILE = path.join(NS_DIR, "transition/executeNavigation.ts");
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+}
+
+/** Property names declared by `interface <name>` in `types.ts`. */
+function interfaceProperties(source: ts.SourceFile, name: string): string[] {
+  const names: string[] = [];
+
+  source.forEachChild((node) => {
+    if (!ts.isInterfaceDeclaration(node) || node.name.text !== name) {
+      return;
+    }
+
+    for (const member of node.members) {
+      if (ts.isPropertySignature(member) && ts.isIdentifier(member.name)) {
+        names.push(member.name.text);
+      }
+    }
+  });
+
+  return names;
+}
+
+/** Property names of every object literal annotated `: NavigationPlan`. */
+function planLiterals(source: ts.SourceFile): string[][] {
+  const literals: string[][] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.type !== undefined &&
+      ts.isTypeReferenceNode(node.type) &&
+      ts.isIdentifier(node.type.typeName) &&
+      node.type.typeName.text === "NavigationPlan" &&
+      node.initializer !== undefined &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      literals.push(
+        node.initializer.properties.flatMap((property) =>
+          property.name !== undefined && ts.isIdentifier(property.name)
+            ? [property.name.text]
+            : [],
+        ),
+      );
+    }
+
+    node.forEachChild(visit);
+  };
+
+  visit(source);
+
+  return literals;
+}
+
+describe("the navigation plan is born in its final shape (#1693)", () => {
+  const types = parse(TYPES_FILE);
+  const declared = [
+    ...interfaceProperties(types, "NavigationContext"),
+    ...interfaceProperties(types, "NavigationPlan"),
+  ];
+
+  it("the scan finds the type and the literal it is about", () => {
+    // Positive control: every assertion below is vacuously true if either half
+    // of the scan silently matches nothing, which is what a rename would do.
+    expect(declared.length).toBeGreaterThan(0);
+    expect(declared).toContain("controller");
+    expect(declared).toContain("detachExternalBridge");
+    expect(planLiterals(parse(EXECUTE_FILE))).toHaveLength(1);
+  });
+
+  it("declares every field of its type, optional ones included", () => {
+    const [literal] = planLiterals(parse(EXECUTE_FILE));
+
+    // Sorted so the failure message names the MISSING field rather than
+    // reporting a set difference the reader has to compute.
+    const byName = (a: string, b: string): number => a.localeCompare(b);
+
+    expect(literal.toSorted(byName)).toStrictEqual(declared.toSorted(byName));
+  });
+});


### PR DESCRIPTION
## Summary

- Every `navigate()` gets its hot path back: **+42.7 %** on `navigate/sync-baseline` and **+10.8 % … +25.3 %** across the other eleven navigate benchmarks — **12 improvements, 0 regressions, 78 unchanged** on this PR's own CodSpeed run.
- **Root cause:** `NavigationPlan` has two optional fields — `controller` and `detachExternalBridge`, both introduced with the AbortController-ownership fix (#1684) — and neither was in the object literal that builds the plan; both were written afterwards. `detachExternalBridge` is cleared *unconditionally* on every settle, so **every** navigation paid that write, including the ones carrying no `signal` and therefore never attaching a bridge at all. A write to an absent property transitions the object's hidden class; the plan is per-navigation, so this happened on every one of them, and every reader downstream — `planPhases`, `completeImmediate`, `completeTransition`, `buildTransitionMeta` — saw two shapes instead of one. That is why the whole navigate family moved together while `matchPath/*`, `buildPath/*` and `state/*`, which never touch a plan, did not move at all.
- The fix is to declare both fields in the literal so the plan is born in its final shape. Behaviour-neutral: both are already `?: … | undefined` on the type, and nothing reads them differently.
- Against the pre-#1684 base every navigate benchmark now reads **unchanged** except `navigate/external-signal`, which also pays for the external-signal bridge itself — ≈330 ns per navigation, measured and attributed in #1690.

### How it was measured

Local wall-clock A/B could not see this at all — three V8 flag sets including CodSpeed's own, alternating processes, three rounds each, all within the A/A control (#1693 records the numbers). It was localised on the benchmark runner with one variable: a throwaway branch holding a single swapped file tree, dispatched on the same runner within the hour.

| benchmark | before | after |
| --- | --: | --: |
| `navigate/sync-baseline` | 11.3 ms | **7.9 ms** (+42.7 %) |
| `navigate/sync-deactivate-guards` | 4.6 ms | 3.7 ms (+25.3 %) |
| `navigate/deep-10` | 5.8 ms | 4.7 ms (+23.6 %) |
| `navigate/sync-guards` | 11.7 ms | 9.6 ms (+22.1 %) |
| `navigate/sync-guards-both-phases` | 5.5 ms | 4.5 ms (+21.2 %) |
| `navigate/forwardTo` | 7.2 ms | 6 ms (+19.1 %) |
| `navigate/params` | 3.6 ms | 3.1 ms (+15.1 %) |
| `navigate/plugins-1` | 6.7 ms | 5.8 ms (+14.9 %) |
| `navigate/deep-5` | 5 ms | 4.4 ms (+13.7 %) |
| `navigate/leave-1` | 3.6 ms | 3.2 ms (+12.1 %) |
| `navigate/leave-3` | 3.6 ms | 3.2 ms (+12.1 %) |
| `navigate/external-signal` | 9.9 ms | 9 ms (+10.8 %) |

Simulated-CPU instructions for `navigate/sync-baseline` go 0.008794 s → 0.006012 s, and its excluded syscall count 58 → 13 — both back to their pre-#1684 values.

## Test plan

- [x] `packages/core/tests/functional/plan-born-in-final-shape.test.ts` (2 tests) — asserts the literal declares **every** field of `NavigationContext` + `NavigationPlan`, optional ones included. A closed-set assertion over the *type*, not over the two names that happen to be optional today, so a third optional field added later re-opens the hole loudly instead of silently.
- [x] Mutation-validated: removing `controller: undefined` alone turns it red; removing `detachExternalBridge: undefined` alone turns it red; the positive-control test stays green in both, proving the failure is about the literal and not a broken scan.
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes — core 3995 tests in 203 files, and the full pre-commit graph is 69/69 tasks green.
- [x] 100% test coverage maintained (the two added lines are on the per-navigation path every existing navigate test already walks).

⚠ The invariant this pins has **no functional symptom** — `plan.controller = c` and `plan.detachExternalBridge = undefined` behave identically whether or not the field was declared. That is exactly why it needs its own test: nothing in the functional suite can tell the two apart, and the 3995 tests were green throughout the regression.

Closes #1693
