### PR TITLE
fix(core): the dependency guard and copy loops answered about different property sets (#1799) + read each key twice (#1816) + adopted inherited keys and leaked a prototype-swap primitive (#1823)

### DIFF
--- a/.changeset/dependencies-copy-own-once-1816.md
+++ b/.changeset/dependencies-copy-own-once-1816.md
@@ -1,0 +1,22 @@
+---
+"@real-router/core": patch
+---
+
+fix(core): the dependencies copy loops read each key twice and stored the second (#1816)
+
+Both doors — the constructor's initial deps and `setAll` — tested
+`deps[key] !== undefined` and then read the same key again for the value they
+stored. Two reads of an object the caller owns, so a key was ADMITTED on one value
+and STORED with another.
+
+```
+a Proxy over a plain object, own data property
+  before  reads 2, stored "read#2"
+  after   reads 1, stored "read#1"
+```
+
+⚠ Inheritance is not required, which is what separates this from #1799 / #1823: a
+Proxy with an own data property passes `guardDependencies` — there is no accessor
+descriptor to find — and the loop still read it twice. The row `setAll · deps` in
+`read-count-authority.test.ts` moves from 2 to 1, and from the "known defect"
+block into the "1 read" block.

--- a/.changeset/dependencies-guard-own-only-1799.md
+++ b/.changeset/dependencies-guard-own-only-1799.md
@@ -1,0 +1,38 @@
+---
+"@real-router/core": patch
+---
+
+fix(core): one `Object.create` put a forbidden getter past the dependencies guard (#1799)
+
+`guardDependencies` enumerated with `for…in`, which walks the prototype chain, and
+then asked `Object.getOwnPropertyDescriptor`, which answers only about OWN
+properties. For an inherited name the descriptor is `undefined`, so `?.get` never
+fired: the guard iterated exactly the names it could not judge.
+
+```
+CONTROL  an OWN getter                 -> TypeError: dependencies cannot contain getters: "svc"
+         the SAME getter, one Object.create away
+           before  ACCEPTED, and get("svc") returns the getter's value
+           after   not a dependency at all
+```
+
+The walk is own-only now, through the module-level `objectKeys` capture this file
+already had — the same set the copy loops walk, so nothing gets past one half that
+the other half never judged.
+
+⚠ **Honest boundary: the walk change buys COHERENCE, not a different verdict.**
+For an inherited name `getOwnPropertyDescriptor` answers `undefined`, so `?.get`
+could never fire on the extra names `for…in` visited — measured across six bag
+shapes, both forms return the identical verdict on every one. What actually keeps
+an inherited getter out of the store is the copy loops, which now walk the same
+own-key set. The one thing the change does alter is the BINDING: `for…in` is
+syntax and cannot be re-pointed, and an early draft of this fix reached for the
+raw `Object.keys` instead of the capture — measured, a post-boot shim then walked
+a forbidden getter straight past the guard. That is what the new
+`reads the CAPTURED Object.keys` cell pins; no behavioural cell can tell the two
+walks apart.
+
+⚠ The always-on guard runs at construction only (`Router.ts`). `setAll` and
+`cloneRouter` reach the store without it — `@real-router/validation-plugin` covers
+`setAll`, nothing covers `cloneRouter`'s override bag. Unchanged here, and stated
+because the copy-loop half of this fix does apply to all three doors.

--- a/.changeset/dependencies-own-keys-and-getall-1823.md
+++ b/.changeset/dependencies-own-keys-and-getall-1823.md
@@ -1,0 +1,51 @@
+---
+"@real-router/core": patch
+---
+
+fix(core): the dependencies channel adopted inherited keys, and `getAll()` handed out a prototype-swap primitive (#1823)
+
+**Inherited keys became dependencies.** Neither copy loop filtered own keys, so
+`setAll(Object.assign(Object.create({ leaked: "LEAK" }), { real: 1 }))` put
+`leaked` in the store, through the constructor door and through `setAll` alike.
+Both loops now walk `Object.keys` — the same walk, through the same kind of
+module-level capture, that `guardDependencies` uses.
+
+⚠ An intermediate draft gated a `for…in` with `Object.hasOwn` instead. Those
+enumerate the same set for a plain object but NOT for a Proxy: `for…in` asks the
+`ownKeys` trap plus the chain, `hasOwn` asks the `getOwnPropertyDescriptor` trap,
+and a bag that answers those two differently got a key past the copy loop that the
+guard had never judged — including #1799's own payload, a forbidden getter that
+reached the store and ran. Walking `ownKeys` once leaves the two halves nothing to
+disagree about. It is also faster: measured −18 % at one key and −25 % at twenty,
+against an A/A floor of 1.6 %.
+
+**`getAll()` is published API and returned a hazard.** The store is
+`Object.create(null)`, so an own `"__proto__"` is an ordinary key there — but the
+spread that built the result re-defined it on a normal object, and the result was
+then a prototype-swap primitive for any consumer merging it with `Object.assign`
+or a `for…in` copy. `cloneRouter` spreads and was safe; a consumer was not. The
+result still comes from a spread — which DEFINES rather than assigns — and the
+one key that cannot be trusted to it is deleted afterwards.
+
+⚠ The first draft replaced the spread with a `all[key] = value` loop, and that
+turned an already-immune site into a member of the class this fix is about: an
+ordinary dependency name carried as an accessor on `Object.prototype` made
+`getAll()` throw. Define-vs-assign is the axis; "copy it key by key" is not a
+safe reflex.
+
+⚠ Asymmetric with `get("__proto__")`, deliberately: the single read hands back a
+value, this door hands back a CONTAINER someone will merge.
+
+⚠ The `delete` is UNCONDITIONAL. Guarding it with `Object.hasOwn(source, …)`
+decides nothing — deleting an absent key is a no-op in every observable respect —
+while putting a re-pointable intrinsic read in front of the one line that
+neutralises the hazard; with `hasOwn` shimmed to `false` the whole primitive came
+back.
+
+⚠ Which assertion discriminates depends on HOW the result is built, and the test
+carries both because the implementation has already moved once. Against the
+shipped spread + `delete`, dropping the delete leaves `"__proto__"` an ordinary
+own key, so the returned object's prototype stays intact and the
+`Object.assign(merged, all)` half is what reds. Against the write-loop draft the
+polarity was the reverse: the write swapped the RESULT's own prototype, and a cell
+checking only the merge target passed on the defect.

--- a/packages/core/INVARIANTS.md
+++ b/packages/core/INVARIANTS.md
@@ -223,7 +223,7 @@ The emit machinery re-entering itself from inside a transition listener (`subscr
 
 `getRoutesApi(router)` provides CRUD operations on the route tree. These invariants verify that add, remove, update, replace, and clear operations behave atomically and consistently.
 
-**Crash-preventing guards** (always enforced by core, regardless of plugins): `guardRouteStructure` rejects non-object routes, non-function `canActivate`/`canDeactivate`, and async `encodeParams`/`decodeParams`/`forwardTo`. `guardDependencies` rejects non-plain-object dependency maps. Circular `forwardTo` chains are detected by `resolveForwardChain` at registration time. These guards prevent silent state corruption and always throw, even without the validation-plugin.
+**Crash-preventing guards** (always enforced by core, regardless of plugins): `guardRouteStructure` rejects non-object routes, non-function `canActivate`/`canDeactivate`, and async `encodeParams`/`decodeParams`/`forwardTo`. `guardDependencies` rejects non-plain-object dependency maps and own enumerable getters — it walks OWN keys, so an inherited getter is not refused; it is never adopted either, because the copy loops walk the same set. Circular `forwardTo` chains are detected by `resolveForwardChain` at registration time. These guards prevent silent state corruption and always throw, even without the validation-plugin.
 
 **Invariants requiring `@real-router/validation-plugin`** are marked _(validation-plugin only)_.
 
@@ -345,7 +345,7 @@ Guards registered via `getLifecycleApi(router)` run during the transition pipeli
 | 1   | set then has        | After `set(name, value)`, `has(name) === true`. A set dependency is immediately visible.                                            |
 | 2   | set then get        | After `set(name, value)`, `get(name) === value`. The stored value is exactly what was set.                                          |
 | 3   | remove then has     | After `set(name, value)` and `remove(name)`, `has(name) === false`. Removal is effective immediately.                               |
-| 4   | setAll then getAll  | After `setAll(deps)`, `getAll()` contains all key-value pairs from `deps`. Bulk set is consistent with bulk get.                    |
+| 4   | setAll then getAll  | After `setAll(deps)`, `getAll()` contains every OWN enumerable pair of `deps` except `"__proto__"`. Inherited keys are not adopted; `"__proto__"` IS stored — reach it with `has`/`get` — but withheld from `getAll`, which hands back a container a consumer will merge. |
 | 5   | Idempotent set      | Calling `set(name, value)` twice with the same arguments does not change the stored value. Overwriting with the same value is safe. |
 | 6   | reset clears all    | After `reset()`, `has(name) === false` for every previously set dependency. `reset()` removes all dependencies.                     |
 | 7   | getAll returns copy | `getAll()` returns a new object on each call (not the internal store). Mutating the result does not affect the store.               |

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -79,6 +79,14 @@ function setMultipleDependencies(
       validator?.dependencies.validateDependencyCount(store, "setDependencies");
     }
 
+    // ⚑ The destination is the dependency store, built with `Object.create(null)`
+    // (`dependenciesStore`), so there is no inherited setter for `"__proto__"` to
+    // dispatch into: the key lands as an ordinary own property. That is the
+    // exemption the SAST rule's own message names, and it is load-bearing rather
+    // than incidental — `set("__proto__", v)` is a supported call whose value
+    // `has`/`get` return, and `getAll()` is the door that withholds it on the way
+    // out (#1823).
+    // nosemgrep: unguarded-computed-key-write
     (store.dependencies as Record<string, unknown>)[key] = value;
   }
 

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -1,10 +1,22 @@
 import { throwIfDisposed } from "./helpers";
+import { UNSAFE_KEY } from "../constants";
 import { getInternals } from "../internals";
 
 import type { DependenciesApi } from "./types";
 import type { DependenciesStore } from "../namespaces";
 import type { DefaultDependencies, Router } from "../types";
 import type { RouterValidator } from "../types/RouterValidator";
+
+/**
+ * Captured at module load, for the same reason `guards` and `dependenciesStore`
+ * capture theirs: a guard is only as strong as the intrinsic it reads WHEN IT
+ * RUNS. ⚠ It does not close a shim evaluated BEFORE this module.
+ *
+ * The bare `Object.hasOwn` calls elsewhere in this file read the STORE, which is
+ * `Object.create(null)` — a re-pointed `hasOwn` misreports there too, but the
+ * store's contents are the router's own, not a caller's bag.
+ */
+const objectKeys = Object.keys;
 
 // =============================================================================
 // Module-private CRUD functions
@@ -50,8 +62,14 @@ function setMultipleDependencies(
 ): void {
   const overwrittenKeys: string[] = [];
 
-  for (const key in deps) {
-    if (deps[key] === undefined) {
+  // ⚑ The same walk and the same single read as the constructor door — and
+  // "the same" is literal, not approximate: both call the captured
+  // `objectKeys`. See `dependenciesStore` for why `for…in` + `Object.hasOwn`
+  // is not an equivalent spelling.
+  for (const key of objectKeys(deps)) {
+    const value = deps[key];
+
+    if (value === undefined) {
       continue;
     }
 
@@ -61,7 +79,7 @@ function setMultipleDependencies(
       validator?.dependencies.validateDependencyCount(store, "setDependencies");
     }
 
-    (store.dependencies as Record<string, unknown>)[key] = deps[key];
+    (store.dependencies as Record<string, unknown>)[key] = value;
   }
 
   if (overwrittenKeys.length > 0) {
@@ -97,7 +115,45 @@ export function getDependenciesApi<
 
       return value as Dependencies[typeof name];
     },
-    getAll: () => ({ ...ctx.dependenciesGetStore().dependencies }),
+    getAll: () => {
+      // ⚑ A spread, then `UNSAFE_KEY` deleted (#1823). The store is
+      // `Object.create(null)`, so an own `"__proto__"` is an ORDINARY key there
+      // — but a spread re-defines it on a normal object, and the result is then
+      // a prototype-swap primitive for any consumer that merges it with
+      // `Object.assign` or a `for…in` copy. `cloneRouter` spreads and is safe;
+      // a consumer merging is not, and this is published API.
+      //
+      // ⚠ Asymmetric with `get("__proto__")`, deliberately: the single read
+      // hands back a value, this door hands back a CONTAINER that someone will
+      // merge. Same asymmetry the route-config records already carry.
+      const source = ctx.dependenciesGetStore().dependencies as Record<
+        string,
+        unknown
+      >;
+      // ⚑ SPREAD, not a write loop, and the difference is the whole point of
+      // this function. A spread DEFINES each key; `all[key] = value` SETS it,
+      // and a `[[Set]]` of an ordinary dependency name that `Object.prototype`
+      // happens to carry as an accessor throws instead of storing (#1852). The
+      // first draft of this fix used the loop and turned an already-immune site
+      // into a member of that class — measured, `getAll()` threw.
+      const all: Record<string, unknown> = { ...source };
+
+      // The one key a spread cannot be trusted with: `source` is built with
+      // `Object.create(null)`, so `"__proto__"` can sit there as an ORDINARY own
+      // key. Spreading defines it as an own key here too — harmless in `all`
+      // itself, but it makes the returned object a prototype-swap primitive for
+      // any consumer that merges it with `Object.assign` or a `for…in` copy.
+      //
+      // ⚠ UNCONDITIONAL, and deliberately. Guarding it with
+      // `Object.hasOwn(source, UNSAFE_KEY)` decides nothing — deleting an
+      // absent key is a no-op in every observable respect, measured — while
+      // putting a re-pointable intrinsic read in front of the one line that
+      // neutralises the hazard. `hasOwn` shimmed to `false` restored the whole
+      // primitive.
+      delete all[UNSAFE_KEY];
+
+      return all as ReturnType<DependenciesApi<Dependencies>["getAll"]>;
+    },
     set: (name, value) => {
       throwIfDisposed(ctx.isDisposed);
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -50,7 +50,8 @@ export const errorCodes: ErrorCodeToValueMap = Object.freeze({
 export const UNKNOWN_ROUTE = "@@router/UNKNOWN_ROUTE";
 
 /**
- * The one key the router will not copy into a state channel (#1792).
+ * The one key the router will not copy into a state channel (#1792), and — at
+ * `getDependenciesApi.getAll` — will not hand back out of a container either.
  *
  * ⚠ It does not REFUSE it — nothing throws, at any door or at registration; the
  * key is dropped where core copies. And this constant is not the only mention
@@ -99,6 +100,15 @@ export const UNKNOWN_ROUTE = "@@router/UNKNOWN_ROUTE";
  * because the merge below it walks own keys. That is the reachability argument
  * this note calls insufficient, and it is recorded as an open exception rather
  * than as a justification.
+ *
+ * ⚑ A THIRD sound exemption, and the only one besides ownership: the TARGET is
+ * `Object.create(null)`. There is no inherited setter to dispatch into, so the
+ * key lands as an ordinary own property and no guard is needed on the way in.
+ * The dependency store is the live case (`dependenciesStore.ts`,
+ * `getDependenciesApi.setAll`) — both copy a caller-owned bag and neither names
+ * `UNSAFE_KEY`, deliberately. It is also why `getAll` is this constant's other
+ * consumer: the key is admitted on the way IN and withheld on the way OUT,
+ * because that door hands back a normal object someone will merge.
  */
 export const UNSAFE_KEY = "__proto__";
 

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -32,7 +32,15 @@ export function guardDependencies(deps: unknown): void {
   ) {
     throw new TypeError("dependencies must be a plain object");
   }
-  for (const key in deps as Record<string, unknown>) {
+  // ⚑ The walk and the check must answer about the SAME property set (#1799).
+  // `for…in` enumerates inherited names; `getOwnPropertyDescriptor` answers
+  // `undefined` for every one of them, so `?.get` never fired and the guard
+  // iterated exactly the names it could not judge — one `Object.create` put a
+  // forbidden getter straight past it. Own-only here, which is also the
+  // supported-input boundary: an inherited key is not supported input, so it is
+  // not a dependency at all and there is nothing to refuse. The copy loops
+  // enforce the same rule, so such a name never reaches the store either.
+  for (const key of objectKeys(deps)) {
     if (getOwnPropertyDescriptor(deps, key)?.get) {
       throw new TypeError(`dependencies cannot contain getters: "${key}"`);
     }

--- a/packages/core/src/namespaces/DependenciesNamespace/dependenciesStore.ts
+++ b/packages/core/src/namespaces/DependenciesNamespace/dependenciesStore.ts
@@ -3,6 +3,15 @@ import { DEFAULT_LIMITS } from "../../constants";
 import type { DefaultDependencies } from "../../types";
 import type { Limits } from "../../types/internal";
 
+/**
+ * Captured at module load. A guard is only as strong as the intrinsic it reads
+ * WHEN IT RUNS, and an application can re-point `Object.keys` after boot —
+ * the doctrine `guards`, `SegmentMatcher` and `helpers` already follow. ⚠ It
+ * does not close a shim evaluated BEFORE this module; the window it closes is
+ * "after boot".
+ */
+const objectKeys = Object.keys;
+
 export interface DependenciesStore<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 > {
@@ -17,9 +26,31 @@ export function createDependenciesStore<
 ): DependenciesStore<Dependencies> {
   const dependencies = Object.create(null) as Partial<Dependencies>;
 
-  for (const key in initialDependencies) {
-    if (initialDependencies[key] !== undefined) {
-      dependencies[key] = initialDependencies[key];
+  // ⚑ `Object.keys`, and read ONCE (#1816 / #1823 / #1799).
+  //
+  // The walk is THE SAME ONE `guardDependencies` uses, and that is the point:
+  // an intermediate draft walked `for…in` and filtered with `Object.hasOwn`,
+  // which enumerates the same set for a plain object but NOT for a Proxy —
+  // `for…in` asks `ownKeys` plus the chain, `hasOwn` asks the
+  // `getOwnPropertyDescriptor` trap, and a bag that answers those two
+  // differently gets a key past the copy loop that the guard never judged.
+  // Measured: a forbidden getter reached the store and ran. Walking `ownKeys`
+  // once leaves nothing for the two halves to disagree about. It is also
+  // faster — measured −18 % at one key and −25 % at twenty.
+  //
+  // Read ONCE: the loop used to read each key twice — the `!== undefined` test
+  // and the value stored — so a key was ADMITTED on one value and STORED with
+  // another. Neither needs inheritance to fire: a Proxy is enough.
+  // `objectKeys` yields `string`, where `for…in` narrowed to the key union — so
+  // both sides are widened once here rather than casting at each index.
+  const source = initialDependencies as Record<string, unknown>;
+  const target = dependencies as Record<string, unknown>;
+
+  for (const key of objectKeys(source)) {
+    const value = source[key];
+
+    if (value !== undefined) {
+      target[key] = value;
     }
   }
 

--- a/packages/core/src/namespaces/DependenciesNamespace/dependenciesStore.ts
+++ b/packages/core/src/namespaces/DependenciesNamespace/dependenciesStore.ts
@@ -50,6 +50,14 @@ export function createDependenciesStore<
     const value = source[key];
 
     if (value !== undefined) {
+      // ⚑ The destination is the dependency store, built with `Object.create(null)`
+      // (`dependenciesStore`), so there is no inherited setter for `"__proto__"` to
+      // dispatch into: the key lands as an ordinary own property. That is the
+      // exemption the SAST rule's own message names, and it is load-bearing rather
+      // than incidental — `set("__proto__", v)` is a supported call whose value
+      // `has`/`get` return, and `getAll()` is the door that withholds it on the way
+      // out (#1823).
+      // nosemgrep: unguarded-computed-key-write
       target[key] = value;
     }
   }

--- a/packages/core/tests/functional/chain-walk-authority.test.ts
+++ b/packages/core/tests/functional/chain-walk-authority.test.ts
@@ -985,10 +985,6 @@ describe("where core walks a chain it does not own", () => {
       // inherited getter passes and is then invoked by the copy loop below it.
       "guards.ts · for (const key in deps as Record<string, unknown>) {":
         "for-in",
-      // #1799 — the copy loop, on both doors.
-      "namespaces/DependenciesNamespace/dependenciesStore.ts · for (const key in initialDependencies) {":
-        "for-in",
-      "api/getDependenciesApi.ts · for (const key in deps) {": "for-in",
 
       // §8 — `recordsShallowEqual` counts OWN keys and then tests membership with
       // `in`, so two states with disjoint own `params` compare EQUAL. Publicly

--- a/packages/core/tests/functional/chain-walk-authority.test.ts
+++ b/packages/core/tests/functional/chain-walk-authority.test.ts
@@ -51,13 +51,37 @@ describe("where core walks a chain it does not own", () => {
     readonly code: string;
   }
 
-  function scan(): Site[] {
-    const found: Site[] = [];
+  /**
+   * ⚑ Takes an optional source list so the CONTROL below can hand it a
+   * SYNTHETIC file. Without that seam the only available non-vacuity check was
+   * "at least N unguarded walks still exist in src" — a threshold that DECREASES
+   * every time someone fixes one, i.e. a guard that penalises progress and reds
+   * on the correct change it is waiting for. #1840 took it from 6 to 4 and this
+   * batch to 3, against a literal `> 2`.
+   */
+  /**
+   * THE read path. `scan()` and its parse CONTROL both go through this, so the
+   * control cannot pass while the scanner reads something else — the exact hole
+   * the first version had, where the control re-globbed on its own and stayed
+   * green with `scan()`'s glob broken.
+   */
+  function sourceFiles(): { readonly file: string; readonly text: string }[] {
+    return globSync(`${SRC}/**/*.ts`).map((file) => ({
+      file,
+      text: readFileSync(file, "utf8"),
+    }));
+  }
 
-    for (const file of globSync(`${SRC}/**/*.ts`)) {
+  function scan(
+    sources?: readonly { readonly file: string; readonly text: string }[],
+  ): Site[] {
+    const found: Site[] = [];
+    const inputs = sources ?? sourceFiles();
+
+    for (const { file, text } of inputs) {
       const source = ts.createSourceFile(
         file,
-        readFileSync(file, "utf8"),
+        text,
         ts.ScriptTarget.Latest,
         // `true`: the `in`-on-a-parameter test walks up to the enclosing
         // function. Without parent pointers that walk silently finds nothing and
@@ -965,6 +989,7 @@ describe("where core walks a chain it does not own", () => {
       "namespaces/DependenciesNamespace/dependenciesStore.ts · for (const key in initialDependencies) {":
         "for-in",
       "api/getDependenciesApi.ts · for (const key in deps) {": "for-in",
+
       // §8 — `recordsShallowEqual` counts OWN keys and then tests membership with
       // `in`, so two states with disjoint own `params` compare EQUAL. Publicly
       // reachable through `areStatesEqual(a, b, false)`.
@@ -1046,17 +1071,84 @@ describe("where core walks a chain it does not own", () => {
     });
   });
 
-  it("CONTROL — the scanner finds both shapes, and finds them in src", () => {
-    // ⚑ Non-vacuity with teeth: an empty result would satisfy `toStrictEqual({})`
-    // if the table above were ever emptied in the same edit, and a scanner that
-    // silently stopped parsing would report zero. Both shapes must be present,
-    // and the file list must be non-trivial.
-    const sites = scan();
+  it("CONTROL — the scanner still detects both shapes, on a synthetic file", () => {
+    // ⚑ This asserts the INSTRUMENT, not the defect population. The previous
+    // form required "at least 3 unguarded for-ins survive in src", which went
+    // down every time one was fixed and would have red on the next correct
+    // change — a non-vacuity guard that fails on success is worse than none,
+    // because the pressure is then to keep a defect alive.
+    //
+    // A synthetic file cannot be fixed away, so this control holds no matter how
+    // clean `src` becomes. It also fails loudly on the rots a count cannot see:
+    // renaming the module-level `hasOwn` capture, or teaching `guardsOwn` a
+    // spelling that accepts a filter which decides nothing.
+    const FILE = "__control__.ts";
+    const sites = scan([
+      {
+        file: `${SRC}/${FILE}`,
+        text: [
+          // ⚑ Three DISTINCT subject names. `code` is `head(node)` — the first
+          // line of the walk — so the subject is what tells the entries apart in
+          // a failure diff. NOT load-bearing for the assertion itself:
+          // `toStrictEqual` on an array reds on LENGTH, so a leaked `gatedBag`
+          // entry is caught whatever it is called. Distinct names make the
+          // failure readable — a smaller claim than this comment used to make.
+          "export function forInShape(openBag: Record<string, unknown>): void {",
+          "  for (const key in openBag) {",
+          "    void openBag[key];",
+          "  }",
+          "}",
+          "export function inOnParamShape(paramBag: object, k: string): boolean {",
+          "  return k in paramBag;",
+          "}",
+          "export function guardedShape(gatedBag: Record<string, unknown>): void {",
+          "  for (const key in gatedBag) {",
+          "    if (!Object.hasOwn(gatedBag, key)) {",
+          "      continue;",
+          "    }",
+          "    void gatedBag[key];",
+          "  }",
+          "}",
+        ].join("\n"),
+      },
+    ]);
 
-    expect(sites.filter((s) => s.shape === "for-in").length).toBeGreaterThan(2);
-    expect(
-      sites.filter((s) => s.shape === "in-on-param").length,
-    ).toBeGreaterThan(2);
-    expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThan(4);
+    // Assert the SET, not two counts plus a substring: a count that fires first
+    // short-circuits everything after it, so the negative half never runs under
+    // the mutation it exists for. One `toStrictEqual` cannot hide that.
+    expect(sites).toStrictEqual([
+      { file: FILE, shape: "for-in", code: "for (const key in openBag) {" },
+      { file: FILE, shape: "in-on-param", code: "k in paramBag" },
+      // `gatedBag` is absent, and THAT is the discriminating half — a scanner
+      // that stops recognising the own-gate reports a third entry here.
+    ]);
+  });
+
+  it("CONTROL — the scanner actually parses src", () => {
+    // ⚑ Separate from the detector control, because they fail for different
+    // reasons. This one catches a scanner that stopped READING: a file renamed
+    // to `.mts`/`.tsx`, a directory moved out of `SRC`, a glob that matches
+    // nothing.
+    //
+    // ⚠ It calls `sourceFiles()` — the function `scan()` itself defaults to —
+    // rather than re-globbing. The first version pasted a SECOND copy of the
+    // glob here, so breaking the glob inside `scan()` left this control green;
+    // measured, and the commit message claiming otherwise was wrong (the
+    // mutation had edited both copies at once). A control that re-implements
+    // the thing it guards is guarding its own copy.
+    //
+    // Measured at 134 files on `origin/master` 594f7e1d0. A file count does NOT
+    // shrink as defects are fixed — the property the count of unguarded walks
+    // lacked.
+    const sources = sourceFiles();
+
+    expect(sources.length).toBeGreaterThan(50);
+    // Matched is not read: a glob can hit while the file comes back empty.
+    expect(sources.every((source) => source.text.length > 0)).toBe(true);
+    // And a structurally permanent file is present, so a directory moved out of
+    // `SRC` fails here rather than silently shrinking the census.
+    expect(sources.map((source) => path.relative(SRC, source.file))).toContain(
+      "guards.ts",
+    );
   });
 });

--- a/packages/core/tests/functional/chain-walk-authority.test.ts
+++ b/packages/core/tests/functional/chain-walk-authority.test.ts
@@ -981,11 +981,19 @@ describe("where core walks a chain it does not own", () => {
     expect(verdicts).toStrictEqual({
       // ── DEFECTS, each with an owner ──────────────────────────────────────
 
-      // #1799 — the guard enumerates through the chain but tests own-only, so an
-      // inherited getter passes and is then invoked by the copy loop below it.
-      "guards.ts · for (const key in deps as Record<string, unknown>) {":
-        "for-in",
-
+      // ⚑ THREE ROWS REMOVED — #1799 / #1823 / #1816 are closed. The guard
+      // enumerated through the chain and tested own-only, so an inherited getter
+      // passed and became a dependency; both copy loops walked the chain and read
+      // each key twice, so a key was admitted on one value and stored with
+      // another. All three now walk the SAME captured `objectKeys` and read once,
+      // so none of them is a `for…in` any more. This is the census working as
+      // designed: the rows were written as DEFECTS WITH AN OWNER, and they leave
+      // when the owner ships.
+      //
+      // ⚠ Rows shrinking is fine HERE, and that is deliberate: the non-vacuity
+      // controls no longer count them. One asserts the detector on a synthetic
+      // file, the other asserts the read path over `src`, so an empty table
+      // reads as a clean codebase rather than as a blind scanner.
       // §8 — `recordsShallowEqual` counts OWN keys and then tests membership with
       // `in`, so two states with disjoint own `params` compare EQUAL. Publicly
       // reachable through `areStatesEqual(a, b, false)`.

--- a/packages/core/tests/functional/dependencies/inherited-getter-bypass-1799.test.ts
+++ b/packages/core/tests/functional/dependencies/inherited-getter-bypass-1799.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getDependenciesApi } from "@real-router/core/api";
+
+/**
+ * `guardDependencies` (`src/guards.ts`) enumerates with `for…in`, which walks the
+ * prototype chain, and then asks `Object.getOwnPropertyDescriptor`, which answers
+ * only about OWN properties. For an inherited name the descriptor is `undefined`,
+ * so `?.get` never fires: the guard iterates exactly the names it cannot answer
+ * about (#1799).
+ *
+ * ⚠ The issue says the guard "passes and the copy loop then reads — getter
+ * invoked 2 times". Corrected while fixing (#1816 spotted it): the guard invokes
+ * the accessor ZERO times — `getOwnPropertyDescriptor` returns a descriptor
+ * without calling it. Both reads are inside the copy loop.
+ */
+const withGetter = (
+  onRead: () => void,
+): { proto: object; own: Record<string, unknown> } => {
+  const proto = {};
+
+  Object.defineProperty(proto, "svc", {
+    enumerable: true,
+    configurable: true,
+    get(): string {
+      onRead();
+
+      return "FORBIDDEN";
+    },
+  });
+
+  const own = {};
+
+  Object.defineProperty(own, "svc", {
+    enumerable: true,
+    configurable: true,
+    get(): string {
+      onRead();
+
+      return "FORBIDDEN";
+    },
+  });
+
+  return { proto, own };
+};
+
+describe("dependencies: an inherited getter must not walk past the guard (#1799)", () => {
+  it("refuses an OWN getter — the control that proves the guard works", () => {
+    let reads = 0;
+    const { own } = withGetter(() => {
+      reads += 1;
+    });
+
+    expect(() =>
+      createRouter([{ name: "a", path: "/a" }], {}, own as never),
+    ).toThrow('dependencies cannot contain getters: "svc"');
+    expect(reads).toBe(0);
+  });
+
+  it("never adopts the SAME getter one Object.create away", () => {
+    let reads = 0;
+    const { proto } = withGetter(() => {
+      reads += 1;
+    });
+
+    const router = createRouter(
+      [{ name: "a", path: "/a" }],
+      {},
+      Object.create(proto) as never,
+    );
+
+    // The inherited name is not supported input, so it must not become a
+    // dependency — by whichever route: refused at the guard, or never copied.
+    expect(getDependenciesApi(router).get("svc")).toBeUndefined();
+    // And the forbidden accessor must not have run at all.
+    expect(reads).toBe(0);
+
+    router.dispose();
+  });
+
+  it("reads the CAPTURED Object.keys, so a post-boot shim cannot blind it", () => {
+    // ⚑ The one cell that pins `guards.ts:43` itself. Everything else in this
+    // file is green on a full revert of that line, because `for…in` and
+    // `Object.keys` return the SAME verdict for every plain bag — an inherited
+    // name has no own descriptor, so `?.get` could never fire on the extra
+    // names `for…in` visits. The walk change bought coherence, not behaviour.
+    //
+    // What it DID change is the binding: `for…in` is syntax and cannot be
+    // re-pointed, a raw `Object.keys` can. The first version of the fix reached
+    // for the raw global three lines below this file's own capture and made the
+    // guard strictly weaker than the code it replaced. This cell is the only
+    // thing that tells the two apart.
+    const bag: Record<string, unknown> = {};
+
+    Object.defineProperty(bag, "svc", {
+      enumerable: true,
+      configurable: true,
+      get: () => "FORBIDDEN",
+    });
+
+    const nativeKeys = Object.keys;
+
+    const attempt = (): string => {
+      try {
+        // Blind the LIVE intrinsic, after core has loaded.
+        (Object as { keys: unknown }).keys = () => [];
+
+        createRouter([{ name: "a", path: "/a" }], {}, bag as never).dispose();
+
+        return "ACCEPTED — the guard was blinded by the shim";
+      } catch (error) {
+        return (error as Error).message;
+      } finally {
+        (Object as { keys: unknown }).keys = nativeKeys;
+      }
+    };
+
+    expect(attempt()).toBe('dependencies cannot contain getters: "svc"');
+  });
+
+  it("keeps an ordinary own value working — the anti-collapse control", () => {
+    const router = createRouter([{ name: "a", path: "/a" }], {}, {
+      svc: "plain",
+    } as never);
+
+    expect(getDependenciesApi(router).get("svc")).toBe("plain");
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/dependencies/inherited-key-and-getall-1823.test.ts
+++ b/packages/core/tests/functional/dependencies/inherited-key-and-getall-1823.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getDependenciesApi } from "@real-router/core/api";
+
+/**
+ * Two faces of the same copy loop (#1823). Its third face — an inherited GETTER
+ * walking past the no-getters guard — is #1799's and is pinned in its own file.
+ *
+ * (a) `for (const key in deps)` with no `Object.hasOwn` filter, on both doors,
+ *     so an inherited name becomes a genuine dependency.
+ * (b) `getAll()` spreads a store built with `Object.create(null)`, where an own
+ *     `"__proto__"` is an ordinary key — the spread re-defines it on a normal
+ *     object, so the RESULT is a prototype-swap primitive for any consumer that
+ *     merges it with `Object.assign` or a `for…in` copy.
+ */
+describe("dependencies: the copy loop and getAll (#1823)", () => {
+  it("does not adopt an inherited key, through either door", () => {
+    const proto = { leaked: "LEAK" };
+
+    // door 1 — the constructor's initial deps
+    const viaCtor = createRouter(
+      [{ name: "a", path: "/a" }],
+      {},
+      Object.assign(Object.create(proto), { real: 1 }) as never,
+    );
+
+    expect(getDependenciesApi(viaCtor).get("real" as never)).toBe(1); // CONTROL
+    expect(getDependenciesApi(viaCtor).get("leaked" as never)).toBeUndefined();
+
+    viaCtor.dispose();
+
+    // door 2 — setAll
+    const viaSetAll = createRouter([{ name: "a", path: "/a" }]);
+    const api = getDependenciesApi(viaSetAll);
+
+    api.setAll(Object.assign(Object.create(proto), { real: 2 }) as never);
+
+    expect(api.get("real" as never)).toBe(2); // CONTROL
+    expect(api.get("leaked" as never)).toBeUndefined();
+
+    viaSetAll.dispose();
+  });
+
+  it("does not throw when a dependency name is an inherited accessor", () => {
+    // ⚑ #1852's axis, and a regression this fix introduced before it fixed it:
+    // the first draft built the result with `all[key] = value`, so an ordinary
+    // dependency name that `Object.prototype` carries as a getter-only accessor
+    // made a published, total API throw. A spread DEFINES and cannot.
+    const router = createRouter([{ name: "a", path: "/a" }]);
+    const api = getDependenciesApi(router);
+
+    api.setAll({ store: 1, other: 2 });
+
+    expect(Object.keys(api.getAll())).toStrictEqual(["store", "other"]); // CONTROL
+
+    Object.defineProperty(Object.prototype, "store", {
+      get: () => "G",
+      configurable: true,
+    });
+
+    try {
+      expect(Object.keys(api.getAll())).toStrictEqual(["store", "other"]);
+    } finally {
+      delete (Object.prototype as Record<string, unknown>).store;
+    }
+
+    router.dispose();
+  });
+
+  it("hands out a getAll() result that cannot swap a merger's prototype", () => {
+    const router = createRouter([{ name: "a", path: "/a" }]);
+    const api = getDependenciesApi(router);
+
+    api.setAll(
+      JSON.parse('{"__proto__":{"pwned":true},"keep":"yes"}') as never,
+    );
+
+    const all = api.getAll() as Record<string, unknown>;
+
+    expect(all.keep).toBe("yes"); // CONTROL — ordinary keys survive
+
+    // ⚠ Two assertions, and which one discriminates depends on HOW the result
+    // is built — keep both, because the implementation has already moved once.
+    // Against a spread + `delete` (today), dropping the delete leaves
+    // `"__proto__"` as an ORDINARY own key on `all`, so this first pair stays
+    // green and the `Object.assign` half below is what reds. Against a
+    // write-loop draft, `all["__proto__"] = value` dispatched into the inherited
+    // setter and swapped `all`'s own prototype, so this pair was the one that
+    // caught it while a merge-target-only cell passed on the defect.
+    expect(Object.getPrototypeOf(all)).toBe(Object.prototype);
+    expect((all as { pwned?: unknown }).pwned).toBeUndefined();
+
+    // ⚠ `Object.assign`, NOT a spread, and it must stay that way: assign uses
+    // [[Set]] — the mechanism under test — while a spread DEFINES and cannot
+    // reproduce it. `eslint --fix` rewrote this line to `{ ...all }` once and
+    // silently removed the whole point of the cell.
+    const merged: Record<string, unknown> = {};
+
+    // eslint-disable-next-line unicorn/no-immediate-mutation -- see above: [[Set]] is the subject under test, a spread DEFINES and cannot reproduce it
+    Object.assign(merged, all);
+
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+    expect((merged as { pwned?: unknown }).pwned).toBeUndefined();
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/dependencies/read-once-1816.test.ts
+++ b/packages/core/tests/functional/dependencies/read-once-1816.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getDependenciesApi } from "@real-router/core/api";
+
+/**
+ * Both copy loops read each key TWICE — once for the `!== undefined` admission
+ * test, once for the value they store — so the key is ADMITTED on one value and
+ * STORED with another (#1816).
+ *
+ * ⚠ Inheritance is not required, which is what separates this from #1799/#1823:
+ * a `Proxy` over a plain object with an OWN data property passes
+ * `guardDependencies` (there is no accessor descriptor to find) and the loop
+ * still reads it twice.
+ */
+const countingProxy = (
+  source: Record<string, unknown>,
+  onRead: (nth: number) => void,
+): Record<string, unknown> => {
+  let n = 0;
+
+  return new Proxy(source, {
+    get(target, key, receiver): unknown {
+      if (key === "svc") {
+        n += 1;
+        onRead(n);
+
+        return `read#${n}`;
+      }
+
+      return Reflect.get(target, key, receiver);
+    },
+  });
+};
+
+describe("dependencies: each key is read once, not twice (#1816)", () => {
+  it("stores the value it admitted, through the constructor door", () => {
+    let reads = 0;
+    const bag = countingProxy({ svc: "seed" }, (n) => {
+      reads = n;
+    });
+
+    const router = createRouter([{ name: "a", path: "/a" }], {}, bag as never);
+
+    expect(reads).toBe(1);
+    expect(getDependenciesApi(router).get("svc" as never)).toBe("read#1");
+
+    router.dispose();
+  });
+
+  it("stores the value it admitted, through setAll", () => {
+    let reads = 0;
+    const bag = countingProxy({ svc: "seed" }, (n) => {
+      reads = n;
+    });
+
+    const router = createRouter([{ name: "a", path: "/a" }]);
+    const api = getDependenciesApi(router);
+
+    api.setAll(bag);
+
+    expect(reads).toBe(1);
+    expect(api.get("svc" as never)).toBe("read#1");
+
+    router.dispose();
+  });
+
+  it("still drops a genuinely undefined value — the anti-collapse control", () => {
+    const router = createRouter([{ name: "a", path: "/a" }], {}, {
+      gone: undefined,
+      kept: "yes",
+    } as never);
+    const api = getDependenciesApi(router);
+
+    expect(api.get("kept" as never)).toBe("yes");
+    expect(api.has("gone")).toBe(false);
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/read-count-authority.test.ts
+++ b/packages/core/tests/functional/read-count-authority.test.ts
@@ -324,6 +324,14 @@ describe("how many times core reads a caller-owned key", () => {
 
     expect(table).toStrictEqual({
       // ── 1 read: the door already snapshots, or reads once by construction ──
+
+      // ⚑ ONE since #1816, and it belongs in THIS block now. The loop used to
+      // test `deps[key] !== undefined` and then read the same key again for the
+      // value it stored, so a Proxy-backed bag was ADMITTED on one value and
+      // STORED with another — no inheritance needed. It now binds the value once
+      // and walks the captured `objectKeys`, so there is no second read and no
+      // second property set to disagree about.
+      "setAll · deps": 1,
       "navigate · params": 1, // normalizeChannel builds from one read per key
       // #1812, FIXED: the query bag was read twice — `stripUndefined` tested each
       // key, then `mergeWithDefault` spread the same bag to copy it — so the key
@@ -412,12 +420,6 @@ describe("how many times core reads a caller-owned key", () => {
       // than that issue documents; measured here, not inferred.
       "add · route.name": 7,
       "add · route.defaultSearch": 3,
-
-      // The double read inside the copy loop — `deps[key] === undefined` as the
-      // gate, then `store.dependencies[key] = deps[key]` as the value. Reachable
-      // past `guardDependencies` through a Proxy or an inherited accessor (#1799
-      // covers the inheritance hole; the double read is separate).
-      "setAll · deps": 2,
     });
   });
 


### PR DESCRIPTION
## Summary

Three defects in the dependency channel of `@real-router/core`, all on the same axis: a read that answers about one set of properties while its partner answers about another.

### #1799 — an inherited getter walked past the "no getters" guard

- `guardDependencies` enumerated with `for…in` (prototype chain) and judged with `getOwnPropertyDescriptor` (own-only), so it iterated exactly the names it could not judge. It now walks the module-level `objectKeys` capture — the same set the copy loops walk.
- **Root cause:** two halves of one check answering about different property sets.
- ⚠ **Honest boundary: the walk change buys coherence, not a different verdict.** For an inherited name the descriptor is `undefined`, so `?.get` could never fire on the extra names — measured across six bag shapes, both forms return the identical verdict on every one. What keeps an inherited getter out of the store is the copy loops, fixed below. What the change *does* alter is the binding: `for…in` is syntax and cannot be re-pointed, and an early draft reached for the raw `Object.keys`, which a post-boot shim walked a forbidden getter straight past. One cell pins that; no behavioural cell can tell the two walks apart.
- The plugin half of this issue is fixed in the stacked PR, so `Closes` for it lives there.

### #1816 — each key was read twice, and the second read was stored

- Both doors tested `deps[key] !== undefined` and then read the same key again for the value they stored, so a bag whose reads differ was ADMITTED on one value and STORED with another. The value is bound once now.
- **Root cause:** a gate and a write reading the caller's object independently. No inheritance needed — a Proxy over a plain object is enough.

### #1823 — inherited keys became dependencies, and `getAll()` returned a hazard

- Neither copy loop filtered own keys, so `Object.create({ leaked })` put `leaked` in the store through both doors. Both now walk `Object.keys`.
- `getAll()` is published API and returned a container carrying `"__proto__"` as an own key — a prototype-swap primitive for any consumer merging it with `Object.assign` or a `for…in` copy. It keeps its spread (which DEFINES) and deletes that one key.
- **Root cause:** the store is `Object.create(null)`, where `"__proto__"` is an ordinary key; the door that hands a container back to a consumer is where that stops being safe.
- ⚠ `for…in` + `Object.hasOwn` was written first and is **not** an equivalent spelling: the two enumerate the same set for a plain object but not for a Proxy, and a bag answering them differently got a key past the copy loop that the guard never judged — including #1799's own payload, a forbidden getter that reached the store and ran. Walking `ownKeys` once leaves the halves nothing to disagree about, and is faster: −18 % at one key, −25 % at twenty, against an A/A floor of 1.6 %.

### Maintainability

- The chain-walk census guard counted *defects*: it required at least three unguarded `for…in` walks to survive in `src`, so it fell every time one was closed and would have red on the next correct fix. Replaced by two controls that assert the **instrument** — a synthetic file the detector must still classify, and the read path over `src` — neither of which shrinks as sites are closed.
- Two dependency-store writes annotated for the `unguarded-computed-key-write` SAST rule. They are false positives by the rule's own message: the destination is `Object.create(null)`, which is the exemption it names.

## Test plan

- [x] `tests/functional/dependencies/inherited-getter-bypass-1799.test.ts` — 4 cells, incl. the only one that separates the captured intrinsic from the raw global
- [x] `tests/functional/dependencies/read-once-1816.test.ts` — 3 cells, both doors
- [x] `tests/functional/dependencies/inherited-key-and-getall-1823.test.ts` — 3 cells, incl. the merge-target prototype
- [x] `tests/functional/read-count-authority.test.ts` — `setAll · deps` moves 2 → 1 and out of the "known defect" block
- [x] `tests/functional/chain-walk-authority.test.ts` — three rows removed, controls rewritten, mutation-validated four ways
- [x] Every commit is green on its own: 4486 → 4492 → 4496 → 4496 tests
- [x] `@real-router/core` — tsc 0, lint 0, **4496 tests**, properties 453, stress 153
- [x] 100% coverage maintained (statements / branches / functions / lines)
- [x] Full pre-push suite passed, including the whole-graph turbo build, knip, syncpack, osv-audit and semgrep

Closes #1816
Closes #1823
