### PR TITLE
fix(core,persistent-params-plugin): a route's own defaults are resolved once per call (#1847)

### DIFF
--- a/.changeset/core-default-read-once-1847.md
+++ b/.changeset/core-default-read-once-1847.md
@@ -1,0 +1,36 @@
+---
+"@real-router/core": minor
+---
+
+Resolve a route's own defaults once per call (#1847)
+
+A route's `defaultParams` / `defaultSearch` is held by reference and read on
+every navigation — that aliasing is deliberate and documented. What was not
+deliberate is that the router read it **2 to 4 times per door**, so an
+accessor-backed default could answer those reads differently and two of them
+would disagree.
+
+Two faces followed, and neither lives inside a single pass:
+
+- **the committed state contradicted its own path** — one read built
+  `state.search`, a later one printed `state.path`, so a default that turned
+  defined in between printed a key the state does not carry;
+- **`buildPath` disagreed with `navigate`** on one intent, breaking the
+  documented "href equals destination" invariant (#1578): a `<Link>` rendered
+  `/u/7` and the click landed on `/u/7?tab=GHOST`.
+
+Every door now reads it exactly **once** — `buildPath`, `isActiveRoute`,
+`canNavigateTo`, `matchPath`, `makeState`, `buildNavigationState` and `navigate`
+alike — because the merge moved above the ⑤a executor, which the pipeline's port
+already documented as taking "already-merged channels", and because the
+withholding pass stopped handing the route's own object back by reference.
+
+**Why `minor`.** A default that answered differently within one navigation now
+cannot. Nothing changes for a stable one, and there is no API change — but the
+observable behaviour of an accessor-backed default does.
+
+⚠ A `buildPath` interceptor now receives the canonical channels rather than the
+caller's raw bags, which is what the navigate path has always handed it. A plugin
+that relied on seeing the raw params bag as its query source must read `search`.
+`@real-router/persistent-params-plugin` is the one such plugin in this repo and
+is updated in the same release.

--- a/.changeset/persistent-params-drop-single-bag-fallback-1847.md
+++ b/.changeset/persistent-params-drop-single-bag-fallback-1847.md
@@ -1,0 +1,32 @@
+---
+"@real-router/persistent-params-plugin": minor
+---
+
+Stop reading the caller's params bag as a query source (#1847)
+
+The `buildPath` interceptor used to fall back to the caller's **params** bag when
+no `search` was given, on the reasoning that "the matcher then reads the query out
+of `params` (`search ?? params`), so that bag is the query source here". Core
+retired that fallback — the query string is printed from the canonical query
+channel alone — and the compensation outlived its cause.
+
+It was not neutral. It made `buildPath` print an href that `navigate` refuses.
+Measured, with `?lang` declared on the root path and `?mode` on the route:
+
+```
+buildPath("a", { lang: "fr" })    → /a?lang=fr             navigate → throws TypeError
+buildPath("c", { mode: "dark" })  → /c?lang=en&mode=dark   navigate → throws TypeError
+buildPath("a", {}, { lang: "de" }) → /a?lang=de            navigate → /a?lang=de   (control)
+```
+
+A `<Link>` rendered a URL whose click throws — the divergence class core closed
+twice (#1552 / #1578), manufactured here.
+
+**Migration.** Pass a tracked value in the `search` argument, which is what this
+package's own docs have prescribed since #1572: `router.buildPath("page", {},
+{ lang: "fr" })`, not `router.buildPath("page", { lang: "fr" })`. The retired
+spelling is now ignored by `buildPath` exactly as core ignores it, and the stored
+value prints instead.
+
+Nothing changes for the supported spelling, for a path parameter, or for the
+persistence itself.

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -564,7 +564,20 @@ export class Router<
     // `search` (RFC-4 M2 / #1548) is the explicit query channel; the matcher
     // builds the query string from it and the path from `params`, resolving a
     // colliding name (`/items/:id?id`). Omitted → the v1 single-bag path.
-    return ctx.buildPath(route, normalizeChannel(params, EMPTY_PARAMS), search);
+    //
+    // ⚑ The INTENT form (#1847), not `ctx.buildPath`. That one is the ⑤a
+    // EXECUTOR, which the port documents as taking already-merged channels — so
+    // the merge belongs to whoever has an intent, and this door is the only
+    // other one that does (`buildURL` is the first). Calling the executor from
+    // here is what made it merge on its own, which cost the navigate path a
+    // SECOND `canonicalize` and a second independent read of the route's live
+    // default. Interceptors are unaffected: the intent form prints through
+    // `buildURL` → `port.buildPath` → `ctx.buildPath`, one layer below.
+    return this.#routes.buildPathFromIntent(
+      route,
+      normalizeChannel(params, EMPTY_PARAMS),
+      search,
+    );
   }
 
   // ============================================================================

--- a/packages/core/src/channels/defaults.ts
+++ b/packages/core/src/channels/defaults.ts
@@ -105,7 +105,25 @@ export function withholdFilledSlots(
     putField(kept, key, value);
   }
 
-  return dropped ? (kept as SearchParams | undefined) : defaults;
+  // ⚑ The COPY is returned on both arms (#1847). It used to hand the route's own
+  // object back whenever nothing was dropped, and that alias is the second half
+  // of the defect: the loop above has already read every key once, and
+  // `mergeWithDefault` downstream then read the LIVE object again. A route's
+  // `defaultSearch` is held by reference and read on every navigation by design,
+  // so an accessor-backed one answered those two reads independently — which is
+  // how `buildPath` came to print a key `navigate` did not ship, and the reverse.
+  //
+  // The literal form is the only caller, so this is also the only place the two
+  // doors could diverge on one intent: with one read each, they agree by
+  // construction rather than by luck.
+  if (kept !== undefined) {
+    return kept as SearchParams;
+  }
+
+  // Nothing survived. Either every key was dropped — in which case there is no
+  // default left — or `defaults` carries no own enumerable key at all, and
+  // handing that one back cannot be observed: there is nothing in it to read.
+  return dropped ? undefined : defaults;
 }
 
 /**

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -307,6 +307,23 @@ export class RoutesNamespace<
    * injects there). What changed is what they SEE on a standalone
    * `router.buildPath`: canonical channels rather than the caller's raw bags,
    * i.e. the same thing the navigate path has always handed them.
+   *
+   * ⚑ It is a TRADE, and the halves point opposite ways. Measured against
+   * `origin/master`, alternating processes, medians of 9 rounds × 150k ops, with
+   * both floors taken (A/A ≤ 2 %, B/B up to 10 % — so the first row is at the
+   * floor and its magnitude is not established, only its direction, which held
+   * in both runs of each side):
+   *
+   *     buildPath, no defaults              156 vs 146 ns    +7 %
+   *     buildPath, with defaultSearch       620 vs 567 ns    +9 %
+   *     buildNavigationState, no defaults   397 vs 514 ns   −23 %
+   *     buildNavigationState, defaultSearch 687 vs 1088 ns  −37 %
+   *
+   * This door pays one extra hop (through `buildURL` → `port.buildPath` → the
+   * interceptable wrapper) plus the copy `withholdFilledSlots` now always
+   * returns; the state-producing doors stop running `canonicalize` a second
+   * time. Both are the same edit seen from two sides, and the side that got
+   * cheaper is the one every navigation takes.
    */
   buildPathFromIntent(
     route: string,

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -14,7 +14,7 @@ import {
 } from "../../channels";
 import { constants, EMPTY_PARAMS, EMPTY_SEARCH } from "../../constants";
 import { mergeDefined, withoutUnsafeKey } from "../../helpers";
-import { canonicalize, materialize } from "../../pipeline";
+import { buildURL, canonicalize, materialize } from "../../pipeline";
 import { getTransitionPath } from "../../transitionPath";
 
 import type { RoutesStore } from "./routesStore";
@@ -238,46 +238,21 @@ export class RoutesNamespace<
       return typeof params.path === "string" ? params.path : "";
     }
 
-    // Stage ③ (each channel's route default under the caller's value — the slot
-    // IS the channel, #1549 as `ba0f6b18b` left it) plus the mode gate (#1575),
-    // one pass through the pipeline (nav-pipeline Phase 2, step 2-1). The LITERAL
-    // form: `buildPath` does not follow `forwardTo` (A.5 — `buildPath("src")`
-    // stays `/src`, a deliberate asymmetry with `navigate`), so stage ① is
-    // skipped and the seam is never entered.
-    // ⚠ The v1 single-bag form is retired here, and skipping the seam is not what
-    // retires it: the seam stopped MOVING a mis-channelled key when stage ② was
-    // deleted (`ba0f6b18b`) — it refuses one now, on the resolving form. A caller
-    // who rides a declared query key in the `params` bag simply keeps it there,
-    // and the query string is printed from `canonical.query` alone. Before this
-    // step the
-    // matcher's `search ?? params` fallback printed it out of the path bag, so
-    // `buildPath` disagreed with `navigate` on the same intent — an undeclared
-    // key in `loose` (`/t?foo=1` vs `/t`), the `/coll/:id?id` collision
-    // (`/items/V?id=V` vs `/items/V`), and a route's arbitrary `defaultParams`
-    // (`/s?theme=d` vs `/s`). All three now agree.
-    const canonical = canonicalize(this.#deps.port, route, params, search, {
-      resolveForward: false,
-    });
+    const query = search ?? EMPTY_SEARCH;
 
-    // Stage ⑤a stays LOCAL to this method rather than going through `buildURL`,
-    // and this is structural, not a preference: `buildURL` prints via
-    // `port.buildPath`, which IS the interceptable `ctx.buildPath` wrapping this
-    // very method (`Router.ts:349-359`) — routing through it would recurse. The
-    // interceptor zone therefore stays exactly where it is (#1231:
-    // `persistent-params` injects here), one layer above.
     // The route codec sees BOTH channels — `encodeParams({ params, search })` →
     // `{ params, search }` (§4) — so an encoder can shape the query as well as
     // the path.
     if (typeof this.#store.config.encoders[route] === "function") {
       const encoded = this.#store.config.encoders[route]({
-        // BOTH channels spread, and the symmetry is the point: `canonical.*` is
-        // frozen at merge time, so handing a channel through verbatim turns a
+        // BOTH channels spread, and the symmetry is the point: the channels
+        // arrive frozen from the merge, so handing one through verbatim turns a
         // codec that edits its argument in place — legal before this entry point
         // joined the pipeline, and still legal for `params` — into a silent no-op
         // (sloppy mode) or a `TypeError` (ESM). Copying `params` alone left the
         // two halves of one documented hook behaving differently.
-        params: { ...canonical.path },
-        search: { ...canonical.query },
+        params: { ...params },
+        search: { ...query },
       });
 
       return this.#store.matcher.buildPath(
@@ -290,9 +265,70 @@ export class RoutesNamespace<
 
     return this.#store.matcher.buildPath(
       route,
-      canonical.path,
-      canonical.query,
+      params,
+      query,
       this.#getBuildPathOptions(options),
+    );
+  }
+
+  /**
+   * The INTENT form of ⑤a: canonicalise, then print.
+   *
+   * ⚠ The merge lives HERE and no longer inside `buildPath` above, and that is
+   * what closes #1847. `buildPath` is wired behind `ctx.buildPath`, which the
+   * port documents as the "stage ⑤a executor — builds the URL from
+   * ALREADY-MERGED channels". Two callers reach it: this one, and `buildURL` on
+   * the navigate path, which hands it a `Canonical`. The executor merged again
+   * regardless, so a navigation ran `canonicalize` TWICE and each pass read the
+   * route's own `defaultSearch` / `defaultParams` independently — the object is
+   * held by reference and read on every navigation by design, so an
+   * accessor-backed one could answer differently between the two.
+   *
+   * Both faces of #1847 followed from that, and neither is within a pass:
+   *
+   * - `state.search` contradicting its own `state.path` — pass 1 built the
+   *   channel, pass 2 printed the URL, and a default that turned defined
+   *   between them printed a key the state does not carry;
+   * - `buildPath` disagreeing with `navigate` on one intent — the INVARIANTS
+   *   row "href equals destination" (#1578) — because the two doors shipped
+   *   different reads of the same default.
+   *
+   * One merge per call is therefore the fix, not a smaller read count: a
+   * per-pass snapshot leaves both faces standing (measured), and snapshotting at
+   * registration is refused by the config contract, which states that nested
+   * config aliases the live store and is read on every navigation.
+   *
+   * The LITERAL form: `buildPath` does not follow `forwardTo` (A.5 —
+   * `buildPath("src")` stays `/src`, a deliberate asymmetry with `navigate`), so
+   * stage ① is skipped and the seam is never entered.
+   *
+   * ⚑ Interceptors still run, and still exactly once — `buildURL` prints through
+   * `port.buildPath`, which IS `ctx.buildPath` (#1231: `persistent-params`
+   * injects there). What changed is what they SEE on a standalone
+   * `router.buildPath`: canonical channels rather than the caller's raw bags,
+   * i.e. the same thing the navigate path has always handed them.
+   */
+  buildPathFromIntent(
+    route: string,
+    rawParams?: Params,
+    search?: SearchParams,
+  ): string {
+    // Same defaulting the interceptable wrapper applies, kept here because this
+    // door is now the one that reaches the executor.
+    const params = rawParams ?? EMPTY_PARAMS;
+
+    if (route === constants.UNKNOWN_ROUTE) {
+      // Nothing to canonicalise — the URL is the payload, not an intent. The
+      // executor owns that branch; going through the port keeps the interceptor
+      // zone identical for it.
+      return this.#deps.port.buildPath(route, params, search ?? EMPTY_SEARCH);
+    }
+
+    return buildURL(
+      canonicalize(this.#deps.port, route, params, search, {
+        resolveForward: false,
+      }),
+      this.#deps.port,
     );
   }
 

--- a/packages/core/tests/functional/api/getPluginApi/addBuildPathInterceptor.test.ts
+++ b/packages/core/tests/functional/api/getPluginApi/addBuildPathInterceptor.test.ts
@@ -24,6 +24,19 @@ describe("addInterceptor('buildPath')", () => {
     }
   });
 
+  // #1847. An interceptor may hand `next` FEWER arguments than it received —
+  // `persistent-params` does exactly that with the fourth one — so the door
+  // behind the seam still defaults an omitted params bag. Core's own callers
+  // stopped exercising that arm when the merge moved above the seam: both of
+  // them (the facade's intent form and `buildURL`) now pass a defined bag.
+  it("defaults the params bag when an interceptor drops it", () => {
+    api.addInterceptor("buildPath", (next, route) => next(route));
+
+    // A route with no required slot, so dropping the bag is survivable — on
+    // `users.view` the matcher legitimately throws `Missing required param`.
+    expect(router.buildPath("home", { unused: "x" })).toBe("/home");
+  });
+
   it("transforms params in facade buildPath() calls", () => {
     api.addInterceptor("buildPath", (next, route, params) =>
       next(route, { ...params, id: "intercepted-42" }),

--- a/packages/core/tests/functional/read-count-authority.test.ts
+++ b/packages/core/tests/functional/read-count-authority.test.ts
@@ -941,3 +941,178 @@ describe("how many times core reads a caller-owned key", () => {
     router.dispose();
   });
 });
+
+/**
+ * The OTHER operand of the same merge (#1847).
+ *
+ * Everything above measures the CALLER's bag. A route's own `defaultSearch` /
+ * `defaultParams` is a caller-owned object too — `packages/core/CLAUDE.md` says
+ * nested config "aliases the live store" and is "read on every navigation", by
+ * design — so the same instrument applies to it, and until #1847 the answers
+ * were 1 to 4 depending on the door.
+ *
+ * Two faces followed, and neither lives inside one pass:
+ *
+ *   - a committed state contradicting its own path — the channel was built from
+ *     one read and the URL printed from another;
+ *   - `buildPath` disagreeing with `navigate` on one intent — INVARIANTS "href
+ *     equals destination" (#1578) — because the two doors shipped different
+ *     reads.
+ *
+ * ⚠ The direction matters and is stated in the issue: a default that turns
+ * defined LATE diverges, one that turns undefined late does not. A cell written
+ * the other way round passes on the defect.
+ */
+describe("how many times core reads the ROUTE's own default (#1847)", () => {
+  /** A `defaultSearch.tab` that logs every read and can answer differently. */
+  const makeRoute = (
+    answer: (readNumber: number) => string | undefined,
+    log: string[],
+  ): { name: string; path: string; defaultSearch: object } => {
+    let reads = 0;
+    const defaultSearch = {};
+
+    Object.defineProperty(defaultSearch, "tab", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        reads += 1;
+
+        const value = answer(reads);
+
+        log.push(String(value));
+
+        return value;
+      },
+    });
+
+    return { name: "u", path: "/u/:id?tab", defaultSearch };
+  };
+
+  const start = async (
+    answer: (readNumber: number) => string | undefined,
+  ): Promise<{ router: ReturnType<typeof createRouter>; log: string[] }> => {
+    const log: string[] = [];
+    const router = createRouter([makeRoute(answer, log)] as never);
+
+    await router.start("/u/1");
+    log.length = 0;
+
+    return { router, log };
+  };
+
+  const STABLE = (): string => "STABLE";
+
+  it("every door reads it exactly once — the whole table", async () => {
+    type Door = (
+      router: Awaited<ReturnType<typeof start>>["router"],
+    ) => unknown;
+
+    const doors: [string, Door][] = [
+      ["buildPath", (r) => r.buildPath("u", { id: "7" })],
+      ["isActiveRoute", (r) => r.isActiveRoute("u", { id: "7" })],
+      ["canNavigateTo", (r) => r.canNavigateTo("u", { id: "7" })],
+      ["matchPath", (r) => getPluginApi(r).matchPath("/u/7")],
+      ["makeState", (r) => getPluginApi(r).makeState("u", { id: "7" }, {})],
+      [
+        "buildNavigationState",
+        (r) => getPluginApi(r).buildNavigationState("u", { id: "7" }, {}),
+      ],
+    ];
+
+    const table: Record<string, number> = {};
+
+    for (const [name, call] of doors) {
+      const { router, log } = await start(STABLE);
+
+      call(router);
+      table[name] = log.length;
+      router.dispose();
+    }
+
+    const nav = await start(STABLE);
+
+    await nav.router.navigate("u", { id: "7" });
+    table.navigate = nav.log.length;
+    nav.router.dispose();
+
+    expect(table).toStrictEqual({
+      buildPath: 1,
+      isActiveRoute: 1,
+      canNavigateTo: 1,
+      matchPath: 1,
+      makeState: 1,
+      buildNavigationState: 1,
+      navigate: 1,
+    });
+  });
+
+  it("FACE 1 — the committed state agrees with its own literal path", async () => {
+    const queryOf = (p: string): string =>
+      p.includes("?") ? p.slice(p.indexOf("?") + 1) : "";
+
+    // Read the LITERAL path string. Re-matching it would read the drifting
+    // default AGAIN, which is the instrument answering itself.
+    for (const from of [2, 3, 4]) {
+      const { router, log } = await start((n) =>
+        n >= from ? "LATE" : undefined,
+      );
+
+      const state = await router.navigate("u", { id: "7" });
+      const shown = queryOf(state.path);
+
+      expect(
+        Object.keys(state.search).length === 0
+          ? ""
+          : `tab=${String(state.search.tab)}`,
+        `state.search must be what state.path shows (drift from read ${String(from)}); log ${log.join(",")}`,
+      ).toBe(shown);
+
+      router.dispose();
+    }
+  });
+
+  it("FACE 2 — buildPath prints what navigate commits", async () => {
+    // "Defined ONLY at read N": the direction that diverged. `buildPath` used to
+    // burn read 1 inside `withholdFilledSlots` and ship read 2, while `navigate`
+    // shipped read 1 — so the two doors disagreed in BOTH directions depending
+    // on which read carried the value.
+    // ⚠ Two routers with identical config, one per door. Sharing one would make
+    // the read counter CUMULATIVE across the pair, and then a default that
+    // answers differently at read 1 and read 2 legitimately gives two answers —
+    // the fix guarantees one read decides one call, not that a value which
+    // changes between a render and a click stays put.
+    for (const only of [1, 2]) {
+      const answer = (n: number): string | undefined =>
+        n === only ? "GHOST" : undefined;
+
+      const forHref = await start(answer);
+      const href = forHref.router.buildPath("u", { id: "7" });
+
+      forHref.router.dispose();
+
+      const forNav = await start(answer);
+      const committed = await forNav.router.navigate("u", { id: "7" });
+
+      forNav.router.dispose();
+
+      expect(
+        href,
+        `href must equal destination (default defined only at read ${String(only)})`,
+      ).toBe(committed.path);
+    }
+  });
+
+  it("CONTROL — a stable default still prints, so the cells above are not empty builds", async () => {
+    const { router } = await start(STABLE);
+
+    expect(router.buildPath("u", { id: "7" })).toBe("/u/7?tab=STABLE");
+
+    const committed = await router.navigate("u", { id: "7" });
+
+    expect(committed.path).toBe("/u/7?tab=STABLE");
+    expect(committed.search).toStrictEqual({ tab: "STABLE" });
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/routes/buildPath.test.ts
+++ b/packages/core/tests/functional/routes/buildPath.test.ts
@@ -775,6 +775,45 @@ describe("core/routes/routePath/buildPath", () => {
           }
         });
 
+        // #1847. `withholdFilledSlots` now returns its COPY on both arms, so the
+        // merge below it never re-reads the route's live default. These two pin
+        // what is left when the copy is empty — the branch that used to be one
+        // `return` and is now two outcomes with different meanings.
+        it("drops the default entirely when the caller filled every slot", () => {
+          const every = createRouter([
+            {
+              name: "e",
+              path: "/e/:id?tab",
+              defaultSearch: { tab: "FROM-CONFIG" },
+            },
+          ]);
+
+          // The retired single-bag spelling: `tab` is a DECLARED query name
+          // handed in the params bag, so the default is withheld and nothing
+          // survives the copy.
+          expect(every.buildPath("e", { id: "7", tab: "FROM-CALLER" })).toBe(
+            "/e/7",
+          );
+
+          // Control: leave the slot alone and the default prints.
+          expect(every.buildPath("e", { id: "7" })).toBe(
+            "/e/7?tab=FROM-CONFIG",
+          );
+
+          every.dispose();
+        });
+
+        it("survives a defaultSearch that declares the slot but carries no key", () => {
+          const empty = createRouter([
+            { name: "z", path: "/z?tab", defaultSearch: {} },
+          ]);
+
+          expect(empty.buildPath("z")).toBe("/z");
+          expect(empty.buildPath("z", {}, { tab: "v" })).toBe("/z?tab=v");
+
+          empty.dispose();
+        });
+
         it("keeps an undeclared params-bag key out of the URL", () => {
           // Renamed from "should include all enumerable properties as query
           // params" when buildPath moved onto the pipeline (Phase 2, step 2-1).

--- a/packages/persistent-params-plugin/src/plugin.ts
+++ b/packages/persistent-params-plugin/src/plugin.ts
@@ -56,11 +56,25 @@ export class PersistentParamsPlugin {
           // Persistent params are QUERY params (declared on the root path as
           // `?a&b`), so they are injected into the SEARCH channel — the channel
           // the built URL takes its query from (RFC-4 M2 / #1548, #1563) — and
-          // the path bag is handed on untouched. A v1 single-bag caller passes
-          // no `search`, and the matcher then reads the query out of `params`
-          // (`search ?? params`), so that bag is the query source here: routing
-          // it back through `search` keeps the caller's query keys on the URL
-          // without the plugin ever writing into the path channel.
+          // the path bag is handed on untouched.
+          //
+          // ⚠ It used to read the caller's PARAMS bag when `search` was absent
+          // (`navSearch ?? navParams`), on the reasoning that "the matcher then
+          // reads the query out of `params` (`search ?? params`), so that bag is
+          // the query source here". Core retired that fallback — the query
+          // string is printed from the canonical query channel alone — and since
+          // #1847 the merge happens ABOVE this seam, so `search` is always the
+          // query source and always defined by core's own two callers.
+          //
+          // Keeping the compensation was not neutral: it made `buildPath` print
+          // an href `navigate` REFUSES. Measured, `?lang` on the root path,
+          // `?mode` on the route — `buildPath("a", { lang: "fr" })` printed
+          // `/a?lang=fr` while the same intent threw `TypeError` from `navigate`
+          // (#1572). That is the #1552 / #1578 class, manufactured here.
+          //
+          // The `?? {}` stays: an interceptor registered around this one may
+          // hand `next` fewer arguments than it received.
+          //
           // Persistent (query) params and the search channel are the same
           // query-bag shape at runtime; the `Params`/`SearchParams` type split is
           // structural only, so cast across the seam.
@@ -68,7 +82,7 @@ export class PersistentParamsPlugin {
             route,
             navParams,
             this.#buildPathSearch(
-              (navSearch as unknown as Params | undefined) ?? navParams ?? {},
+              (navSearch as unknown as Params | undefined) ?? {},
             ) as unknown as SearchParams,
           ),
       );

--- a/packages/persistent-params-plugin/tests/functional/plugin.test.ts
+++ b/packages/persistent-params-plugin/tests/functional/plugin.test.ts
@@ -227,9 +227,23 @@ describe("Persistent params plugin", () => {
       // beforeEach already called router.start(), navigate to set mode from URL
       await router.navigate("route1", { id: "1" }, { mode: "dev" });
 
-      const path = router.buildPath("route2", { id: "2", mode: "test" });
+      // #1847. "Explicit" means the SEARCH argument. It used to mean the params
+      // bag too — the plugin read that bag as the query source, compensating for
+      // core's retired `search ?? params` fallback — and that made `buildPath`
+      // print an href `navigate` refuses: the same call in the params bag throws
+      // `TypeError` (#1572), pinned in `search-channel-injection.test.ts`.
+      const path = router.buildPath("route2", { id: "2" }, { mode: "test" });
 
       expect(path).toBe("/route2/2?mode=test");
+
+      // href equals destination, on the spelling that has one.
+      const committed = await router.navigate(
+        "route2",
+        { id: "2" },
+        { mode: "test" },
+      );
+
+      expect(committed.path).toBe(path);
     });
 
     it("buildPath should include stored value if explicit one is missing", async () => {

--- a/packages/persistent-params-plugin/tests/functional/search-channel-injection.test.ts
+++ b/packages/persistent-params-plugin/tests/functional/search-channel-injection.test.ts
@@ -116,25 +116,73 @@ describe("Persistent params inject into the search channel (#1563)", () => {
     router.stop();
   });
 
-  it("keeps the query keys the caller rode in the single-bag params argument", async () => {
+  // #1847. These two used to pin the plugin's single-bag fallback: it read the
+  // caller's PARAMS bag as the query source, on the reasoning that "the caller's
+  // params bag IS the query source core would read (`search ?? params`)". Core
+  // retired that fallback — the query string is printed from the canonical query
+  // channel alone — so the compensation outlived its cause and began
+  // MANUFACTURING the divergence #1552 / #1578 exist to close.
+  //
+  // Measured before the change, with `?lang` declared on the root path and
+  // `?mode` on route `c`:
+  //
+  //     buildPath("a", { lang: "fr" })   → /a?lang=fr    navigate → THROWS
+  //     buildPath("c", { mode: "dark" }) → /c?lang=en&mode=dark   navigate → THROWS
+  //
+  // An href whose click cannot navigate. Both spellings are the retired
+  // single-bag form — a DECLARED query name handed in the path bag — which this
+  // package's own CLAUDE.md already calls gone (#1572): "tracked values ride the
+  // `search` argument". `buildPath` may not throw (it is a render-path
+  // predicate, #1581), so it prints what the SUPPORTED intent gives instead, and
+  // the caller's retired-form value is ignored exactly as core ignores it.
+  it("ignores a declared query name handed in the params bag, as navigate does", async () => {
     const router = makeRouter();
 
     await router.start("/a");
 
-    expect(router.buildPath("c", { mode: "dark" })).toBe(
-      "/c?lang=en&mode=dark",
-    );
+    // The value is not honoured — the stored one prints — and the assertion
+    // below is what makes that the RIGHT answer rather than merely the new one.
+    // P1 throws SYNCHRONOUSLY on the raw argument, before any transition exists
+    // — an argument-shape defect at the API boundary, not a navigation failure.
+    expect(router.buildPath("c", { mode: "dark" })).toBe("/c?lang=en");
+    expect(() => router.navigate("c", { mode: "dark" })).toThrow(TypeError);
+
+    expect(router.buildPath("a", { lang: "fr" })).toBe("/a?lang=en");
+    expect(() => router.navigate("a", { lang: "fr" })).toThrow(TypeError);
+
+    // CONTROL — a path slot in the path bag is not a channel error, so it still
+    // builds, and the persistent value still rides the query.
     expect(router.buildPath("b", { id: "7" })).toBe("/b/7?lang=en");
 
     router.stop();
   });
 
-  it("lets the caller's value win over the stored one in either channel", async () => {
+  // #1847. Core's two callers both hand this seam a defined `search` now, so the
+  // `?? {}` inside the interceptor is reachable only from ANOTHER interceptor
+  // that drops the argument — which is not hypothetical: this plugin does
+  // exactly that with the fourth one.
+  it("still injects when an outer interceptor drops the search argument", async () => {
+    const router = makeRouter();
+
+    // Registered AFTER the plugin ⇒ outermost in the LIFO chain ⇒ it is the one
+    // calling into the plugin's interceptor.
+    getPluginApi(router).addInterceptor("buildPath", (next, name, params) =>
+      next(name, params),
+    );
+
+    await router.start("/a");
+
+    expect(router.buildPath("a")).toBe("/a?lang=en");
+
+    router.stop();
+  });
+
+  it("lets the caller's value win over the stored one, in the search channel", async () => {
     const router = makeRouter();
 
     await router.start("/a");
 
-    expect(router.buildPath("a", { lang: "fr" })).toBe("/a?lang=fr");
+    // The supported spelling, and the one the plugin's own docs prescribe.
     expect(router.buildPath("a", {}, { lang: "de" })).toBe("/a?lang=de");
 
     const viaParams = await router.navigate("b", { id: "1" }, { lang: "fr" });
@@ -144,6 +192,12 @@ describe("Persistent params inject into the search channel (#1563)", () => {
     const viaSearch = await router.navigate("b", { id: "2" }, { lang: "de" });
 
     expect(viaSearch.search).toStrictEqual({ lang: "de" });
+
+    // href equals destination on that spelling — the invariant the retired
+    // fallback was breaking.
+    expect(router.buildPath("b", { id: "2" }, { lang: "de" })).toBe(
+      viaSearch.path,
+    );
 
     router.stop();
   });


### PR DESCRIPTION
## Summary

- A route's own `defaultParams` / `defaultSearch` is held by reference and read
  on every navigation — that aliasing is documented and deliberate. Reading it
  **2 to 4 times per door** was not, and an accessor-backed default answers those
  reads independently, so two of them disagreed.
- Every door now reads it **exactly once**, on both channels.
- Four source files, and the fix is two changes that guard different faces.

### #1847 — the state contradicted its own path, and `buildPath` disagreed with `navigate`

- **Root cause:** `ctx.buildPath` is wired behind what `src/pipeline/port.ts`
  documents as the *"stage ⑤a executor — builds the URL from **already-merged
  channels**"*. It merged again anyway, so a navigation ran `canonicalize`
  **twice**; and `withholdFilledSlots` handed the route's own object back by
  reference on its no-drop arm, after its loop had already read every key, so the
  merge below read the LIVE object a second time.

| door | before | after |
| --- | --- | --- |
| `buildPath` · `isActiveRoute` | 2 | **1** |
| `canNavigateTo` · `navigate` | 3 | **1** |
| `makeState` (3-arg) | 4 | **1** |
| `buildNavigationState` | 3 | **1** |
| `matchPath` | 1 | 1 |

- **Face 1** — `state.search {}` while `state.path` printed `?tab=LATE`.
- **Face 2** — `buildPath /u/7` while `navigate` committed `/u/7?tab=GHOST`, the
  INVARIANTS row "href equals destination" (#1578). Measured in **both**
  directions: with the default defined only at read 2 the doors swap, because
  `buildPath` shipped read 2 and `navigate` read 1.
- **Fix:** the merge moves above the executor (the facade canonicalises and
  prints through `buildURL`, as the navigate path already did), and
  `withholdFilledSlots` returns its copy on both arms.

### Three designs rejected

The issue's own comment rejects a per-pass snapshot (both faces are cross-pass)
and a registration-time one (refused by the config contract — nested config
"aliases the live store" and is "read on every navigation"). A third turned out
**impossible**: threading the resolved default through the seam as an argument
cannot work, because `persistent-params` calls `next(route, params, search)` with
three arguments and **drops the fourth**.

### `persistent-params` — a fix, not a lost capability

Its `buildPath` interceptor read the caller's PARAMS bag as a query source,
justified as *"the matcher then reads the query out of `params` (`search ??
params`)"*. Core retired that fallback; the compensation stayed and began
manufacturing the divergence core closed twice:

```
buildPath("a", { lang: "fr" })     → /a?lang=fr             navigate → THROWS TypeError
buildPath("c", { mode: "dark" })   → /c?lang=en&mode=dark   navigate → THROWS TypeError
buildPath("a", {}, { lang: "de" }) → /a?lang=de             navigate → /a?lang=de   CONTROL
```

An href whose click cannot navigate. The package's own `CLAUDE.md` already calls
that spelling gone (#1572) — the code disagreed with its docs and three tests
pinned the code. Coverage then showed the fallback had become dead; it is removed.

### The trade, measured on both sides

Alternating processes, medians of 9 rounds × 150k ops, both floors taken
(A/A ≤ 2 %, B/B up to 10 %):

```
buildPath, no defaults              156 vs 146 ns    +7 %
buildPath, with defaultSearch       620 vs 567 ns    +9 %
buildNavigationState, no defaults   397 vs 514 ns   −23 %
buildNavigationState, defaultSearch 687 vs 1088 ns  −37 %
```

The first two sit AT the noisier floor, so only their direction is established —
recorded that way in the docblock rather than as a figure. The side that got
cheaper is the one every navigation takes.

### Scope

`Closes #1847` entirely. What it does NOT fix is filed as **#1938**: the double
merge, the half-canonical bags of #1849 / #1928, and the plugin needing two
interceptors for one value are one root — `ctx.buildPath` is both an interception
point and the ⑤a executor. This PR moves the merge but not the interception
point, which is exactly why the plugin's tests changed.

## Test plan

- [x] **Class guard** in `read-count-authority.test.ts` — a read-count row per
      door for the ROUTE's default, mirroring the caller-bag rows above it, plus
      one drifting cell per face and a stable-default control.
- [x] Both halves mutationally validated, and they come apart: restoring the
      alias reds the table + **Face 2**; restoring the executor's merge reds the
      table + **Face 1**. Neither half is redundant.
- [x] ⚠ The Face-2 cell uses **two routers**, one per door. Sharing one makes the
      read counter cumulative, and then a default that changes between a render
      and a click legitimately gives two answers — the fix guarantees one read
      decides one CALL. The one-router version was written first and failed.
- [x] The **`defaultParams` column** verified as well as `defaultSearch` — every
      door 1, drifting cell agrees. Only the query channel was measured at first.
- [x] Two coverage cells fell out of the change: the interceptable wrapper's
      `params ?? EMPTY_PARAMS` is now reachable only from an interceptor that
      DROPS the argument (which `persistent-params` does with the fourth), and
      `withholdFilledSlots`' new return has two outcomes with different meanings.
- [x] Three `persistent-params` cells rewritten to assert **both doors on one
      intent**, so what is pinned is agreement rather than a literal string.
- [x] `@real-router/core` — **4606** functional · **455** property · **153** stress
- [x] `@real-router/persistent-params-plugin` — **152** functional · **38** property
- [x] `browser-plugin` 412 · `hash-plugin` 108 · `navigation-plugin` 226 ·
      `search-schema-plugin` 78 · `react` 850 · `vue` 471 · `sources` 290 — unchanged
- [x] `type-check` and `lint --max-warnings 0` clean in both changed packages
- [x] 100% coverage maintained
- [x] Full pre-push graph green — build across the workspace, knip, syncpack,
      osv-scanner and semgrep all passed

Closes #1847
