### PR TITLE
⛔ DO NOT MERGE — perf probe: ONE added field that IS read (#1728)

### DIFF
--- a/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/completeTransition.ts
@@ -1,23 +1,21 @@
 import { errorCodes, constants } from "../../../constants";
 import { RouterError } from "../../../RouterError";
 
-import type { State, TransitionMeta } from "../../../types";
+import type { NavigationOptions, State, TransitionMeta } from "../../../types";
 import type { NavigationDependencies, NavigationContext } from "../types";
 
 type MutableTransitionMeta = {
   -readonly [K in keyof TransitionMeta]: TransitionMeta[K];
 };
 
-/**
- * Built entirely from the PLAN — no argument of this function comes from
- * anywhere else, and that is the point (#1719). Its three flags used to be read
- * off the caller's `NavigationOptions`, which is accessor- or Proxy-backed by
- * contract, so building the meta was a call into application code from inside
- * the commit. The entry point snapshots them before it announces anything.
- */
-function buildTransitionMeta(nav: NavigationContext): TransitionMeta {
-  const { fromState, toDeactivate, toActivate, intersection } = nav;
-
+function buildTransitionMeta(
+  fromState: State | undefined,
+  opts: NavigationOptions,
+  toDeactivate: string[],
+  toActivate: string[],
+  intersection: string,
+  redirectedFromPlan: boolean | undefined,
+): TransitionMeta {
   Object.freeze(toDeactivate);
   Object.freeze(toActivate);
 
@@ -37,16 +35,16 @@ function buildTransitionMeta(nav: NavigationContext): TransitionMeta {
     meta.from = fromState.name;
   }
 
-  if (nav.reload !== undefined) {
-    meta.reload = nav.reload;
+  if (opts.reload !== undefined) {
+    meta.reload = opts.reload;
   }
 
-  if (nav.replace !== undefined) {
-    meta.replace = nav.replace;
+  if (opts.replace !== undefined) {
+    meta.replace = opts.replace;
   }
 
-  if (nav.redirected !== undefined) {
-    meta.redirected = nav.redirected;
+  if (redirectedFromPlan !== undefined) {
+    meta.redirected = redirectedFromPlan;
   }
 
   return Object.freeze(meta);
@@ -56,7 +54,15 @@ export function completeTransition(
   deps: NavigationDependencies,
   nav: NavigationContext,
 ): State {
-  const { toState, fromState, toDeactivate, toActivate } = nav;
+  const {
+    toState,
+    fromState,
+    opts,
+    toDeactivate,
+    toActivate,
+    intersection,
+    redirected,
+  } = nav;
 
   if (
     toState.name !== constants.UNKNOWN_ROUTE &&
@@ -90,33 +96,33 @@ export function completeTransition(
   // force the caller to copy an identity into it by hand.
   const commit = nav;
 
-  // The meta and the freeze still stand above the ask, but they are no longer
-  // KEPT there by an ordering rule — there is nothing left below to order them
-  // against (#1719).
+  // ⚠ The meta and the freeze stand ABOVE the ask, and that is not cosmetic:
+  // `buildTransitionMeta` reads `opts.reload` / `opts.replace` /
+  // `opts.redirected` off the CALLER'S options object, and an accessor- or
+  // Proxy-backed `opts` is a supported input (`navigate/edge-cases-proxy`
+  // pins three of them). So this is the one place in `completeTransition` that
+  // runs application code, and it has to run BEFORE the verdict — a getter that
+  // calls `stop()` / `dispose()` under it must be something the ask can still
+  // SEE. Ran below the ask, it invalidated a verdict already given: `COMPLETE`
+  // then hit a table with no such edge, the send was a silent no-op, and this
+  // function still returned `finalState` — `navigate()` resolving a state that
+  // was never committed, with no `TRANSITION_SUCCESS` and a `getState()` that
+  // disagrees. Measured A/B on the getter (`resolved` vs `rejected:CANCELLED`),
+  // and it is exactly the phantom the #1649 write-up forbids in §8.1.
   //
-  // ⚑ **This function reads no `opts` field at all now, and that is what makes
-  // the window between the ask and the send empty STRUCTURALLY.** It used to
-  // build the meta out of `opts.reload` / `opts.replace` / `opts.redirected` —
-  // the CALLER's object, accessor- or Proxy-backed by contract
-  // (`navigate/edge-cases-proxy` pins three of them) — so this was the one place
-  // in `completeTransition` that ran application code, and it had to run BEFORE
-  // the verdict: a getter calling `stop()` / `dispose()` under it invalidated a
-  // verdict already given, `COMPLETE` then hit a table with no such edge, the
-  // send was a silent no-op, and this function still returned `finalState` —
-  // `navigate()` resolving a state nobody committed, with no
-  // `TRANSITION_SUCCESS` and a `getState()` that disagrees. The three flags are
-  // snapshotted at the entry now (`NavigationContext.reload` and its two
-  // siblings), so a getter cannot reach this frame at all.
-  //
-  // ⚠ **Not "no application code runs in `completeTransition`" — that is false
-  // and the difference matters.** The ANNOUNCE below the verdict runs plenty:
-  // `sendTransitionDone` emits `TRANSITION_SUCCESS` synchronously into every
-  // plugin hook and every `router.subscribe` listener, and the `ROUTE_NOT_FOUND`
-  // arm above does the same through `sendTransitionFail`. Both stand BELOW the
-  // verdict and were never what the rule was about. The exact claim is: between
-  // the ask and the send there is bookkeeping and nothing else.
-  (toState as { transition: TransitionMeta }).transition =
-    buildTransitionMeta(nav);
+  // ⚑ The general rule this is an instance of: the ask is a snapshot, so
+  // EVERYTHING that can move the router must sit above it and everything below
+  // it must be inert. Nothing here throws once the meta is built, so hoisting
+  // costs a refused commit one meta it will not use — 11 refusals in the whole
+  // functional tier — and buys the window its emptiness.
+  (toState as { transition: TransitionMeta }).transition = buildTransitionMeta(
+    fromState,
+    opts,
+    toDeactivate,
+    toActivate,
+    intersection,
+    redirected,
+  );
 
   const finalState = Object.freeze(toState);
 

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -273,28 +273,8 @@ function beginTransition(
   fromState: State | undefined,
   opts: NavigationOptions,
 ): NavigationPlan {
-  // ⚑ **The meta's three inputs, read FIRST — before anything else this
-  // function does (#1719).** Their only consumer is `buildTransitionMeta`,
-  // which used to read them off the caller's object several phases later, in
-  // the middle of `completeTransition`; that read was the one call into
-  // application code inside the commit, and the whole "build the meta ABOVE the
-  // ask" ordering rule existed to survive it.
-  //
-  // ⚠ **ABOVE `abortPreviousNavigation`, not below it, and the difference is
-  // measured rather than stylistic.** One statement lower, these reads sit
-  // between the previous navigation's cancel and this one's announce — a window
-  // where the machine has left the band and this navigation has not entered it.
-  // A getter starting a nested navigation there parks the machine back IN the
-  // band, and this navigation's own `send(NAVIGATE)` then takes a self-loop the
-  // table documents as never traversed and `fsm-edge-reachability` holds in
-  // `UNREACHED`. Instrumented on both positions: here `TRANSITION_STARTED` and
-  // `LEAVE_APPROVED` self-loops fire zero times, one statement lower the
-  // `LEAVE_APPROVED` one fires. Here they share the window the prologue already
-  // reads `opts` in (`forceReplaceFromUnknown`, `isSameNavigation`), so a
-  // nested navigation started from a getter is an ordinary one that the cancel
-  // below supersedes.
-  const reload = opts.reload;
-  const replace = opts.replace;
+  // ⛔ PROBE #1728 — the ONE variable: one field added to the literal AND read
+  // in the commit. The control (this code without it) measures 8.3 ms.
   const redirected = opts.redirected;
 
   abortPreviousNavigation(deps, opts.signal);
@@ -393,8 +373,6 @@ function beginTransition(
     cancelReason: undefined,
     detachExternalBridge: undefined,
     externalSignal,
-    reload,
-    replace,
     redirected,
   };
 

--- a/packages/core/src/namespaces/NavigationNamespace/types.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/types.ts
@@ -33,20 +33,14 @@ declare const COMMIT_PERMIT: unique symbol;
  * ⚠ It proves the ask HAPPENED, not that it is still true. That is sufficient
  * here and nowhere else by default: nothing runs between the ask and the clear
  * — the cleanup is `Map` bookkeeping over the compiled forms #1649 stored, so
- * no code exists that could invalidate the verdict in between.
- *
- * ⚑ **That sufficiency used to lean on a SECOND ordering rule the permit does
- * not express; since #1719 it stands on its own.** The rule was: the one step
- * that ran application code — `buildTransitionMeta` reading the caller's `opts`
- * accessors — had to be hoisted ABOVE the ask, because built below it a getter
- * calling `stop()` / `dispose()` invalidated the verdict and the send became a
- * silent table no-op while `completeTransition` still returned its state (the
- * phantom resolve). The three flags are snapshotted at the entry now, so
- * `completeTransition` reads no `opts` field at all and there is no application
- * code left in the function to order. Pinned by
- * `commit-window-empty-1719.test.ts`, which COUNTS the caller's getter
- * invocations and requires zero below the announce. Reuse the permit across
- * anything that CAN run user code and it would be theatre.
+ * no code exists that could invalidate the verdict in between. What makes that
+ * hold is a SECOND ordering rule the permit does not express: the one step that
+ * runs application code, `buildTransitionMeta` reading the caller's `opts`
+ * accessors, is hoisted ABOVE the ask. Built below it, a getter calling
+ * `stop()` / `dispose()` invalidated the verdict and the send became a silent
+ * table no-op while `completeTransition` still returned its state — the phantom
+ * resolve, pinned by `commit-ask-snapshot-1649.test.ts`. Reuse the permit
+ * across anything that CAN run user code and it would be theatre.
  */
 export interface CommitPermit {
   readonly [COMMIT_PERMIT]: true;
@@ -146,45 +140,7 @@ export interface NavigationContext {
    * bridge would then be detached from something it was never attached to.
    */
   externalSignal?: AbortSignal | undefined;
-  /**
-   * The caller's `reload` / `replace` / `redirected`, read ONCE at the entry
-   * and kept here — the three inputs of `buildTransitionMeta` (#1719).
-   *
-   * ⚑ **They exist to empty a WINDOW, not to save a read.** The meta used to be
-   * built from `opts` in the middle of `completeTransition`, which made it the
-   * one place there that ran application code — `opts` is accessor- or
-   * Proxy-backed by contract, so a getter could `stop()` / `dispose()` /
-   * renavigate from inside the commit. That forced an ordering rule of its own:
-   * the meta had to be built ABOVE the commit ask, so a verdict already given
-   * could not be invalidated under it. With the values snapshotted at the entry
-   * the window is empty structurally rather than by care, and the rule has no
-   * subject left. ⚠ Not "no application code runs in `completeTransition`" —
-   * the ANNOUNCE below the verdict still runs plenty (`TRANSITION_SUCCESS` into
-   * every hook and subscriber, synchronously). The claim is narrower and exact:
-   * nothing between the ask and the send.
-   *
-   * Three flat slots rather than one nested record: the plan is per-navigation
-   * and `plan-born-in-final-shape` puts every slot in the literal, so a record
-   * would be an allocation разрез А has no use for.
-   *
-   * ⚠ **These three slots cost `navigate/sync-baseline` ≈14 %, and PACKING THEM
-   * DOES NOT HELP — measured, do not re-try it (#1722).** Snapshotting them made
-   * that arc go 8.3–8.8 ms → 9.6–9.9 (two head runs against two bases), while
-   * the two commits before them, which add no slot to this literal, measured 90
-   * benchmarks unchanged. The obvious remedy was tried and refuted: folding all
-   * three into one packed number measured **90 unchanged against this form** —
-   * one slot costs exactly what three cost, so the price is not the plan's
-   * width. What it IS remains open; the suspects and the measurements are in
-   * #1722.
-   *
-   * ⚠ Snapshotting them does NOT change what plugins receive — the
-   * announcement still hands over `opts` ITSELF, because keys core never
-   * declared are a shipped contract on it: `memory-plugin` round-trips its own
-   * `source` marker through `navigate(...)` to `onTransitionSuccess`, and a
-   * flattened record would drop it silently.
-   */
-  reload?: boolean | undefined;
-  replace?: boolean | undefined;
+  /** ⛔ PROBE #1728 — ONE snapshotted flag, read in the commit. */
   redirected?: boolean | undefined;
 }
 


### PR DESCRIPTION
Throwaway probe for #1728. **Never to be merged.** Behaviour is deliberately at the pre-#1719 state, so CI is red by design — the benchmark job is what this is for.

**The question.** Six configurations left one hypothesis standing: *a field added to the plan's object literal AND then read inside the commit costs ≈15 %; adding it without reading it is free; reading pre-existing fields is free.* The unread-dummy probe established the second clause. This tests the first.

**The setup.** Control (pre-#1719 code, 17 fields, meta reads `opts` — measured **8.3 ms**) plus exactly ONE field: `redirected` is snapshotted at the entry and read from the plan in the commit, while `reload` and `replace` still come from `opts`. One real flag rather than a synthetic dummy, so there is no risk the read is optimised away and no artificial shape.

**How to read it**, against master (which carries the ≈15 %):

- **90 unchanged** ⇒ the probe reproduced master's 9.8 from the control, so ONE added-and-read field is enough. The rule is about reading a newly added slot, not about how many — which points at object layout / map transitions and, importantly, admits a workaround by form (put the value in an EXISTING field or on the state object rather than widening the plan).
- **improvement on `navigate/sync-baseline`** ⇒ one is free and the cost needs several, so the hypothesis is wrong again and the next step is reading generated code rather than bisecting shapes.

⚠ That arc's run-to-run spread is 3–6 % against a global 10 % threshold; a single pair is a range, not a verdict.
