### PR TITLE
fix(core): the plain-object guard read a key the caller owns (#1858) + a teardown mid-write landed in the dead store (#1859)

### DIFF
--- a/.changeset/dependencies-mirror-plain-object-1858.md
+++ b/.changeset/dependencies-mirror-plain-object-1858.md
@@ -1,0 +1,25 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+fix(validation-plugin): the dependency validators refused two shapes core accepts (#1858, #1799)
+
+`validateDependenciesObject` and `validateCloneArgs` judged "is this a plain
+object?" by reading `deps.constructor` — the spelling core replaced in #1858
+because it reads a key the caller owns. While these two copies lagged, an
+application running this plugin got a **false reject** on exactly the shapes core
+had just widened: `setDependencies` and `cloneRouter`'s override bag both threw
+on a bag carrying a `constructor` key, which is the #1858 defect itself, on a
+different door. A null-prototype bag was refused here and accepted by core.
+
+This plugin's contract is `plugin ⊇ core` — diagnose more, never refuse what core
+accepts — so a stale mirror is a defect even when the newer half is the one that
+moved. Both now ask the prototype, through a shared `isPlainBag`.
+
+Their key walks move from `for…in` + `getOwnPropertyDescriptor` to `Object.keys`
+for the same reason core's did (#1799): the two answer about different property
+sets, so the loop iterated exactly the names it could not judge, and on a Proxy
+they disagree about ownership outright.
+
+The four intrinsics these validators depend on are captured at module load,
+matching `core/src/guards.ts`.

--- a/.changeset/dependencies-plain-object-guard-1858.md
+++ b/.changeset/dependencies-plain-object-guard-1858.md
@@ -1,0 +1,57 @@
+---
+"@real-router/core": minor
+---
+
+fix(core): a dependency named `constructor` made the router permanently un-clonable (#1858)
+
+`guardDependencies` decided "is this a plain object?" by reading `deps.constructor`
+— a key the caller owns. `constructor` is an ordinary dependency name: `set` stores
+it and `has`/`get` agree about it, and from that point the bag's own `constructor`
+is the stored value rather than `Object`. Every door that rebuilds a dependency bag
+and re-guards it then refused the router's own dependencies.
+
+```
+one dependency named …   cloneRouter(router)   createRouter(routes, {}, getAll())
+  "constructor"          TypeError             TypeError
+  "toString"             ok                    ok
+  "valueOf"              ok                    ok
+  "hasOwnProperty"       ok                    ok
+```
+
+`cloneRouter` is the documented SSR multi-tenancy path, so one ordinary name made a
+router unusable for per-request scoping — and the message named the wrong thing: the
+bag *is* a plain object; what failed was a heuristic about it.
+
+The predicate now asks the PROTOTYPE's `constructor`, which an ordinary dependency
+name cannot shadow.
+
+**`Object.create(null)` is now accepted**, which the old spelling refused. That is a
+deliberate widening rather than a side effect: a null-prototype bag is a plain bag
+with nothing to inherit through, and the dependency store itself is built that way.
+
+⚠ `proto === Object.prototype` was written first and rejected: it also refuses
+`Object.create({ … })`, which #1799 and #1823 rely on reaching the copy loop,
+where an inherited key is DROPPED rather than the whole bag rejected. That is
+also the spelling `engine/validation/route-batch` uses for route objects, so the
+two guards now deliberately disagree about what a plain object is — the
+constraint to unify around, if they are ever unified.
+
+⚠ **The two rows above are the intended differences, not the only ones.** An
+earlier draft of this entry claimed "differs on exactly two rows"; that was
+measured over ten hand-picked shapes and is false over the family. Also moved:
+`Object.setPrototypeOf([1, 2], null)` from refused to accepted; an array, `Map`
+or class instance whose OWN `constructor` is forged to `Object` from accepted to
+refused; and a Proxy answering `get` and `getPrototypeOf` inconsistently moves in
+both directions. The middle group is a tightening and the first is harmless, but
+none was intended.
+
+⚠ The forgery is not closed, only relocated — a prototype is something the caller
+can write to as well, and a class instance whose `prototype.constructor` is set
+to `Object` is accepted by the new predicate exactly as it was by the old. A cell
+pins that as an open hole so closing it stays a decision rather than an accident.
+
+`Object` itself joins this file's captured intrinsics. `Object.prototype` needs
+no capture — it is non-writable and non-configurable — but `proto.constructor`
+resolves through `Object.prototype.constructor`, which is writable and cannot be
+closed without comparing prototype identity. Re-point it and every plain bag is
+refused; that hole predates this change and is now stated rather than implied.

--- a/.changeset/dependencies-setall-reentrancy-1859.md
+++ b/.changeset/dependencies-setall-reentrancy-1859.md
@@ -1,0 +1,32 @@
+---
+"@real-router/core": patch
+---
+
+fix(core): a teardown triggered from inside a dependency write landed in the disposed store (#1859)
+
+`setDependency` and `setMultipleDependencies` re-read `store.dependencies` on
+every access, and both `dispose()` and `reset()` clear this channel by REPLACING
+that property. A teardown triggered from inside the call therefore did not stop
+it: the remaining writes found the fresh object and landed there. Every clear
+path is a write path and refuses on a disposed router, so the caller's value was
+pinned with nothing able to release it, while `getAll()` kept answering with it.
+
+Both functions now capture the write target once, so an interrupted call writes
+into the object the teardown discarded — garbage by construction rather than
+guarded. The facades re-check disposal after the write, which is what tells the
+caller their write landed nowhere instead of reporting success.
+
+⚠ **There are TWO user-code windows per key, and the obvious fix only closes
+one.** Reading `deps[key]` runs a caller's accessor; `validateDependencyCount`
+and `warnOverwrite` reach `logger.warn` → the application's own
+`LoggerConfig.callback`, which is public `RouterOptions` API and runs between
+that read and the write. A disposal probe placed between them leaves the second
+window wide open — measured, the callback route reproduced the leak in full on a
+bag with **no accessors at all**. Capturing the target closes both, and closes
+`reset()` with them.
+
+⚠ `set()` was affected too and was never guarded: it wrote into the disposed
+store and returned success.
+
+The capture is also cheaper than the re-read it replaces — one property load
+leaves the loop.

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -33,15 +33,28 @@ function setDependency(
     return;
   }
 
-  const isNewKey = !Object.hasOwn(store.dependencies, dependencyName);
+  // ⚑ Captured ONCE, and this is the whole re-entrancy defence (#1859).
+  //
+  // `validateDependencyCount` and `warnOverwrite` both reach `logger.warn`, i.e.
+  // the application's own `LoggerConfig.callback` — public `RouterOptions` API,
+  // called synchronously between the reads above and the write below. That
+  // callback can `dispose()` or `reset()` the router, and both clear this channel
+  // by REPLACING `store.dependencies`. Re-reading the slot afterwards wrote into
+  // the fresh post-teardown object, which every clear path then refused to touch
+  // (they all `throwIfDisposed` first) while `getAll()` kept answering with it.
+  //
+  // Holding the reference makes that unreachable rather than merely guarded: the
+  // write lands in the object the teardown discarded, so it is garbage by
+  // construction. A per-call disposal probe cannot do this — there is a user-code
+  // window on either side of it, and it would have to sit in both.
+  const target = store.dependencies as Record<string, unknown>;
+  const isNewKey = !Object.hasOwn(target, dependencyName);
 
   if (isNewKey) {
     // Only check limit when adding new keys (overwrites don't increase count)
     validator?.dependencies.validateDependencyCount(store, "setDependency");
   } else {
-    const oldValue = (store.dependencies as Record<string, unknown>)[
-      dependencyName
-    ];
+    const oldValue = target[dependencyName];
     const isChanging = oldValue !== dependencyValue;
     // Special case for NaN idempotency (NaN !== NaN is always true)
     const bothAreNaN = Number.isNaN(oldValue) && Number.isNaN(dependencyValue);
@@ -51,8 +64,7 @@ function setDependency(
     }
   }
 
-  (store.dependencies as Record<string, unknown>)[dependencyName] =
-    dependencyValue;
+  target[dependencyName] = dependencyValue;
 }
 
 function setMultipleDependencies(
@@ -61,6 +73,16 @@ function setMultipleDependencies(
   validator?: RouterValidator | null,
 ): void {
   const overwrittenKeys: string[] = [];
+
+  // ⚑ Captured ONCE — see `setDependency` above for the mechanism. This loop has
+  // TWO user-code windows per key, not one: reading `deps[key]` runs an accessor
+  // if the caller supplied one, and `validateDependencyCount` reaches
+  // `logger.warn` → the application's `LoggerConfig.callback`. A disposal probe
+  // between them closes the first and leaves the second open — measured, the
+  // callback route reproduced the leak in full on a bag with no accessors at all.
+  // Holding the reference closes both, and closes `reset()` (which replaces the
+  // same slot) with them.
+  const target = store.dependencies as Record<string, unknown>;
 
   // ⚑ The same walk and the same single read as the constructor door — and
   // "the same" is literal, not approximate: both call the captured
@@ -73,7 +95,7 @@ function setMultipleDependencies(
       continue;
     }
 
-    if (Object.hasOwn(store.dependencies, key)) {
+    if (Object.hasOwn(target, key)) {
       overwrittenKeys.push(key);
     } else {
       validator?.dependencies.validateDependencyCount(store, "setDependencies");
@@ -87,7 +109,7 @@ function setMultipleDependencies(
     // `has`/`get` return, and `getAll()` is the door that withholds it on the way
     // out (#1823).
     // nosemgrep: unguarded-computed-key-write
-    (store.dependencies as Record<string, unknown>)[key] = value;
+    target[key] = value;
   }
 
   if (overwrittenKeys.length > 0) {
@@ -172,6 +194,15 @@ export function getDependenciesApi<
       );
 
       setDependency(ctx.dependenciesGetStore(), name, value, ctx.validator);
+
+      // ⚑ Again, AFTER the write (#1859). The guard above answers "was the
+      // router alive when you called?"; this one answers "was it still alive
+      // when the write landed?". Between them sit `validateDependencyCount` and
+      // `warnOverwrite`, which reach `logger.callback` — the application's own
+      // code. The write itself is already harmless (the target is captured, so a
+      // teardown mid-call sends it to the discarded object); this is what stops
+      // the call REPORTING success for a store that no longer exists.
+      throwIfDisposed(ctx.isDisposed);
     },
     setAll: (deps) => {
       throwIfDisposed(ctx.isDisposed);
@@ -188,6 +219,9 @@ export function getDependenciesApi<
         deps as Record<string, unknown>,
         ctx.validator,
       );
+
+      // ⚑ See `set` above — same reason, same placement.
+      throwIfDisposed(ctx.isDisposed);
     },
     remove: (name) => {
       throwIfDisposed(ctx.isDisposed);

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -4,7 +4,8 @@ import type { LoggerConfig, LogLevelConfig, Route } from "./types";
 import type { RouterValidator } from "./types/RouterValidator";
 
 /**
- * Intrinsics captured at module load: `objectKeys`, `getOwnPropertyDescriptor`.
+ * Intrinsics captured at module load: `objectKeys`, `getOwnPropertyDescriptor`,
+ * `getPrototypeOf`, `Object` itself.
  *
  * ⚑ A guard is only as strong as the intrinsic it reads WHEN IT RUNS, and an
  * application can re-point any of these AFTER boot — which is what this closes.
@@ -19,17 +20,74 @@ import type { RouterValidator } from "./types/RouterValidator";
  */
 const objectKeys = Object.keys;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
+const ObjectCtor = Object;
 
 // ============================================================================
 // Structural invariant guards (dependencies + route-tree shape)
 // ============================================================================
 
 export function guardDependencies(deps: unknown): void {
-  if (
-    !deps ||
-    typeof deps !== "object" ||
-    (deps as { constructor: unknown }).constructor !== Object
-  ) {
+  if (!deps || typeof deps !== "object") {
+    throw new TypeError("dependencies must be a plain object");
+  }
+
+  // ⚑ The PROTOTYPE, not `deps.constructor` (#1858). `constructor` is an
+  // ordinary dependency name — `set("constructor", v)` stores it and `has`/`get`
+  // agree — and reading it back made the router permanently un-clonable, since
+  // `cloneRouter` rebuilds the bag and re-guards it. Measured: `constructor`
+  // failed all three doors while `toString` / `valueOf` / `hasOwnProperty`
+  // passed, so the predicate depended on one name the caller controls.
+  //
+  // It was also forgeable both ways: `Object.assign(Object.create(null),
+  // { constructor: Object })` was ACCEPTED while a bare `Object.create(null)`
+  // was refused — i.e. it admitted neither exactly the plain objects nor
+  // exactly the others.
+  //
+  // The instance is what the caller writes to; the PROTOTYPE is not, so asking
+  // it the same question is out of reach of an ordinary dependency name.
+  //
+  // `null` is admitted deliberately: `Object.create(null)` is a plain bag with
+  // no prototype to inherit through, and the dependency store itself is built
+  // that way. Refusing it was an accident of the old spelling.
+  //
+  // ⚠ The two rows above are the INTENDED differences from the old predicate,
+  // not the only ones. A first draft of this comment claimed "differs on exactly
+  // two rows and agrees on the rest"; that was measured over ten hand-picked
+  // shapes and is false over the family. The others, all found by review:
+  //
+  //   Object.setPrototypeOf([1, 2], null)              refused -> ACCEPTED
+  //   array / Map / class instance whose OWN
+  //     `constructor` is forged to `Object`            accepted -> REFUSED
+  //   Proxy answering `get` and `getPrototypeOf`
+  //     inconsistently                                 moves in BOTH directions
+  //
+  // The middle row is a tightening and the top one is harmless (only own
+  // enumerable string keys are ever copied), but none of them was intended, and
+  // a comment that under-reports its own blast radius is worse than one that
+  // says nothing. What the change really does is move the caller-controlled lie
+  // from the `get` trap to the `getPrototypeOf` trap.
+  //
+  // ⚠ This predicate DISAGREES with its sibling: `engine/validation/route-batch`
+  // asks `proto !== Object.prototype && proto !== null` for the same question
+  // about route objects, so `Object.create({ … })` is a plain object here and is
+  // not one there. Deliberate, and it is the reason the sibling's spelling was
+  // not reused: it would refuse the bag #1799 / #1823 need to REACH the copy
+  // loop, where an inherited key is dropped rather than the bag rejected. If the
+  // two are ever unified, that is the constraint to unify around.
+  //
+  // ⚠ `getPrototypeOf` and `Object` are both captured; `Object.prototype` needs
+  // no capture — it is `writable: false, configurable: false`, and neither
+  // `Reflect.setPrototypeOf` nor `__proto__` assignment can move it. But the
+  // read below is `proto.constructor`, which resolves through
+  // `Object.prototype.constructor` — writable, configurable, and NOT closeable
+  // without comparing prototype identity, which the paragraph above rules out.
+  // Re-point it and every plain bag is refused. That hole is open, in both this
+  // spelling and the one it replaced, and it is stated here rather than left for
+  // the next reader to find.
+  const proto = getPrototypeOf(deps) as { constructor?: unknown } | null;
+
+  if (proto !== null && proto.constructor !== ObjectCtor) {
     throw new TypeError("dependencies must be a plain object");
   }
   // ⚑ The walk and the check must answer about the SAME property set (#1799).

--- a/packages/core/tests/functional/dependencies/plain-object-guard-1858.test.ts
+++ b/packages/core/tests/functional/dependencies/plain-object-guard-1858.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { cloneRouter, getDependenciesApi } from "@real-router/core/api";
+
+/**
+ * #1858 — `guardDependencies` decided "is this a plain object?" by reading
+ * `deps.constructor`, a key the CALLER owns. `constructor` is an ordinary
+ * dependency name, so storing it made the router permanently un-clonable: every
+ * door that rebuilds the bag and re-guards it refused the router's own
+ * dependencies. The predicate now asks the PROTOTYPE, which an ordinary
+ * dependency name cannot shadow.
+ */
+const ROUTES = [{ name: "a", path: "/a" }];
+
+/**
+ * ⚑ Returns the error's CLASS as well as its message. A helper that reports only
+ * `"ok"` / `message` cannot tell the guard's own `TypeError` from a foreign
+ * throw raised by the caller's own object, and every cell below would read the
+ * same for both.
+ */
+const attempt = (fn: () => unknown): string => {
+  try {
+    fn();
+
+    return "ok";
+  } catch (error) {
+    return `${(error as Error).name}: ${(error as Error).message}`;
+  }
+};
+
+const REFUSED = "TypeError: dependencies must be a plain object";
+
+describe("the plain-object guard judges the prototype (#1858)", () => {
+  it("a dependency named `constructor` SURVIVES every rebuild door", () => {
+    // ⚑ Survives, not merely "does not throw". An earlier version of this cell
+    // asserted only that the doors did not reject, which a change silently
+    // dropping the key from `mergedDeps` would have left green.
+    const router = createRouter(ROUTES);
+    const api = getDependenciesApi(router);
+
+    api.set("constructor" as never, "V" as never);
+
+    const clone = cloneRouter(router);
+
+    expect(getDependenciesApi(clone).get("constructor" as never)).toBe("V");
+
+    clone.dispose();
+
+    const rebuilt = createRouter(ROUTES, {}, api.getAll());
+
+    expect(getDependenciesApi(rebuilt).get("constructor" as never)).toBe("V");
+
+    rebuilt.dispose();
+
+    // A DIFFERENT value, so the cell can tell "the override was applied" from
+    // "the source already had this pair" — with the same value it could not.
+    const overridden = cloneRouter(router, { constructor: "W" });
+
+    expect(getDependenciesApi(overridden).get("constructor" as never)).toBe(
+      "W",
+    );
+
+    overridden.dispose();
+
+    router.dispose();
+  });
+
+  it("CONTROL — the other reserved-looking names survive too", () => {
+    // `__proto__` is in the list deliberately: it is the one name with
+    // `getAll()`'s `UNSAFE_KEY` deletion behind it (#1823), so it takes a
+    // different route through the rebuild doors than its neighbours.
+    for (const name of [
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+      "__proto__",
+      "ordinary",
+    ]) {
+      const router = createRouter(ROUTES);
+      const api = getDependenciesApi(router);
+
+      api.set(name as never, "V" as never);
+
+      const clone = cloneRouter(router);
+
+      expect([
+        name,
+        getDependenciesApi(clone).get(name as never),
+      ]).toStrictEqual([name, "V"]);
+
+      clone.dispose();
+      router.dispose();
+    }
+  });
+
+  it("accepts a null-prototype bag, which the old spelling refused", () => {
+    const bag = Object.create(null) as Record<string, unknown>;
+
+    bag.svc = "V";
+
+    const router = createRouter(ROUTES, {}, bag as never);
+
+    expect(getDependenciesApi(router).get("svc" as never)).toBe("V");
+
+    router.dispose();
+  });
+
+  it("still accepts a bag built on another plain object", () => {
+    // ⚑ The #1799 / #1823 shape. A `proto === Object.prototype` test would have
+    // refused this at the door — which is also the spelling
+    // `engine/validation/route-batch` uses for route objects, so the two guards
+    // deliberately disagree. Those fixes rely on the bag REACHING the copy loop,
+    // where the inherited key is dropped rather than the whole bag rejected.
+    const bag = Object.assign(Object.create({ leaked: "LEAK" }), { real: 1 });
+
+    const router = createRouter(ROUTES, {}, bag as never);
+    const api = getDependenciesApi(router);
+
+    expect(api.get("real" as never)).toBe(1);
+    expect(api.get("leaked" as never)).toBeUndefined();
+
+    router.dispose();
+  });
+
+  it("CONTROL — non-plain bags are refused, with the guard's own error", () => {
+    class Service {
+      a = 1;
+    }
+
+    for (const bag of [[1, 2], new Service(), new Map(), "abc", 7, null]) {
+      expect(
+        attempt(() => {
+          createRouter(ROUTES, {}, bag as never).dispose();
+        }),
+      ).toBe(REFUSED);
+    }
+  });
+
+  it("pins the forgery that is still OPEN, in both spellings", () => {
+    // ⚠ Not a passing grade — a record. The predicate reads a `constructor` off
+    // the prototype, and a prototype is something the caller can write to as
+    // well. Both of these were accepted BEFORE this change and still are, so the
+    // fix moved which object has to lie, not whether lying works.
+    //
+    // The cell exists so that a future reader does not mistake "judges the
+    // prototype" for "cannot be forged", and so that closing it is a visible
+    // decision rather than an accident.
+    class Forged {
+      a = 1;
+    }
+
+    Object.defineProperty(Forged.prototype, "constructor", {
+      value: Object,
+      writable: true,
+      configurable: true,
+    });
+
+    expect(
+      attempt(() => {
+        createRouter(ROUTES, {}, new Forged() as never).dispose();
+      }),
+    ).toBe("ok");
+
+    // The honest half: a prototype that lies the OTHER way is refused, so the
+    // hole is one-directional.
+    expect(
+      attempt(() => {
+        createRouter(
+          ROUTES,
+          {},
+          Object.create({ constructor: "V" }) as never,
+        ).dispose();
+      }),
+    ).toBe(REFUSED);
+  });
+});

--- a/packages/core/tests/functional/dependencies/setall-reentrancy-1859.test.ts
+++ b/packages/core/tests/functional/dependencies/setall-reentrancy-1859.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getDependenciesApi } from "@real-router/core/api";
+
+/**
+ * #1859 — the write paths re-read `store.dependencies` on every access, and
+ * `dispose()` / `reset()` clear this channel by REPLACING that property. So a
+ * teardown triggered from inside the call found the fresh object and had the
+ * remaining writes land in it. Every clear path is a write path and refuses on a
+ * disposed router, so the caller's value was pinned with nothing able to release
+ * it, while `getAll()` kept answering with the leak.
+ *
+ * ⚑ There are TWO user-code windows per key, not one, and that is why the fix is
+ * a captured target rather than a disposal probe: reading `deps[key]` runs an
+ * accessor if the caller supplied one, and `validateDependencyCount` /
+ * `warnOverwrite` reach `logger.warn` → the application's `LoggerConfig.callback`.
+ * A probe between them closes the first and leaves the second wide open — the
+ * callback route reproduced the leak in full on a bag with no accessors at all.
+ */
+const ROUTES = [{ name: "a", path: "/a" }];
+
+/**
+ * ⚠ The VALIDATOR window — `validateDependencyCount` / `warnOverwrite` reaching
+ * `logger.callback` — is exercised in `@real-router/validation-plugin`'s own
+ * suite, not here. It needs the plugin installed, and reaching it from core
+ * would mean injecting through `src/internals`, which functional tests are
+ * forbidden from importing. See
+ * `validation-plugin/tests/functional/dependencies-reentrancy-1859.test.ts`.
+ */
+const attempt = (fn: () => unknown): string => {
+  try {
+    fn();
+
+    return "ok";
+  } catch (error) {
+    return (error as Error).message;
+  }
+};
+
+describe("a teardown from inside the call cannot land a write (#1859)", () => {
+  it("setAll: the GETTER window writes nothing and pins nothing", () => {
+    const router = createRouter(ROUTES, {}, { boot: "B" } as never);
+    const api = getDependenciesApi(router);
+    const retained = { big: "PAYLOAD" };
+
+    expect(
+      attempt(() => {
+        api.setAll({
+          a: 1,
+          get b() {
+            router.dispose();
+
+            return retained;
+          },
+          c: 3,
+        } as never);
+      }),
+    ).toBe("DISPOSED");
+
+    expect(Object.keys(api.getAll())).toStrictEqual([]);
+    expect(Object.values(api.getAll())).not.toContain(retained);
+  });
+
+  it("reset() mid-call leaves a coherent store, not a straddled one", () => {
+    // ⚠ `reset()` replaces the same slot `dispose()` does, so it is the second
+    // path this class covers. It is not an error — the router is still alive —
+    // so the call succeeds; what matters is that one `setAll` cannot end up
+    // spanning two store objects.
+    const router = createRouter(ROUTES, {}, { boot: "B" } as never);
+    const api = getDependenciesApi(router);
+
+    expect(
+      attempt(() => {
+        api.setAll({
+          a: 1,
+          get b() {
+            api.reset();
+
+            return 2;
+          },
+          c: 3,
+        } as never);
+      }),
+    ).toBe("ok");
+
+    expect(Object.keys(api.getAll())).toStrictEqual([]);
+
+    router.dispose();
+  });
+
+  it("CONTROL — an accessor that does NOT tear down is copied normally", () => {
+    const router = createRouter(ROUTES);
+    const api = getDependenciesApi(router);
+
+    api.setAll({
+      a: 1,
+      get b() {
+        return "B";
+      },
+      c: 3,
+    });
+
+    expect(Object.keys(api.getAll())).toStrictEqual(["a", "b", "c"]);
+    expect(api.get("b" as never)).toBe("B");
+
+    router.dispose();
+  });
+});

--- a/packages/validation-plugin/src/validators/dependencies.ts
+++ b/packages/validation-plugin/src/validators/dependencies.ts
@@ -7,6 +7,41 @@ import type { RouterLogger } from "@real-router/core";
 
 const DEFAULT_MAX_DEPENDENCIES = 100;
 
+/**
+ * Captured at module load, mirroring `core/src/guards.ts`. A validator is only
+ * as strong as the intrinsic it reads WHEN IT RUNS.
+ */
+const objectKeys = Object.keys;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
+const ObjectCtor = Object;
+
+/**
+ * ⚑ The MIRROR of `guardDependencies` (core `guards.ts`), and it has to stay one.
+ *
+ * This plugin's whole contract is `plugin ⊇ core`: it may diagnose more, never
+ * refuse what core accepts. Core moved this predicate from `deps.constructor` to
+ * the PROTOTYPE's `constructor` (#1858) and began admitting a null prototype;
+ * while these two copies still read the instance, an application running the
+ * plugin got a false reject on exactly the shapes core had just widened —
+ * `setDependencies` and `cloneRouter`'s override bag both threw on a bag
+ * carrying a `constructor` key, which is the #1858 defect on a different door.
+ *
+ * ⚠ The walk is `objectKeys`, not `for…in`, for the same reason core's is
+ * (#1799): `for…in` visits inherited names that `getOwnPropertyDescriptor`
+ * answers `undefined` for, so the loop iterated exactly the names it could not
+ * judge — and on a Proxy the two disagree about ownership outright.
+ */
+function isPlainBag(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const proto = getPrototypeOf(value) as { constructor?: unknown } | null;
+
+  return proto === null || proto.constructor === ObjectCtor;
+}
+
 export function validateDependencyName(
   name: unknown,
   methodName: string,
@@ -32,14 +67,14 @@ export function validateDependenciesObject(
   deps: unknown,
   methodName: string,
 ): asserts deps is Record<string, unknown> {
-  if (!(deps && typeof deps === "object" && deps.constructor === Object)) {
+  if (!isPlainBag(deps)) {
     throw new TypeError(
       `[router.${methodName}] Invalid argument: expected plain object, received ${getTypeDescription(deps)}`,
     );
   }
 
-  for (const key in deps) {
-    if (Object.getOwnPropertyDescriptor(deps, key)?.get) {
+  for (const key of objectKeys(deps)) {
+    if (getOwnPropertyDescriptor(deps, key)?.get) {
       throw new TypeError(
         `[router.${methodName}] Getters not allowed: "${key}"`,
       );
@@ -100,18 +135,14 @@ export function validateCloneArgs(dependencies: unknown): void {
     return;
   }
 
-  if (!(
-    dependencies &&
-    typeof dependencies === "object" &&
-    dependencies.constructor === Object
-  )) {
+  if (!isPlainBag(dependencies)) {
     throw new TypeError(
       `[cloneRouter] Invalid dependencies: expected plain object or undefined, received ${typeof dependencies}`,
     );
   }
 
-  for (const key in dependencies as Record<string, unknown>) {
-    if (Object.getOwnPropertyDescriptor(dependencies, key)?.get) {
+  for (const key of objectKeys(dependencies)) {
+    if (getOwnPropertyDescriptor(dependencies, key)?.get) {
       throw new TypeError(
         `[cloneRouter] Getters not allowed in dependencies: "${key}"`,
       );

--- a/packages/validation-plugin/tests/functional/dependencies-reentrancy-1859.test.ts
+++ b/packages/validation-plugin/tests/functional/dependencies-reentrancy-1859.test.ts
@@ -1,0 +1,137 @@
+import { createRouter } from "@real-router/core";
+import { getDependenciesApi } from "@real-router/core/api";
+import { describe, expect, it } from "vitest";
+
+import { validationPlugin } from "../../src";
+
+/**
+ * #1859, the half that only this package can reach.
+ *
+ * Core's write paths have TWO user-code windows per key. The first is reading
+ * `deps[key]`, which runs a caller's accessor — pinned in core's own suite. The
+ * second is THIS one: `validateDependencyCount` and `warnOverwrite` call
+ * `logger.warn`, and `logger.callback` is public `RouterOptions` API, invoked
+ * synchronously between the read and the write.
+ *
+ * It matters because it needs no accessor at all — a plain data bag reaches it.
+ * A disposal probe placed between the read and the write closes the first window
+ * and leaves this one open; core's fix is a captured write target, which closes
+ * both. These cells are what tell those two designs apart.
+ *
+ * ⚑ Everything here goes through the public surface. Core cannot host it: it
+ * does not depend on this plugin, and functional tests may not import
+ * `src/internals` to fake a validator.
+ */
+const ROUTES = [{ name: "a", path: "/a" }];
+
+/** `computeThresholds` warns at `floor(limit * 0.2)`, so 5 warns from 1 key up. */
+const LIMITS = { maxDependencies: 5 };
+
+const attempt = (fn: () => unknown): string => {
+  try {
+    fn();
+
+    return "ok";
+  } catch (error) {
+    return (error as Error).message;
+  }
+};
+
+const routerThatDisposesFromItsLogger = () => {
+  // A holder rather than a forward-declared binding: the callback has to reach a
+  // router that does not exist yet when the options object is built.
+  const holder: { dispose?: () => void } = {};
+
+  let disposed = false;
+
+  const router = createRouter<Record<string, unknown>>(
+    ROUTES,
+    {
+      limits: LIMITS,
+      logger: {
+        level: "all",
+        callback: () => {
+          if (!disposed) {
+            disposed = true;
+            holder.dispose?.();
+          }
+        },
+      },
+    },
+    { boot: "B" },
+  );
+
+  holder.dispose = () => {
+    router.dispose();
+  };
+  router.usePlugin(validationPlugin());
+
+  return router;
+};
+
+describe("a logger callback that disposes mid-write lands nothing (#1859)", () => {
+  it("setAll: a bag with NO accessor still cannot leak through the callback", () => {
+    const router = routerThatDisposesFromItsLogger();
+    const api = getDependenciesApi(router);
+    const retained = { big: "PAYLOAD" };
+
+    expect(
+      attempt(() => {
+        api.setAll({ leak: retained, second: 2 });
+      }),
+    ).toBe("DISPOSED");
+
+    expect(Object.values(api.getAll())).not.toContain(retained);
+    expect(Object.keys(api.getAll())).toStrictEqual([]);
+  });
+
+  it("set: the single-key door, which used to report success while leaking", () => {
+    const router = routerThatDisposesFromItsLogger();
+    const api = getDependenciesApi(router);
+    const retained = { big: "PAYLOAD" };
+
+    // An overwrite of the seeded `boot`, so `warnOverwrite` reaches the callback.
+    expect(
+      attempt(() => {
+        api.set("boot" as never, retained);
+      }),
+    ).toBe("DISPOSED");
+
+    expect(Object.values(api.getAll())).not.toContain(retained);
+    expect(Object.keys(api.getAll())).toStrictEqual([]);
+  });
+
+  it("CONTROL — the same calls on a logger that does not dispose", () => {
+    const seen: string[] = [];
+    const router = createRouter<Record<string, unknown>>(
+      ROUTES,
+      {
+        limits: LIMITS,
+        logger: { level: "all", callback: () => seen.push("warned") },
+      },
+      { boot: "B" },
+    );
+
+    router.usePlugin(validationPlugin());
+
+    const api = getDependenciesApi(router);
+
+    expect(
+      attempt(() => {
+        api.setAll({ x: 1 });
+      }),
+    ).toBe("ok");
+    expect(
+      attempt(() => {
+        api.set("boot" as never, "NEW");
+      }),
+    ).toBe("ok");
+    expect(Object.keys(api.getAll())).toStrictEqual(["boot", "x"]);
+    expect(api.get("boot" as never)).toBe("NEW");
+    // The callback really did fire — otherwise the two cells above would be
+    // green for want of a window rather than because the window is closed.
+    expect(seen.length).toBeGreaterThan(0);
+
+    router.dispose();
+  });
+});


### PR DESCRIPTION
> Opened stacked on #1863; that has since merged, so this now sits directly on `master` and carries only its own three commits. Rebased onto the squash rather than merged, so the history stays linear.

## Summary

Two defects on the same channel, plus the mirror in `@real-router/validation-plugin` that #1863 left one-sided.

### #1858 — a dependency named `constructor` made the router permanently un-clonable

- `guardDependencies` decided "is this a plain object?" by reading `deps.constructor` — a key the caller owns. `constructor` is an ordinary dependency name: `set` stores it and `has`/`get` agree, and from that point every door that rebuilds the bag and re-guards it refused the router's own dependencies. Measured with a control across five names — only `constructor` failed.
- **Root cause:** a structural predicate reading a caller-writable property of the thing it judges. It now asks the PROTOTYPE, which an ordinary dependency name cannot shadow.
- `cloneRouter` is the documented SSR multi-tenancy path, so one ordinary name made a router unusable for per-request scoping.

### #1859 — a teardown from inside the call landed in the store it had just destroyed

- `setDependency` and `setMultipleDependencies` re-read `store.dependencies` on every access, and both `dispose()` and `reset()` clear this channel by REPLACING that property. A teardown triggered from inside the call did not stop it: the remaining writes found the fresh object and landed there. Every clear path is a write path and refuses on a disposed router, so the caller's value was pinned with nothing able to release it, while `getAll()` kept answering with it.
- **Root cause:** the write target was resolved per access instead of once, so caller code running mid-call could move it. Both capture it now; an interrupted call writes into the object the teardown discarded — garbage by construction rather than guarded.
- ⚠ **There are TWO user-code windows per key, and the obvious fix closes one.** Reading `deps[key]` runs a caller's accessor; `validateDependencyCount` / `warnOverwrite` reach `logger.warn` → the application's own `LoggerConfig.callback`, public `RouterOptions` API, which runs between that read and the write. The first version of this fix was a disposal probe between them; measured, the callback route then reproduced the leak in full on a bag with **no accessors at all**. Capturing the target closes both windows and `reset()` with them, costs nothing, and removes a property load from the loop.
- `set()` was affected too and had no guard at all — it wrote into the disposed store and returned success.

### Maintainability

- `@real-router/validation-plugin`'s two dependency validators still judged `deps.constructor`. While they lagged, an application running the plugin got a **false reject** on exactly the shapes core had just widened — `setDependencies` and `cloneRouter`'s override bag both threw on a bag carrying a `constructor` key, which is #1858 itself on a different door, and a null-prototype bag was refused here while core accepted it. The contract is `plugin ⊇ core`, so a stale mirror is a defect even when the newer half moved. Their key walks also move to `Object.keys`, closing the plugin half of #1799.

## Breaking changes

`createRouter(routes, options, Object.create(null))` is accepted from here on; it previously threw. A deliberate widening — the dependency store is itself a null-prototype object, so refusing one as *input* was an accident of the old spelling. The changeset is `minor` for that reason.

⚠ Two smaller shifts were **not** intended and are recorded rather than claimed as design: `Object.setPrototypeOf([1, 2], null)` moved from refused to accepted, and an array / `Map` / class instance whose OWN `constructor` is forged to `Object` moved from accepted to refused. The second is a tightening; the first is harmless, since only own enumerable string keys are ever copied.

⚠ The predicate now disagrees with its sibling `engine/validation/route-batch`, which asks `proto !== Object.prototype && proto !== null` about route objects. Deliberate: that spelling would refuse `Object.create({ … })`, which #1799 / #1823 need to reach the copy loop. Recorded at both sites as the constraint any future unification has to respect.

⚠ The forgery is relocated, not closed — a prototype is writable too, and a class instance whose `prototype.constructor` is set to `Object` is accepted by both spellings. A cell pins that as an open hole so closing it stays a decision.

## Test plan

- [x] `core/tests/functional/dependencies/plain-object-guard-1858.test.ts` — 6 cells. They read a dependency **back** off each rebuilt router rather than asserting the door did not throw, and the override cell uses a different value so it can tell "the override applied" from "the source already had this pair"
- [x] `core/tests/functional/dependencies/setall-reentrancy-1859.test.ts` — 3 cells (getter window, `reset()`, control)
- [x] `validation-plugin/tests/functional/dependencies-reentrancy-1859.test.ts` — 3 cells. The validator window lives here because reaching it needs the plugin installed, and faking a validator from core would mean importing `src/internals`, which functional tests are barred from
- [x] Mutation-validated, eight ways: restoring the instance read, the narrow `Object.prototype` form, re-reading the slot in either write path, and removing a facade check each red their own cells and nothing else
- [x] Every commit is green on its own, across **both** packages
- [x] `@real-router/core` — tsc 0, lint 0, **4505 tests**, properties 453, stress 153
- [x] `@real-router/validation-plugin` — tsc 0, lint 0, **758 tests**, properties 199
- [x] 100% coverage maintained
- [x] Full pre-push suite passed, including the whole-graph turbo build and semgrep

Closes #1799
Closes #1858
Closes #1859
