### PR TITLE
fix(core): the channel verdict covers the bag that ships, not the one it was shown (#1927)

### DIFF
--- a/.changeset/channel-verdict-covers-shipped-bag-1927.md
+++ b/.changeset/channel-verdict-covers-shipped-bag-1927.md
@@ -1,0 +1,45 @@
+---
+"@real-router/core": patch
+---
+
+The channel verdict now covers the bag that ships (#1927)
+
+A caller's `params` bag was read twice: once by a channel guard to decide, once by
+the normaliser that builds `state.params`. Between the two reads the object still
+belongs to the application — a Proxy, a framework's reactive object, a plain
+getter — so a bag answering `undefined` while the guard looked (the documented
+removal marker, correctly waved through) and a value afterwards committed a
+**declared query name into the path channel**:
+
+```
+makeState("x", driftingBag)   state.path   /x
+                              state.params {"page":"9"}   ← declared `?page`
+                              state.search {}
+CONTROL, the honest bag { page: "9" }: refused, as it always was
+```
+
+Measured read counts of the caller's bag before the fix: `makeState` 2,
+`navigate` 3, `buildNavigationState` 3, the decoder bag on `matchPath` 3.
+
+The fix is the SAME predicate, one position later — on the canonical bag, which
+core owns and which has no accessors, so the verdict cannot be overtaken. It runs
+at the four doors that PUBLISH a State: `navigate`, `makeState`,
+`buildNavigationState`, `matchPath`.
+
+⚑ `buildPath` and `isActiveRoute` are deliberately untouched. They return a string
+and a boolean — nothing ships for a verdict to vouch for — and #1572 / #1581
+record that the render-path predicates are not instrumented: detecting there is
+fine, throwing is not. They express that the way they always have, by not calling.
+
+⚑ `canNavigateTo` is out too, and that was measured rather than assumed: adding
+the call changed no answer for any bag blindness from 0 to 3 reads, because the
+seam already sees the same key one read earlier — while costing a predicate call
+per `<Link>` per render.
+
+Behaviour change, bounded: an input that previously produced a corrupt committed
+state is now refused. A stable bag is unaffected, and `undefined` remains the
+removal marker.
+
+Four written claims this fix refutes are corrected in the same change — two code
+comments and two `CLAUDE.md` passages that each said the shape was already
+unreachable "on the same predicate". That phrase was the defect.

--- a/packages/core/src/api/getPluginApi.ts
+++ b/packages/core/src/api/getPluginApi.ts
@@ -1,3 +1,4 @@
+import { assertShippedChannelCorrect } from "../channels";
 import { buildURL, canonicalize, materialize } from "../pipeline";
 import { throwIfDisposed, throwIfReentrantTreeMutation } from "./helpers";
 import { errorCodes } from "../constants";
@@ -174,6 +175,13 @@ export function getPluginApi<
       // cannot derive from differently-merged bags. `buildURL` is usable here for
       // the same reason it is in `canNavigateTo`: this point is not the one the
       // port prints through, so there is no recursion (contrast `buildPath`).
+      assertShippedChannelCorrect(
+        "buildNavigationState",
+        canonical.name,
+        canonical.path,
+        ctx.port().queryNames(canonical.name),
+      );
+
       return materialize(canonical, {
         path: buildURL(canonical, ctx.port()),
       });

--- a/packages/core/src/channels/CLAUDE.md
+++ b/packages/core/src/channels/CLAUDE.md
@@ -35,18 +35,19 @@ The distinction inside `guard` is load-bearing (#1581): `assertChannelCorrect` n
 
 ## Why a subsystem and not a namespace method
 
-The other four always-on guards each have an owning module — `subscribe` belongs to `EventBusNamespace`, `start(path)` to `RouterLifecycleNamespace`, `navigateToNotFound` to the facade, `claimContextNamespace` to `getPluginApi`. This one has no owner, and its callers are more numerous than they look — **twelve sites in seven modules**, counted rather than recalled:
+The other four always-on guards each have an owning module — `subscribe` belongs to `EventBusNamespace`, `start(path)` to `RouterLifecycleNamespace`, `navigateToNotFound` to the facade, `claimContextNamespace` to `getPluginApi`. This one has no owner, and its callers are more numerous than they look — **sixteen sites in ten modules**, counted rather than recalled:
 
-| Site                                                | Module                                                                | Mechanism                                        |
-| --------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------ |
-| P1 raw-argument guard                               | `internals.ts`                                                        | `assertChannelCorrect`                           |
-| the `forwardState` seam                             | `Router.ts`                                                           | `assertChannelCorrect`                           |
-| `canNavigateTo`                                     | `Router.ts`                                                           | `findMisChanneledKey`                            |
-| P3 `navigateToState` — predicate **and** message    | `NavigationNamespace.ts` (×2)                                         | `findMisChanneledKey` / `misChanneledKeyMessage` |
-| the `decodeParams` boundary                         | `RoutesNamespace.ts`                                                  | `assertChannelCorrect`                           |
-| `updateRoute`'s incoming `defaultParams`            | `routesStore.ts`                                                      | `assertChannelCorrect`                           |
-| four registration entry points                      | `routesStore.ts` ×2 (`setRootPath`, `addRoute`), `getRoutesApi.ts` ×2 | `assertRouteDefaultChannelsFor`                  |
-| the store-layer adapter those four reach it through | `RoutesNamespace/helpers.ts`                                          | `assertRouteDefaultChannels`                     |
+| Site                                                          | Module                                                                                                                                                     | Mechanism                                        |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| P1 raw-argument guard                                         | `internals.ts`                                                                                                                                             | `assertChannelCorrect`                           |
+| the `forwardState` seam                                       | `Router.ts`                                                                                                                                                | `assertChannelCorrect`                           |
+| `canNavigateTo`                                               | `Router.ts`                                                                                                                                                | `findMisChanneledKey`                            |
+| P3 `navigateToState` — predicate **and** message              | `NavigationNamespace.ts` (×2)                                                                                                                              | `findMisChanneledKey` / `misChanneledKeyMessage` |
+| the `decodeParams` boundary                                   | `RoutesNamespace.ts`                                                                                                                                       | `assertChannelCorrect`                           |
+| `updateRoute`'s incoming `defaultParams`                      | `routesStore.ts`                                                                                                                                           | `assertChannelCorrect`                           |
+| four registration entry points                                | `routesStore.ts` ×2 (`setRootPath`, `addRoute`), `getRoutesApi.ts` ×2                                                                                      | `assertRouteDefaultChannelsFor`                  |
+| the four State-PUBLISHING doors, on the bag they ship (#1927) | `wiring/wireNamespaces.ts` (`navigate`), `StateNamespace.ts` (`makeState`), `getPluginApi.ts` (`buildNavigationState`), `RoutesNamespace.ts` (`matchPath`) | `assertShippedChannelCorrect`                    |
+| the store-layer adapter those four reach it through           | `RoutesNamespace/helpers.ts`                                                                                                                               | `assertRouteDefaultChannels`                     |
 
 (The two applying mechanisms add two more sites, in `pipeline/canonicalize.ts` — `withholdFilledSlots` and `admittedSearch` — which is the pipeline consuming the rule rather than a further position that checks it.)
 

--- a/packages/core/src/channels/defaults.ts
+++ b/packages/core/src/channels/defaults.ts
@@ -70,9 +70,14 @@ export function withholdFilledSlots(
     // resolving form still applied it — `buildPath` out of agreement with
     // `navigate`, printing an href its own `matchPath` does not reproduce, which
     // is the #1552/#1578 class this very rule exists to close. (`makeState`
-    // joined the literal form in Phase 4, so it withholds too; the shape stayed
-    // unreachable there because `PluginApi.makeState`'s P1 guard refuses the
-    // triggering bag on the same predicate.)
+    // joined the literal form in Phase 4, so it withholds too; the shape is
+    // unreachable there because `makeState` checks the bag it SHIPS, after the
+    // canonical channels are built (#1927).
+    //
+    // ⚠ It used to say "because P1 refuses the triggering bag on the same
+    // predicate", and "the same predicate" was the defect: P1 reads the CALLER's
+    // object and the producer reads it again, so a bag answering `undefined`
+    // while P1 looked shipped a value P1 never saw.)
     if (
       hasOwn(params, key) &&
       params[key] !== undefined &&

--- a/packages/core/src/channels/guard.ts
+++ b/packages/core/src/channels/guard.ts
@@ -129,6 +129,57 @@ export function assertChannelCorrect(
  *
  * @internal
  */
+/**
+ * The channel verdict, re-asked on the bag that actually SHIPS (#1927).
+ *
+ * Every position above a producer reads the CALLER's object — P1 at the door,
+ * the `forwardState` seam, the `decodeParams` boundary. The canonical bag is
+ * then built by a SECOND read of that same object, and between the two it still
+ * belongs to the application: a Proxy, a framework's reactive object, a plain
+ * getter. Measured before this existed: `makeState` read the bag twice and
+ * `navigate` three times, and a bag answering `undefined` while the guards
+ * looked — the documented removal marker, correctly waved through — committed a
+ * declared query name into `state.params` while `state.path` printed without it.
+ *
+ * The SAME predicate, one position later, on core's own object. A canonical bag
+ * has no accessors, so this verdict cannot be overtaken: the invariant is
+ * structural rather than maintained by care.
+ *
+ * ⚑ Called by the four doors that PUBLISH a State, and by no one else. The two
+ * render-path predicates — `buildPath` (a string) and `isActiveRoute` (a boolean)
+ * — ship no value for a verdict to vouch for, and #1572 / #1581 record that they
+ * are deliberately not instrumented: detecting there is fine, throwing is not.
+ * They express that the way they always have, by not calling.
+ *
+ * ⚠ `canNavigateTo` produces a State too and is deliberately NOT here — measured,
+ * not assumed. It discards the state, so nothing ships for a verdict to vouch
+ * for, and every bag this check would refuse it already answers `false` to: the
+ * seam sees the same key one read earlier. Adding the call changed no answer for
+ * any blindness from 0 to 3 reads, while costing one predicate call on the render
+ * path, which runs per `<Link>` per render.
+ *
+ * ⚑ On a canonical bag the `value !== undefined` arm is vacuous — those keys are
+ * already dropped — so `undefined` stays the removal marker (#1550 / #1551).
+ *
+ * ⚑ The declarations are the RESOLVED route's, which is why callers pass
+ * `canonical.name`: the bag came out of the chain, and the resolved route owns
+ * the URL that gets printed — the same authority the seam names.
+ */
+export function assertShippedChannelCorrect(
+  method: string,
+  routeName: string,
+  shipped: Params,
+  queryNames: readonly string[],
+): void {
+  assertChannelCorrect(
+    method,
+    routeName,
+    shipped,
+    queryNames,
+    "the `params` bag this call is about to ship — the channel check above it read a different value, so the caller's object answered differently between the two reads",
+  );
+}
+
 export function misChanneledKeyMessage(
   routeName: string,
   key: string,

--- a/packages/core/src/channels/index.ts
+++ b/packages/core/src/channels/index.ts
@@ -21,6 +21,7 @@
 
 export {
   assertChannelCorrect,
+  assertShippedChannelCorrect,
   findMisChanneledKey,
   misChanneledKeyMessage,
 } from "./guard";

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -8,7 +8,10 @@ import {
   urlParamsOf,
 } from "./helpers";
 import { createRoutesStore, applyRootPath, resetStore } from "./routesStore";
-import { assertChannelCorrect } from "../../channels";
+import {
+  assertChannelCorrect,
+  assertShippedChannelCorrect,
+} from "../../channels";
 import { constants, EMPTY_PARAMS, EMPTY_SEARCH } from "../../constants";
 import { mergeDefined, withoutUnsafeKey } from "../../helpers";
 import { canonicalize, materialize } from "../../pipeline";
@@ -404,6 +407,13 @@ export class RoutesNamespace<
     // applied (#1575). Both are read from ONE object, so the
     // rebuilt `state.path` and the committed `state.search` cannot derive from
     // differently-merged bags (INVARIANTS makeState #6).
+    assertShippedChannelCorrect(
+      "matchPath",
+      canonical.name,
+      canonical.path,
+      this.getQueryParams(canonical.name),
+    );
+
     const routeParams = canonical.path;
     const forwardedSearch = canonical.query;
 

--- a/packages/core/src/namespaces/StateNamespace/StateNamespace.ts
+++ b/packages/core/src/namespaces/StateNamespace/StateNamespace.ts
@@ -1,5 +1,6 @@
 // packages/core/src/namespaces/StateNamespace/StateNamespace.ts
 
+import { assertShippedChannelCorrect } from "../../channels";
 import { EMPTY_PARAMS } from "../../constants";
 import { areParamValuesEqual } from "../../helpers";
 import { buildURL, canonicalize, materialize } from "../../pipeline";
@@ -143,6 +144,13 @@ export class StateNamespace {
     // reached through `materialize`, not through this primitive. Coverage is
     // what surfaced it — the same way it caught `deps.makeState` and
     // `paramsMatchExcluding` when Phase 2 migrated their last consumers.
+    assertShippedChannelCorrect(
+      "makeState",
+      canonical.name,
+      canonical.path,
+      port.queryNames(canonical.name),
+    );
+
     return materialize<P, S>(canonical, {
       path: path ?? buildURL(canonical, port),
     });

--- a/packages/core/src/pipeline/CLAUDE.md
+++ b/packages/core/src/pipeline/CLAUDE.md
@@ -37,7 +37,7 @@ Two entry points print stage ⑤a **locally** rather than through `buildURL`, an
 
 ## Stage ③ has exactly ONE implementation
 
-`canonicalize` — since Phase 4 folded `StateNamespace.makeState` onto its LITERAL form. `makeState` used to carry a parallel copy of ③ **and** of the mode gate, which is how #1584's existence precondition came to land on one terminal and not the other. The fold was verified byte-identical across a 71-cell snapshot: the only door to `makeState` is `PluginApi.makeState`, and its P1 guard refuses exactly the bag the literal form's `withholdFilledSlots` would act on.
+`canonicalize` — since Phase 4 folded `StateNamespace.makeState` onto its LITERAL form. `makeState` used to carry a parallel copy of ③ **and** of the mode gate, which is how #1584's existence precondition came to land on one terminal and not the other. The fold was verified byte-identical across a 71-cell snapshot: the only door to `makeState` is `PluginApi.makeState`. ⚠ This line used to finish "and its P1 guard refuses exactly the bag the literal form's `withholdFilledSlots` would act on" — it does not, and could not: P1 reads the caller's object and the producer reads it again, so a bag that answers differently between the two slips past (#1927). What makes the shape unreachable is the check on the SHIPPED bag, which every State-publishing door now runs.
 
 Ordering is forced by the data, not by discipline: ③ needs the RESOLVED name (target defaults cannot be read before `forwardTo` resolves), so ① always precedes it.
 

--- a/packages/core/src/pipeline/canonicalize.ts
+++ b/packages/core/src/pipeline/canonicalize.ts
@@ -26,7 +26,14 @@ export interface CanonicalizeOptions {
    *
    * ⚠ The literal form also skips the seam's channel CHECK. The seam does not
    * SEPARATE channels — stage ② was deleted (`ba0f6b18b`), so the resolving form
-   * REFUSES a mis-channelled bag while the literal form simply does not look.
+   * REFUSES a mis-channelled bag while the literal form does not look HERE.
+   *
+   * ⚠ That is about this function, not about the door. Since #1927 every door
+   * that PUBLISHES a State — `navigate`, `makeState`, `buildNavigationState`,
+   * `matchPath` — checks the canonical bag it is about to ship, literal form or
+   * not. The two that do not are `buildPath` (returns a string) and
+   * `isActiveRoute` (returns a boolean): nothing ships, and #1572 / #1581 record
+   * that the render-path predicates are deliberately not instrumented.
    * Either way nothing is moved: a caller who rides a declared query key in the
    * `params` bag keeps it there, and the URL build prints from the query channel
    * alone. That is what makes channel-correctness the producer's contract.

--- a/packages/core/src/wiring/wireNamespaces.ts
+++ b/packages/core/src/wiring/wireNamespaces.ts
@@ -1,5 +1,6 @@
 // packages/core/src/wiring/wireNamespaces.ts
 
+import { assertShippedChannelCorrect } from "../channels";
 import { getInternals } from "../internals";
 import { COMMIT_PERMIT_TOKEN } from "../namespaces/NavigationNamespace";
 import { resolveOption } from "../namespaces/OptionsNamespace";
@@ -300,6 +301,13 @@ function wireNavigation<Dependencies extends DefaultDependencies>(
       // args), so `state.path` stays in step with `state.search`. `skipFreeze`
       // defers the freeze of the state OBJECT for the transition pipeline; the
       // channels were already frozen at merge time.
+      assertShippedChannelCorrect(
+        "navigate",
+        canonical.name,
+        canonical.path,
+        port.queryNames(canonical.name),
+      );
+
       return materialize(canonical, {
         path: buildURL(canonical, port),
         skipFreeze: true,

--- a/packages/core/tests/functional/state/channel-guard.test.ts
+++ b/packages/core/tests/functional/state/channel-guard.test.ts
@@ -262,4 +262,110 @@ describe("channel guard (#1572)", () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("the verdict must cover the value that SHIPS (#1927)", () => {
+    // The guard reads the caller's bag to decide; `normalizeChannel` reads the
+    // same bag again to build what becomes `state.params`. Between the two the
+    // object belongs to the application — a Proxy, a framework's reactive object,
+    // a plain getter. A bag that answers `undefined` while the guard looks (the
+    // documented removal marker, correctly waved through) and a value afterwards
+    // lands a declared query name in the PATH channel.
+    //
+    // `normalizeChannel`'s own docblock forbids exactly this pair — "ONE read per
+    // key, and the result is built from it. A test-then-re-read pair here would be
+    // a TOCTOU on an object the caller owns" — and the query channel had it until
+    // #1812. The pair here spans two functions, so neither could see it.
+    const blindFor = (key: string, reads: number, rest: Params): Params => {
+      const bag: Record<string, unknown> = { ...rest };
+      let seen = 0;
+
+      Object.defineProperty(bag, key, {
+        enumerable: true,
+        configurable: true,
+        get: () => (++seen <= reads ? undefined : "SHIPPED"),
+      });
+
+      return bag as Params;
+    };
+
+    it("makeState refuses a bag that answers undefined only while the guard looks", () => {
+      expect(() => api.makeState("q", blindFor("page", 1, {}))).toThrow(
+        /declares `page` as a query param/,
+      );
+    });
+
+    it("navigate refuses it too — the seam is one more read, not a second mechanism", async () => {
+      await expect(
+        router.navigate("q", blindFor("page", 2, {}), undefined, {
+          reload: true,
+        }),
+      ).rejects.toThrow(/declares `page` as a query param/);
+    });
+
+    it("CONTROL — a stable bag with the same key is refused, as it always was", () => {
+      expect(() => api.makeState("q", { page: "9" })).toThrow(
+        /declares `page` as a query param/,
+      );
+    });
+
+    it("CONTROL — an undefined value stays the removal marker, not a mis-channel", () => {
+      const state = api.makeState("q", { page: undefined });
+
+      expect(Object.hasOwn(state.params, "page")).toBe(false);
+      expect(state.path).toBe("/q");
+    });
+
+    it("buildNavigationState refuses it too — the third door P1 guards", () => {
+      expect(() =>
+        // Blind for BOTH guard reads (P1 and the seam) — measured, this door
+        // reads three times — so only the shipped-bag check can refuse it.
+        api.buildNavigationState("q", blindFor("page", 2, {})),
+      ).toThrow(/declares `page` as a query param/);
+    });
+
+    it("matchPath refuses a decoder whose bag drifts after the boundary check", () => {
+      // The decoder boundary checks `decoded.params` and `canonicalize`
+      // normalises it — the same two reads, one door further out. A decoder is
+      // application code by contract, so its output is exactly the kind of bag
+      // that can answer twice.
+      let seen = 0;
+      const drifting = createRouter([
+        {
+          name: "d",
+          path: "/d?page",
+          decodeParams: () => {
+            const bag: Record<string, unknown> = {};
+
+            Object.defineProperty(bag, "page", {
+              enumerable: true,
+              configurable: true,
+              // Blind for BOTH checks the boundary makes — measured, the decoder
+              // bag is read three times — so only the shipped-bag check refuses it.
+              get: () => (++seen <= 2 ? undefined : "SHIPPED"),
+            });
+
+            return { params: bag as Params, search: {} };
+          },
+        },
+      ]);
+
+      expect(() => getPluginApi(drifting).matchPath("/d")).toThrow(
+        /declares `page` as a query param/,
+      );
+    });
+
+    it("CONTROL — with no query names the normaliser IS read #1, so nothing is doubled", () => {
+      // The guard short-circuits on `queryNames.length === 0`, so it never reads
+      // the bag. `normalizeChannel` then gets the FIRST answer — `undefined` —
+      // and drops the key. That is the whole point: on a route with no `?`
+      // declarations there is no second read to disagree with, today or after the
+      // fix, and the added check costs a length test.
+      // `/plain/:id` needs the slot, so losing it surfaces as the matcher's own
+      // "missing required param" — which is precisely the evidence: the value the
+      // normaliser saw was read #1's `undefined`.
+      expect(() => api.makeState("plain", blindFor("id", 1, {}))).toThrow(
+        /Missing required param 'id'/,
+      );
+    });
+  });
 });

--- a/packages/core/tests/property/channelIsolation.properties.ts
+++ b/packages/core/tests/property/channelIsolation.properties.ts
@@ -137,6 +137,79 @@ describe("channel isolation — params and search meet only in the URL", () => {
   //    the route's own defaults. This is the half `separateChannels` violated:
   //    it moved a declared `?` name out of the params bag, and every producer
   //    downstream published a bag its author had not written.
+  /**
+   * The drift axis (#1927). Every property above hands the router a PLAIN bag, so
+   * the rule they state is only enforced for an object that answers the same way
+   * twice — and the router reads a caller's bag more than once by construction
+   * (a door guard, then the normaliser that builds the shipped channel).
+   *
+   * A bag that answers `undefined` while the guard looks and a value afterwards
+   * is not exotic: `undefined` is the documented removal marker, so waving it
+   * through is correct, and Vue `reactive()`, Svelte `$props()` and any getter
+   * produce a second answer without anyone writing a Proxy.
+   */
+  const driftingParams = (
+    slots: string[],
+    key: string,
+    blind: number,
+  ): Params => {
+    const bag: Record<string, unknown> = {};
+
+    for (const slot of slots) {
+      bag[slot] = VALUE;
+    }
+
+    let seen = 0;
+
+    Object.defineProperty(bag, key, {
+      enumerable: true,
+      configurable: true,
+      get: () => (++seen <= blind ? undefined : VALUE),
+    });
+
+    return bag as Params;
+  };
+
+  test.prop([arbShape, arbMode], { numRuns: NUM_RUNS.standard })(
+    "a bag that changes its answer between reads cannot smuggle a query name into the path channel",
+    async (shape, mode) => {
+      const router = createRouter([{ name: "r", path: buildRoute(shape) }], {
+        queryParamsMode: mode,
+      });
+
+      const slotPath = shape.pathSlots.map(() => `/${VALUE}`).join("");
+      const startPath = `/r${slotPath}`;
+
+      await router.start(startPath);
+
+      const api = getPluginApi(router);
+      const key = shape.queryNames[0];
+
+      // `makeState` reads the bag twice — the P1 guard, then the normaliser that
+      // builds what ships. Blind for the first is blind for every check there is.
+      expect(() =>
+        api.makeState("r", driftingParams(shape.pathSlots, key, 1)),
+      ).toThrow(new RegExp(`declares \`${key}\` as a query param`));
+
+      // CONTROL — the same drifting key in the channel it belongs to is not a
+      // mis-channel at all, whatever it answers.
+      const searchBag: Record<string, unknown> = {};
+      let seen = 0;
+
+      Object.defineProperty(searchBag, key, {
+        enumerable: true,
+        configurable: true,
+        get: () => (++seen <= 1 ? undefined : VALUE),
+      });
+
+      expect(() =>
+        api.makeState("r", bagOf(shape.pathSlots), searchBag as SearchParams),
+      ).not.toThrow();
+
+      router.stop();
+    },
+  );
+
   test.prop([arbShape, arbMode], { numRuns: NUM_RUNS.standard })(
     "a name supplied in one channel never appears in the other",
     async (shape, mode) => {


### PR DESCRIPTION
## Summary

- A caller's `params` bag was read **twice** — once by a channel guard to decide,
  once by the normaliser that builds `state.params`. Between the two reads the
  object still belongs to the application, so a bag that answered `undefined`
  while the guard looked and a value afterwards committed a **declared query name
  into the path channel**, in a frozen state whose own `state.path` printed
  without it.
- The verdict now covers the bag that ships. Same predicate, one position later,
  on an object core owns and that carries no accessors — the invariant becomes
  structural rather than maintained by care.
- A stable bag is unaffected, and `undefined` stays the documented removal marker.

### #1927 — the guard vouched for a value that never shipped

- **Root cause:** the predicate reads the caller's object and the consumer reads
  it again, and nothing carried the verdict across. Measured reads of the caller's
  bag, per door:

  | door | reads | what precedes the shipping read |
  | --- | --- | --- |
  | `navigate` | 3 | P1 + the `forwardState` seam |
  | `buildNavigationState` | 3 | P1 + the seam |
  | `matchPath` (the decoder's bag) | 3 | the boundary's two checks |
  | `makeState` | 2 | P1 only |
  | `buildPath` | 1 | none, by design (#1572) |

- The fix calls the same predicate at the **four doors that PUBLISH a State** —
  `navigate`, `makeState`, `buildNavigationState`, `matchPath` — through a thin
  `assertShippedChannelCorrect` in the subsystem, so the wording lives once.

### Scope — what is deliberately NOT instrumented

`buildPath` returns a string and `isActiveRoute` a boolean: nothing ships for a
verdict to vouch for, and #1572 / #1581 record that the render-path predicates are
not instrumented — detecting there is fine, throwing is not. They express that the
way they always have, by not calling.

`canNavigateTo` is out too, **measured rather than assumed**: adding the call
changed no answer for any bag blindness from 0 to 3 reads — the seam sees the same
key one read earlier — while costing a predicate call per `<Link>` per render.

### Three designs measured and rejected

1. **Normalise at the door and again in the pipeline** — rejected on cost:
   `normalizeChannel` measures **131 ns** at one key and **338 ns** at three.
2. **Move the check inside `normalizeChannel`** — it reads each key once and its
   own docblock forbids this exact pair, so it looked ideal. Rejected because two
   of the five guard positions are **config-time** and never reach the normaliser,
   so the predicate would exist twice — which `channels/CLAUDE.md` records the
   subsystem exists to prevent.
3. **A `skipChannelCheck` option on `canonicalize`** — written, then removed. The
   discriminator is not "does this door have a guard" but "does this call ship a
   value", and an opt-out added public surface to say what the render-path
   predicates already say by omission.

### Maintainability

Four written claims this fix refutes are corrected in the same change:
`channels/defaults.ts` and `pipeline/CLAUDE.md` each said the shape was unreachable
because P1 "refuses the triggering bag on the same predicate" — that phrase was
the defect; `CanonicalizeOptions` said the literal form "does not look", true of
the function but not of `makeState`'s door; and the site census in
`channels/CLAUDE.md` moved from twelve sites in seven modules to **sixteen in ten**.

## Test plan

- [x] **7 new functional cells** in `tests/functional/state/channel-guard.test.ts` —
      two defects, three controls (a stable bag still refused, `undefined` still
      the removal marker, a route with no query names untouched) and the two
      further doors. Fail before, pass after.
- [x] ⚠ **Two of those seven were vacuous when first written** and are recorded as
      such: both were blind for ONE read, so the SEAM refused them and the new
      check was never exercised. Both doors read three times, measured; blinding
      for two makes them discriminate. The wrapper mutant now reds four cells
      instead of two.
- [x] **1 new property**, extending `channelIsolation.properties.ts` rather than
      sitting beside it — of the **12** property files that touch channels, exactly
      one generated an accessor bag at all, and its getter THROWS (`canNavigateTo`,
      pinning that a diagnostic must not become the thing that throws). No property
      generated a bag whose VALUE differs between two reads, so the layer had no
      coverage on this axis. Runs over
      the same generated shapes across all three `queryParamsMode` values, with a
      control that the same drifting key in its OWN channel must not throw.
      Mutationally validated: removing the fix fails it with a counterexample.
- [x] Every added term mutated, `5/5`: removing the wrapper reds four cells;
      removing each door's call reds its own cell; removing `canNavigateTo`'s
      changed nothing, which is why that call is gone.
- [x] `pnpm -F @real-router/core test -- --run` — **4599 passed**.
- [x] `test:properties` **455 passed** · `test:stress` **153 passed**.
- [x] `tsc --noEmit` and `eslint --max-warnings 0` clean.
- [x] 100% test coverage maintained.

Perf is left to CI rather than asserted here; the two figures above are microbench
medians for a design that was rejected, not a claim about this one.

Closes #1927
