### PR TITLE
fix(core): the internal-prefix backstop type-checks the name it polices (#1896)

### DIFF
--- a/.changeset/internal-prefix-backstop-1896-fix.md
+++ b/.changeset/internal-prefix-backstop-1896-fix.md
@@ -1,0 +1,49 @@
+---
+"@real-router/core": patch
+---
+
+Route-CRUD doors name the door when a route name is not a string (#1896)
+
+`assertNoInternalRouteName` — the always-on backstop that keeps the reserved
+`@@` prefix out of the public API (#1047) — implements its rule as
+`name.startsWith(...)` on a value typed `string` and never checked. So the guard
+that exists to police route names was the thing that crashed on a route name of
+the wrong type, at every one of the five doors that reach it.
+
+Measured before the fix, `{ toString: () => "kid" }` at each door:
+
+| door                                | before                                         | now                                                            |
+| ----------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| `createRouter([{ name, path }])`    | `TypeError: name.startsWith is not a function` | `[router.addRoute] Route name must be a string, got object`    |
+| `getRoutesApi(r).add(...)`          | same                                           | same                                                           |
+| `getRoutesApi(r).replace(...)`      | same                                           | same                                                           |
+| `getRoutesApi(r).remove(name)`      | same                                           | `[router.removeRoute] Route name must be a string, got object` |
+| `getRoutesApi(r).update(name, ...)` | same                                           | `[router.updateRoute] Route name must be a string, got object` |
+
+`null` and `undefined` were worse still — `Cannot read properties of null
+(reading 'startsWith')`, naming a private local to a consumer who never wrote it.
+
+**No new refusal.** Every one of these doors already rejected a non-string name,
+before any mutation, and still does: the tree is untouched by a rejected batch,
+and the value is read **zero** times (`typeof` does not coerce). What changes is
+the SHAPE of the refusal — the same transformation `start()` already had, where
+a `codePointAt` crash became `[router.start] path must be a string`.
+
+**Bare core now matches the validated build, message for message.** The wording
+is `@real-router/validation-plugin`'s `validateRouteName`, byte for byte,
+including its `typeof` quirks (`typeof null` is `"object"`, so it reports `got
+object` for `null` too) — the same mirroring #1047 and #1763 used, so the
+production posture (`__DEV__ && validationPlugin()`) does not change which error
+a consumer reads. Pinned from the plugin side, where both layers are importable:
+a one-character drift in either message fails the build.
+
+**The constructor is the door that gains most.** The plugin installs through
+`router.usePlugin()` — after the initial route array has already been built — so
+it never sees that array. Measured: with the plugin installed, `createRouter`
+still produced the raw `startsWith` crash. Bare core is the only layer there,
+which matters exactly where non-string names come from: a route table assembled
+at runtime from a CMS, a filesystem walk or JSON.
+
+This is not a route-name **gate** in the sense of `ARCHITECTURE.md`
+"Route-Name Type Gates": no door that previously ANSWERED starts refusing, and
+no predicate is added to a door — an existing always-on predicate stops crashing.

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -549,6 +549,16 @@ degrading means here; the validator throws on every one of them at zero reads,
 so a `typeof` in core would restate an answer the opt-in layer already gives —
 permanently, on the render path, for a shape TypeScript already rejects.
 
+⚠ A refusal's SHAPE is not a gate, and the route-CRUD doors are where the two
+get confused. The constructor, `add`, `replace`, `remove` and `update` refuse a
+non-string name and always have — their always-on reserved-prefix backstop is a
+string method, so the value never had anywhere to go. What that backstop
+type-checks is its own input, so it can answer in the router's vocabulary and
+name the door instead of a private local. No door that ANSWERED starts refusing,
+which is the only thing this section governs; the wording it answers with is
+`@real-router/validation-plugin`'s, byte for byte, so the two builds report the
+same error.
+
 The asymmetry is the design, not a gap: a caller that hands core a non-string
 name can see one door answer and another refuse, because the two doors differ in
 what the value DOES there, not in how much they distrust it.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -205,6 +205,18 @@ there is no answer to degrade into — a `canDeactivate` deny-guard is silently
 never installed. A read-count instrument cannot see this one either: it coerces
 zero times before and after. Not gated yet.
 
+**A different question, and not a gate (#1896):** the five route-CRUD doors —
+`createRouter([...])`, `add`, `replace`, `remove`, `update` — refuse a non-string
+name at **0** reads and always did, because `assertNoInternalRouteName` is a
+string method. Its type check exists so the refusal names the door
+(`[router.removeRoute] Route name must be a string, got object`) rather than a
+private local; the wording is validation-plugin's, byte for byte, pinned by
+`packages/validation-plugin/tests/functional/bare-core-message-parity.test.ts`.
+The constructor is the one that gains most — the plugin installs through
+`usePlugin`, i.e. after construction, so it never had a message from either
+layer. Same shape as `start()`'s guard, which turns a `codePointAt` crash into
+`[router.start] path must be a string`.
+
 **Unguarded at either level:** the exported `resolveForwardChain` coerces and
 resolves the chain, returning what it would have returned for the string. It is
 a free function with no validator seam.

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -586,9 +586,36 @@ const INTERNAL_ROUTE_PREFIX = "@@";
  * one.
  */
 export function assertNoInternalRouteName(
-  name: string,
+  name: unknown,
   methodName: string,
-): void {
+): asserts name is string {
+  // ⚑ The type check belongs HERE and not at each door because this is the
+  // first always-on name check every one of the five runs — `remove` / `update`
+  // call it directly, `add` / `replace` / the constructor through
+  // {@link assertNoInternalNamesInBatch} — and {@link assertNoDottedRouteName}
+  // already documents that ordering as load-bearing for its own reasoning. So
+  // one check covers every caller-supplied route name in core (#1896).
+  //
+  // ⚠ NOT a gate in the sense of `ARCHITECTURE.md` "Route-Name Type Gates":
+  // these doors already refused a non-string, and no door that previously
+  // ANSWERED starts refusing. What changes is the SHAPE of the refusal — the
+  // `startsWith` below is a string method on a value nothing had type-checked,
+  // so bare core answered `TypeError: name.startsWith is not a function`, and
+  // `null` / `undefined` leaked `Cannot read properties of null (reading
+  // 'startsWith')`. Both name a private local rather than the door.
+  //
+  // The wording is validation-plugin's `validateRouteName`, byte for byte,
+  // including its `typeof` quirks (`typeof null === "object"`) — the same
+  // mirroring #1047 and #1763 used, so the no-plugin error matches the
+  // with-plugin one. The constructor is the door that gains the most: the
+  // plugin installs through `usePlugin`, i.e. after construction, so it never
+  // had a message from either layer.
+  if (typeof name !== "string") {
+    throw new TypeError(
+      `[router.${methodName}] Route name must be a string, got ${typeof name}`,
+    );
+  }
+
   if (name.startsWith(INTERNAL_ROUTE_PREFIX)) {
     throw new Error(
       `[router.${methodName}] Route name "${name}" uses the reserved "${INTERNAL_ROUTE_PREFIX}" prefix. Routes with this prefix are internal and cannot be modified through the public API.`,

--- a/packages/core/tests/functional/no-validation-plugin.test.ts
+++ b/packages/core/tests/functional/no-validation-plugin.test.ts
@@ -722,4 +722,120 @@ describe("core/without validation plugin", () => {
       router.stop();
     });
   });
+
+  // #1896: the always-on reserved-prefix backstop ran `name.startsWith(...)` on
+  // a value it never type-checked, so every route-CRUD door answered a
+  // non-string name with `TypeError: name.startsWith is not a function` — an
+  // implementation detail, where the with-plugin build names the door and the
+  // expected type. Measured before the fix: all five doors, all seven forms.
+  describe("non-string route name — refusal shape (#1896)", () => {
+    const bag = { toString: () => "kid" };
+
+    it("createRouter(): the door no validator can reach", () => {
+      // ⚑ The plugin installs through `usePlugin`, i.e. AFTER construction, so
+      // this is the one door where bare core's message is the only message a
+      // consumer can ever get. Measured with the plugin installed: identical
+      // `name.startsWith is not a function` before this fix.
+      expect(() => {
+        createRouter([{ name: bag, path: "/kid" }] as never);
+      }).toThrow("[router.addRoute] Route name must be a string, got object");
+    });
+
+    it("add(): rejects a non-string route name", () => {
+      const router = createTestRouter();
+      const api = getRoutesApi(router);
+
+      expect(() => {
+        api.add([{ name: bag, path: "/kid" }] as never);
+      }).toThrow("[router.addRoute] Route name must be a string, got object");
+
+      router.stop();
+    });
+
+    it("replace(): rejects a non-string route name", () => {
+      const router = createTestRouter();
+      const api = getRoutesApi(router);
+
+      expect(() => {
+        api.replace([{ name: bag, path: "/kid" }] as never);
+      }).toThrow("[router.addRoute] Route name must be a string, got object");
+
+      router.stop();
+    });
+
+    it("remove(): rejects a non-string route name", () => {
+      const router = createTestRouter();
+      const api = getRoutesApi(router);
+
+      expect(() => {
+        api.remove(bag as never);
+      }).toThrow(
+        "[router.removeRoute] Route name must be a string, got object",
+      );
+
+      router.stop();
+    });
+
+    it("update(): rejects a non-string route name", () => {
+      const router = createTestRouter();
+      const api = getRoutesApi(router);
+
+      expect(() => {
+        api.update(bag as never, { path: "/x" } as never);
+      }).toThrow(
+        "[router.updateRoute] Route name must be a string, got object",
+      );
+
+      router.stop();
+    });
+
+    it("every non-string form names its own type, and none leaks an internal identifier", () => {
+      // ⚑ `null` and `undefined` used to produce a DIFFERENT message from the
+      // rest — `Cannot read properties of null (reading 'startsWith')` — so a
+      // cell built only on an object bag would have left them uncovered. The
+      // `typeof` spelling is the with-plugin one, quirks included: `typeof null`
+      // is `"object"`, and the validator says `got object` for it too.
+      const router = createTestRouter();
+      const api = getRoutesApi(router);
+      const forms: [unknown, string][] = [
+        [bag, "object"],
+        [null, "object"],
+        [undefined, "undefined"],
+        [42, "number"],
+        [Symbol("kid"), "symbol"],
+        [true, "boolean"],
+        [10n, "bigint"],
+      ];
+
+      // Anti-vacuum: an emptied `forms` would assert nothing and stay green.
+      expect(forms).toHaveLength(7);
+
+      for (const [name, expected] of forms) {
+        expect(() => {
+          api.remove(name as never);
+        }).toThrow(
+          `[router.removeRoute] Route name must be a string, got ${expected}`,
+        );
+      }
+
+      router.stop();
+    });
+
+    it("CONTROL: a plain string name still reaches every door", () => {
+      // Without this the whole describe passes on a guard that refuses
+      // everything.
+      const router = createRouter([{ name: "kept", path: "/kept" }]);
+      const api = getRoutesApi(router);
+
+      api.add([{ name: "added", path: "/added" }]);
+      api.update("added", { defaultParams: { via: "a" } });
+      api.remove("added");
+      api.replace([{ name: "fresh", path: "/fresh" }]);
+
+      expect(api.has("fresh")).toBe(true);
+      expect(api.has("added")).toBe(false);
+
+      router.stop();
+    });
+  });
 });

--- a/packages/validation-plugin/tests/functional/bare-core-message-parity.test.ts
+++ b/packages/validation-plugin/tests/functional/bare-core-message-parity.test.ts
@@ -1,0 +1,115 @@
+import { createRouter } from "@real-router/core";
+import { getRoutesApi } from "@real-router/core/api";
+import { describe, expect, it } from "vitest";
+
+import { validationPlugin } from "@real-router/validation-plugin";
+
+import type { RoutesApi } from "@real-router/core/api";
+
+/**
+ * A route-CRUD door must refuse a non-string route name with the SAME message
+ * whether or not this plugin is installed (#1896).
+ *
+ * Core's always-on backstops deliberately mirror this plugin's wording — #1047
+ * for the reserved `@@` prefix, #1763 for a dotted name, #1896 for the type —
+ * so that the production posture (`__DEV__ && validationPlugin()`) does not
+ * change which error a consumer reads. The mirroring is a convention with two
+ * copies of the string and nothing holding them together, which is exactly the
+ * shape that drifts; this pins it.
+ *
+ * ⚑ It lives HERE and not in core because core devDepends only on
+ * `@real-router/ssr-utils` — the two layers can only be compared from this side.
+ */
+const ROUTES = [{ name: "home", path: "/home" }];
+
+function bare(): RoutesApi {
+  return getRoutesApi(createRouter(ROUTES, {}));
+}
+
+function withPlugin(): RoutesApi {
+  const router = createRouter(ROUTES, {});
+
+  router.usePlugin(validationPlugin());
+
+  return getRoutesApi(router);
+}
+
+function messageOf(run: () => unknown): string {
+  try {
+    run();
+
+    return "NO THROW";
+  } catch (error) {
+    return (error as Error).message;
+  }
+}
+
+const DOORS: readonly [string, (api: RoutesApi, name: unknown) => unknown][] = [
+  [
+    "add",
+    (api, name) => {
+      api.add([{ name, path: "/kid" }] as never);
+    },
+  ],
+  [
+    "replace",
+    (api, name) => {
+      api.replace([{ name, path: "/kid" }] as never);
+    },
+  ],
+  [
+    "remove",
+    (api, name) => {
+      api.remove(name as never);
+    },
+  ],
+  [
+    "update",
+    (api, name) => {
+      api.update(name as never, { defaultParams: {} });
+    },
+  ],
+];
+
+describe("bare core matches the validated build, message for message (#1896)", () => {
+  it("covers every route-CRUD door that both layers can see", () => {
+    // Anti-vacuum: an emptied table would assert nothing and stay green.
+    expect(DOORS).toHaveLength(4);
+  });
+
+  it.each(DOORS)("%s: a non-string route name", (_door, call) => {
+    const nonString = { toString: () => "kid" };
+
+    const withoutPlugin = messageOf(() => call(bare(), nonString));
+    const validated = messageOf(() => call(withPlugin(), nonString));
+
+    // CONTROL first: the equality below is true when BOTH sides answer
+    // "NO THROW", so it needs a companion that fails in that state. ⚑ One
+    // assert, not two — a `not.toBe("NO THROW")` beside this was measured
+    // INERT (removing it left 6/6 green, because this line reds on the same
+    // state and says more), i.e. a planted equivalent mutant.
+    expect(withoutPlugin).toContain("must be a string");
+    expect(withoutPlugin).toBe(validated);
+    // And the message names the DOOR, not a private local — the whole point of
+    // #1896, and the half that a plain equality between the two layers cannot
+    // see (both could drift to the same wrong string).
+    expect(withoutPlugin).toMatch(/^\[router\.[a-zA-Z]+Route]/);
+  });
+
+  it("createRouter: the door no validator can reach, so bare core is the only message", () => {
+    // ⚑ Not a parity cell — there is nothing to compare against. The plugin is
+    // installed through `usePlugin`, i.e. AFTER construction, so a non-string
+    // route name in the initial route array is refused by core or by nothing.
+    const nonString = { toString: () => "kid" };
+
+    expect(
+      messageOf(() => {
+        const router = createRouter([
+          { name: nonString, path: "/kid" },
+        ] as never);
+
+        router.usePlugin(validationPlugin());
+      }),
+    ).toBe("[router.addRoute] Route name must be a string, got object");
+  });
+});


### PR DESCRIPTION
## Summary

- A route name of the wrong type is now refused with a message that names the door and the expected type, at all five doors that can take one — `createRouter([...])`, `add`, `replace`, `remove`, `update`. Before, every one of them answered `TypeError: name.startsWith is not a function`, and `null` / `undefined` leaked `Cannot read properties of null (reading 'startsWith')`.
- **Bare core and the validated build now report the same error, byte for byte.** Pinned by a new test on the plugin side — a one-character drift in either message fails the build.
- **The constructor gains the most.** `@real-router/validation-plugin` installs through `router.usePlugin()`, i.e. *after* the initial route array is built, so it never sees that array. Measured: with the plugin registered, `createRouter` still produced the raw crash. Bare core is the only layer there — which is exactly where a route table assembled at runtime lands.

### Root cause

`assertNoInternalRouteName` (`packages/core/src/namespaces/RoutesNamespace/routesStore.ts`) is the always-on backstop that keeps the reserved `@@` prefix out of the public API (#1047). It implements that rule as `name.startsWith(INTERNAL_ROUTE_PREFIX)` on a value typed `string` and never checked — so the guard that exists to police route names was the thing that crashed on a route name of the wrong type. All five doors reach it: `remove` / `update` directly, `add` / `replace` / the constructor through `assertNoInternalNamesInBatch`.

Measured with `{ toString: () => "kid" }`, 5 doors × 7 non-string forms — **35 of 35 cells threw the raw message**. Re-measured after the fix, the same matrix is uniform on the mirrored one.

| door | before | after |
| --- | --- | --- |
| `createRouter([{ name, path }])` | `TypeError: name.startsWith is not a function` | `[router.addRoute] Route name must be a string, got object` |
| `getRoutesApi(r).add(...)` | same | same |
| `getRoutesApi(r).replace(...)` | same | same |
| `getRoutesApi(r).remove(name)` | same | `[router.removeRoute] Route name must be a string, got object` |
| `getRoutesApi(r).update(name, ...)` | same | `[router.updateRoute] Route name must be a string, got object` |

### No new refusal, and nothing working is taken away

Every one of these doors already rejected a non-string name, before any mutation, and still does: a rejected batch leaves the existing tree intact, and the value is read **zero** times (`typeof` does not coerce). What changes is the SHAPE of the refusal — the same transformation `start()` already had, where a `codePointAt` crash became `[router.start] path must be a string`.

The wording is `@real-router/validation-plugin`'s `validateRouteName`, byte for byte, including its `typeof` quirks (`typeof null` is `"object"`, so it reports `got object` for `null` too) — the same mirroring #1047 and #1763 used, so the production posture (`__DEV__ && validationPlugin()`) does not change which error a consumer reads.

Measured on the one input that could have been a regression: a boxed `new String("kid")` used to pass the backstop, because `typeof` is `"object"` while `.startsWith` works on it. It was already broken there — a boxed String is not interchangeable with the primitive as a `Map` key, so the route registered under a name nothing could address. The refusal replaces a silent mis-registration, not a working call.

### Not a route-name gate

`packages/core/ARCHITECTURE.md` **"Route-Name Type Gates"** decides whether a door REFUSES or ANSWERS. No door that answered starts refusing here, and no predicate is added to a door — an existing always-on predicate stops crashing. The section gained a paragraph making that distinction explicit, since the code would otherwise read as contradicting it.

### Scope — what this does NOT close

`assertNoDottedRouteName` carries the same shape one line down (`name.includes(".")` on an unchecked value) and is deliberately left alone: every one of its call sites runs the internal-prefix walker first, so a non-string never reaches it — measured with an instrumented marker across the predicate's exact / ancestor / descendant / unrelated / forwarding shapes. A guard there would be an equivalent mutant with no public path to pin it.

#1804 (eight `validateRouteName` rules never lifted onto the live path) is **not** closed and not touched. Its table is entirely string-shaped; this is the `typeof` row, which that table does not contain. Whoever picks up #1804 should cover `remove` / `update` too — they are not registration and are outside its scope.

### Maintainability

- `packages/core/ARCHITECTURE.md`, `packages/core/CLAUDE.md` — the refusal-shape vs gate distinction, and the five CRUD doors added to the always-on inventory.
- Wiki (separate repo): `addRoute.md` documented the defect verbatim, quoting `TypeError: name.startsWith is not a function` as a known limitation — that paragraph is gone and its table row moves from `plugin` to `✅ always`. `removeRoute.md`, `updateRoute.md`, `replaceRoutes.md` carried the same now-false "type validations still require the plugin" claim. `createRouter.md` had no route-name rows at all; two added, plus why that door has no plugin coverage.

## Test plan

- [x] `packages/core/tests/functional/no-validation-plugin.test.ts` — new `describe("non-string route name — refusal shape (#1896)")`, **7 cells**: one per door, one over a **7-row** form table (`object` / `null` / `undefined` / `number` / `symbol` / `boolean` / `bigint`, with `expect(forms).toHaveLength(7)` so an emptied table cannot pass vacuously), and a CONTROL proving a plain string still reaches every door.
- [x] `packages/validation-plugin/tests/functional/bare-core-message-parity.test.ts` — new, 115 lines, 3 declarations expanding to **6 cells** at runtime. It lives on the plugin side because core devDepends only on `@real-router/ssr-utils` — the two layers can only be compared from there.
- [x] Mutation-validated, both files: removing the guard reds **6 of 7** core cells and **5 of 6** parity cells; breaking `methodName` at one call site reds exactly that door (**3** cells, including an existing #1047 cell); a **one-character** wording drift (`,` → `;`) reds **5** parity cells; emptying the door table drops the run from **6 → 5** tests and reds the length assert; making the guard unconditional reds **64 of 68** in the core file, so the CONTROL is not vacuous.
- [x] One assertion was removed as INERT rather than shipped: a `not.toBe("NO THROW")` control beside the `toContain` left 6/6 green when deleted — an equivalent mutant planted by hand. The surviving `toContain` reds 5/6 on the same mutation.
- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes — the pre-push gate ran the full graph plus knip, syncpack, dependency audit and the semgrep diff scan.
- [x] 100% test coverage maintained — `@real-router/core` **4550** tests at 100% statements/branches/functions/lines; `@real-router/validation-plugin` **772** at 100%.
- [x] Sweep suites green on this HEAD: core `test:properties` **454**, core `test:stress` **153**.

Closes #1896
