### PR TITLE
perf(core): the external-signal bridge stands only when the band can abort (#1690)

### DIFF
--- a/.changeset/bridge-only-when-the-band-can-abort-1690.md
+++ b/.changeset/bridge-only-when-the-band-can-abort-1690.md
@@ -1,0 +1,19 @@
+---
+"@real-router/core": patch
+---
+
+The external-signal bridge is registered only when something in the band can abort ([#1690](https://github.com/greydragon888/real-router/issues/1690))
+
+Passing `opts.signal` to `navigate()` used to attach a listener to the caller's signal on every navigation, from before the announce. The listener routes an abort onto FSM `CANCEL` ([#1684](https://github.com/greydragon888/real-router/issues/1684)) — but it can only ever fire while application code is running between the announce and the commit, and exactly three things put code there: a pre-commit plugin hook (`onTransitionStart` / `onTransitionLeaveApprove`), the `subscribeLeave` dispatch, and a guard on the path. With none of them the navigation runs to completion without yielding, so the listener was attached and detached having never had a chance to fire.
+
+**Measured**: a signal used to add **363 ns** to such a navigation and now adds **20 ns** — 1095 → 765 ns per navigation on the guard-free arm, alternating processes, four rounds.
+
+The decision is per PATH, not per router: a router with a guard on one route still skips the bridge for navigations that do not walk it. In a two-route loop over a guarded and an unguarded target, registrations drop from 100 to 50 per 100 navigations.
+
+The main beneficiary is `@real-router/navigation-plugin`, the one consumer in the ecosystem that passes a signal — the Navigation API hands it a fresh `NavigateEvent.signal` for **every** intercepted navigation, guarded or not.
+
+Two of the three conditions are knowable before the announce; `hasGuards` is not, because a `TRANSITION_START` listener may still register one. So the bridge has two moments: early when either of the first two holds, and late — after the walk is planned — when only guards remain. The late moment is in time precisely because the first two were false, so nothing ran during the announce.
+
+⚠ Deferring a registration is not the same as the window being empty, and the difference is that `addEventListener` never fires retroactively. The late moment therefore carries its own already-aborted check — the same one `finishAsyncNavigation` keeps at its entry, for the same reason. Without it, an abort arriving from a Proxy-backed `opts` getter (a supported shape: reading `opts` is a call into application code) produced no `TRANSITION_CANCEL` and left the band in `LEAVE_APPROVED`.
+
+Two supporting changes fall out of the same fact. `opts.forceDeactivate` is now read once at the entry beside `opts.signal`, instead of inside the pipeline after the announce; and `finishAsyncNavigation` reads the signal the bridge was attached to rather than re-reading `opts.signal`, which with a Proxy could hand back a different object.

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -163,6 +163,54 @@ function detachExternalBridge(plan: NavigationContext): void {
 }
 
 /**
+ * SECOND of the bridge's two moments (#1690), and a no-op unless it is the one
+ * that applies.
+ *
+ * Reached only when the first declined — `detachExternalBridge` is set iff the
+ * bridge is standing, so it doubles as the flag and no field was added for it.
+ * Registering this late is in time for the same reason the first moment
+ * declined: with no pre-commit listener NOTHING ran during the announce, so no
+ * listener could have registered a guard and `plan.hasGuards` is exactly what
+ * it would have been before it. The guards are the only in-band code left, and
+ * they run after the caller returns from here.
+ *
+ * ⚠ **Deferring a registration is not the same as making the window empty, and
+ * the difference is what `addEventListener` does not do.** It never fires
+ * retroactively, so an abort that landed anywhere between the entry pre-check
+ * and this point reaches a listener that did not exist yet — and the caller's
+ * signal is the application's object, abortable at any moment. Reading `opts`
+ * is itself a call into application code when it is Proxy-backed, which is a
+ * supported shape. Measured on a getter that aborts: no `TRANSITION_CANCEL` at
+ * all and `isLeaveApproved()` stuck true, i.e. the #1684 symptom, against a
+ * base that emitted the cancel.
+ *
+ * Hoisting the last `opts` read out of the window (see `forceDeactivate`)
+ * shrinks it but cannot close it. So the deferral carries its own
+ * already-aborted check — the same one `finishAsyncNavigation` keeps at its
+ * entry, for the same reason. Verified: identical trace to registering early.
+ */
+function bridgeLateIfOnlyGuardsCanAbort(
+  deps: NavigationDependencies,
+  plan: NavigationPlan,
+): void {
+  const signal = plan.externalSignal;
+
+  if (
+    signal === undefined ||
+    plan.detachExternalBridge !== undefined ||
+    !plan.hasGuards
+  ) {
+    return;
+  }
+
+  bridgeExternalSignal(deps, plan, signal);
+
+  if (signal.aborted) {
+    deps.cancelNavigation(signal.reason);
+  }
+}
+
+/**
  * Pass 1 of the shared prologue: reserve the navigation, then announce it.
  *
  * Ends with `startTransition` DELIBERATELY, and nothing follows it here. That
@@ -193,20 +241,45 @@ function beginTransition(
   // front of the previous navigation's cancel listeners, which is a behaviour
   // change and not this one's business.
   const externalSignal = opts.signal;
+  // Read ONCE here for the same reason, and not where it is used: its only
+  // consumer is `planPhases`, which runs AFTER the announce — i.e. inside the
+  // window the bridge's late registration below assumes contains no
+  // application code (#1690).
+  const forceDeactivate = opts.forceDeactivate === true;
+
+  // The two halves of "application code runs between the announce and the
+  // settle" that are knowable BEFORE the announce. The third — `hasGuards` — is
+  // not, and that is what splits the bridge's registration into two moments
+  // below (#1690).
+  //
+  // ⚑ These two reads used to sit inside `suspendable`'s `||`, where a
+  // navigation carrying a signal short-circuited past them. They are made
+  // unconditionally now because they are also the bridge's predicate; two
+  // listener-count reads against the ~350 ns the bridge costs is not a trade
+  // that needs measuring.
+  const announceOrLeaveCanAbort =
+    deps.hasLeaveListeners() || deps.hasPreCommitListeners();
 
   // `suspendable` is true only when a synchronous supersede is reachable — an
   // external `opts.signal`, `subscribeLeave` listeners, or a pre-commit plugin
   // listener (`onTransitionStart` / `onTransitionLeaveApprove`); the pure
   // synchronous navigate (none of these) is uncancellable and skips the
   // commit-gate, keeping the #307 hot path perf-neutral.
+  //
+  // ⚠ **The `externalSignal` term is load-bearing for the BRIDGE, not only for
+  // cancellability, and that is not obvious from reading it.** Разрез А returns
+  // through `completeImmediate` BEFORE the synchronous `detachExternalBridge`
+  // site, so a signal-carrying navigation that reached the fast path would
+  // leave its listener on the caller's signal. Measured on the mutation that
+  // drops this term: 200 live listeners after 200 navigations, against 0 today,
+  // and the arm goes from ~1.1 µs to ~62 µs per navigation as the list grows.
+  // Do not "simplify" it away without moving the detach first.
   const plan: NavigationPlan = {
     toState,
     fromState,
     opts,
-    suspendable:
-      externalSignal !== undefined ||
-      deps.hasLeaveListeners() ||
-      deps.hasPreCommitListeners(),
+    suspendable: externalSignal !== undefined || announceOrLeaveCanAbort,
+    forceDeactivate,
     // Write-once placeholders — pass 2 fills them (see `NavigationPlan`).
     toDeactivate: NO_SEGMENTS,
     toActivate: NO_SEGMENTS,
@@ -229,14 +302,22 @@ function beginTransition(
     // `navigate/sync-baseline` alone. `plan-born-in-final-shape.test.ts` pins it.
     controller: undefined,
     detachExternalBridge: undefined,
+    externalSignal,
   };
 
-  // The bridge stands from here: after the already-aborted pre-check above,
-  // before the announce below — the placement is argued in full on
-  // `bridgeExternalSignal`, and it is what covers a plugin's
-  // `onTransitionStart`. The test is the CALLER's, so разрез А pays a null
-  // check on a value it has already loaded rather than a call.
-  if (externalSignal) {
+  // FIRST of the bridge's two moments, and the one #1684 argued for: after the
+  // already-aborted pre-check, before the announce — which is what covers a
+  // plugin's `onTransitionStart` / `onTransitionLeaveApprove`.
+  //
+  // ⚑ Now conditional (#1690). The bridge exists to route an abort that lands
+  // WHILE the navigation is in the band, and the only things that can land one
+  // there are application callbacks: the two announce hooks, the
+  // `subscribeLeave` dispatch, and the guards. With none of the first three, no
+  // code runs between here and the walk, so registering here would buy a
+  // listener that provably cannot fire before the second moment gets the same
+  // chance — measured at ~350 ns per navigation, essentially the whole cost a
+  // signal used to add to an otherwise guard-free navigation.
+  if (externalSignal && announceOrLeaveCanAbort) {
     bridgeExternalSignal(deps, plan, externalSignal);
   }
 
@@ -341,7 +422,7 @@ function planPhases(deps: NavigationDependencies, plan: NavigationPlan): void {
   plan.toActivate = toActivate;
   plan.intersection = intersection;
   plan.shouldDeactivate =
-    !!plan.fromState && !plan.opts.forceDeactivate && toDeactivate.length > 0;
+    !!plan.fromState && !plan.forceDeactivate && toDeactivate.length > 0;
   plan.shouldActivate =
     plan.toState.name !== constants.UNKNOWN_ROUTE && toActivate.length > 0;
   // The guards of THIS transition, not of the router. Asking the Maps for
@@ -396,6 +477,8 @@ export function executeNavigation(
     // a reentrant navigate() is banned — REENTRANT_NAVIGATION.)
 
     planPhases(deps, plan);
+
+    bridgeLateIfOnlyGuardsCanAbort(deps, plan);
 
     // Разрез А (RFC §5.1). `immediate` is the RFC's four-term predicate
     // written in the terms that already exist: `suspendable` IS
@@ -569,7 +652,11 @@ async function finishAsyncNavigation(
     !controller.signal.aborted &&
     deps.isActive();
 
-  const externalSignal = nav.opts.signal;
+  // The SAME object the bridge was attached to, not a re-read of
+  // `nav.opts.signal` (#1690). With a Proxy-backed `opts` the second read can
+  // hand back a different signal, and this pre-check would then be asking a
+  // stranger whether this navigation was cancelled.
+  const externalSignal = nav.externalSignal;
   let onInternalAbort: (() => void) | undefined;
   let succeeded = false;
   let failureReason: unknown;

--- a/packages/core/src/namespaces/NavigationNamespace/types.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/types.ts
@@ -101,6 +101,19 @@ export interface NavigationContext {
    * which signal this navigation was carrying.
    */
   detachExternalBridge?: (() => void) | undefined;
+  /**
+   * The caller's `opts.signal`, read ONCE at the entry point and kept here
+   * (#1690).
+   *
+   * The bridge onto it is registered at one of two moments — before the
+   * announce when something in the announce or the leave dispatch can abort,
+   * and after the walk is planned when only guards can — so the second site
+   * needs the same signal OBJECT the first would have used. Re-reading
+   * `opts.signal` there is not equivalent: `opts` may be accessor- or
+   * Proxy-backed, so a second read can hand back a different object, and the
+   * bridge would then be detached from something it was never attached to.
+   */
+  externalSignal?: AbortSignal | undefined;
 }
 
 /**
@@ -121,6 +134,19 @@ export interface NavigationContext {
 export interface NavigationPlan extends NavigationContext {
   /** Whether a synchronous supersede is reachable at all (#1169 commit-gate). */
   suspendable: boolean;
+  /**
+   * `opts.forceDeactivate`, read ONCE at the entry point (#1690).
+   *
+   * It belongs to the first pass for the same reason `externalSignal` does:
+   * `opts` may be accessor- or Proxy-backed, so reading it is a call into
+   * application code, and `planPhases` — which is the only consumer — runs
+   * AFTER the announce. Leaving the read there put application code inside the
+   * one window the bridge's late registration assumes is empty, and a getter
+   * that aborted the signal from inside it reached nobody. Measured on that
+   * shape before the hoist: no `TRANSITION_CANCEL`, `isLeaveApproved()` stuck
+   * true — the #1684 symptom, on the arc where `opts` is exotic.
+   */
+  forceDeactivate: boolean;
   canActivateFunctions: Map<string, GuardFn>;
   shouldDeactivate: boolean;
   shouldActivate: boolean;

--- a/packages/core/tests/functional/navigation/bridge-only-when-the-band-can-abort-1690.test.ts
+++ b/packages/core/tests/functional/navigation/bridge-only-when-the-band-can-abort-1690.test.ts
@@ -1,0 +1,220 @@
+// The external-signal bridge is registered when it can matter, and not before.
+//
+// The bridge routes an abort of the caller's `opts.signal` onto FSM `CANCEL`
+// (#1684). It can only ever fire while application code is running between the
+// announce and the commit, and there are exactly three things that put code
+// there: a pre-commit listener (`onTransitionStart` / `onTransitionLeaveApprove`),
+// the `subscribeLeave` dispatch, and a guard on the path. With none of them the
+// navigation runs to completion without yielding, so the listener is attached
+// and detached without ever having had a chance to fire — measured at ~350 ns
+// per navigation, which was essentially the whole cost a signal added to an
+// otherwise guard-free navigation.
+//
+// Two of the three are knowable before the announce; `hasGuards` is not, because
+// a `TRANSITION_START` listener may still register one. Hence two moments: early
+// when either of the first two holds, late — after the walk is planned — when
+// only guards are left. The late moment is in time precisely because the first
+// two were false, so nothing ran during the announce and no guard could have
+// appeared.
+//
+// ⚠ The last case is the one that is easy to get wrong and impossible to see
+// without asking for it. Deferring a registration is NOT the same as the window
+// being empty: `addEventListener` never fires retroactively, so an abort that
+// lands before the late moment reaches a listener that does not exist yet. The
+// caller's signal is the application's object, and reading `opts` is itself a
+// call into application code when it is Proxy-backed — a supported shape. Before
+// the deferral carried its own already-aborted check, that produced no
+// `TRANSITION_CANCEL` at all and left `isLeaveApproved()` stuck true: the #1684
+// symptom, reintroduced.
+
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getLifecycleApi } from "@real-router/core/api";
+
+import type { Router } from "@real-router/core";
+
+interface Spied {
+  signal: AbortSignal;
+  controller: AbortController;
+  registrations: () => number;
+  removals: () => number;
+}
+
+function spiedSignal(): Spied {
+  const controller = new AbortController();
+  const add = vi.spyOn(controller.signal, "addEventListener");
+  const remove = vi.spyOn(controller.signal, "removeEventListener");
+
+  return {
+    controller,
+    signal: controller.signal,
+    registrations: () => add.mock.calls.length,
+    removals: () => remove.mock.calls.length,
+  };
+}
+
+/** `a` → `b`, with nothing in the band unless a case adds it. */
+function bareRouter(): Router {
+  return createRouter([
+    { name: "a", path: "/a" },
+    { name: "b", path: "/b" },
+  ]);
+}
+
+describe("the external-signal bridge stands only when the band can abort (#1690)", () => {
+  let router: Router | undefined;
+
+  beforeEach(() => {
+    router = undefined;
+  });
+
+  afterEach(() => {
+    router?.dispose();
+  });
+
+  it("registers nothing when nothing in the band can abort", async () => {
+    router = bareRouter();
+    await router.start("/a");
+
+    const spied = spiedSignal();
+    const state = await router.navigate("b", undefined, undefined, {
+      signal: spied.signal,
+    });
+
+    expect(state.name).toBe("b");
+    expect(spied.registrations()).toBe(0);
+    expect(spied.removals()).toBe(0);
+    // The navigation is unaffected in every other respect.
+    expect(spied.signal.aborted).toBe(false);
+  });
+
+  describe("…and each of the three things that CAN abort brings it back", () => {
+    it("a guard on the path — registered late, after the walk is planned", async () => {
+      router = bareRouter();
+      getLifecycleApi(router).addActivateGuard("b", () => () => true);
+      await router.start("/a");
+
+      const spied = spiedSignal();
+
+      await router.navigate("b", undefined, undefined, {
+        signal: spied.signal,
+      });
+
+      expect(spied.registrations()).toBe(1);
+      expect(spied.removals()).toBe(1);
+    });
+
+    it("a subscribeLeave listener — registered early", async () => {
+      router = bareRouter();
+      await router.start("/a");
+      router.subscribeLeave(() => {
+        /* its existence is the point */
+      });
+
+      const spied = spiedSignal();
+
+      await router.navigate("b", undefined, undefined, {
+        signal: spied.signal,
+      });
+
+      expect(spied.registrations()).toBe(1);
+      expect(spied.removals()).toBe(1);
+    });
+
+    it("a pre-commit plugin hook — registered early", async () => {
+      router = bareRouter();
+      router.usePlugin(() => ({
+        onTransitionStart: () => {
+          /* its existence is the point */
+        },
+      }));
+      await router.start("/a");
+
+      const spied = spiedSignal();
+
+      await router.navigate("b", undefined, undefined, {
+        signal: spied.signal,
+      });
+
+      expect(spied.registrations()).toBe(1);
+      expect(spied.removals()).toBe(1);
+    });
+  });
+
+  it("the decision is per PATH, not per router — a guarded router still skips an unguarded route", async () => {
+    // The reason the predicate reads `plan.hasGuards` and not "does this router
+    // have any guards at all": the coarse question answers `true` for a router
+    // with a single guard anywhere, which in a real application is most of them.
+    router = createRouter([
+      { name: "a", path: "/a" },
+      { name: "b", path: "/b" },
+      { name: "guarded", path: "/guarded" },
+    ]);
+    getLifecycleApi(router).addActivateGuard("guarded", () => () => true);
+    await router.start("/a");
+
+    const unguarded = spiedSignal();
+
+    await router.navigate("b", undefined, undefined, {
+      signal: unguarded.signal,
+    });
+
+    expect(unguarded.registrations()).toBe(0);
+
+    const guarded = spiedSignal();
+
+    await router.navigate("guarded", undefined, undefined, {
+      signal: guarded.signal,
+    });
+
+    expect(guarded.registrations()).toBe(1);
+    expect(guarded.removals()).toBe(1);
+  });
+
+  it("an abort landing BEFORE the late moment still reaches the machine", async () => {
+    // The attack this design has to survive. `opts` may be Proxy-backed — a
+    // supported shape — so reading it is a call into application code, and the
+    // pipeline reads it after the entry pre-check. A getter that aborts there
+    // fires no listener, because the bridge is not standing yet and
+    // `addEventListener` does not fire retroactively.
+    //
+    // Without the deferral's own already-aborted check this row is the #1684
+    // symptom: `navigate()` still rejects (the commit gate reads the signal off
+    // the payload), but no `TRANSITION_CANCEL` is emitted and the band is left
+    // in `LEAVE_APPROVED` with `isLeaveApproved()` lying.
+    const cancels: string[] = [];
+
+    router = bareRouter();
+    getLifecycleApi(router).addActivateGuard("b", () => () => true);
+    router.usePlugin(() => ({
+      onTransitionCancel: () => {
+        cancels.push("CANCEL");
+      },
+    }));
+    await router.start("/a");
+
+    const controller = new AbortController();
+    let armed = true;
+    const opts = new Proxy(
+      { signal: controller.signal },
+      {
+        get(target, key, receiver) {
+          if (key === "forceDeactivate" && armed) {
+            armed = false;
+            controller.abort(new Error("aborted from a Proxy getter"));
+          }
+
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+
+    await expect(
+      router.navigate("b", undefined, undefined, opts),
+    ).rejects.toMatchObject({ code: "CANCELLED" });
+
+    expect(cancels).toStrictEqual(["CANCEL"]);
+    expect(router.isLeaveApproved()).toBe(false);
+  });
+});

--- a/packages/core/tests/functional/navigation/navigate/abort-signal.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/abort-signal.test.ts
@@ -379,15 +379,53 @@ describe("router.navigate() - AbortController / AbortSignal integration", () => 
       // `mayCommit` refused the commit without moving the machine, so the band
       // stayed in `LEAVE_APPROVED` and route-CRUD was silently blocked.
       //
-      // The bridge is registered for every navigation carrying a signal, from
-      // before the announce. What this test guards is the other half, and it is
-      // the half its own title always claimed: the listener is REMOVED when the
-      // navigation settles. The caller's signal outlives the navigation — it is
-      // the application's object — so a leaked listener would let a later abort
+      // What this test guards is the other half, and it is the half its own
+      // title always claimed: NOTHING IS LEFT on the caller's signal when the
+      // navigation settles. The signal outlives the navigation — it is the
+      // application's object — so a leaked listener would let a later abort
       // cancel an unrelated navigation.
-      expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
-      expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+      //
+      // ⚑ Stated as a balance rather than as "exactly one add" since #1690.
+      // The bridge is registered at the moment it can first matter, and this
+      // route reaches none of them: `users` carries no guard, and the fixture
+      // has no `subscribeLeave` and no pre-commit plugin listener, so no
+      // application code runs between the announce and the commit and an abort
+      // in that window is unreachable. Zero registrations and zero removals is
+      // the same guarantee as one and one — which is why the assertion is the
+      // balance. The sibling below keeps the discrimination: a route that CAN
+      // abort still registers, so this pair cannot both pass on a bridge that
+      // stopped working.
+      expect(removeEventListenerSpy).toHaveBeenCalledTimes(
+        addEventListenerSpy.mock.calls.length,
+      );
       // Success never aborts it (#722).
+      expect(controller.signal.aborted).toBe(false);
+    });
+
+    it("11a. …and a navigation that CAN be aborted mid-flight still registers, once (#1690)", async () => {
+      // The discriminating half of the pair above. Without it the balance
+      // assertion is satisfied by a bridge that never registers at all, which
+      // is exactly the defect #1684 fixed — so the two must be read together.
+      //
+      // A `subscribeLeave` listener is the cheapest of the three things that
+      // put application code between the announce and the commit (the other two
+      // are a pre-commit plugin hook and a guard on the path).
+      const controller = new AbortController();
+
+      router.subscribeLeave(() => {
+        /* its existence is the point — it is what can abort */
+      });
+
+      const addSpy = vi.spyOn(controller.signal, "addEventListener");
+      const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+      const state = await router.navigate("users", {}, undefined, {
+        signal: controller.signal,
+      });
+
+      expect(state.name).toBe("users");
+      expect(addSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledTimes(1);
       expect(controller.signal.aborted).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

- Passing `opts.signal` to `navigate()` no longer costs anything on a navigation that cannot be interrupted. **Measured: a signal added 363 ns and now adds 20 ns** — 1095 → 765 ns per navigation on the guard-free arm, alternating processes, four rounds, spreads not overlapping.
- **Root cause:** the bridge that routes an abort of the caller's signal onto FSM `CANCEL` (#1684) was registered on *every* signal-carrying navigation, from before the announce. It can only ever fire while application code runs between the announce and the commit, and exactly three things put code there — a pre-commit plugin hook (`onTransitionStart` / `onTransitionLeaveApprove`), the `subscribeLeave` dispatch, and a guard on the path. With none of them the navigation runs to completion without yielding, so the listener was attached and detached having never had a chance to fire.
- The decision is per **path**, not per router: a router with a guard on one route still skips the bridge for navigations that do not walk it. In a loop over a guarded and an unguarded target, registrations drop from 100 to 50 per 100 navigations — which the coarse "does this router have guards at all" question would have missed entirely.
- The beneficiary is concrete rather than hypothetical. `@real-router/navigation-plugin` is the only consumer of `signal` anywhere in the repo, and the Navigation API hands it a fresh `NavigateEvent.signal` for **every** intercepted navigation, guarded or not.

### How the two moments work

Two of the three conditions are knowable before the announce; `hasGuards` is not, because a `TRANSITION_START` listener may still register one. So the bridge stands at whichever moment can first matter: **early** when a pre-commit or leave listener exists, **late** — after the walk is planned — when only guards remain. The late moment is in time precisely because the first two were false: nothing ran during the announce, so no guard could have appeared, and `planPhases` executes no application code.

⚠ **Deferring a registration is not the same as the window being empty**, and the difference is that `addEventListener` never fires retroactively. The late moment therefore carries its own already-aborted check — the same one `finishAsyncNavigation` keeps at its entry, for the same reason. This was found by attacking the first draft: with a Proxy-backed `opts` (a supported shape, so reading `opts` is itself a call into application code) a getter that aborted produced **no `TRANSITION_CANCEL` at all** and left `isLeaveApproved()` stuck true — the #1684 symptom, reintroduced. Hoisting the read out of the window shrinks it but cannot close it; only the check does.

### Two supporting changes from the same fact

- `opts.forceDeactivate` is read once at the entry beside `opts.signal`, instead of inside the pipeline after the announce.
- `finishAsyncNavigation` reads the signal the bridge was attached to instead of re-reading `opts.signal`, which with a Proxy could hand back a different object — a latent inconsistency of the same class.

### Recorded, not changed

`suspendable`'s `externalSignal` term is load-bearing for the bridge's **detach**, not only for cancellability: разрез А returns through `completeImmediate` before the synchronous detach site, so a signal-carrying navigation on the fast path would leak its listener. Measured on that mutation: **200 live listeners after 200 navigations** against 0 today, and the arm goes from ~1.1 µs to ~62 µs as the list grows. The term now says so.

## Test plan

- [x] `packages/core/tests/functional/navigation/bridge-only-when-the-band-can-abort-1690.test.ts` — **6 tests**: nothing registered when nothing can abort; each of the three conditions bringing it back; the per-path decision; and the Proxy-getter abort still reaching the machine.
- [x] **Mutation-validated three ways**, one per moving part: making the early registration unconditional reds 3 of 6, dropping the late call reds 3 of 6, and removing the already-aborted check reds **exactly** the Proxy row.
- [x] **Listener balance across five shapes**, 100 navigations each — zero left behind on every one; registrations go 100 → 0 (bare), 100 → 50 (guard on one of two routes), and stay 100 for the three shapes that can abort.
- [x] **No arm regressed.** Разрез А (no signal, no guards) is unchanged with overlapping spreads — the hot path #1693 was about is untouched. Guards-with-signal, where the bridge is still registered every time, measured −3 %; guards without a signal −5 %. Those two are near noise and are **not** claimed as wins; the claim is only that nothing got slower.
- [x] **Correctness sweep over the whole tier**: instrumenting both the guard-pipeline entry and the actual guard invocation across 4016 tests gives 25 × `sig=true bridged=true`, 425 × `sig=false`, and **0 × `sig=true bridged=false`** — no navigation ever runs a guard on a signal it is not bridged to.
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes — core **4016 tests in 206 files**, property **450 in 44**, full pre-commit graph 69/69.
- [x] 100% test coverage maintained.

⚠ Two honest limits. The improvements on the non-target arms are **not attributed** — the likely cause is the hoisted read becoming a plan-field access, but that was not isolated. And "how common is the target shape" is measured on this repo's own workload and its one consumer; there is no data about real applications.

`abort-signal.test.ts` 11 is restated as a **balance** (removals === registrations, which zero-and-zero satisfies) with a new sibling 11a keeping its discrimination — without it the balance would also pass on a bridge that never registers, which is the defect #1684 fixed.

Closes #1690
