### PR TITLE
fix(persistent-params-plugin): refuse a param name the router can never publish (#1810)

### DIFF
--- a/.changeset/proto-param-name-refused-1810-fix.md
+++ b/.changeset/proto-param-name-refused-1810-fix.md
@@ -1,0 +1,48 @@
+---
+"@real-router/persistent-params-plugin": minor
+---
+
+A persistent-param name the router can never publish is refused at the factory (#1810)
+
+`validateParamKey` only ever checked a charset (`= & ? # % / \` and whitespace),
+so `"__proto__"` was accepted as a param name. It can never work: the router
+withholds that one key from `state.params` / `state.search` at the channel copy,
+so the value has no way to reach a URL. Measured before this change:
+
+```
+persistentParamsPluginFactory(["__proto__", "mode"])   ACCEPTED
+navigate("page", {}, { __proto__: "V", mode: "dev" })
+  href                              /page?mode=dev
+  state.context.persistentParams    { __proto__: undefined, mode: "dev" }
+```
+
+So the plugin published a key that was both unusable and `undefined`-valued,
+beside the params that do work. It now throws a `TypeError` at factory time, and
+the message says why rather than reporting the name as malformed — `"__proto__"`
+IS a non-empty string, so the generic "Expected array of non-empty strings"
+reads as a contradiction to whoever wrote it.
+
+⚠ **The refusal is NARROW, and that is measured.** Across all twelve own members
+of `Object.prototype`, each tracked and navigated with a value, eleven print
+`/page?<name>=V` and land in `state.search` — including the four `__define*__` /
+`__lookup*__` accessors. Only `__proto__` never arrives. Refusing the others
+would retire a working capability.
+
+⚠ A SOURCE LITERAL `{ __proto__: "x" }` is unaffected and always was: it sets the
+object's prototype and creates no own key, so there is no param by that name to
+refuse. The own-key spellings (`Object.fromEntries`, `JSON.parse`, a computed
+key) are the ones this reaches.
+
+**Documentation, and the other half of the issue.** `extractOwnParams` was named,
+documented and commented as the plugin's prototype-pollution boundary while its
+example built the wrong shape — `Object.create({ __proto__: … })` creates no own
+key, so it demonstrated inherited-key filtering and never the concern it named —
+and promised an output "(no `__proto__`)" that the function does not produce. Both
+docblocks now state what the helpers actually guarantee: own keys only, every own
+key kept as ordinary data whatever it is called, and the write safe against an
+ambient accessor since `putField`. Stripping the key there would be redundant
+rather than safer — an untracked name is filtered downstream (measured: it
+reaches neither the URL, nor `state.search`, nor the published context), and a
+tracked one can no longer be `"__proto__"`.
+
+Part of #1901.

--- a/packages/persistent-params-plugin/ARCHITECTURE.md
+++ b/packages/persistent-params-plugin/ARCHITECTURE.md
@@ -175,7 +175,7 @@ router.buildPath(routeName, navParams, navSearch?)        ← navSearch is RFC-4
         │     │                                               with no explicit search the
         │     │                                               params bag IS the query source
         │     ├── extractOwnParams(source)
-        │     │     └── strips inherited properties (prototype pollution guard)
+        │     │     └── copies OWN keys only; every own key is kept as data
         │     └── #buildPathSearch(safeParams)            ← inject into the SEARCH channel
         │           ├── validateParamValue(key, value) for each key
         │           ├── mergeParams(#persistentParams, safeParams)

--- a/packages/persistent-params-plugin/CLAUDE.md
+++ b/packages/persistent-params-plugin/CLAUDE.md
@@ -151,8 +151,9 @@ src/
 ├── plugin.ts       — PersistentParamsPlugin class: registers interceptors in constructor,
 │                     claims "persistentParams" context namespace,
 │                     exposes getPlugin() returning { onTransitionSuccess, teardown }
-├── param-utils.ts  — extractOwnParams (prototype pollution guard), mergeParams (merge logic)
-├── validation.ts   — validateConfig (factory-time), validateParamValue (nav-time),
+├── param-utils.ts  — extractOwnParams (own-keys-only copy), mergeParams (merge logic)
+├── validation.ts   — validateConfig (factory-time; refuses `__proto__` as a param
+│                     name, #1810), validateParamValue (nav-time),
 │                     isValidParamsConfig, validateParamKey
 ├── types.ts        — PersistentParamsConfig = string[] | Record<string, string|number|boolean>
 ├── constants.ts    — ERROR_PREFIX, LOGGER_CONTEXT

--- a/packages/persistent-params-plugin/src/param-utils.ts
+++ b/packages/persistent-params-plugin/src/param-utils.ts
@@ -5,16 +5,41 @@ import { putField } from "@real-router/core/utils";
 import type { Params } from "@real-router/core";
 
 /**
- * Safely extracts own properties from params object.
- * Uses Object.hasOwn to prevent prototype pollution attacks.
+ * Copies a caller's bag into a fresh object, keeping its OWN keys only.
  *
- * @param params - Parameters object (may contain inherited properties)
- * @returns New object with only own properties
+ * ⚠ What this guarantees, precisely — the previous docblock promised something
+ * else and had been doing so since the function was written (#1810):
+ *
+ *   - an INHERITED key is dropped (`Object.hasOwn` gate). Measured:
+ *     `Object.create({ inheritedKey: "X" })` plus an own `mode` comes back as
+ *     `{ mode }`.
+ *   - an OWN key is kept, WHATEVER it is called, and lands as ordinary data —
+ *     including `"__proto__"`, and including a name the application happens to
+ *     have put on `Object.prototype`. `putField` (#1852) is what makes the
+ *     second half true; before it, an ambient accessor under a tracked param
+ *     name took the value silently.
+ *
+ * ⚠ It does NOT strip `"__proto__"`, and the old example claimed it did
+ * (`// { mode: 'dev' } (no __proto__)`). Two things were wrong with it. The
+ * output DOES carry the key, as own data with the prototype intact; and the
+ * input it built — the source literal `{ __proto__: { admin: true } }` inside
+ * `Object.create(...)` — creates no own key of that name at all, so the example
+ * exercised the inherited-key branch while describing the other one.
+ *
+ * Stripping it here would be redundant rather than safer: a name the plugin does
+ * not track is filtered downstream (measured — an untracked `__proto__` in a
+ * caller's bag reaches neither the URL, nor `state.search`, nor the published
+ * context), and a name it DOES track can no longer be `"__proto__"`, because
+ * `validateParamKey` refuses it at the factory (#1810).
+ *
+ * @param params - Parameters object (may carry inherited keys)
+ * @returns New object carrying only the own keys of `params`
  *
  * @example
- * const malicious = Object.create({ __proto__: { admin: true } });
- * malicious.mode = 'dev';
- * const safe = extractOwnParams(malicious); // { mode: 'dev' } (no __proto__)
+ * const bag = JSON.parse('{"mode":"dev","__proto__":{"marker":"INJ"}}');
+ * const safe = extractOwnParams(bag);
+ * // → { mode: 'dev', __proto__: {...} } — own data, prototype NOT swapped,
+ * //   and `safe.marker` is undefined.
  */
 export function extractOwnParams(params: Params): Params {
   const result: Params = {};
@@ -37,8 +62,14 @@ export function extractOwnParams(params: Params): Params {
 /**
  * Merges persistent and current parameters into a single Params object.
  *
- * IMPORTANT: `current` must be pre-sanitized via `extractOwnParams()` by the caller.
- * This function does NOT perform prototype pollution protection on its own.
+ * IMPORTANT: `current` must be pre-sanitized via `extractOwnParams()` by the
+ * caller — this function does not drop inherited keys on its own.
+ *
+ * ⚠ It does not need to guard the WRITE, though, and that half of the old
+ * warning was misleading: both loops store through `putField` (#1852), so a
+ * name the application put on `Object.prototype` cannot intercept them and an
+ * own `"__proto__"` lands as ordinary data. What the caller owes it is the
+ * own-key filter, nothing more.
  *
  * @param persistent - Frozen persistent parameters
  * @param current - Pre-sanitized current parameters (own properties only)

--- a/packages/persistent-params-plugin/src/validation.ts
+++ b/packages/persistent-params-plugin/src/validation.ts
@@ -8,10 +8,36 @@ import type { PersistentParamsConfig } from "./types";
 const INVALID_PARAM_KEY_REGEX = /[\s#%&/=?\\]/;
 const INVALID_CHARS_MESSAGE = String.raw`Cannot contain: = & ? # % / \ or whitespace`;
 
+/**
+ * The one name the router withholds from `state.params` / `state.search` at the
+ * channel copy (#1792 / #1852), so a persistent param called this can never
+ * reach a URL (#1810).
+ *
+ * ⚠ Deliberately ONE name, not `Object.prototype`'s twelve. Measured, each
+ * tracked and navigated with a value: `toString`, `constructor`, `valueOf` and
+ * `hasOwnProperty` all print `/page?<name>=V` and land in `state.search` — they
+ * are ordinary data to the router, and refusing them would retire a working
+ * capability. `__proto__` alone prints `/page` with an empty `search`.
+ *
+ * Not imported from core: the constant is internal there, and duplicating one
+ * string literal is cheaper than widening core's public surface for it. The
+ * behaviour it mirrors is pinned on both sides.
+ */
+const UNPUBLISHABLE_PARAM_KEY = "__proto__";
+
 export function validateParamKey(key: string): void {
   if (INVALID_PARAM_KEY_REGEX.test(key)) {
     throw new TypeError(
       `${ERROR_PREFIX} Invalid parameter name "${key}". ${INVALID_CHARS_MESSAGE}`,
+    );
+  }
+
+  // Refused here rather than left to fail silently later: accepted, it produced
+  // a `state.context.persistentParams` carrying `__proto__: undefined` beside
+  // the params that do work, and no URL ever showed it.
+  if (key === UNPUBLISHABLE_PARAM_KEY) {
+    throw new TypeError(
+      `${ERROR_PREFIX} Invalid parameter name "${key}". The router never publishes this key into a state channel, so a persistent param named it can never reach a URL.`,
     );
   }
 }
@@ -112,6 +138,38 @@ export function validateParamValue(
  * @param params - Configuration to validate
  * @throws {TypeError} If params is not a valid configuration
  */
+/**
+ * Names the ONE refusal whose reason the generic message cannot convey (#1810).
+ *
+ * `"__proto__"` IS a non-empty string, so "Expected array of non-empty strings"
+ * reads as a contradiction to whoever wrote it. Every other rejection this
+ * validator makes is visible in the value itself (a number, an empty string, a
+ * name carrying `?`); this one is a rule about the router, so it has to be said.
+ *
+ * ⚠ Appended rather than substituted: `plugin.test.ts` pins the
+ * `Invalid params configuration` prefix in THIRTEEN assertions
+ * (`grep -c 'Invalid params configuration'`), and the charset rejections keep
+ * the message they always had.
+ */
+function unpublishableClause(params: unknown): string {
+  // ⚠ `Object.keys` on the ARRAY form would give indices, not the names, so the
+  // branch is load-bearing; `?? {}` covers `null`, which reaches here (an
+  // invalid config of any shape does). An earlier revision spelled the second
+  // arm `typeof params === "object" && params !== null`, and the `typeof` half
+  // was an equivalent mutant — the only value it uniquely guarded was
+  // `undefined`, which the factory accepts as an empty config and never
+  // forwards here.
+  const names: readonly string[] = Array.isArray(params)
+    ? (params as string[])
+    : Object.keys(params ?? {});
+
+  if (!names.includes(UNPUBLISHABLE_PARAM_KEY)) {
+    return "";
+  }
+
+  return ` The name "${UNPUBLISHABLE_PARAM_KEY}" is refused: the router never publishes it into a state channel, so a persistent param named it can never reach a URL.`;
+}
+
 export function validateConfig(params: unknown): void {
   if (!isValidParamsConfig(params)) {
     let actualType: string;
@@ -126,7 +184,9 @@ export function validateConfig(params: unknown): void {
 
     throw new TypeError(
       `${ERROR_PREFIX} Invalid params configuration. ` +
-        `Expected array of non-empty strings or object with primitive values, got ${actualType}.`,
+        `Expected array of non-empty strings or object with primitive values, got ${actualType}.${unpublishableClause(
+          params,
+        )}`,
     );
   }
 }

--- a/packages/persistent-params-plugin/tests/functional/proto-name-refused-1810.test.ts
+++ b/packages/persistent-params-plugin/tests/functional/proto-name-refused-1810.test.ts
@@ -1,0 +1,145 @@
+// #1810 — a persistent-param name the router can never publish is refused at the
+// factory, instead of being accepted and then silently never working.
+//
+// `validateParamKey` only ever checked a charset (`= & ? # % / \` and whitespace),
+// so `"__proto__"` was accepted as a param name. It can never persist: the router
+// withholds that one key from `state.params` / `state.search` at the channel copy
+// (#1792 / #1852), so the value never reaches a URL. Measured before this fix:
+//
+//   persistentParamsPluginFactory(["__proto__", "mode"])   ACCEPTED
+//   navigate("page", {}, { __proto__: "V", mode: "dev" })
+//     href                                    /page?mode=dev      ← never printed
+//     state.context.persistentParams          { __proto__: undefined, mode: "dev" }
+//
+// So the plugin published a key that is both unusable AND `undefined`-valued.
+//
+// ⚠ The refusal is NARROW on purpose, and the control below is what keeps it so.
+// Measured across ALL TWELVE own members of `Object.prototype`, each tracked and
+// navigated with a value: eleven print `/page?<name>=V` and land in
+// `state.search` — including the four `__define*__` / `__lookup*__` accessors,
+// which look dangerous and are not. Only `__proto__` never arrives. Refusing any
+// of the other eleven would retire a working capability.
+//
+// ⚑ The control list is DERIVED from `Object.getOwnPropertyNames`, not written
+// out: a hand-listed control silently stops covering a member the runtime adds,
+// and an empty derived list would make every `each` cell vanish without failing
+// anything — hence the length assertions below.
+
+import { createRouter } from "@real-router/core";
+import { describe, expect, it } from "vitest";
+
+import { persistentParamsPluginFactory } from "../../src";
+
+/** An OWN `"__proto__"` key — a source literal would set the prototype instead. */
+const ownProto = (value: unknown): Record<string, unknown> =>
+  Object.fromEntries([["__proto__", value]]);
+
+const PROTOTYPE_MEMBERS = Object.getOwnPropertyNames(Object.prototype);
+const PUBLISHABLE = PROTOTYPE_MEMBERS.filter((name) => name !== "__proto__");
+
+describe("a persistent-param name the router cannot publish is refused (#1810)", () => {
+  it("the ARRAY config form refuses `__proto__`", () => {
+    expect(() => persistentParamsPluginFactory(["__proto__"])).toThrow(
+      TypeError,
+    );
+  });
+
+  it("the RECORD config form refuses it too", () => {
+    // ⚠ Built with `Object.fromEntries`, not `{ __proto__: "x" }`: the source
+    // literal sets the object's prototype and creates NO own key, so it never
+    // reaches the name at all. The issue's own first comment fell into that.
+    expect(() =>
+      persistentParamsPluginFactory(ownProto("x") as Record<string, string>),
+    ).toThrow(TypeError);
+  });
+
+  it("CONTROL — a SOURCE-LITERAL `{ __proto__: … }` is not the refused shape", () => {
+    // It sets the object's prototype and creates no own key, so `Object.entries`
+    // sees an empty config and the factory accepts it — there is no param by
+    // that name to refuse. Pinned so the refusal is understood to key on OWN
+    // names, and because the issue's own first comment reported this spelling as
+    // the failing one and had to correct itself.
+    expect(() =>
+      persistentParamsPluginFactory({ __proto__: "x" }),
+    ).not.toThrow();
+  });
+
+  it("the message says WHY, not just that the name is invalid", () => {
+    let message = "";
+
+    try {
+      persistentParamsPluginFactory(["__proto__"]);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain("__proto__");
+    expect(message).toMatch(/never|cannot|withheld/i);
+  });
+
+  it("the added clause is TARGETED — a charset rejection does not carry it", () => {
+    // Vector-1 finding: without this, deleting the `includes` guard in
+    // `unpublishableClause` left all 144 tests green, i.e. the clause could be
+    // appended to every configuration error and nothing would notice.
+    let message = "";
+
+    try {
+      persistentParamsPluginFactory(["has space"]);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain("Invalid params configuration");
+    expect(message).not.toContain("never publishes");
+  });
+
+  it.each([null, 42, "str"])(
+    "a non-object config (%s) still reports the PLUGIN's error, not the engine's",
+    (config) => {
+      // The key scan runs on a config that is already known invalid, so it sees
+      // shapes `Object.keys` refuses. `null` is the live one — measured, it is
+      // rejected here while `undefined` and `{}` are ACCEPTED as an empty config
+      // and never reach the scan at all. Without the `?? {}`, `Object.keys(null)`
+      // throws `Cannot convert undefined or null to object` — still a TypeError,
+      // so every `toThrow(TypeError)` assertion in the package stays green while
+      // the caller gets an engine message about a config they can see is wrong.
+      let message = "";
+
+      try {
+        persistentParamsPluginFactory(config as never);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+
+      expect(message).toContain("Invalid params configuration");
+    },
+  );
+
+  it("CONTROL — the derived member list is populated and excludes the refused name", () => {
+    // Without this, a runtime whose `Object.prototype` enumerated nothing would
+    // reduce every cell below to zero and the file would pass with 3 tests.
+    expect(PROTOTYPE_MEMBERS).toHaveLength(12);
+    expect(PUBLISHABLE).toHaveLength(11);
+    expect(PUBLISHABLE).not.toContain("__proto__");
+  });
+
+  it.each(PUBLISHABLE)(
+    "CONTROL — %s is still accepted AND still reaches the URL",
+    async (name) => {
+      const router = createRouter([
+        { name: "home", path: "/" },
+        { name: "page", path: "/page" },
+      ]);
+
+      router.usePlugin(persistentParamsPluginFactory([name]));
+      await router.start("/home");
+      await router.navigate("page", {}, { [name]: "V" });
+
+      const href = router.buildPath("page");
+
+      router.dispose();
+
+      expect(href).toBe(`/page?${name}=V`);
+    },
+  );
+});

--- a/packages/persistent-params-plugin/tests/property/validation.properties.ts
+++ b/packages/persistent-params-plugin/tests/property/validation.properties.ts
@@ -32,11 +32,25 @@ const INVALID_CHARS = [
   "\\",
 ];
 
-const arbValidKey = fc.string({
-  unit: fc.constantFrom(...SAFE_CHARS),
-  minLength: 1,
-  maxLength: 20,
-});
+/**
+ * The one charset-legal name the validator refuses anyway (#1810): the router
+ * never publishes it into a state channel, so a persistent param called it can
+ * never reach a URL.
+ *
+ * ⚠ Excluded from `arbValidKey` rather than left to chance. `fast-check` biases
+ * its string generator toward exactly this literal — it produced `"__proto__"`
+ * on run 156 of 200 the first time this partition ran against the refusal — so
+ * the domain is not "narrowed for a hypothetical", it was actively wrong.
+ */
+const REFUSED_PUBLISHABLE_KEY = "__proto__";
+
+const arbValidKey = fc
+  .string({
+    unit: fc.constantFrom(...SAFE_CHARS),
+    minLength: 1,
+    maxLength: 20,
+  })
+  .filter((key) => key !== REFUSED_PUBLISHABLE_KEY);
 
 const arbInvalidKey = fc
   .tuple(
@@ -85,6 +99,22 @@ describe("validation: validateParamKey partition property", () => {
       expect(() => {
         validateParamKey(key);
       }).not.toThrow();
+    },
+  );
+
+  test.prop([arbValidKey], { numRuns: NUM_RUNS })(
+    "the refused name is the ONLY charset-legal key that throws",
+    (key) => {
+      // The sister of the partition above, and what keeps its `.filter` honest:
+      // without it, widening the refusal to a second name would silently shrink
+      // the generator instead of failing anything.
+      expect(() => {
+        validateParamKey(key);
+      }).not.toThrow();
+
+      expect(() => {
+        validateParamKey(REFUSED_PUBLISHABLE_KEY);
+      }).toThrow(TypeError);
     },
   );
 

--- a/packages/persistent-params-plugin/tests/unit/param-utils.test.ts
+++ b/packages/persistent-params-plugin/tests/unit/param-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 
 import { extractOwnParams, mergeParams } from "../../src/param-utils";
 
+import type { Params } from "@real-router/core";
+
 describe("extractOwnParams", () => {
   it("should copy own properties", () => {
     expect(extractOwnParams({ a: "1", b: "2" })).toStrictEqual({
@@ -40,6 +42,47 @@ describe("extractOwnParams", () => {
     obj.own = "value";
 
     expect(extractOwnParams(obj)).toStrictEqual({ own: "value" });
+  });
+
+  it("keeps an OWN `__proto__` as ordinary data, prototype intact (#1810)", () => {
+    // The other half of the boundary, and the half the docstring used to deny.
+    // ⚠ Built with `JSON.parse`, not a source literal: `{ __proto__: v }` sets
+    // the object's prototype and creates no own key, so a literal would exercise
+    // the inherited branch above while claiming to test this one.
+    const bag = JSON.parse(
+      '{"mode":"dev","__proto__":{"marker":"INJ"}}',
+    ) as Params;
+
+    const out = extractOwnParams(bag);
+
+    expect(Object.keys(out)).toStrictEqual(["mode", "__proto__"]);
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect((out as { marker?: unknown }).marker).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(out, "__proto__")).toStrictEqual({
+      value: { marker: "INJ" },
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  it("stores under a name the application put on Object.prototype (#1852)", () => {
+    // The CONTROL for the sentence above: `__proto__` is not the rule, it is one
+    // instance. A plain store here would reach the ambient setter and lose the
+    // value with no error at all.
+    Object.defineProperty(Object.prototype, "zzAmbient", {
+      get: () => "hijack",
+      set: () => undefined,
+      configurable: true,
+    });
+
+    try {
+      expect(extractOwnParams({ zzAmbient: "mine" })).toStrictEqual({
+        zzAmbient: "mine",
+      });
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "zzAmbient");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- A persistent param named `__proto__` used to be accepted and then silently never work. It is refused at the factory now, with a message that says why.
- Nothing else changes: measured across all twelve own members of `Object.prototype`, the other eleven are accepted and reach the URL exactly as any other name.
- The plugin's own "prototype-pollution boundary" documentation described a guarantee the code does not make, in an example that built the wrong shape. Both docblocks now say what the helpers actually do.

### #1810 — a name the router can never publish was accepted

`validateParamKey` only ever checked a charset (`= & ? # % / \` and whitespace), so `"__proto__"` passed. It can never work: the router withholds that one key from `state.params` / `state.search` at the channel copy, so the value has no way to reach a URL.

```
persistentParamsPluginFactory(["__proto__", "mode"])   ACCEPTED
navigate("page", {}, { __proto__: "V", mode: "dev" })
  href                            /page?mode=dev              ← never printed
  state.context.persistentParams  { __proto__: undefined, mode: "dev" }
```

The plugin published a key that was both unusable and `undefined`-valued, beside the params that do work.

**Root cause — and it is not the one the issue names.** The body asks for `extractOwnParams` / `mergeParams` to stop producing an own `__proto__`; both have been safe since #1852. The decisive measurement is that an **untracked** name leaks nowhere — not to the URL, not to `state.search`, not to the published context. Every observable symptom therefore traces to the single door that lets the name become tracked.

⚠ **The refusal is narrow, and that is measured, not asserted.** Each of `Object.prototype`'s twelve own members was tracked and navigated with a value: eleven print `/page?<name>=V` and land in `state.search`, including the four `__define*__` / `__lookup*__` accessors that look dangerous and are not. Only `__proto__` never arrives. Refusing the others would retire a working capability.

⚠ A SOURCE LITERAL `{ __proto__: "x" }` is unaffected and always was — it sets the object's prototype and creates no own key, so there is no param by that name to refuse. This is the correction the issue's own second comment had to make about itself; it ships here as a pinned control.

The message is APPENDED rather than substituted, because `plugin.test.ts` pins the `Invalid params configuration` prefix in thirteen assertions and the charset rejections keep the wording they always had. It has to say something, though: `"__proto__"` IS a non-empty string, so the generic "Expected array of non-empty strings" reads as a contradiction to whoever wrote it.

### Documentation — the other half of the issue

`extractOwnParams` was named, documented and commented as this plugin's prototype-pollution boundary while its example built `Object.create({ __proto__: … })`, which creates no own key — so it demonstrated inherited-key filtering and never the concern it named — and promised an output "(no `__proto__`)" that the function does not produce. Both docblocks now state the real guarantee: own keys only, every own key kept as ordinary data whatever it is called, and the write safe against an ambient accessor since `putField`.

Stripping the key inside the helper would be redundant rather than safer, per the untracked-name measurement above — so the fork raised in the issue ("keep or drop") is resolved as **keep**, on evidence.

### Maintainability

- The `validateParamKey` partition property had `__proto__` in its domain, and `fast-check` biases toward that literal — it produced it on run 156 of 200 the first time the partition met the refusal. The domain excludes it now, with a sister property asserting the refusal deterministically so the exclusion cannot quietly widen.
- The eleven publishable-member controls are DERIVED from `Object.getOwnPropertyNames`, with length assertions on both the full list and the filtered one, so an empty derived list cannot remove the cells without failing.

## Test plan

- [x] `pnpm -F @real-router/persistent-params-plugin type-check` — RC=0
- [x] `pnpm -F @real-router/persistent-params-plugin lint` — RC=0 (fresh, `.eslintcache` removed)
- [x] `pnpm -F @real-router/persistent-params-plugin test -- --run` — RC=0, **7 files / 151 tests**
- [x] `pnpm -F @real-router/persistent-params-plugin test:properties` — RC=0, **38**
- [x] 100% coverage maintained — `100% (145/145)` statements, `100% (94/94)` branches, `100% (23/23)` functions, `100% (144/144)` lines
- [x] New: `tests/functional/proto-name-refused-1810.test.ts` — 8 `it` blocks, 15 cells once the derived `it.each` expands
- [x] New cells in `tests/unit/param-utils.test.ts` — the own-key case and an ambient-accessor control (`__proto__` is one instance of the rule, not the rule)
- [x] Mutationally validated, **5/5** added terms; four red deterministically, the fifth (the property's domain filter) is seed-dependent and pinned deterministically by its sister
- [x] Two defects in this fix were found by that mutation and closed: the message clause's `includes` gate was unguarded, and a `typeof params === "object"` term was an equivalent mutant whose only unique subject was `undefined` — which the factory accepts as an empty config and never forwards here
- [ ] `test:stress` — the package has no `tests/stress`, so nothing was run
- [ ] Full `pnpm build` — delegated to the maintainer

Closes #1810

Part of #1901
