### PR TITLE
docs(core): record what the meta snapshot costs, and which remedies are refuted (#1728)

### DIFF
--- a/.changeset/record-meta-snapshot-cost-1728.md
+++ b/.changeset/record-meta-snapshot-cost-1728.md
@@ -1,0 +1,25 @@
+---
+"@real-router/core": patch
+---
+
+Record what the transition meta's entry snapshot costs, and that the obvious remedies are refuted (#1728)
+
+Documentation only — no behaviour change, no runtime change.
+
+`0.89.9` moved the transition meta's three flags (`reload` / `replace` /
+`redirected`) onto a snapshot taken at the navigation's entry, so the commit no
+longer reads the caller's `NavigationOptions`. That is what makes the window
+between the commit ask and the send empty structurally rather than by an ordering
+rule. It costs **≈15 %** on `navigate/sync-baseline` and ≈12 % on
+`navigate/pre-commit-listener`; every other benchmark is unchanged.
+
+The cost is accepted rather than reverted: without the snapshot, the same
+guarantee rests on a rule that has been got wrong twice on record, and a
+structure does not admit that class of mistake. What is recorded here — in the
+`NavigationContext` docblock and in `IMPLEMENTATION_NOTES.md` — is the
+measurement table and the five suspects already eliminated, so the next reader
+does not re-propose a remedy that was tried: the plan literal's width, the call
+shape, the entry reads, field count as such, and the runner are all ruled out.
+What survives is narrower — a field added to that literal **and then read inside
+the commit** costs, while adding it without reading it does not — and the
+mechanism is still unexplained, tracked in #1728.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -7126,6 +7126,37 @@ came back with a number:
   self-consistent; the new one is the rule the rest of the pipeline already follows, whereas the old
   one let a value read inside a commit reach back and cancel that commit.
 
+**What it cost, and why it stays anyway (#1722 / #1728).** The change is not free: `navigate/sync-baseline`
+went 8.3 → 9.8 ms (**≈15 %**) and `navigate/pre-commit-listener` ≈12 %, everything else unchanged. Six
+runner configurations were measured, each killing one suspect:
+
+| configuration | plan literal fields | meta reads flags from | `navigate/sync-baseline` |
+| --- | --: | --- | --- |
+| before this change | 17 | `opts` | 8.3 ms |
+| before + one UNREAD field | 18 | `opts` | 8.3 ms |
+| three flags packed into one | 18 | the plan | 9.8 ms |
+| five value arguments restored | 20 | the plan | 9.8 ms |
+| entry reads replaced by constants | 20 | the plan | 9.8 ms |
+| shipped `0.89.9` | 20 | the plan | 9.8 ms |
+
+Ruled out, each by its own measurement rather than by argument: the plan literal's **width** (rows 3 vs
+6), the **call shape** (row 4), the **entry reads** (row 5), **field count as such** (row 2 — an unread
+field is free), a **hidden-class transition** (the slots stand in the literal) and the **runner** (row 1
+re-measured hours later still reads 8.3, which killed an earlier "maybe it is co-tenancy" reading).
+
+What survives all six: **a field added to this literal AND then read inside `completeTransition` costs;
+adding it without reading it does not.** The mechanism is unexplained — and it is the SECOND effect of
+this size in the same two files, after #1704's first form cost 13.4 % for extracting a helper while the
+identical code inline cost nothing. Two unexplained ~14 % effects in one seam is a property of the seam,
+which is how #1728 is framed.
+
+⚠ **A revert was written, measured and deliberately NOT merged.** Without the snapshot the window is
+protected by the ordering rule above rather than by structure, and that rule has been got wrong twice on
+record — the #1641 review, and the #1649 write-up itself, which prescribed the ask below the cleanup. A
+structure does not admit that class of mistake; a rule does. So the cost is carried as tracked debt
+instead of buying it back by weakening the guarantee. If #1728 explains the mechanism, the shape is
+already the right one and only its price needs fixing.
+
 **Test.** `tests/functional/navigation/commit-window-empty-1719.test.ts` replaces the file above. Its
 load-bearing case COUNTS the caller's getter invocations and requires **zero** below the announce —
 mutationally validated: putting `buildTransitionMeta` back on `opts` makes it three (`reload` /

--- a/packages/core/src/namespaces/NavigationNamespace/types.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/types.ts
@@ -167,6 +167,36 @@ export interface NavigationContext {
    * and `plan-born-in-final-shape` puts every slot in the literal, so a record
    * would be an allocation разрез А has no use for.
    *
+   * ⛔ **These three slots cost ≈15 % on `navigate/sync-baseline` and ≈12 % on
+   * `navigate/pre-commit-listener`, the cost is ACCEPTED, and the obvious
+   * remedies are already refuted — read #1728 before touching this (#1722).**
+   * Six configurations on the runner, each killing one suspect by measurement:
+   *
+   * | configuration | plan fields | meta reads from | `sync-baseline` |
+   * | --- | --: | --- | --- |
+   * | before this change | 17 | `opts` | 8.3 ms |
+   * | before + one UNREAD field | 18 | `opts` | 8.3 ms |
+   * | three flags packed into one | 18 | the plan | 9.8 ms |
+   * | five value arguments | 20 | the plan | 9.8 ms |
+   * | entry reads → constants | 20 | the plan | 9.8 ms |
+   * | shipped | 20 | the plan | 9.8 ms |
+   *
+   * So it is NOT the plan's width (rows 3 vs 6), NOT the call shape (row 4), NOT
+   * the entry reads (row 5), NOT field count as such (row 2 — an unread field is
+   * free) and NOT the runner (row 1 re-measured hours later still reads 8.3).
+   * What survives: **a field added to this literal AND then read inside
+   * `completeTransition` costs; adding it without reading it does not.** The
+   * mechanism is unexplained, and it is the second such effect in this seam —
+   * #1704's first form cost 13.4 % for extracting a helper while the identical
+   * code inline cost nothing.
+   *
+   * ⚠ **Kept anyway, deliberately.** Without the snapshot `buildTransitionMeta`
+   * reads the caller's accessor-backed `opts` from inside the commit, and the
+   * window is then protected by an ordering RULE rather than by structure — a
+   * rule that has been got wrong twice on record (the #1641 review, and the
+   * #1649 write-up itself). Correctness first; the cost is tracked, not paid
+   * down by weakening the guarantee.
+   *
    * ⚠ **These three slots cost `navigate/sync-baseline` ≈14 %, and PACKING THEM
    * DOES NOT HELP — measured, do not re-try it (#1722).** Snapshotting them made
    * that arc go 8.3–8.8 ms → 9.6–9.9 (two head runs against two bases), while


### PR DESCRIPTION
Documentation only — no runtime change. Tier 4071/4071; the diff is a docblock, a record in `IMPLEMENTATION_NOTES.md` and a changeset.

`0.89.9` snapshots the transition meta's three flags at the navigation's entry, which is what makes the window between the commit ask and the send empty **structurally** instead of by an ordering rule. It costs **≈15 %** on `navigate/sync-baseline` and ≈12 % on `navigate/pre-commit-listener`.

**The cost is accepted, not reverted.** A revert was written and measured (#1727) and closed unmerged: without the snapshot the same guarantee rests on a rule — build the meta ABOVE the ask — and that rule has been got wrong twice on record, in the #1641 review and in the #1649 write-up itself. A structure does not admit that class of mistake; a rule does. Correctness first, with the price tracked in #1728.

What this PR adds is what stops someone re-proposing a remedy that was already tried:

| configuration | plan fields | meta reads from | `navigate/sync-baseline` |
| --- | --: | --- | --- |
| before the change | 17 | `opts` | 8.3 ms |
| before + one UNREAD field | 18 | `opts` | 8.3 ms |
| three flags packed into one | 18 | the plan | 9.8 ms |
| five value arguments | 20 | the plan | 9.8 ms |
| entry reads → constants | 20 | the plan | 9.8 ms |
| shipped | 20 | the plan | 9.8 ms |

Ruled out by measurement: the literal's width, the call shape, the entry reads, field count as such (an unread field is free), a hidden-class transition, and the runner. What survives is narrower — **a field added to that literal and then READ inside the commit costs, adding it without reading it does not** — and the mechanism is unexplained. It is the second such effect in this seam: #1704's first form cost 13.4 % for extracting a helper while the identical code inline cost nothing.
