### PR TITLE
refactor(browser-env): one product decision, one copy — URL-plugin defaults (#1651)

### DIFF
--- a/.changeset/shared-url-defaults-1651-browser-refactor.md
+++ b/.changeset/shared-url-defaults-1651-browser-refactor.md
@@ -1,0 +1,9 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Read `forceDeactivate` and `base` defaults from the shared `browser-env` object (#1651)
+
+`defaultOptions` now spreads `sharedUrlPluginDefaults` from `shared/browser-env/defaults.ts`, the single value read by `browser-plugin`, `hash-plugin` and `navigation-plugin`. Values are unchanged (`forceDeactivate: false`, `base: ""`) — the point is that "does browser Back honour `canDeactivate`" stops being three independently editable copies, the arrangement whose drift reached users in #524/#1645.
+
+The stale `@default true` on `BrowserPluginOptions.forceDeactivate` is corrected to `false`, matching what the plugin has shipped since #1645.

--- a/.changeset/shared-url-defaults-1651-hash-refactor.md
+++ b/.changeset/shared-url-defaults-1651-hash-refactor.md
@@ -1,0 +1,9 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Read `forceDeactivate` and `base` defaults from the shared `browser-env` object (#1651)
+
+`defaultOptions` now spreads `sharedUrlPluginDefaults` from `shared/browser-env/defaults.ts`, the single value read by `browser-plugin`, `hash-plugin` and `navigation-plugin`; `hashPrefix` stays local as URL mechanics only this plugin owns. Values are unchanged (`forceDeactivate: false`, `base: ""`, `hashPrefix: ""`) — the point is that "does browser Back honour `canDeactivate`" stops being three independently editable copies, the arrangement whose drift reached users in #524/#1645.
+
+The stale `@default true` on `HashPluginOptions.forceDeactivate` is corrected to `false`, matching what the plugin has shipped since #1645.

--- a/.changeset/shared-url-defaults-1651-navigation-refactor.md
+++ b/.changeset/shared-url-defaults-1651-navigation-refactor.md
@@ -1,0 +1,7 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Read `forceDeactivate` and `base` defaults from the shared `browser-env` object (#1651)
+
+`defaultOptions` now spreads `sharedUrlPluginDefaults` from `shared/browser-env/defaults.ts`, the single value read by `browser-plugin`, `hash-plugin` and `navigation-plugin`. Values are unchanged (`forceDeactivate: false`, `base: ""`) — the point is that "does browser Back honour `canDeactivate`" stops being three independently editable copies, the arrangement whose drift reached users in #524/#1645.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -7080,3 +7080,87 @@ real case ever appears.
 side-effect-free positive control that also asserts the hoisted meta still carries the getter's value.
 Mutationally validated: putting the meta build back below the ask reds exactly the two teardown cases
 and leaves the control green.
+
+## One product decision had three copies; the move needed a guard against the second failure mode (2026-08-08)
+
+### Problem
+
+"Does browser Back honour `canDeactivate`" is one question about an app, and the three URL-owning
+plugins each wrote down their own answer: `forceDeactivate` and `base` lived in
+`packages/{browser,hash,navigation}-plugin/src/constants.ts`, three times, with three copies of the
+comment explaining them. The option's TYPE had been shared all along
+(`shared/browser-env/popstate-handler.ts` → `PopstateTransitionOptions.forceDeactivate`); only its
+value was not.
+
+The copies had already drifted and the drift reached users. #524 flipped the default to `false` in
+`navigation-plugin` alone, on the stated premise that confirm-on-back already worked under
+`browser-plugin` — measured false in #1645: the guard was invoked ZERO times on a matched
+back/forward, and had been since v0.1.0. For a year and a half the repo shipped two plugins whose
+READMEs contradicted each other about the same behaviour. After #1643 the not-found arm of the same
+gesture began consulting the guard, so one option gave the two halves of a single Back press opposite
+answers.
+
+Nothing caught it, and nothing structurally could: each plugin's suite pins its OWN default
+(`deactivate-default-1645.test.ts` in browser and hash, "forceDeactivate default is false" in
+navigation's `navigate.test.ts`). Those three tests are green for a one-plugin change, because the
+author edits the plugin and its test together. Nothing below the repo level ever compared the three.
+
+### Solution
+
+Two parts, and the second is not optional.
+
+**The move (#1651).** `shared/browser-env/defaults.ts` exports
+`sharedUrlPluginDefaults = { forceDeactivate: false, base: "" } as const`; each plugin spreads it.
+The criterion for what moves: the option describes **router behaviour**. URL mechanics (`hashPrefix`)
+and identifiers (`source`, `POPSTATE_SOURCE`, `LOGGER_CONTEXT`) stay per-plugin. The
+`Required<*PluginOptions>` annotation on each `defaultOptions` is what keeps the split honest — an
+option a plugin declares and the shared object does not carry fails to type-check.
+
+**The guard.** `scripts/url-plugin-defaults-parity.test.mjs`, joining the existing
+`node --test scripts/*.test.mjs` step in repo-lints. The move alone closes only "forgot to fix the
+other two"; it does nothing about "fixed it here on purpose" — a local override after the spread, or
+a spread quietly swapped back for literals, rebuilds precisely the arrangement that failed in #524.
+The guard asserts four things, reading `constants.ts` through the TypeScript AST:
+
+1. a key repeated across plugins holds the same value;
+2. a key held by **two or more** plugins is READ from the shared object, never re-typed locally;
+3. the spread resolves to an IMPORT of `sharedUrlPluginDefaults` from `./browser-env`, not a
+   same-named local;
+4. a positive control — the shared object parses to a non-empty map and all three plugins are found.
+
+Invariant 2 is keyed on "repeated", not on "is a key of the shared object", deliberately: the narrow
+form is blind to how the class returns — two plugins agreeing on a NEW option, each with its own
+literal, is the #524 shape again on the day after it is written.
+
+### Why
+
+**AST, not regex.** `{ ...shared, k: v }` is order-sensitive — a key after the spread wins, a key
+before it loses. A line-oriented parser cannot see which side of the spread an override landed on,
+and that override is the mutation the guard exists to catch.
+
+**The guard does not pin the values.** Flipping `forceDeactivate` in the shared object keeps it green
+(validated). The invariant is single-sourcing, not `false`; a product decision must stay changeable
+in one edit, which is the whole point of the move.
+
+**Mutationally validated in seven directions**, each applied to a clean tree: a local override with a
+different value (red), the spread replaced by literals with IDENTICAL values (red — invariant 1 alone
+would have missed it), the SAME override applied to all three so values still agree (red), a new
+shared-in-practice option added by literal to two plugins (red), the import replaced by a same-named
+local object (red), a value change inside the shared object (green — the negative control), and
+`defaultOptions` renamed in one plugin so the scan loses a member (red, via the positive control).
+
+**The scan is fail-closed by an explicit member list.** `git grep -- 'packages/*/src'` returns
+nothing at all — a pathspec `*` does not cross `/` — and `:(glob)` does not expand braces either, so
+`packages/{browser,hash}-plugin` is another silent zero. Both empty results read exactly like "no
+duplicates". `REQUIRED_MEMBERS` turns a broken scan into a failure instead of a pass.
+
+**Family membership is by content, not by name.** A plugin carrying its own copy of a shared key
+joins the family without importing anything — otherwise the regression could opt out of the guard by
+being a regression.
+
+**The other two shared-source families were checked separately, not by analogy** (the issue asked for
+exactly that). `shared/ssr`: no copies — the defaults are centralised in `createSsrLoaderPlugin`
+itself (`ssr === undefined || ssr === true → "full"`, `allowedModes ?? ALL_SSR_MODES`), and the two
+plugins pass config in. `shared/dom-utils`: five adapters repeat `EMPTY_PARAMS` / `EMPTY_OPTIONS`,
+but that is not one product decision — their per-package IDENTITY is load-bearing (Link's fast path
+compares by reference), so sharing them would be the regression.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -6870,12 +6870,12 @@ check (verified: `gh api /repos/greydragon888/real-router/rulesets/12148150` ret
 `Require Changeset`, `CI Result`, `Validate Changesets`, `Dependency Review`, `SonarCloud`),
 and #1520 is a closed, unrelated issue ("Fold the internal foundation packages into core").
 
-This is not a comment nit: the `OUTSIDE_GATE` string is *enforcement* — the meta-test prints
+This is not a comment nit: the `OUTSIDE_GATE` string is _enforcement_ — the meta-test prints
 it when a job is missing from the gate, so it is what the next reader uses to decide whether
 the exclusion is still sound. Left as-is it invites exactly the wrong fix (re-adding
 `sonarcloud` to `needs`, paying the 90 s back for a guarantee that already exists).
 
-**Solution.** Both texts now state what is true — the exclusion is about *latency*, the
+**Solution.** Both texts now state what is true — the exclusion is about _latency_, the
 gating lives in the ruleset — and name the command that verifies it, so the next audit can
 re-check in one call instead of re-deriving.
 
@@ -6886,7 +6886,7 @@ re-check in one call instead of re-deriving.
 - `sonar` (`dotenv -- sonar-scanner-npm -Dsonar.login=$SONAR_TOKEN`) — broken by its own
   admission: `scripts/sonar-local.sh` documents that `$SONAR_TOKEN` expanded in a shell
   without `.env` was "always empty" and that `-Dsonar.login` is deprecated, which is why it
-  invokes the scanner directly and explicitly *not* via `pnpm run sonar`.
+  invokes the scanner directly and explicitly _not_ via `pnpm run sonar`.
 - `verify:examples` — no caller anywhere; example validation is `examples.yml` + the
   `examples-build` job.
 
@@ -6895,7 +6895,7 @@ said `pnpm sonar`, now `pnpm sonar:local`; `sonar-local.sh` credited `.env` load
 `sonar` npm script", now to its own `dotenv --` wrapper.
 
 **The one non-obvious consequence — knip.** `@sonar/scan` and `dotenv-cli` were reachable
-*only* through the deleted `sonar` script, so removing it made knip report both as unused
+_only_ through the deleted `sonar` script, so removing it made knip report both as unused
 devDependencies. They are genuinely used, by `scripts/sonar-local.sh`. Measured, not assumed:
 knip lists `scripts/*.{sh,mjs,ts}` as entry, but it does **not** resolve binaries out of shell
 scripts at all — dropping the `pnpm exec` prefix (`exec dotenv -- sonar-scanner-npm`) changes
@@ -6914,7 +6914,7 @@ bad trade.
 
 **Problem.** `RouteLifecycleNamespace.#recompileSlot` re-derives a route's compiled
 `canActivate` / `canDeactivate` when one origin (definition or external) is cleared and the
-other survives. It did so by *invoking the surviving factory*. Two callers of that clear are
+other survives. It did so by _invoking the surviving factory_. Two callers of that clear are
 DESTRUCTIVE operations, so both were running application code in the middle of themselves:
 
 - `completeTransition`'s post-leave cleanup — one step before the commit;
@@ -6922,7 +6922,7 @@ DESTRUCTIVE operations, so both were running application code in the middle of t
 
 A factory that called `dispose()` / `stop()` / `navigate()` from there tore the router down
 under the very operation that had invoked it. Each occurrence was fixed by adding another
-guard *around the verdict*: #1611 (an interim re-check), #1626 (a supersession token in that
+guard _around the verdict_: #1611 (an interim re-check), #1626 (a supersession token in that
 re-check), the #1641 review BLOCKER (a SECOND commit-gate ask, before the cleanup), #1627 (the
 same shape on `replace()`). Four patches, one unnamed root — the repo's own "much effort = wrong
 axis" signal.
@@ -6934,9 +6934,9 @@ Two things measured on `cee5b6877` before the change, because neither was obviou
   **once** in the entire tier, and the late ask refuses after a cleanup **6** times — all six
   inside the regression file written for #1611. The mechanism was defending a scenario nothing
   but its own test produced.
-- **residual loss** — the early ask protects the *commit*, not the *cleanup*. A navigation that
+- **residual loss** — the early ask protects the _commit_, not the _cleanup_. A navigation that
   is ultimately REFUSED had already unregistered the external `canDeactivate` of the route the
-  user stays on. Reproduced on HEAD, with the discriminating control (kill it *before* the
+  user stays on. Reproduced on HEAD, with the discriminating control (kill it _before_ the
   cleanup and the guard survives).
 
 **Solution.** Store each factory's compiled form beside it — four Maps, the same origin×type
@@ -6949,17 +6949,17 @@ With no application code in the window, the two commit-gate asks collapse into o
 
 **Why the surviving ask moved ABOVE the cleanup — the one part that is not interchangeable.**
 The natural reading is that "before the cleanup" and "after the cleanup" became the same point,
-since nothing runs between them. They did not. The cleanup is still *destructive* even though
+since nothing runs between them. They did not. The cleanup is still _destructive_ even though
 it is now silent, so an ask below it lets a cancelled navigation eat the guard first and refuse
 afterwards. Built both ways and measured: ask-below reds `commit-gate-1169 › an aborted
 opts.signal leaves the external canDeactivate registered` — the #1641 BLOCKER, restored — while
 ask-above is green. Only the SECOND ask lost its subject; the FIRST one is the survivor.
 
-**Why not the alternatives.** Moving the cleanup *after* the send (so "cleaned up" implies
+**Why not the alternatives.** Moving the cleanup _after_ the send (so "cleaned up" implies
 "committed") fixes one site and leaves `replace()`'s untouched, and changes #1611's outcome:
 the factory's teardown lands after a successful commit instead of cancelling it. A `permit`
 type (the ask returns a branded token the clear demands) compiles, costs nothing at runtime and
-makes the forbidden ordering a type error — but it fixes the *order* while the *execution* is
+makes the forbidden ordering a type error — but it fixes the _order_ while the _execution_ is
 the defect, so the residual loss and the second site both survive it. It remains available as
 cheap insurance on top, not as the fix.
 
@@ -6975,7 +6975,7 @@ scenario that no longer exists; they were retired, not repaired, and replaced by
 COUNTS factory invocations across a navigation and a `replace()` (expected: zero) — restoring
 the invocation reds all eight. One non-obvious follow-on: deleting the #1627 block dropped the
 only cover for `EventBusNamespace.#refuseSystemCommit`'s plain "not started" phase, which that
-block had been reaching *incidentally* via a factory that stopped the router mid-swap. Coverage
+block had been reaching _incidentally_ via a factory that stopped the router mid-swap. Coverage
 caught it; the phase now has a direct test through the internals door
 (`getInternals(router).navigateToNotFound(...)` on a never-started router — the facade refuses
 earlier and never reaches the table).
@@ -7003,7 +7003,7 @@ returns a token reference instead of `true` — but the token is module-level, s
 navigation.
 
 **Scope, stated honestly.** The permit proves the ask HAPPENED, not that it is still true. That is
-sufficient *here and nowhere else by default*: since the guard-clear stopped executing factories,
+sufficient _here and nowhere else by default_: since the guard-clear stopped executing factories,
 nothing runs between the ask and the clear. Reused across a span that can run user code it would be
 theatre.
 
@@ -7017,7 +7017,7 @@ of the shipped stage 1 and measured:
   place — diverges: shipped order keeps the guard (`CANNOT_DEACTIVATE` on the next departure), stage 2
   **silently deletes it** (`resolved`).
 - The mechanism is the point: `sendTransitionDone` emits `TRANSITION_SUCCESS` synchronously, so under
-  stage 2 arbitrary application code runs *between the commit and the destructive cleanup*. That is
+  stage 2 arbitrary application code runs _between the commit and the destructive cleanup_. That is
   the same property #1649 exists to remove, mirrored rather than removed — user code used to sit
   between the ask and the cleanup (via the factory), and would now sit between the commit and the
   cleanup (via listeners).
@@ -7150,9 +7150,30 @@ local object (red), a value change inside the shared object (green — the negat
 `defaultOptions` renamed in one plugin so the scan loses a member (red, via the positive control).
 
 **The scan is fail-closed by an explicit member list.** `git grep -- 'packages/*/src'` returns
-nothing at all — a pathspec `*` does not cross `/` — and `:(glob)` does not expand braces either, so
-`packages/{browser,hash}-plugin` is another silent zero. Both empty results read exactly like "no
-duplicates". `REQUIRED_MEMBERS` turns a broken scan into a failure instead of a pass.
+nothing at all, and `packages/{browser,hash}-plugin/src` is a second silent zero. Both empty results
+read exactly like "no duplicates", so `REQUIRED_MEMBERS` turns a broken scan into a failure instead
+of a pass.
+
+The reason is worth recording correctly, because the folklore — stated in #1651's own text, and
+repeated in the first draft of this note and of the guard's header — says "a pathspec `*` does not
+cross `/`", and for the DEFAULT mode that is false. Measured here with
+`git grep -l defaultOptions -- <pathspec>`:
+
+| pathspec                        | files | what it shows                                |
+| ------------------------------- | ----- | -------------------------------------------- |
+| `packages/*/src`                | 0     | the trap                                     |
+| `packages/*/src/*`              | 15    | same star, one more segment — matches        |
+| `packages/*/src/constants.ts`   | 4     | ditto                                        |
+| `packages/browser-plugin/src`   | 3     | no wildcard → read as a directory PREFIX     |
+| `packages/browser-plugi*/src`   | 0     | one wildcard, and the prefix reading is gone |
+| `packages/*constants.ts`        | 5     | the star DOES cross `/` without `:(glob)`    |
+| `:(glob)packages/*constants.ts` | 0     | under `:(glob)` it stops crossing            |
+| `:(glob)packages/{a,b}/…`       | 0     | braces expand in NEITHER mode                |
+
+The mechanism: a pathspec with **no** wildcard is a directory prefix; **any** wildcard turns it into
+a full-path match, and a pattern ending at `src` matches no file. `:(glob)` additionally stops `*` at
+`/`. Three different causes, one indistinguishable empty output — which is why the guard asserts its
+members by name rather than trusting a scan to be non-empty.
 
 **Family membership is by content, not by name.** A plugin carrying its own copy of a shared key
 joins the family without importing anything — otherwise the regression could opt out of the guard by

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -421,6 +421,8 @@ Popstate event handling, critical error recovery, and deferred event processing 
 
 The `Required<BrowserPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
 
+A repo-level guard — `scripts/url-plugin-defaults-parity.test.mjs`, run by repo-lints — fails when any of the three plugins re-types a shared option locally (whether or not the value still agrees), or when two of them grow the same new option outside the shared object. The single object stops the copies from drifting; the guard stops a copy from being created.
+
 ## Options Validation
 
 `validation.ts` delegates to `createOptionsValidator` from `browser-env`. The validator iterates over the keys of the provided options, compares `typeof value` against `typeof defaultOptions[key]`.

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -26,7 +26,7 @@ browser-plugin/
 │   ├── types.ts           — Types (BrowserPluginOptions, BrowserContext, BrowserSource)
 │   ├── browser-env/       — Symlink → shared/browser-env (extractPath, buildUrl, urlToPath, popstate, validation, createUpdateBrowserState, …)
 │   ├── validation.ts      — Options validation (delegates to browser-env)
-│   └── constants.ts       — Constants (defaultOptions, POPSTATE_SOURCE, LOGGER_CONTEXT)
+│   └── constants.ts       — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env, POPSTATE_SOURCE, LOGGER_CONTEXT)
 ```
 
 ## Module Dependency Graph
@@ -38,6 +38,7 @@ index.ts
             ├── validation.ts
             │       └── constants.ts
             └── constants.ts
+                    └── browser-env (sharedUrlPluginDefaults)
 
 types.ts  ← imported by factory.ts, validation.ts, index.ts
 ```
@@ -413,6 +414,12 @@ Popstate event handling, critical error recovery, and deferred event processing 
 - `shared/browser-env/popstate-handler.ts` — `createPopstateHandler` (deferred-queue, last-write-wins, `RouterError` vs critical-error split), `createPopstateLifecycle` (popstate listener add/remove + `cleanup` callback)
 - `historyState` is a subset of `State`: only `{ name, params, search, path }` are stored in `history.state` — `transition`, `context`, etc. are not persisted across reloads
 - Error categorization in `popstate-handler.ts`: `RouterError` instances are routed through `rollbackUrlToCurrentState()` (sync URL with current router state); anything else triggers `recoverFromCriticalError()` (warns + `replaceState` to last good URL)
+
+## Option Defaults
+
+`defaultOptions` is `sharedUrlPluginDefaults` from `browser-env` — the single value of `forceDeactivate` and `base` for every URL-owning plugin (`browser`, `hash`, `navigation`). Those two options describe **router behaviour**, and a user asking "does Back honour `canDeactivate`" is asking one question about their app, not about a URL encoding: the three plugins answer it identically or not at all. URL mechanics (`hashPrefix`) and identifiers (`POPSTATE_SOURCE`, `LOGGER_CONTEXT`) stay in this package — they differ by construction.
+
+The `Required<BrowserPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
 
 ## Options Validation
 

--- a/packages/browser-plugin/CLAUDE.md
+++ b/packages/browser-plugin/CLAUDE.md
@@ -13,6 +13,8 @@ browserPluginFactory({
 
 Only two options. Hash routing is handled by a separate `@real-router/hash-plugin`.
 
+Both defaults come from `sharedUrlPluginDefaults` (`shared/browser-env/defaults.ts`) — `browser`, `hash` and `navigation` read the SAME object, because "does Back honour `canDeactivate`" is one product decision, not three. Changing it here changes it for all three, which is the point: the three former copies had drifted, and the drift reached users (#524 → #1645). URL mechanics (`hashPrefix`) and identifiers stay per-plugin.
+
 ## Navigation Flow
 
 ```
@@ -157,7 +159,7 @@ src/
 ├── types.ts       — BrowserPluginOptions, BrowserContext, BrowserSource
 ├── browser-env/   — Symlink → shared/browser-env (extractPath, buildUrl, urlToPath, popstate, validation, createUpdateBrowserState, …)
 ├── validation.ts  — Options validation (delegates to createOptionsValidator from browser-env)
-├── constants.ts   — Constants (defaultOptions, POPSTATE_SOURCE, LOGGER_CONTEXT)
+├── constants.ts   — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env, POPSTATE_SOURCE, LOGGER_CONTEXT)
 └── index.ts       — Public exports + module augmentation (StateContext.browser, NavigationOptions.source)
 ```
 

--- a/packages/browser-plugin/src/constants.ts
+++ b/packages/browser-plugin/src/constants.ts
@@ -1,18 +1,15 @@
+import { sharedUrlPluginDefaults } from "./browser-env";
+
 import type { BrowserPluginOptions } from "./types";
 
+/**
+ * Router-behaviour defaults (`forceDeactivate`, `base`) come from
+ * `browser-env` — one value for all three URL plugins, see
+ * `sharedUrlPluginDefaults` for why. `Required<BrowserPluginOptions>` is the
+ * check that every option is covered.
+ */
 export const defaultOptions: Required<BrowserPluginOptions> = {
-  // Default `false` respects `canDeactivate` guards on browser back/forward,
-  // matching `navigation-plugin` (#524) and the core router. Apps that want the
-  // browser's native history buttons to bypass guards (e.g. to avoid dead-end
-  // UX) can opt in via `forceDeactivate: true`.
-  //
-  // It shipped as `true` from v0.1.0 and #524 left it there, on the stated
-  // premise that confirm-on-back already worked here — measured false: the
-  // guard was called zero times on a matched back/forward (#1645). Since #1643
-  // the not-found arm of the SAME gesture did consult the guard, so one option
-  // gave the two halves of one back button opposite answers.
-  forceDeactivate: false,
-  base: "",
+  ...sharedUrlPluginDefaults,
 };
 
 /**

--- a/packages/browser-plugin/src/types.ts
+++ b/packages/browser-plugin/src/types.ts
@@ -21,9 +21,9 @@ export interface BrowserContext {
 
 export interface BrowserPluginOptions {
   /**
-   * Force deactivation of current route even if canDeactivate returns false.
+   * Bypass canDeactivate guards on browser back/forward.
    *
-   * @default true
+   * @default false
    */
   forceDeactivate?: boolean;
 

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -27,7 +27,7 @@ hash-plugin/
 │   ├── types.ts           — Types (HashPluginOptions)
 │   ├── hash-utils.ts      — Hash URL utility functions (extractHashPath, hashUrlToPath, createHashPrefixRegex)
 │   ├── validation.ts      — Options validation (delegates to browser-env)
-│   └── constants.ts       — Constants (defaultOptions, source, LOGGER_CONTEXT)
+│   └── constants.ts       — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env + local hashPrefix, source, LOGGER_CONTEXT)
 ```
 
 ## Module Dependency Graph
@@ -42,6 +42,7 @@ index.ts
             ├── validation.ts
             │       └── constants.ts
             ├── constants.ts
+            │       └── browser-env (sharedUrlPluginDefaults)
             └── hash-utils.ts
 
 types.ts  ← imported by factory.ts, plugin.ts, validation.ts
@@ -434,6 +435,12 @@ See [browser-env/ARCHITECTURE.md](../browser-env/ARCHITECTURE.md) for details on
 - `historyState` as a subset of `State` (only `name`, `params`, `path` stored in `history.state`)
 - Error categorization (RouterError = expected, anything else = critical recovery via `replaceState`)
 
+## Option Defaults
+
+`defaultOptions` spreads `sharedUrlPluginDefaults` from `browser-env` — the single value of `forceDeactivate` and `base` for every URL-owning plugin (`browser`, `hash`, `navigation`). Those two options describe **router behaviour**, and the three plugins answer that question identically or not at all. `hashPrefix` stays here: it is URL mechanics this plugin owns alone, as do `source` and `LOGGER_CONTEXT`.
+
+The `Required<HashPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
+
 ## Options Validation
 
 `validation.ts` delegates to `createOptionsValidator` from `browser-env`. The validator iterates over the keys of the provided options, compares `typeof value` against `typeof defaultOptions[key]`.
@@ -536,7 +543,7 @@ buildUrl("users.profile", { id: "123" })
 | Regex              | Not needed                                 | Pre-computed once at factory time               |
 | Server config      | Requires fallback (all paths → index.html) | No server config needed                         |
 | `buildUrl` formula | `base + path`                              | `urlPrefix + path` (pre-computed prefix)        |
-| Options            | `forceDeactivate`, `base`                  | `forceDeactivate`, `base`, `hashPrefix`         |
+| Options            | `forceDeactivate`, `base` (both from `sharedUrlPluginDefaults`) | `forceDeactivate`, `base` (shared) + `hashPrefix` (local) |
 
 ## Related Documents
 

--- a/packages/hash-plugin/ARCHITECTURE.md
+++ b/packages/hash-plugin/ARCHITECTURE.md
@@ -441,6 +441,8 @@ See [browser-env/ARCHITECTURE.md](../browser-env/ARCHITECTURE.md) for details on
 
 The `Required<HashPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
 
+A repo-level guard — `scripts/url-plugin-defaults-parity.test.mjs`, run by repo-lints — fails when any of the three plugins re-types a shared option locally (whether or not the value still agrees), or when two of them grow the same new option outside the shared object. `hashPrefix` is untouched by it: an option only one plugin has is nobody's shared decision.
+
 ## Options Validation
 
 `validation.ts` delegates to `createOptionsValidator` from `browser-env`. The validator iterates over the keys of the provided options, compares `typeof value` against `typeof defaultOptions[key]`.

--- a/packages/hash-plugin/CLAUDE.md
+++ b/packages/hash-plugin/CLAUDE.md
@@ -14,6 +14,8 @@ hashPluginFactory({
 
 Three options. History API routing is handled by a separate `@real-router/browser-plugin`.
 
+`forceDeactivate` and `base` come from `sharedUrlPluginDefaults` (`shared/browser-env/defaults.ts`) — `browser`, `hash` and `navigation` read the SAME object, because "does Back honour `canDeactivate`" is one product decision, not three (the former copies drifted and the drift reached users: #524 → #1645). `hashPrefix` stays local: it is URL mechanics only this plugin has.
+
 ## Navigation Flow
 
 ```
@@ -168,7 +170,7 @@ src/
 ├── types.ts       — HashPluginOptions (hashPrefix, base, forceDeactivate)
 ├── hash-utils.ts  — Hash URL parsing (extractHashPath, hashUrlToPath, createHashPrefixRegex)
 ├── validation.ts  — Options validation (delegates to createOptionsValidator from browser-env)
-├── constants.ts   — Constants (defaultOptions, source, LOGGER_CONTEXT)
+├── constants.ts   — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env + local hashPrefix, source, LOGGER_CONTEXT)
 └── index.ts       — Public exports + module augmentation
 ```
 

--- a/packages/hash-plugin/src/constants.ts
+++ b/packages/hash-plugin/src/constants.ts
@@ -1,14 +1,19 @@
 // packages/hash-plugin/src/constants.ts
 
+import { sharedUrlPluginDefaults } from "./browser-env";
+
 import type { HashPluginOptions } from "./types";
 
+/**
+ * Router-behaviour defaults (`forceDeactivate`, `base`) come from
+ * `browser-env` — one value for all three URL plugins, see
+ * `sharedUrlPluginDefaults` for why. `hashPrefix` stays here: it is URL
+ * mechanics this plugin owns alone. `Required<HashPluginOptions>` is the check
+ * that every option is covered.
+ */
 export const defaultOptions: Required<HashPluginOptions> = {
+  ...sharedUrlPluginDefaults,
   hashPrefix: "",
-  base: "",
-  // Default `false` respects `canDeactivate` guards on browser back/forward,
-  // matching `browser-plugin` and `navigation-plugin` (#524/#1645). A
-  // deliberate bypass stays available via `forceDeactivate: true`.
-  forceDeactivate: false,
 };
 
 /**

--- a/packages/hash-plugin/src/types.ts
+++ b/packages/hash-plugin/src/types.ts
@@ -20,9 +20,9 @@ export interface HashPluginOptions {
   base?: string;
 
   /**
-   * Force deactivation of current route even if canDeactivate returns false.
+   * Bypass canDeactivate guards on browser back/forward.
    *
-   * @default true
+   * @default false
    */
   forceDeactivate?: boolean;
 }

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -33,7 +33,7 @@ navigation-plugin/
 │   ├── href-utils.ts          — isSameHref(target, currentHref) pure helper for the same-URL guard (#580); URL-canonical equality predicate
 │   ├── ssr-fallback.ts        — createNavigationFallbackBrowser (no-op fallback for SSR)
 │   ├── validation.ts          — Options validation (delegates to browser-env)
-│   ├── constants.ts           — Constants (defaultOptions, source, LOGGER_CONTEXT)
+│   ├── constants.ts           — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env, source, LOGGER_CONTEXT)
 │   └── browser-env/           — Symlink → shared/browser-env (extractPath, buildUrl, urlToPath, safeParseUrl, shouldReplaceHistory, createStartInterceptor, createReplaceHistoryState, createPluginBuildUrl, hash encoding helpers, etc.)
 ```
 
@@ -60,6 +60,7 @@ index.ts
             │       ├── constants.ts
             │       └── browser-env (createOptionsValidator, safeBaseRule)
             ├── constants.ts
+            │       └── browser-env (sharedUrlPluginDefaults)
             └── browser-env (isBrowserEnvironment, normalizeBase)
 
 types.ts  ← imported by factory.ts, plugin.ts, navigate-handler.ts, navigation-browser.ts, plugin-utils.ts, ssr-fallback.ts
@@ -152,6 +153,12 @@ function createBrowser(base: string): NavigationBrowser {
   return createNavigationFallbackBrowser("navigation-plugin");
 }
 ```
+
+## Option Defaults
+
+`defaultOptions` is `sharedUrlPluginDefaults` from `browser-env` — the single value of `forceDeactivate` and `base` for every URL-owning plugin (`browser`, `hash`, `navigation`). Those two options describe **router behaviour**: whether browser Back consults `canDeactivate` is one question about the app, not about a URL encoding, and the three plugins answer it identically or not at all. Identifiers (`source`, `LOGGER_CONTEXT`) stay in this package — they differ by construction.
+
+The `Required<NavigationPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
 
 ## Browser API Abstraction
 

--- a/packages/navigation-plugin/ARCHITECTURE.md
+++ b/packages/navigation-plugin/ARCHITECTURE.md
@@ -160,6 +160,8 @@ function createBrowser(base: string): NavigationBrowser {
 
 The `Required<NavigationPluginOptions>` annotation is what keeps the split honest: an option this package adds and the shared object does not carry fails to type-check here.
 
+A repo-level guard — `scripts/url-plugin-defaults-parity.test.mjs`, run by repo-lints — fails when any of the three plugins re-types a shared option locally (whether or not the value still agrees), or when two of them grow the same new option outside the shared object. The single object stops the copies from drifting; the guard stops a copy from being created.
+
 ## Browser API Abstraction
 
 The `NavigationBrowser` interface wraps `globalThis.navigation` and provides a testable seam:

--- a/packages/navigation-plugin/CLAUDE.md
+++ b/packages/navigation-plugin/CLAUDE.md
@@ -11,7 +11,7 @@ navigationPluginFactory({
 });
 ```
 
-Same two options as `browser-plugin`. Plugins are interchangeable at the options level.
+Same two options as `browser-plugin`. Plugins are interchangeable at the options level — literally: both read `sharedUrlPluginDefaults` (`shared/browser-env/defaults.ts`), as does `hash-plugin`, because "does Back honour `canDeactivate`" is one product decision, not three (the former copies drifted and the drift reached users: #524 → #1645).
 
 ## Navigation Flow
 
@@ -293,7 +293,7 @@ src/
 ├── href-utils.ts          — isSameHref(target, currentHref) pure helper backing the same-URL guard in onTransitionSuccess (#580)
 ├── ssr-fallback.ts        — createNavigationFallbackBrowser (no-op fallback for SSR)
 ├── validation.ts          — Options validation (delegates to createOptionsValidator from browser-env)
-├── constants.ts           — Constants (defaultOptions, source, LOGGER_CONTEXT)
+├── constants.ts           — Constants (defaultOptions = sharedUrlPluginDefaults from browser-env, source, LOGGER_CONTEXT)
 ├── index.ts               — Public exports + module augmentation (@real-router/types for StateContext, @real-router/core for Router)
 └── browser-env/           — Symlink to shared/browser-env (extractPath, buildUrl, urlToPath, shouldReplaceHistory, normalizeBase, createStartInterceptor, createReplaceHistoryState, etc.)
 ```

--- a/packages/navigation-plugin/src/constants.ts
+++ b/packages/navigation-plugin/src/constants.ts
@@ -1,12 +1,15 @@
+import { sharedUrlPluginDefaults } from "./browser-env";
+
 import type { NavigationPluginOptions } from "./types";
 
+/**
+ * Router-behaviour defaults (`forceDeactivate`, `base`) come from
+ * `browser-env` — one value for all three URL plugins, see
+ * `sharedUrlPluginDefaults` for why. `Required<NavigationPluginOptions>` is the
+ * check that every option is covered.
+ */
 export const defaultOptions: Required<NavigationPluginOptions> = {
-  // Default `false` respects `canDeactivate` guards on browser back/forward,
-  // matching the documented contract of `browser-plugin` and the core router.
-  // Apps that want the browser's native history buttons to bypass guards
-  // (e.g. to avoid dead-end UX) can opt in via `forceDeactivate: true`.
-  forceDeactivate: false,
-  base: "",
+  ...sharedUrlPluginDefaults,
 };
 
 /**

--- a/scripts/url-plugin-defaults-parity.test.mjs
+++ b/scripts/url-plugin-defaults-parity.test.mjs
@@ -1,0 +1,338 @@
+// The URL plugins must answer one product question with one value.
+//
+// `browser-plugin`, `hash-plugin` and `navigation-plugin` all decide "does
+// browser Back honour `canDeactivate`" and "what is the base path". Those two
+// options describe ROUTER behaviour, not URL encoding, so the three plugins
+// answer them identically or not at all. #1651 made that structural: the values
+// live once, in `shared/browser-env/defaults.ts`, and each plugin spreads them.
+//
+// Why a guard on top of the move (the move alone is not enough):
+//
+//   the move protects against "forgot to fix it in the other two" — a single
+//   object cannot drift. It does NOT protect against "fixed it here on
+//   purpose": a local override after the spread, or a spread quietly replaced
+//   by literals, restores exactly the arrangement #1651 removed. That
+//   arrangement already cost users once — #524 flipped the default in
+//   `navigation-plugin` alone on a premise measured false in #1645, and for a
+//   year and a half two plugins' READMEs contradicted each other about the same
+//   behaviour.
+//
+// Each plugin's own suite pins its own default (browser + hash:
+// `deactivate-default-1645.test.ts`; navigation: "forceDeactivate default is
+// false" in `navigate.test.ts`). Those go green together with a deliberate
+// one-plugin change — the author edits the plugin and its test. Nothing below
+// the repo level compares the three. This file is that comparison.
+//
+// What it does NOT pin: the values themselves. Flipping `forceDeactivate` in
+// the shared object is a legitimate product decision and keeps this file green
+// — the invariant is single-sourcing, not `false`.
+//
+// Runs in the repo-lints CI job via `node --test scripts/*.test.mjs` — picked
+// up by glob, no wiring of its own. Reads through the TypeScript AST rather
+// than by regex: `{ ...shared, k: v }` is order-sensitive (a later key wins),
+// and a line-oriented parser cannot see that the override came after the
+// spread, which is precisely the mutation this guard exists to catch.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PACKAGES = join(ROOT, "packages");
+const SHARED = join(ROOT, "shared/browser-env/defaults.ts");
+const SHARED_EXPORT = "sharedUrlPluginDefaults";
+
+// The plugins that must be in the family. A scan that loses one of them has
+// broken, not "found nothing" — an empty or short family would make every
+// assertion below trivially true, and the scans in this area fail SILENTLY: a
+// git pathspec star does not cross a slash, so `packages/<star>/src` matches
+// nothing, and `:(glob)` does not expand braces either, so a `{a,b}-plugin`
+// pathspec is a second silent zero. Both empty results read exactly like "no
+// duplicates". This list is what makes such a failure loud instead.
+const REQUIRED_MEMBERS = ["browser-plugin", "hash-plugin", "navigation-plugin"];
+
+function parse(file) {
+  return ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+/** `{ … } as const` → the object literal inside; a bare literal → itself. */
+function objectLiteralOf(node) {
+  const inner =
+    node !== undefined && ts.isAsExpression(node) ? node.expression : node;
+
+  return inner !== undefined && ts.isObjectLiteralExpression(inner)
+    ? inner
+    : undefined;
+}
+
+/** The initializer of `export const <name> = …`, or undefined. */
+function exportedInitializer(source, name) {
+  let found;
+
+  const visit = (node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = node.initializer;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+
+  return found;
+}
+
+/** The shared decision: key → source text of its value. */
+function readSharedDefaults() {
+  assert.ok(
+    existsSync(SHARED),
+    `${SHARED} is missing — the shared defaults moved, this guard has not (#1651)`,
+  );
+
+  const literal = objectLiteralOf(
+    exportedInitializer(parse(SHARED), SHARED_EXPORT),
+  );
+
+  assert.ok(
+    literal,
+    `${SHARED_EXPORT} must be an object literal (optionally \`as const\`)`,
+  );
+
+  const defaults = new Map();
+
+  for (const prop of literal.properties) {
+    assert.ok(
+      ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name),
+      `${SHARED_EXPORT}: every entry must be a plain \`key: value\` pair`,
+    );
+
+    defaults.set(prop.name.text, prop.initializer.getText());
+  }
+
+  return defaults;
+}
+
+/**
+ * A plugin's EFFECTIVE defaults — the object as JavaScript would build it.
+ *
+ * Properties are walked in source order, so a key written after the spread
+ * overwrites the shared one and is recorded as `local`. That ordering IS the
+ * finding: `{ ...shared, forceDeactivate: true }` and
+ * `{ forceDeactivate: true, ...shared }` mean opposite things.
+ */
+function readPluginDefaults(pkg, sharedKeys) {
+  const file = join(PACKAGES, pkg, "src/constants.ts");
+
+  if (!existsSync(file)) {
+    return undefined;
+  }
+
+  const source = parse(file);
+  const literal = objectLiteralOf(
+    exportedInitializer(source, "defaultOptions"),
+  );
+
+  if (!literal) {
+    return undefined;
+  }
+
+  // A local `const sharedUrlPluginDefaults = …` would spread something that
+  // merely LOOKS shared. Only an import binds the name to the one object.
+  let importedFrom;
+
+  for (const statement of source.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      statement.importClause?.namedBindings === undefined ||
+      !ts.isNamedImports(statement.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    for (const element of statement.importClause.namedBindings.elements) {
+      if (element.name.text === SHARED_EXPORT) {
+        importedFrom = statement.moduleSpecifier.getText().slice(1, -1);
+      }
+    }
+  }
+
+  const entries = new Map();
+
+  for (const prop of literal.properties) {
+    if (ts.isSpreadAssignment(prop)) {
+      assert.ok(
+        ts.isIdentifier(prop.expression) &&
+          prop.expression.text === SHARED_EXPORT,
+        `${pkg}: defaultOptions spreads \`${prop.expression.getText()}\` — the only ` +
+          `spread this guard can reason about is ${SHARED_EXPORT}`,
+      );
+
+      for (const [key, value] of sharedKeys) {
+        entries.set(key, { value, origin: "shared" });
+      }
+
+      continue;
+    }
+
+    assert.ok(
+      ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name),
+      `${pkg}: every defaultOptions entry must be a plain \`key: value\` pair or a spread`,
+    );
+
+    entries.set(prop.name.text, {
+      value: prop.initializer.getText(),
+      origin: "local",
+    });
+  }
+
+  return { pkg, file, entries, importedFrom };
+}
+
+/** Every package whose defaults take part in the shared product decision. */
+function readFamily() {
+  const shared = readSharedDefaults();
+  const family = [];
+
+  for (const pkg of readdirSync(PACKAGES).sort()) {
+    const plugin = readPluginDefaults(pkg, shared);
+
+    if (plugin === undefined) {
+      continue;
+    }
+
+    // Membership is by content, not by name: a plugin that carries its OWN
+    // copy of a shared key (no spread) still belongs to the family — and is
+    // exactly the regression this file must fail on, so it cannot be allowed
+    // to opt out by not importing.
+    const touchesSharedKeys = [...plugin.entries.keys()].some((key) =>
+      shared.has(key),
+    );
+
+    if (touchesSharedKeys) {
+      family.push(plugin);
+    }
+  }
+
+  return { shared, family };
+}
+
+test("positive control: the shared object and the family both parse", () => {
+  // Without this, a parser broken by a refactor returns an empty family, every
+  // assertion below passes over nothing, and this file guards air.
+  const { shared, family } = readFamily();
+
+  assert.ok(
+    shared.size > 0,
+    `${SHARED_EXPORT} parsed to zero keys — the guard would be vacuous`,
+  );
+
+  const names = family.map((member) => member.pkg);
+
+  for (const required of REQUIRED_MEMBERS) {
+    assert.ok(
+      names.includes(required),
+      `${required} is not in the URL-defaults family (found: ${names.join(", ") || "none"}) — ` +
+        `either it stopped sharing the decision, or this scan is broken`,
+    );
+  }
+});
+
+test("a repeated option carries the same value in every plugin that has it", () => {
+  const { family } = readFamily();
+  const seen = new Map();
+
+  for (const member of family) {
+    for (const [key, entry] of member.entries) {
+      const previous = seen.get(key);
+
+      if (previous === undefined) {
+        seen.set(key, { value: entry.value, pkg: member.pkg });
+
+        continue;
+      }
+
+      assert.strictEqual(
+        entry.value,
+        previous.value,
+        `${key}: ${member.pkg} defaults to ${entry.value}, ${previous.pkg} to ${previous.value} — ` +
+          `one product decision, two answers. This is the #524/#1645 shape.`,
+      );
+    }
+  }
+});
+
+test("an option held by two plugins is READ from the shared object, never re-typed locally", () => {
+  // Deliberately keyed on "repeated", not on "is a key of the shared object".
+  // The narrower form is blind to the way the class comes BACK: two plugins
+  // agreeing on a NEW option, each with its own literal, is the #524 shape
+  // again — same values on the day it is written, two editable copies from the
+  // day after. A repeated key that is not single-sourced fails here whether or
+  // not the shared object knows about it yet.
+  const { family } = readFamily();
+  const holders = new Map();
+
+  for (const member of family) {
+    for (const key of member.entries.keys()) {
+      holders.set(key, [...(holders.get(key) ?? []), member]);
+    }
+  }
+
+  for (const [key, members] of holders) {
+    if (members.length < 2) {
+      // Genuinely one plugin's own knob (`hashPrefix`) — URL mechanics, not a
+      // shared product decision. Nothing to compare.
+      continue;
+    }
+
+    for (const member of members) {
+      assert.strictEqual(
+        member.entries.get(key).origin,
+        "shared",
+        `${member.file}: '${key}' is written locally, but ${members.length} plugins carry it ` +
+          `(${members.map((m) => m.pkg).join(", ")}). Equal values today are not the invariant — ` +
+          `a second editable copy is the defect, because the copies drift on the next edit. ` +
+          `Move it into ${SHARED_EXPORT} (#1651).`,
+      );
+    }
+  }
+});
+
+test("the spread resolves to the shared module, not a same-named local", () => {
+  const { shared, family } = readFamily();
+
+  for (const member of family) {
+    const usesShared = [...shared.keys()].some(
+      (key) => member.entries.get(key)?.origin === "shared",
+    );
+
+    if (!usesShared) {
+      continue;
+    }
+
+    assert.ok(
+      member.importedFrom !== undefined,
+      `${member.file}: spreads ${SHARED_EXPORT} without importing it`,
+    );
+
+    assert.match(
+      member.importedFrom,
+      /^\.\/browser-env/,
+      `${member.file}: ${SHARED_EXPORT} must come from the ./browser-env symlink, ` +
+        `got '${member.importedFrom}'`,
+    );
+  }
+});

--- a/scripts/url-plugin-defaults-parity.test.mjs
+++ b/scripts/url-plugin-defaults-parity.test.mjs
@@ -48,11 +48,27 @@ const SHARED_EXPORT = "sharedUrlPluginDefaults";
 
 // The plugins that must be in the family. A scan that loses one of them has
 // broken, not "found nothing" — an empty or short family would make every
-// assertion below trivially true, and the scans in this area fail SILENTLY: a
-// git pathspec star does not cross a slash, so `packages/<star>/src` matches
-// nothing, and `:(glob)` does not expand braces either, so a `{a,b}-plugin`
-// pathspec is a second silent zero. Both empty results read exactly like "no
-// duplicates". This list is what makes such a failure loud instead.
+// assertion below trivially true, and the scans in this area fail SILENTLY.
+//
+// Measured on this repo (`git grep -l defaultOptions -- <pathspec>`), because
+// the folklore about it is wrong in both directions:
+//
+//   packages/<star>/src                 0 files   <- the trap
+//   packages/<star>/src/<star>         15
+//   packages/<star>/src/constants.ts    4
+//   packages/browser-plugin/src         3         <- no wildcard: directory prefix
+//   packages/browser-plugi<star>/src    0         <- one wildcard, and the prefix
+//                                                    reading is gone
+//
+// So the cause is NOT "a star does not cross a slash" — without `:(glob)` it
+// crosses freely (`packages/<star>constants.ts` matches 5 files). The cause is
+// that a wildcard turns the pathspec from a directory PREFIX into a full-path
+// match, and a pattern ending at `src` matches no file. Under `:(glob)` the
+// star stops crossing `/` (that same pattern matches 0), and braces expand in
+// NEITHER mode — `{a,b}-plugin` is a second silent zero.
+//
+// Every one of those zeros reads exactly like "no duplicates". This list is
+// what makes such a failure loud instead.
 const REQUIRED_MEMBERS = ["browser-plugin", "hash-plugin", "navigation-plugin"];
 
 function parse(file) {
@@ -142,11 +158,22 @@ function readPluginDefaults(pkg, sharedKeys) {
   }
 
   const source = parse(file);
-  const literal = objectLiteralOf(
-    exportedInitializer(source, "defaultOptions"),
-  );
+  const declared = exportedInitializer(source, "defaultOptions");
+  const literal = objectLiteralOf(declared);
 
   if (!literal) {
+    // A package with no `defaultOptions` at all is simply not in the family.
+    // A package that HAS one this parser cannot read is a different animal:
+    // `Object.freeze({ … })`, `{ … } satisfies Required<…>`, a builder call.
+    // Silently dropping it would let a plugin leave the guard by changing how
+    // it writes the object, so say what actually happened instead.
+    assert.ok(
+      declared === undefined,
+      `${file}: \`defaultOptions\` is declared in a form this guard cannot read ` +
+        `(expected an object literal, optionally \`as const\`). Extend the parser — ` +
+        `an unreadable form must not silently leave the family (#1651).`,
+    );
+
     return undefined;
   }
 

--- a/shared/browser-env/defaults.ts
+++ b/shared/browser-env/defaults.ts
@@ -1,0 +1,27 @@
+/**
+ * Option defaults shared by the URL-owning plugins — `browser-plugin`,
+ * `hash-plugin` and `navigation-plugin`.
+ *
+ * What belongs here: an option that describes **router behaviour**, where all
+ * three plugins must give the same answer because the user is asking one
+ * question about their app, not about a URL encoding. URL mechanics
+ * (`hashPrefix`) and identifiers (`source`, `LOGGER_CONTEXT`) stay with each
+ * plugin — they differ by construction.
+ *
+ * `forceDeactivate: false` — browser back/forward consults `canDeactivate`
+ * guards, exactly like `router.navigate()` does. A deliberate bypass stays
+ * available per plugin via `forceDeactivate: true`.
+ *
+ * The value lives in one place because the three copies it replaces had already
+ * drifted, and the drift reached users: #524 flipped the default in
+ * `navigation-plugin` alone, on the stated premise that confirm-on-back already
+ * worked under `browser-plugin` — measured false in #1645, where the guard was
+ * called ZERO times on a matched back/forward. Since #1643 the not-found arm of
+ * the SAME gesture did consult the guard, so one option gave the two halves of
+ * one Back press opposite answers. The option's type has always been shared
+ * (`PopstateTransitionOptions.forceDeactivate`); now its value is too (#1651).
+ */
+export const sharedUrlPluginDefaults = {
+  forceDeactivate: false,
+  base: "",
+} as const;

--- a/shared/browser-env/index.ts
+++ b/shared/browser-env/index.ts
@@ -1,5 +1,7 @@
 export type { HistoryBrowser, Browser, SharedFactoryState } from "./types.js";
 
+export { sharedUrlPluginDefaults } from "./defaults.js";
+
 export { isBrowserEnvironment } from "./detect.js";
 
 export {


### PR DESCRIPTION
## Summary

- `forceDeactivate` and `base` — the two options that decide **router behaviour** for every URL-owning plugin — now have one value: `sharedUrlPluginDefaults` in `shared/browser-env/defaults.ts`. `browser-plugin`, `hash-plugin` and `navigation-plugin` spread it. `hashPrefix` and the `source` / `LOGGER_CONTEXT` identifiers stay per-plugin: they are URL mechanics, not a product decision.
- Behaviour is unchanged — `forceDeactivate: false`, `base: ""` everywhere, verified in the built bundles and not only in source. All three changesets are `patch`.
- The stale `@default true` JSDoc on `forceDeactivate` in `browser-plugin` and `hash-plugin` is corrected to `false`. Both have shipped `false` since #1645, so the published types documented the opposite of the shipped default.
- A repo-level guard now fails when a shared option is re-typed locally in any of the three plugins, or when two of them grow the same new option outside the shared object.

**Root cause** — why three copies were a defect rather than a matter of taste: the option's *type* had been shared all along (`PopstateTransitionOptions.forceDeactivate` in `shared/browser-env/popstate-handler.ts`); only its *value* was not. The copies drifted and the drift reached users. #524 flipped the default to `false` in `navigation-plugin` alone, on the stated premise that confirm-on-back already worked under `browser-plugin` — measured false in #1645: the guard was invoked zero times on a matched back/forward, and had been since v0.1.0. After #1643 the not-found arm of the same gesture did consult the guard, so one option gave the two halves of a single Back press opposite answers. Values equal today were never the invariant; three independently editable copies were the defect.

**Why the move alone is not enough.** A single object cannot drift, which closes "forgot to fix the other two". It does nothing about "fixed it here on purpose": a local override after the spread, or a spread quietly swapped back for literals, rebuilds exactly the arrangement that failed in #524. Each plugin already pins its own default (`deactivate-default-1645.test.ts` in browser and hash, "forceDeactivate default is false" in navigation's `navigate.test.ts`), and those three stay green for a deliberate one-plugin change — the author edits the plugin and its test together. Nothing below the repo level compared the three. `scripts/url-plugin-defaults-parity.test.mjs` is that comparison, reading `constants.ts` through the TypeScript AST because `{ ...shared, k: v }` is order-sensitive and a line parser cannot see which side of the spread an override landed on.

### Scope of the open tail

The issue also asked whether the same class lives in the two other shared-source families. Both were checked separately, not by analogy, and neither reproduces it:

- **`shared/ssr`** — no copies to move: the defaults are centralised in `createSsrLoaderPlugin` itself (`ssr === undefined || ssr === true → "full"`, `allowedModes ?? ALL_SSR_MODES`), and the two SSR plugins pass config in.
- **`shared/dom-utils`** — five adapters repeat `EMPTY_PARAMS` / `EMPTY_OPTIONS`, but that is not one product decision: their per-package **identity** is load-bearing (Link's fast path compares by reference), so sharing them would be the regression.

### Maintainability

- `IMPLEMENTATION_NOTES.md` — a Problem → Solution → Why record covering both the move and the guard, including a **measured** table of the silent-scan traps met on the way. The claim in this issue's own text — that a git pathspec `*` does not cross `/` — is false for the default mode (`packages/*constants.ts` matches 5 files); the real cause of the empty `packages/*/src` is that any wildcard turns the pathspec from a directory prefix into a full-path match, and braces expand in neither mode. Three distinct causes, one indistinguishable empty output.
- `ARCHITECTURE.md` / `CLAUDE.md` of all three plugins — the shared-vs-local criterion, the dependency-graph edge `constants.ts → browser-env`, and the guard.

## Test plan

- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes — the full pre-push graph ran green on this branch (88 turbo tasks, including `test:stress`)
- [x] 100% test coverage maintained — statements/branches/functions all 100%: browser-plugin 359 tests (466/282/96), hash-plugin 105 tests (61/33/17), navigation-plugin 223 tests (263/128/77)
- [x] Property suites unchanged and green — 77 / 34 / 93
- [x] `scripts/url-plugin-defaults-parity.test.mjs` — 4 checks joining the repo-lints suite by glob (69 → 73 tests, both counts measured)
- [x] The guard is mutationally validated in 8 directions, each applied to a clean tree: a local override with a different value (red), the spread replaced by **identical** literals (red — the value-equality check alone misses this), the same override applied to all three so values still agree (red), a new option added by literal to two plugins (red), the import replaced by a same-named local object (red), `defaultOptions` renamed so the scan loses a member (red, via the positive control), a value change **inside** the shared object (green — the guard pins single-sourcing, not `false`), and the healthy tree (green)
- [x] Adversarial pass over the result, beyond the mutation set — every item measured, not argued:
  - `Required<*PluginOptions>` does reject an option the shared object lacks — probed by adding one, `TS2741`
  - the guard is blind to a bypass written in `factory.ts` (it audits where a value comes FROM, not that it is used) — but that bypass is caught twice over: `tsc` flags the orphaned import (`TS6133`) and the plugin's own default test fails; verified separately in all three packages
  - five alternative ways to write `defaultOptions` (`Object.freeze`, `satisfies`, spreading an alias, a string key, a non-literal value) all fail closed — none passes silently
  - changing `base` in the shared object alone reds 28 / 19 / 32 tests across the three packages — live proof that one source really feeds all three
  - `sharedUrlPluginDefaults` leaks into no published `.d.ts`; `size-limit` green (3.37 / 3.38 / 3.77 kB against 3.5 / 3.5 / 4 kB)
  - the options object is built once per plugin factory, not per navigation, so the changed key order cannot cost a hidden-class transition on a hot path (#1684's failure mode)
- [x] Built bundles carry the unchanged values — `{forceDeactivate:!1,base:``}` in all three ESM outputs, with hash-plugin's `{...i,hashPrefix:``}` on top

Closes #1651
