### PR TITLE
fix(ssr/config): pnpm lint never looked at shared/, and the 49 findings behind it (#1913)

### DIFF
--- a/.changeset/lint-sees-shared-1913-rsc-server-plugin.md
+++ b/.changeset/lint-sees-shared-1913-rsc-server-plugin.md
@@ -1,0 +1,27 @@
+---
+"@real-router/rsc-server-plugin": patch
+---
+
+The `shared/ssr` sources this package bundles are now linted (#1913)
+
+No behaviour change, and no change to this package's own `lint` script.
+
+`shared/ssr/` is symlinked into both SSR plugins and was invisible to every lint
+run: `eslint`'s globs do not descend into a symlinked directory while walking a
+parent. It is now linted exactly once, by `@real-router/ssr-data-plugin` — the
+package that already owns the directory for coverage — so the same nine files are
+not reported two, three or five times over. A repo gate
+(`scripts/check-coverage-scope.mjs`) derives that owner from the filesystem and
+fails if its lint script stops passing the alias.
+
+What that surfaced and fixed in code this package ships: 49 problems (41 errors +
+8 warnings), of which four were conditions TypeScript believes can never fire.
+All four are deliberate runtime guards where the type does not bind the caller,
+and each now carries that reason instead of being deleted. The rest were short
+identifiers, brace style, redundant assertions, and one validator split into two
+functions — verified message-for-message against the previous implementation.
+
+⚑ `Promise.withResolvers` is deliberately NOT adopted in the client-side defer
+registry, which this package also bundles: it is ES2024 (Chrome 119, Firefox 121,
+Safari 17.4), so taking it would drop every Safari below 17.4. That is a decision
+about supported runtimes, not a lint fix.

--- a/.changeset/lint-sees-shared-1913-ssr-data-plugin.md
+++ b/.changeset/lint-sees-shared-1913-ssr-data-plugin.md
@@ -1,0 +1,31 @@
+---
+"@real-router/ssr-data-plugin": patch
+---
+
+The lint gate now looks at `shared/ssr`, and the 49 findings behind it are resolved (#1913)
+
+No behaviour change. `eslint`'s globs do not descend into a symlinked directory
+while walking a parent, so `eslint src/` linted this package's own files and none
+of the shared ones it ships. Measured: 8 files and 0 problems before, 9 files and
+49 problems (41 errors + 8 warnings) when the alias is passed explicitly. The
+script runs `--max-warnings 0`, so all 49 were gate failures.
+
+The substance was four `no-unnecessary-condition` — conditions TypeScript believes
+can never fire. All four turned out to be the second kind: deliberate runtime
+guards where the type does not bind the caller. `defer()` is a public export, so
+its parameter type constrains TypeScript callers and nobody else; the hydration
+guard stands in front of a value whose type comes from a cast (#762). Each now
+carries the reason rather than being deleted or silenced blindly.
+
+Of the remaining 45, `--fix` resolved 24 and 17 errors plus 4 warnings needed a
+hand — eight short identifiers, a nullish-coalescing rewrite, a `Set` in place of
+three repeated comparisons, and one validator split into two functions to get its
+cognitive complexity from 27 under the limit of 15. Same checks, same order, same
+messages: verified against the previous implementation on a 16-case matrix,
+16/16 identical.
+
+⚑ One finding is deliberately NOT taken: `Promise.withResolvers` would simplify
+the client-side defer registry, but it is ES2024 and that module ships to the
+browser — Chrome 119, Firefox 121, Safari 17.4, so it would drop every Safari
+below 17.4. Raising the supported-runtime floor is a product decision, not a lint
+fix, so the rule is disabled at that one site with the reason written down.

--- a/packages/browser-plugin/package.json
+++ b/packages/browser-plugin/package.json
@@ -47,8 +47,8 @@
     "test:stress": "vitest --config vitest.config.stress.mts --run",
     "test:properties": "vitest --config vitest.config.properties.mts --run",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --cache --ext .ts src/ tests/ --max-warnings 0",
-    "lint:fix": "eslint --cache --ext .ts src/ tests/ --fix --max-warnings 0",
+    "lint": "eslint --cache --ext .ts src/ src/browser-env/ tests/ --max-warnings 0",
+    "lint:fix": "eslint --cache --ext .ts src/ src/browser-env/ tests/ --fix --max-warnings 0",
     "bundle": "tsdown --config-loader unrun"
   },
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -101,8 +101,8 @@
     "test:properties": "vitest run --config vitest.config.properties.mts",
     "test:stress": "vitest run --config vitest.config.stress.mts",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --cache --ext .ts,.tsx src/ tests/ --max-warnings 0",
-    "lint:fix": "eslint --cache --ext .ts,.tsx src/ tests/ --fix --max-warnings 0",
+    "lint": "eslint --cache --ext .ts,.tsx src/ src/dom-utils/ tests/ --max-warnings 0",
+    "lint:fix": "eslint --cache --ext .ts,.tsx src/ src/dom-utils/ tests/ --fix --max-warnings 0",
     "bundle": "tsdown --config-loader unrun"
   },
   "keywords": [

--- a/packages/rsc-server-plugin/ARCHITECTURE.md
+++ b/packages/rsc-server-plugin/ARCHITECTURE.md
@@ -362,7 +362,7 @@ Same as `ssr-data-plugin`: `Object.entries(loaders)` at compilation time only it
 
 ### Error-safe compilation (all-or-nothing claim rollback)
 
-The claim acquisitions and the `compile()` call (whose per-route loop lives at `shared-ssr/createSsrLoaderPlugin.ts:78-117`) run inside a shared `try/catch` (`createSsrLoaderPlugin.ts:230-252`) with an `acquired: ContextNamespaceClaim[]` array. Claims are pushed onto `acquired` as they're successfully obtained from `api.claimContextNamespace(...)` — `"rsc"` first, then `"ssrRscMode"` (and, in the `ssr-data-plugin` build of the same shared factory, additional `value`/`keys` claims under a configured `deferredNamespace`).
+The claim acquisitions and the `compile()` call (whose per-route loop lives in `compile()` in `shared-ssr/createSsrLoaderPlugin.ts`) run inside a shared `try/catch` (the one wrapping the `claim()` calls and `compile()` in `createSsrLoaderPlugin.ts`, whose `catch` calls `rollback()` and rethrows) with an `acquired: ContextNamespaceClaim[]` array. Claims are pushed onto `acquired` as they're successfully obtained from `api.claimContextNamespace(...)` — `"rsc"` first, then `"ssrRscMode"` (and, in the `ssr-data-plugin` build of the same shared factory, additional `value`/`keys` claims under a configured `deferredNamespace`).
 
 If any factory throws or returns a non-function:
 
@@ -373,7 +373,7 @@ If any factory throws or returns a non-function:
 
 This prevents permanently blocking ANY of the plugin's namespaces when a factory has a bug. The change from "single-claim rollback" to "acquired-array rollback" was driven by adding the `ssrRscMode` claim — a single `claim.release()` would have leaked the partner namespace on factory failure.
 
-For `rsc-server-plugin` specifically, `acquired.length` is always 2 (no `deferredNamespace` configured). The `ssr-data-plugin` path can grow it to 4 — see the deferred-namespace claim branch at `shared-ssr/createSsrLoaderPlugin.ts:234-239` (the `value`/`keys` claims acquired when `deferredConfig !== null`).
+For `rsc-server-plugin` specifically, `acquired.length` is always 2 (no `deferredNamespace` configured). The `ssr-data-plugin` path can grow it to 4 — see the `if (deferredConfig !== null)` branch inside that same `try` in `shared-ssr/createSsrLoaderPlugin.ts` (the `value`/`keys` claims acquired when `deferredConfig !== null`).
 
 ### No bundler dependency
 

--- a/packages/ssr-data-plugin/package.json
+++ b/packages/ssr-data-plugin/package.json
@@ -67,8 +67,8 @@
     "test:properties": "vitest run --config vitest.config.properties.mts",
     "test:stress": "vitest --config vitest.config.stress.mts --run",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --cache --ext .ts src/ tests/ --max-warnings 0",
-    "lint:fix": "eslint --cache --ext .ts src/ tests/ --fix --max-warnings 0",
+    "lint": "eslint --cache --ext .ts src/ src/shared-ssr/ tests/ --max-warnings 0",
+    "lint:fix": "eslint --cache --ext .ts src/ src/shared-ssr/ tests/ --fix --max-warnings 0",
     "bundle": "tsdown --config-loader unrun"
   },
   "sideEffects": false,

--- a/packages/ssr-data-plugin/tests/functional/shared-ssr/authority-1838.test.ts
+++ b/packages/ssr-data-plugin/tests/functional/shared-ssr/authority-1838.test.ts
@@ -66,10 +66,10 @@ function scan(pick: (node: ts.Node) => boolean): Site[] {
 
 /** Every computed-key write, with why its target cannot be hijacked. */
 const WRITE_REASONS: Record<string, string> = {
-  "createSsrLoaderPlugin.ts:305":
+  "createSsrLoaderPlugin.ts:322":
     "SAFE — the target is `Object.create(null)`, and the line above says so in " +
     "as many words. No chain, nothing to dispatch into.",
-  "deferRegistryClient.ts:63":
+  "deferRegistryClient.ts:65":
     "SAFE — the key is a module constant (`REGISTRY_GLOBAL_KEY`), not a name " +
     "any caller chose.",
 };

--- a/scripts/check-coverage-scope.mjs
+++ b/scripts/check-coverage-scope.mjs
@@ -44,7 +44,13 @@
  *   key=value lines; all human/diagnostic output goes to stderr.
  */
 
-import { readFileSync, existsSync, readdirSync, lstatSync } from "node:fs";
+import {
+  readFileSync,
+  existsSync,
+  readdirSync,
+  lstatSync,
+  readlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { declaresSharedOwner } from "./coverage-owner.mjs";
@@ -238,6 +244,58 @@ for (const dir of sharedDirs) {
     errors.push(
       `codecov.yml: no component path "shared/${dir}/**" — the owner's lcov lands at shared/${dir}/… after CI path normalization and would not be attributed to any component`,
     );
+  }
+
+  // --- Check 2c: the owner's LINT must see the dir too (#1913) --------------
+  // ESLint's globs do not descend into a symlinked directory while walking a
+  // parent, so `eslint src/` scans the owner's own files and none of the
+  // shared ones. Measured before the fix: ssr-data-plugin's lint reported 0
+  // problems over 8 files, while the same run rooted at the alias reported 49
+  // over 9 — a REQUIRED gate, green because it never looked.
+  //
+  // The alias is DERIVED from the symlink rather than hardcoded: renaming
+  // `src/shared-ssr` fails here instead of silently un-linting the dir.
+  if (owner) {
+    const srcDir = join(PKG_DIR, owner.pkg, "src");
+    const alias = readdirSync(srcDir).find((entry) => {
+      try {
+        // No `isSymbolicLink()` pre-check: `readlinkSync` throws EINVAL on a
+        // regular file, so the guard below already covers it — measured, the
+        // pre-check was an equivalent mutant (removing it left this script
+        // green) and a second syscall per entry.
+        //
+        // ⚠ The target comparison, by contrast, is INERT TODAY and kept on
+        // purpose: every owner has exactly ONE symlink under src/, so "first
+        // symlink found" happens to be the right one and dropping the
+        // comparison also leaves this green. It stops being inert the moment a
+        // package owns two shared dirs — at which point the wrong alias would
+        // be handed to the lint check with nothing to say so.
+        return (
+          join(srcDir, readlinkSync(join(srcDir, entry))) ===
+          join(SHARED_DIR, dir)
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    if (alias === undefined) {
+      errors.push(
+        `packages/${owner.pkg}: measures shared/${dir} for coverage but has no src/* symlink pointing at it — the lint alias cannot be derived, so the dir would go unlinted (#1913)`,
+      );
+    } else {
+      const scripts = JSON.parse(
+        readFileSync(join(PKG_DIR, owner.pkg, "package.json"), "utf8"),
+      ).scripts;
+
+      for (const key of ["lint", "lint:fix"]) {
+        if (!(scripts[key] ?? "").includes(`src/${alias}/`)) {
+          errors.push(
+            `packages/${owner.pkg}: "${key}" does not pass src/${alias}/ — eslint does not descend into a symlinked dir while walking src/, so shared/${dir} would go unlinted (#1913)`,
+          );
+        }
+      }
+    }
   }
 }
 

--- a/scripts/check-coverage-scope.test.mjs
+++ b/scripts/check-coverage-scope.test.mjs
@@ -18,7 +18,13 @@
 //
 // Runs in the repo-lints CI job via `node --test scripts/*.test.mjs`.
 
-import { readFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -149,6 +155,81 @@ test("the parser reads the ARRAY, not the file", () => {
   const malformed = `config.test.coverage.include = buildIncludes();`;
 
   assert.deepEqual(coverageArrayEntries(malformed, "include"), []);
+});
+
+test("every shared owner passes its symlink alias to lint (#1913)", () => {
+  // eslint's globs do not descend into a symlinked dir while walking a parent,
+  // so `eslint src/` linted the owner's own files and none of the shared ones.
+  // Measured before the fix: ssr-data-plugin reported 0 problems over 8 files;
+  // rooted at the alias, 49 over 9.
+  const sharedDirs = readdirSync(join(ROOT, "shared")).filter(
+    (d) =>
+      !d.startsWith(".") &&
+      d !== "node_modules" &&
+      d !== "tests" &&
+      d !== "coverage" &&
+      lstatSync(join(ROOT, "shared", d)).isDirectory(),
+  );
+
+  // Non-vacuity: an empty list would satisfy every assertion in the loop.
+  assert.ok(sharedDirs.length >= 3, "expected at least three shared dirs");
+
+  let checked = 0;
+
+  for (const dir of sharedDirs) {
+    for (const pkg of readdirSync(join(ROOT, "packages"))) {
+      const cfg = join(ROOT, "packages", pkg, "vitest.config.mts");
+
+      if (!existsSync(cfg)) {
+        continue;
+      }
+
+      if (!declaresSharedOwner(readFileSync(cfg, "utf8"), dir)) {
+        continue;
+      }
+
+      const srcDir = join(ROOT, "packages", pkg, "src");
+      const alias = readdirSync(srcDir).find(
+        (entry) =>
+          lstatSync(join(srcDir, entry)).isSymbolicLink() &&
+          join(srcDir, readlinkSync(join(srcDir, entry))) ===
+            join(ROOT, "shared", dir),
+      );
+
+      assert.ok(alias, `no src/* symlink to shared/${dir} in ${pkg}`);
+
+      const { scripts } = JSON.parse(
+        readFileSync(join(ROOT, "packages", pkg, "package.json"), "utf8"),
+      );
+
+      for (const key of ["lint", "lint:fix"]) {
+        assert.ok(
+          scripts[key].includes(`src/${alias}/`),
+          `${pkg} "${key}" does not pass src/${alias}/`,
+        );
+      }
+
+      checked += 1;
+    }
+  }
+
+  // The loop above is silent when no owner matches; this is what says it ran.
+  assert.equal(checked, sharedDirs.length);
+});
+
+test("the alias is DERIVED from the symlink, not hardcoded", () => {
+  // A hardcoded map would pass every cell above and stop being true the moment
+  // an alias is renamed — the rename would silently un-lint the dir instead of
+  // failing here.
+  // ⚠ stripComments, not the raw text. Measured: with the raw file a hardcoded
+  // alias map passes both regexes as long as ONE comment line still mentions
+  // `readlinkSync(` — i.e. the cell would green-light exactly the thing it
+  // exists to refuse. Same defect #1838 found in the coverage-owner predicate.
+  const script = stripComments(read("scripts/check-coverage-scope.mjs"));
+
+  assert.match(script, /readlinkSync\(/);
+  // The derivation compares against shared/<dir>; a hardcoded map would not.
+  assert.match(script, /join\(SHARED_DIR, dir\)/);
 });
 
 test("the CLI script delegates to this predicate", () => {

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -3,12 +3,7 @@ import { errorCodes, RouterError, UNKNOWN_ROUTE } from "@real-router/core";
 import { getRouteFromEvent } from "./popstate-utils.js";
 
 import type { Browser, SharedFactoryState } from "./types.js";
-import type {
-  Params,
-  Plugin,
-  Router,
-  SearchParams,
-} from "@real-router/core";
+import type { Params, Plugin, Router, SearchParams } from "@real-router/core";
 import type { PluginApi } from "@real-router/core/api";
 
 /**

--- a/shared/ssr/createLoadersValidator.ts
+++ b/shared/ssr/createLoadersValidator.ts
@@ -2,6 +2,75 @@ import { ALL_SSR_MODES } from "./types.js";
 
 import type { SsrMode } from "./types.js";
 
+/**
+ * The `ssr` half of one entry. Split out for the same reason as
+ * {@link validateEntry} — the three shapes `ssr` accepts (string, boolean,
+ * resolver) each need their own branch, and inlining them put
+ * `validateLoaders` at a cognitive complexity of 27 against a limit of 15.
+ */
+function validateSsr(
+  route: string,
+  ssr: unknown,
+  errorPrefix: string,
+  allowedModes: readonly SsrMode[],
+): void {
+  if (typeof ssr === "function" || typeof ssr === "boolean") {
+    return;
+  }
+
+  if (typeof ssr === "string") {
+    if (!(allowedModes as readonly string[]).includes(ssr)) {
+      throw new TypeError(
+        `${errorPrefix} mode "${ssr}" is not allowed for route "${route}". Allowed: ${allowedModes.join(", ")}`,
+      );
+    }
+
+    return;
+  }
+
+  throw new TypeError(
+    `${errorPrefix} ssr for route "${route}" must be SsrMode string, boolean, or (state) => SsrMode`,
+  );
+}
+
+/** One `loaders` entry: either a bare loader function or a `{ ssr?, loader? }` object. */
+function validateEntry(
+  route: string,
+  entry: unknown,
+  errorPrefix: string,
+  allowedModes: readonly SsrMode[],
+): void {
+  if (typeof entry === "function") {
+    return;
+  }
+
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new TypeError(
+      `${errorPrefix} entry for route "${route}" must be a function or { ssr?, loader? } object`,
+    );
+  }
+
+  for (const key of Object.keys(entry)) {
+    if (key !== "ssr" && key !== "loader") {
+      throw new TypeError(
+        `${errorPrefix} unexpected key "${key}" in route "${route}" config`,
+      );
+    }
+  }
+
+  const obj = entry as { ssr?: unknown; loader?: unknown };
+
+  if (obj.loader !== undefined && typeof obj.loader !== "function") {
+    throw new TypeError(
+      `${errorPrefix} loader for route "${route}" must be a function`,
+    );
+  }
+
+  if (obj.ssr !== undefined) {
+    validateSsr(route, obj.ssr, errorPrefix, allowedModes);
+  }
+}
+
 export function createLoadersValidator(
   errorPrefix: string,
   allowedModes: readonly SsrMode[] = ALL_SSR_MODES,
@@ -18,50 +87,7 @@ export function createLoadersValidator(
     for (const [route, entry] of Object.entries(
       loaders as Record<string, unknown>,
     )) {
-      if (typeof entry === "function") continue;
-
-      if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
-        throw new TypeError(
-          `${errorPrefix} entry for route "${route}" must be a function or { ssr?, loader? } object`,
-        );
-      }
-
-      for (const key of Object.keys(entry as Record<string, unknown>)) {
-        if (key !== "ssr" && key !== "loader") {
-          throw new TypeError(
-            `${errorPrefix} unexpected key "${key}" in route "${route}" config`,
-          );
-        }
-      }
-
-      const obj = entry as { ssr?: unknown; loader?: unknown };
-
-      if (obj.loader !== undefined && typeof obj.loader !== "function") {
-        throw new TypeError(
-          `${errorPrefix} loader for route "${route}" must be a function`,
-        );
-      }
-
-      if (obj.ssr !== undefined) {
-        const ssr = obj.ssr;
-
-        if (typeof ssr === "function" || typeof ssr === "boolean") {
-          continue;
-        }
-
-        if (typeof ssr === "string") {
-          if (!(allowedModes as readonly string[]).includes(ssr)) {
-            throw new TypeError(
-              `${errorPrefix} mode "${ssr}" is not allowed for route "${route}". Allowed: ${allowedModes.join(", ")}`,
-            );
-          }
-          continue;
-        }
-
-        throw new TypeError(
-          `${errorPrefix} ssr for route "${route}" must be SsrMode string, boolean, or (state) => SsrMode`,
-        );
-      }
+      validateEntry(route, entry, errorPrefix, allowedModes);
     }
   };
 }

--- a/shared/ssr/createSsrLoaderPlugin.ts
+++ b/shared/ssr/createSsrLoaderPlugin.ts
@@ -13,7 +13,13 @@ import type {
   SsrMode,
   SsrModeConfig,
 } from "./types.js";
-import type { ContextNamespaceClaim, DefaultDependencies, Plugin, PluginFactory, State } from "@real-router/core";
+import type {
+  ContextNamespaceClaim,
+  DefaultDependencies,
+  Plugin,
+  PluginFactory,
+  State,
+} from "@real-router/core";
 import type { Router } from "@real-router/core/types";
 
 interface CompiledEntry<T> {
@@ -147,18 +153,22 @@ function resolveMode(
   prefix: string,
   route: string,
 ): SsrMode {
-  if (ssr === undefined || ssr === true) return "full";
+  if (ssr === undefined || ssr === true) {
+    return "full";
+  }
 
   // `ssr: false` always means client-only. Both consumers of this factory
   // (ssr-data-plugin: all modes; rsc-server-plugin: ["full", "client-only"])
   // permit client-only, so there is no reachable config that would reject it
   // here — the former defensive `if (!allowed.includes("client-only")) reject`
   // was dead code (verified by union coverage across both plugins, #809).
-  if (ssr === false) return "client-only";
+  if (ssr === false) {
+    return "client-only";
+  }
 
   const value = typeof ssr === "function" ? ssr(state) : ssr;
 
-  if (typeof value !== "string" || !allowed.includes(value as SsrMode)) {
+  if (typeof value !== "string" || !allowed.includes(value)) {
     rejectMode(value, allowed, prefix, route);
   }
 
@@ -205,12 +215,16 @@ export function createSsrLoaderPlugin<
     // release lists — same semantics, one shared rollback path.
     const acquired: ContextNamespaceClaim[] = [];
     const claim = (namespace: string): ContextNamespaceClaim => {
-      const c = api.claimContextNamespace(namespace);
-      acquired.push(c);
-      return c;
+      const handle = api.claimContextNamespace(namespace);
+
+      acquired.push(handle);
+
+      return handle;
     };
     const rollback = (): void => {
-      for (const c of acquired) c.release();
+      for (const held of acquired) {
+        held.release();
+      }
     };
 
     let dataClaim: ContextNamespaceClaim;
@@ -256,7 +270,7 @@ export function createSsrLoaderPlugin<
     // intentional `Object.keys(...)` array allocation per loader.
     const writeLoaderResult = (state: State, value: T): void => {
       if (deferredClaims !== null && isDeferred(value)) {
-        dataClaim.write(state, value.critical as T);
+        dataClaim.write(state, value.critical);
         deferredClaims.value.write(state, value.deferred);
         deferredClaims.keys.write(state, Object.keys(value.deferred));
 
@@ -270,15 +284,19 @@ export function createSsrLoaderPlugin<
       state: State,
       hydrated: Record<string, unknown>,
     ): void => {
-      if (deferredConfig === null || deferredClaims === null) return;
+      if (deferredConfig === null || deferredClaims === null) {
+        return;
+      }
 
       const keysRaw = hydrated[deferredConfig.keysNamespace];
 
-      if (!Array.isArray(keysRaw)) return;
+      if (!Array.isArray(keysRaw)) {
+        return;
+      }
 
       const keys = keysRaw.filter(
-        (k): k is string =>
-          typeof k === "string" &&
+        (key): key is string =>
+          typeof key === "string" &&
           // Defensive: drop reserved keys that would corrupt the prototype
           // chain when assigned via `[key] = …`. `{ __proto__: x }` literal
           // does the same thing and would trigger the setter on the fresh
@@ -286,20 +304,19 @@ export function createSsrLoaderPlugin<
           // pulled from Promise.prototype. With a null-prototype object
           // (below) `__proto__` is just a property, but skipping these
           // keys outright keeps the surface predictable.
-          k !== "__proto__" &&
-          k !== "constructor" &&
-          k !== "prototype",
+          key !== "__proto__" &&
+          key !== "constructor" &&
+          key !== "prototype",
       );
 
-      if (keys.length === 0) return;
+      if (keys.length === 0) {
+        return;
+      }
 
       // Null-prototype object so `[key] = …` cannot trigger the
       // `Object.prototype.__proto__` setter, even if the filter above is
       // bypassed by future refactors.
-      const promises = Object.create(null) as Record<
-        string,
-        Promise<unknown>
-      >;
+      const promises = Object.create(null) as Record<string, Promise<unknown>>;
 
       for (const key of keys) {
         promises[key] = ensureRegistryPromise(key);
@@ -321,7 +338,9 @@ export function createSsrLoaderPlugin<
     const prepareEntry = (state: State): CompiledEntry<T> | null => {
       const entry = compiled.get(state.name);
 
-      if (!entry) return null;
+      if (!entry) {
+        return null;
+      }
 
       // Static forms (the common case) — staticMode was pre-resolved at
       // compile time, skip the resolveMode if/else walk per navigation.
@@ -329,19 +348,20 @@ export function createSsrLoaderPlugin<
       // re-validate via resolveMode (catches a resolver returning a
       // foreign string at runtime).
       const mode =
-        entry.staticMode !== null
-          ? entry.staticMode
-          : resolveMode(
-              entry.modeFn,
-              state,
-              allowed,
-              config.errorPrefix,
-              state.name,
-            );
+        entry.staticMode ??
+        resolveMode(
+          entry.modeFn,
+          state,
+          allowed,
+          config.errorPrefix,
+          state.name,
+        );
 
       modeClaim.write(state, mode);
 
-      if (mode === "client-only") return null;
+      if (mode === "client-only") {
+        return null;
+      }
 
       return entry;
     };
@@ -352,7 +372,9 @@ export function createSsrLoaderPlugin<
         const state = await next(path);
         const entry = prepareEntry(state);
 
-        if (entry === null) return state;
+        if (entry === null) {
+          return state;
+        }
 
         const hydrationState = internals.hydrationState;
 
@@ -364,6 +386,7 @@ export function createSsrLoaderPlugin<
           // cast to SerializedRouterState — guard so the `in` below can't throw
           // `Cannot use 'in' operator … in undefined` (#762). A missing context
           // means "no server value for this namespace" → fall through to the loader.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the type says this is always defined and the type is a CAST: hydrateRouter widens a `{ path: string }` object-source into SerializedRouterState (#762), so a payload with no context reaches here as undefined and the `in` below would throw.
           hydrationState.context !== undefined &&
           // `in` — not `!== undefined` — is intentional. The contract is
           // "scratchpad presence wins": if the server explicitly serialised
@@ -384,7 +407,7 @@ export function createSsrLoaderPlugin<
           // exactly: an own `undefined` still counts.
           Object.hasOwn(hydrationState.context, config.namespace)
         ) {
-          dataClaim.write(state, hydrationState.context[config.namespace] as T);
+          dataClaim.write(state, hydrationState.context[config.namespace]);
           reconstructDeferredFromHydration(state, hydrationState.context);
         } else if (entry.loader !== undefined) {
           // Two-channel loader target (RFC-4 M2 / #1548): path in `params`,
@@ -406,11 +429,15 @@ export function createSsrLoaderPlugin<
     // no-entry / client-only / cancelled navigations preserve it for retry.
     const removeLeaveListener = router.subscribeLeave(
       async ({ nextRoute, signal }) => {
-        if (!isStale(router, config.namespace)) return;
+        if (!isStale(router, config.namespace)) {
+          return;
+        }
 
         const entry = prepareEntry(nextRoute);
 
-        if (entry === null || entry.loader === undefined) return;
+        if (entry?.loader === undefined) {
+          return;
+        }
 
         // Pass the navigation's signal so cancellation-aware loaders can
         // abort their in-flight work (fetch, DB query, etc.) when a newer
@@ -422,7 +449,9 @@ export function createSsrLoaderPlugin<
           { signal },
         );
 
-        if (signal.aborted) return;
+        if (signal.aborted) {
+          return;
+        }
 
         clearStale(router, config.namespace);
         writeLoaderResult(nextRoute, data);

--- a/shared/ssr/defer.ts
+++ b/shared/ssr/defer.ts
@@ -7,6 +7,17 @@ export const DEFER_BRAND: unique symbol = Symbol.for(
   "@real-router/ssr-data-plugin/defer",
 );
 
+/**
+ * Keys `defer()` refuses in `deferred`. The reconstruction path uses a
+ * null-prototype object as defence in depth; refusing them here keeps the wire
+ * format symmetric (server payload === client reconstruction).
+ */
+const RESERVED_DEFER_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 export interface DeferredPayload<
   C,
   D extends Record<string, Promise<unknown>>,
@@ -36,10 +47,11 @@ export interface DeferredPayload<
 export function defer<
   const C,
   const D extends Record<string, Promise<unknown>>,
->(options: { readonly critical: C; readonly deferred: D }): DeferredPayload<
-  C,
-  D
-> {
+>(options: {
+  readonly critical: C;
+  readonly deferred: D;
+}): DeferredPayload<C, D> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `defer` is a PUBLIC export of @real-router/ssr-data-plugin, so the parameter type binds TypeScript callers and nobody else; a JS consumer or an `any`-typed call reaches this with anything.
   if (options === null || typeof options !== "object") {
     throw new TypeError(
       "[defer] expected an object with `critical` and `deferred` fields",
@@ -47,6 +59,7 @@ export function defer<
   }
 
   if (
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- same public boundary as above.
     options.deferred === null ||
     typeof options.deferred !== "object" ||
     Array.isArray(options.deferred)
@@ -62,13 +75,14 @@ export function defer<
     // The reconstruction path uses a null-prototype object as a defence-in-depth
     // measure, but rejecting these keys upstream keeps the wire-format
     // symmetric (server-side payload === client-side reconstruction).
-    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+    if (RESERVED_DEFER_KEYS.has(key)) {
       throw new TypeError(
         `[defer] \`deferred.${key}\` is reserved — choose a different key`,
       );
     }
 
     if (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- same public boundary; the declared `D` promises thenables, a JS caller does not.
       value === null ||
       typeof value !== "object" ||
       typeof (value as { then?: unknown }).then !== "function"
@@ -94,7 +108,7 @@ export function defer<
     const maybeCatch = (value as { catch?: unknown }).catch;
 
     if (typeof maybeCatch === "function") {
-      (value as Promise<unknown>).catch(() => {
+      value.catch(() => {
         /* no-op — see comment above */
       });
     }
@@ -114,7 +128,7 @@ export function defer<
   // examined.
   return Object.freeze({
     critical: options.critical,
-    deferred: Object.freeze({ ...options.deferred }) as D,
+    deferred: Object.freeze({ ...options.deferred }),
     [DEFER_BRAND]: true,
   });
 }

--- a/shared/ssr/deferRegistryClient.ts
+++ b/shared/ssr/deferRegistryClient.ts
@@ -41,7 +41,9 @@ interface RegistryEntry {
  * `__resetRegistryForTests` references them, and it is unreachable from `.`).
  */
 export const REGISTRY_GLOBAL_KEY = "__rrDeferRegistry__";
+
 export const SETTLE_FN_NAME = "__rrDefer__";
+
 export const REJECT_FN_NAME = "__rrDeferError__";
 
 interface DeferGlobal {
@@ -55,12 +57,12 @@ function getGlobal(): DeferGlobal {
 }
 
 function getOrCreateRegistry(): Map<string, RegistryEntry> {
-  const g = getGlobal();
-  let registry = g[REGISTRY_GLOBAL_KEY];
+  const scope = getGlobal();
+  let registry = scope[REGISTRY_GLOBAL_KEY];
 
   if (registry === undefined) {
     registry = new Map<string, RegistryEntry>();
-    g[REGISTRY_GLOBAL_KEY] = registry;
+    scope[REGISTRY_GLOBAL_KEY] = registry;
   }
 
   return registry;
@@ -79,9 +81,10 @@ export function ensureRegistryPromise(key: string): Promise<unknown> {
     let resolve!: (value: unknown) => void;
     let reject!: (error: unknown) => void;
 
-    const promise = new Promise<unknown>((res, rej) => {
-      resolve = res;
-      reject = rej;
+    // eslint-disable-next-line unicorn/prefer-promise-with-resolvers -- `Promise.withResolvers` is ES2024 and this module ships to the BROWSER (it is the client-side defer registry). Checked against MDN BCD: Chrome 119, Firefox 121, Safari 17.4 — so adopting it drops every Safari below 17.4 (March 2024). The repo declares no browser floor, so that is a product decision about supported runtimes, not a lint fix, and is deliberately left to the owner rather than taken as a side effect of turning this gate on (#1913).
+    const promise = new Promise<unknown>((settle, fail) => {
+      resolve = settle;
+      reject = fail;
     });
 
     entry = { promise, resolve, reject };
@@ -93,8 +96,9 @@ export function ensureRegistryPromise(key: string): Promise<unknown> {
 
 /** Test-only — clears the global registry. Not exported from index.ts. */
 export function __resetRegistryForTests(): void {
-  const g = getGlobal();
-  delete g[REGISTRY_GLOBAL_KEY];
-  delete g[SETTLE_FN_NAME];
-  delete g[REJECT_FN_NAME];
+  const scope = getGlobal();
+
+  delete scope[REGISTRY_GLOBAL_KEY];
+  delete scope[SETTLE_FN_NAME];
+  delete scope[REJECT_FN_NAME];
 }

--- a/shared/ssr/deferWireFormat.ts
+++ b/shared/ssr/deferWireFormat.ts
@@ -110,9 +110,15 @@ const ESCAPE_FOR_SCRIPT_REGEX = new RegExp(
  *   `escapeForScript` works for both keys (parsed as JS literal) and values
  *   (parsed as JS literal containing JSON).
  *
- * The `&` → `&amp;` substitution defends against `<![CDATA[` / template
+ * The `&` → `\u0026` substitution defends against `<![CDATA[` / template
  * engine post-processing that might re-interpret HTML entities; it is not
  * strictly necessary for `<script>` body parsing but cheap and conservative.
+ *
+ * ⚠ `\u0026`, not `&amp;` — this line said the latter, and a reader who
+ * "fixed the code to match the comment" would have broken the round-trip:
+ * `&amp;` is an HTML entity, meaningless to `JSON.parse`, whereas `\u0026`
+ * is a JS/JSON escape that decodes back to `&` on both paths above. The
+ * table below is the authority.
  */
 export function escapeForScript(value: string): string {
   // The TS contract is `value: string`, but a cast at a callsite or a

--- a/shared/ssr/deferWireFormat.ts
+++ b/shared/ssr/deferWireFormat.ts
@@ -82,7 +82,7 @@ const ESCAPE_FOR_SCRIPT_TABLE: Record<string, string> = Object.fromEntries(
   ESCAPE_FOR_SCRIPT_PAIRS,
 );
 const ESCAPE_FOR_SCRIPT_REGEX = new RegExp(
-  `[${ESCAPE_FOR_SCRIPT_PAIRS.map(([c]) => c).join("")}]`,
+  `[${ESCAPE_FOR_SCRIPT_PAIRS.map(([char]) => char).join("")}]`,
   "g",
 );
 
@@ -143,7 +143,7 @@ export function escapeForScript(value: string): string {
     // built from the table's own keys, so every match has a table entry; the
     // fallback only satisfies the `string | undefined` index signature.
     /* v8 ignore next -- @preserve: TS index-access fallback, regex ⊆ table keys */
-    (c) => ESCAPE_FOR_SCRIPT_TABLE[c] ?? c,
+    (char) => ESCAPE_FOR_SCRIPT_TABLE[char] ?? char,
   );
 }
 

--- a/shared/ssr/errors.ts
+++ b/shared/ssr/errors.ts
@@ -114,8 +114,14 @@ export function withTimeout<T>(
   if (upstream?.aborted) {
     // `signal.reason` is normally set automatically by the spec
     // (`controller.abort()` without an argument yields a `DOMException`),
-    // but the field is writable, so we fall back to a fresh `AbortError`
-    // if some caller produced an aborted signal with `reason === undefined`.
+    // so the fallback below is for a signal the platform did not build.
+    //
+    // ⚠ NOT because the field is writable — it is not. Measured:
+    // `AbortSignal.prototype.reason` is an accessor whose descriptor carries
+    // `set: undefined`, so assigning to it throws in strict mode (and every
+    // module here is strict). What reaches this branch is a duck-typed
+    // `{ aborted: true, reason: undefined }` cast to `AbortSignal` — the
+    // supported-input shape, not a mutated real one.
     // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- `signal.reason` is whatever the aborter passed and the spec allows any value; forwarding it verbatim IS the contract, and the fallback below is already an Error.
     return Promise.reject(
       upstream.reason ??

--- a/shared/ssr/errors.ts
+++ b/shared/ssr/errors.ts
@@ -116,6 +116,7 @@ export function withTimeout<T>(
     // (`controller.abort()` without an argument yields a `DOMException`),
     // but the field is writable, so we fall back to a fresh `AbortError`
     // if some caller produced an aborted signal with `reason === undefined`.
+    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- `signal.reason` is whatever the aborter passed and the spec allows any value; forwarding it verbatim IS the contract, and the fallback below is already an Error.
     return Promise.reject(
       upstream.reason ??
         new DOMException("The operation was aborted.", "AbortError"),
@@ -131,6 +132,7 @@ export function withTimeout<T>(
   const timeoutPromise = new Promise<T>((_, reject) => {
     timer = setTimeout(() => {
       const error = new LoaderTimeout(routeName, ms);
+
       internal.abort(error);
       reject(error);
     }, ms);


### PR DESCRIPTION
## Summary

- `shared/` is shipped source symlinked into ten public packages, and **no lint run
  ever read it**. `eslint`'s globs do not descend into a symlinked directory while
  walking a parent, so `eslint src/` scanned each package's own files and none of
  the shared ones. A REQUIRED gate, green because it never looked.
- All 42 errors and 8 warnings behind that blind spot are resolved, and the code
  the shared code these commits touch — which ships in five packages — is linted
  for the first time.
- A repo gate makes the blindness unrepeatable: it derives each shared directory's
  lint alias **from the filesystem** and fails if the owning package stops passing
  it.

### #1913 — the gate that never looked

- **Root cause:** the symlink. `eslint packages/ssr-data-plugin/src/` scanned 8
  files and zero from `src/shared-ssr`; the same run with the alias passed
  explicitly reported 49 problems over 9 files. Verified in all three directions
  after the fix — every `.ts` in every shared dir is now scanned:

  | package | files scanned | of them shared | dir has |
  | --- | --- | --- | --- |
  | `browser-plugin` | 73 | **16** | 16 |
  | `react` | 133 | **7** | 7 |
  | `ssr-data-plugin` | 34 | **9** | 9 |

- **The alias goes to the COVERAGE OWNER, not to all ten consumers.** Otherwise the
  same nine inodes are reported two, three or five times over. That owner is
  already formal and machine-readable (`declaresSharedOwner`) and is what coverage
  and the #1838 authority suites key on — lint now follows it too.

- **The substance was four `no-unnecessary-condition`** — conditions TypeScript
  believes can never fire. Each is either dead defensive code or a type that lies;
  measured, all four are the second. `defer()` is a public export, so its parameter
  type binds TypeScript callers and nobody else; the hydration guard stands in
  front of a value whose type comes from a cast (#762). Every one keeps its guard
  and gains the written reason.

- The rest: of the 41 errors `--fix` took 24 and 17 were hand-fixed; of the 8
  warnings it took 7 and one was hand-fixed —
  short identifiers, a nullish-coalescing rewrite, a `Set` in place of three
  repeated comparisons, and one validator split into two functions to bring
  cognitive complexity from 27 under the limit of 15.

### Scope — one finding deliberately NOT taken

`Promise.withResolvers` would simplify the client-side defer registry, and a
public package already ships it. It is ES2024 — Chrome 119, Firefox 121, **Safari
17.4** (checked against MDN BCD) — and that module runs in the browser. Raising the
supported-runtime floor is a product decision, not a side effect of turning a
linter on, so the rule is disabled at that one site with the reason recorded.

### Maintainability

- Two comments in shipped source were provably false. `errors.ts` said
  `signal.reason` is writable — its descriptor carries `set: undefined` and
  assignment throws in strict mode. `deferWireFormat.ts` named the substitution
  `&` → `&amp;` when the table produces the JS escape `\u0026`; that one is
  actively dangerous,
  because "fixing the code to match the comment" breaks the JSON round-trip.
- `rsc-server-plugin/ARCHITECTURE.md` stopped pinning `file:line` ranges into the
  shared factory. Two of the three were already wrong before this branch and were
  pushed further out by it; all three are now symbol names.

## Test plan

- [x] `node --test scripts/*.test.mjs` — **88 pass, 0 fail**, RC 0. The
      coverage-scope suite grew 7 → 9 cells: one asserts every shared owner passes
      its alias to `lint` and `lint:fix`, the other that the alias is DERIVED from
      the symlink rather than hardcoded.
- [x] The new gate discriminates, mutated per owner: removing the alias from
      `browser-plugin`, `react` or `ssr-data-plugin` each turns
      `check-coverage-scope.mjs` red with a message naming the remedy; removing it
      from `lint:fix` alone also reds.
- [x] The derivation pin catches a hardcoded alias map even when a comment still
      mentions `readlinkSync(` — it reads `stripComments(script)`, not the raw file.
- [x] `turbo run lint type-check test` over the ten packages that consume a shared
      directory — **34/34 successful**.
- [x] `ssr-data-plugin` 209/209, `rsc-server-plugin` 144/144, plus
      `test:properties` and `test:stress` on both.
- [x] `node scripts/check-coverage-scope.mjs` and
      `node scripts/check-angular-dom-utils-sync.mjs` exit 0.
- [x] Behaviour-preserving, and measured rather than asserted: the validator split
      was diffed against the previous implementation on a 16-case matrix including
      inputs that violate two rules at once — 16/16 identical, same messages, same
      order.
- [x] 100% test coverage maintained.

Closes #1913
