### PR TITLE
fix(core): a forwardTo hop reads the caller's bag once, on both channels (#1848)

### DIFF
--- a/.changeset/hop-bag-read-once-1848.md
+++ b/.changeset/hop-bag-read-once-1848.md
@@ -1,0 +1,35 @@
+---
+"@real-router/core": minor
+---
+
+A `forwardTo` hop reads the caller's bag once, on both channels (#1848)
+
+#1812 routed both channels through `normalizeChannel` so the merge never sees an
+object the caller owns. That held for a direct navigation and not for a hop:
+`mergeDefined(undefined, bag)` short-circuits to `stripUndefined`, which reads
+every key and then returns **the same object** when there is nothing to strip, so
+the caller's bag flowed on to `canonicalize` and was read a second time.
+
+Measured, route `src → u` with the hop carrying no defaults:
+
+| door | before | after |
+| --- | --- | --- |
+| `navigate` | params 2, search 2 | 1, 1 |
+| `canNavigateTo` | params 2, search 2 | 1, 1 |
+| `isActiveRoute` | params 2, search 2 | 1, 1 |
+| `buildNavigationState` | params 2, search 2 | 1, 1 |
+
+⚠ Only a hop carrying **no** defaults leaked — the plain alias, which is the
+common one. A hop with `defaultParams` / `defaultSearch` already read once,
+because the merge allocates and the caller's bag stops flowing there.
+
+These bags are accessor-backed in practice without anyone writing a getter — Vue
+`reactive()` and Svelte `$props()` produce them — so the second read was the
+router calling into application code twice for one question. No outcome changes:
+the committed `params` / `search`, the printed URL, and what a `forwardState`
+interceptor receives are byte-identical to the previous release.
+
+Two shipped claims were false and are corrected by the guard rather than by
+prose: #1812's "the PATH channel is immune … (measured: 1 read)" is true only of
+a direct navigation, and PR #1820's "pinned by the read-count table" had no
+forwarding row to pin it with. The table has one now, per channel per door.

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -13,7 +13,11 @@ import {
   assertShippedChannelCorrect,
 } from "../../channels";
 import { constants, EMPTY_PARAMS, EMPTY_SEARCH } from "../../constants";
-import { mergeDefined, withoutUnsafeKey } from "../../helpers";
+import {
+  normalizeChannel,
+  mergeDefined,
+  withoutUnsafeKey,
+} from "../../helpers";
 import { buildURL, canonicalize, materialize } from "../../pipeline";
 import { getTransitionPath } from "../../transitionPath";
 
@@ -1087,12 +1091,50 @@ export class RoutesNamespace<
       // The caller's params stay ABOVE the path half, and their `undefined`
       // keys are stripped exactly as before — this merge runs whether or not
       // the chain contributed anything.
-      params: mergeDefined(hopDefaults as P | undefined, params),
+      // ⚑ `normalizeChannel` on the way out, and it is the whole of #1848. The
+      // `undefined` arm of `mergeDefined` is `stripUndefined`, which READS every
+      // key of the caller's bag and then returns the SAME OBJECT when there is
+      // nothing to strip — so a hop carrying NO defaults handed the caller's own
+      // bag onward, and `canonicalize` read it a SECOND time. Measured: params 2
+      // / search 2 at all four doors of the resolving form, against 1 for a
+      // direct navigation. That is a call into application code the router made
+      // twice for one question — and these bags are accessor-backed in practice
+      // without anyone writing a getter (Vue `reactive()`, Svelte `$props()`).
+      //
+      // ⚠ A hop that DOES carry defaults never leaked: `mergeDefined` allocates
+      // a merged object, so the caller's bag stops flowing there. That is why the
+      // guard cell uses a hop WITHOUT defaults — a cell built on the other shape
+      // reads once and pins nothing.
+      //
+      // ⚠ BOTH halves are load-bearing, and each was tried alone first:
+      //
+      //   • skipping `mergeDefined` alone costs no allocation and leaves the
+      //     committed state and URL byte-identical — but it changes what a
+      //     `forwardState` INTERCEPTOR sees, because the `undefined`-valued keys
+      //     the strip removed now reach it. That seam is public and
+      //     `persistent-params-plugin` sits on it;
+      //   • normalizing alone leaves the count at 2: `stripUndefined` reads the
+      //     bag inside `mergeDefined`, and `normalizeChannel` reads it again.
+      //
+      // Together they are one read and an unchanged seam — measured end to end
+      // against the pre-fix build: the interceptor's key lists, the committed
+      // `params` / `search` and the printed path are identical.
+      params: normalizeChannel(
+        hopDefaults === undefined
+          ? params
+          : mergeDefined(hopDefaults as P, params),
+        EMPTY_PARAMS,
+      ),
       // `mergeDefined`, not a spread: an explicit `undefined` from the caller is
       // ABSENCE (#1550 / #1551), so it must not delete the hop default. A spread
       // copied the `undefined` key over and killed it — asymmetric with a
       // route-level `defaultSearch`, where the rule already held.
-      search: mergeDefined(hopSearchDefaults, search) as S,
+      search: normalizeChannel(
+        hopSearchDefaults === undefined
+          ? search
+          : mergeDefined(hopSearchDefaults, search),
+        EMPTY_SEARCH,
+      ) as S,
     };
   }
 

--- a/packages/core/tests/functional/read-count-authority.test.ts
+++ b/packages/core/tests/functional/read-count-authority.test.ts
@@ -159,6 +159,129 @@ describe("how many times core reads a caller-owned key", () => {
       router.dispose();
     }
     {
+      // ⚑ A FORWARDING route, and the hop carries NO defaults — the shape the
+      // table never had (#1848). Both matter:
+      //
+      //   • forwarding, because the seam (`#layerChainDefaults`) is what hands
+      //     the bag onward, and a direct navigation never reaches it;
+      //   • no defaults, because `mergeDefined(undefined, bag)` short-circuits
+      //     to `stripUndefined`, which returns its INPUT BY REFERENCE when there
+      //     is nothing to strip. A hop that DOES carry defaults allocates a
+      //     merged object instead, so the caller's bag stops flowing and a cell
+      //     built on one would pin nothing.
+      //
+      // Measured before the fix: params 2, search 2 at all four doors of the
+      // resolving form, where a direct navigation reads 1.
+      const fwdRoutes = [
+        { name: "u", path: "/u/:id?tab" },
+        { name: "src", path: "/src/:id?tab", forwardTo: "u" },
+        { name: "elsewhere", path: "/elsewhere" },
+      ];
+      const fwdRouter = (): ReturnType<typeof createRouter> =>
+        createRouter(fwdRoutes as never);
+
+      {
+        const router = fwdRouter();
+
+        await router.start("/elsewhere");
+
+        const params = countingBag({ id: "7" });
+        const search = countingBag({ tab: "x" });
+
+        await router
+          .navigate("src", params.bag as never, search.bag as never)
+          .catch(() => undefined);
+
+        table["navigate · params (forwarding hop)"] = peak(params.reads);
+        table["navigate · search (forwarding hop)"] = peak(search.reads);
+        router.dispose();
+      }
+
+      {
+        const router = fwdRouter();
+
+        await router.start("/elsewhere");
+
+        const params = countingBag({ id: "7" });
+        const search = countingBag({ tab: "x" });
+
+        router.canNavigateTo("src", params.bag, search.bag);
+        table["canNavigateTo · params (forwarding hop)"] = peak(params.reads);
+        table["canNavigateTo · search (forwarding hop)"] = peak(search.reads);
+        router.dispose();
+      }
+
+      {
+        // ⚠ Started ON the forward TARGET. With the router anywhere else this
+        // door early-outs before the seam and reads once — a fixture that looks
+        // like a cell and measures nothing. Cost me a wrong first reading.
+        const router = fwdRouter();
+
+        await router.start("/u/7");
+
+        const params = countingBag({ id: "7" });
+        const search = countingBag({ tab: "x" });
+
+        router.isActiveRoute("src", params.bag, search.bag);
+        table["isActiveRoute · params (forwarding hop)"] = peak(params.reads);
+        table["isActiveRoute · search (forwarding hop)"] = peak(search.reads);
+        router.dispose();
+      }
+
+      {
+        const router = fwdRouter();
+        const params = countingBag({ id: "7" });
+        const search = countingBag({ tab: "x" });
+
+        getPluginApi(router).buildNavigationState(
+          "src",
+          params.bag,
+          search.bag,
+        );
+        table["buildNavigationState · params (forwarding hop)"] = peak(
+          params.reads,
+        );
+        table["buildNavigationState · search (forwarding hop)"] = peak(
+          search.reads,
+        );
+        router.dispose();
+      }
+
+      {
+        // CONTROL — the SAME doors on a hop that DOES carry defaults. It reads
+        // once today and must keep reading once, which is what makes the rows
+        // above a measurement of the leak rather than of forwarding itself.
+        const router = createRouter([
+          { name: "u", path: "/u/:id?tab" },
+          {
+            name: "src",
+            path: "/src/:id?tab",
+            forwardTo: "u",
+            defaultParams: { z: "1" },
+            defaultSearch: { w: "1" },
+          },
+          { name: "elsewhere", path: "/elsewhere" },
+        ] as never);
+
+        await router.start("/elsewhere");
+
+        const params = countingBag({ id: "7" });
+        const search = countingBag({ tab: "x" });
+
+        await router
+          .navigate("src", params.bag as never, search.bag as never)
+          .catch(() => undefined);
+
+        table["CONTROL navigate · params (hop WITH defaults)"] = peak(
+          params.reads,
+        );
+        table["CONTROL navigate · search (hop WITH defaults)"] = peak(
+          search.reads,
+        );
+        router.dispose();
+      }
+    }
+    {
       // The commit doors have no row until now, and their bags ARE caller-owned:
       // `navigateToState` takes a State a plugin built (#1792).
       const router = mk();
@@ -653,6 +776,24 @@ describe("how many times core reads a caller-owned key", () => {
       // so there is no longer a number to report. Its refusal cell lives with the
       // other two below.
       "navigate · params": 1, // normalizeChannel builds from one read per key
+
+      // ⚑ #1848 — a forwarding hop WITHOUT defaults. The seam returned the
+      // caller's own bag (`mergeDefined(undefined, bag)` → `stripUndefined` →
+      // identity), so `canonicalize` read it a SECOND time. Two shipped claims
+      // said otherwise and both were false: #1812's "the PATH channel is immune
+      // … (measured: 1 read)" is true only of a direct navigation, and PR
+      // #1820's "pinned by the read-count table" had no forwarding row to pin
+      // it with — this is that row.
+      "navigate · params (forwarding hop)": 1,
+      "navigate · search (forwarding hop)": 1,
+      "canNavigateTo · params (forwarding hop)": 1,
+      "canNavigateTo · search (forwarding hop)": 1,
+      "isActiveRoute · params (forwarding hop)": 1,
+      "isActiveRoute · search (forwarding hop)": 1,
+      "buildNavigationState · params (forwarding hop)": 1,
+      "buildNavigationState · search (forwarding hop)": 1,
+      "CONTROL navigate · params (hop WITH defaults)": 1,
+      "CONTROL navigate · search (hop WITH defaults)": 1,
       // #1812, FIXED: the query bag was read twice — `stripUndefined` tested each
       // key, then `mergeWithDefault` spread the same bag to copy it — so the key
       // was ADMITTED on one value and SHIPPED with another. Four doors reached

--- a/packages/core/tests/functional/routes/hop-bag-read-once-1848.test.ts
+++ b/packages/core/tests/functional/routes/hop-bag-read-once-1848.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getPluginApi } from "@real-router/core/api";
+
+import type { Route } from "@real-router/core/types";
+
+/**
+ * The `forwardTo` seam hands core's own bag onward (#1848).
+ *
+ * `mergeDefined(undefined, bag)` short-circuits to `stripUndefined`, which READS
+ * every key and then returns the SAME OBJECT when there is nothing to strip — so
+ * a hop carrying no defaults leaked the caller's bag to `canonicalize`, which
+ * read it again. The read COUNT is pinned by the forwarding rows in
+ * `read-count-authority.test.ts`.
+ *
+ * ⚑ This file pins the OTHER half, and it exists because mutation said the
+ * count alone does not: removing the `normalizeChannel` wrapper leaves every
+ * count at 1 and the whole suite green, because what that wrapper buys is not a
+ * count — it is that the seam keeps handing on a bag with the same SHAPE it
+ * always had. `forwardState` is a public interception point and
+ * `@real-router/persistent-params-plugin` sits on it.
+ */
+describe("the forwardTo seam's output keeps its shape (#1848)", () => {
+  const ROUTES = (): Route[] => [
+    { name: "u", path: "/u/:id?tab" },
+    { name: "src", path: "/src/:id?tab", forwardTo: "u" },
+    { name: "elsewhere", path: "/elsewhere" },
+  ];
+
+  it("an undefined-valued key never reaches a forwardState interceptor", async () => {
+    // Measured before the fix and required to stay: `stripUndefined` removed
+    // these keys on the way through, so an interceptor never saw them. Skipping
+    // `mergeDefined` alone — which fixes the read count on its own — puts them
+    // back in front of the plugin.
+    const router = createRouter(ROUTES());
+    const seen: { params: string[]; search: string[] }[] = [];
+
+    getPluginApi(router).addInterceptor(
+      "forwardState",
+      (next, name, params, search) => {
+        const resolved = next(name, params, search);
+
+        seen.push({
+          params: Object.keys(resolved.params ?? {}),
+          search: Object.keys(resolved.search ?? {}),
+        });
+
+        return resolved;
+      },
+    );
+
+    await router.start("/elsewhere");
+    await router.navigate(
+      "src",
+      { id: "7", dropMe: undefined } as never,
+      { tab: "x", alsoDrop: undefined } as never,
+    );
+
+    const atTheHop = seen.at(-1);
+
+    expect(atTheHop?.params).toStrictEqual(["id"]);
+    expect(atTheHop?.search).toStrictEqual(["tab"]);
+
+    router.dispose();
+  });
+
+  it("the seam does not hand back the caller's own object", async () => {
+    // The leak stated directly rather than through a read count: whatever the
+    // interceptor receives must not BE the object the caller passed.
+    const router = createRouter(ROUTES());
+    const callerParams = { id: "7" };
+    const callerSearch = { tab: "x" };
+    let sameParams = false;
+    let sameSearch = false;
+
+    getPluginApi(router).addInterceptor(
+      "forwardState",
+      (next, name, params, search) => {
+        const resolved = next(name, params, search);
+
+        sameParams ||= resolved.params === (callerParams as never);
+        sameSearch ||= resolved.search === (callerSearch as never);
+
+        return resolved;
+      },
+    );
+
+    await router.start("/elsewhere");
+    await router.navigate("src", callerParams as never, callerSearch as never);
+
+    expect(sameParams, "the params bag must be core's own").toBe(false);
+    expect(sameSearch, "the search bag must be core's own").toBe(false);
+
+    router.dispose();
+  });
+
+  it("CONTROL — the committed state and the URL are what they always were", async () => {
+    const router = createRouter(ROUTES());
+
+    await router.start("/elsewhere");
+
+    const state = await router.navigate(
+      "src",
+      { id: "7", dropMe: undefined } as never,
+      { tab: "x", alsoDrop: undefined } as never,
+    );
+
+    expect(state.name).toBe("u");
+    expect(state.params).toStrictEqual({ id: "7" });
+    expect(state.search).toStrictEqual({ tab: "x" });
+    expect(state.path).toBe("/u/7?tab=x");
+
+    router.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

A `forwardTo` hop read the caller's params and search bags **twice**, on both
channels. Now once — and nothing else about the seam changes.

- **The router stops calling into application code twice for one question.** These bags are accessor-backed in practice without anyone writing a getter: Vue's `reactive()` and Svelte 5's `$props()` produce them.
- **No outcome moves.** The committed `params` / `search`, the printed URL, and what a `forwardState` interceptor receives are byte-identical to the previous release.
- **The read-count table gains a forwarding row per channel per door** — the shape it never had, and the one two shipped claims said was already covered.

### #1848 — Root cause

`mergeDefined(undefined, bag)` short-circuits to `stripUndefined`, which reads
every key and then returns **the same object** when there is nothing to strip. So
the caller's bag flowed on to `canonicalize`, which read it again. Measured on
route `src → u`, hop carrying no defaults:

| door | before | after |
| --- | --- | --- |
| `navigate` | params 2, search 2 | 1, 1 |
| `canNavigateTo` | params 2, search 2 | 1, 1 |
| `isActiveRoute` | params 2, search 2 | 1, 1 |
| `buildNavigationState` | params 2, search 2 | 1, 1 |

⚠ Only a hop carrying **no** defaults leaked — the plain alias, which is the
common one. A hop with `defaultParams` / `defaultSearch` already read once,
because the merge allocates and the caller's bag stops flowing there. That is
also why the guard cell must use the defaults-free shape: a cell built on the
other one pins nothing.

⚑ **The issue's characterization is one step coarse, and the sweep sharpens it.**
It says a hop carrying no defaults leaks. Measured, the leak is **per channel**
and the two are independent — and an **empty** defaults object is enough to close
its own channel, because `mergeDefined({}, bag)` still allocates:

| hop shape | before | after |
| --- | --- | --- |
| no defaults at all | params 2, search 2 | 1, 1 |
| `defaultParams: {}` | params 1, **search 2** | 1, 1 |
| `defaultSearch: {}` | **params 2**, search 1 | 1, 1 |
| both empty | params 1, search 1 | 1, 1 — never leaked |
| chain: bare hop → hop with defaults | params 1, **search 2** | 1, 1 |

So the precise rule is "a channel with no hop default leaks", and `{}` counts as
having one. The guard cell uses the no-defaults-at-all shape because it is the
only one that leaks on both channels at once.

### The fix is two halves, and each was tried alone first

- **Skipping `mergeDefined`** when there is nothing to merge costs no allocation
  and leaves the committed state and URL byte-identical — but it changes what a
  `forwardState` **interceptor** sees, because the `undefined`-valued keys the
  strip removed reach it. That seam is public and
  `@real-router/persistent-params-plugin` sits on it.
- **Wrapping in `normalizeChannel`** alone leaves the count at 2: `stripUndefined`
  reads the bag inside `mergeDefined`, and `normalizeChannel` reads it again.

Together: one read, and a seam whose output has the shape it always had.

### Two shipped claims were false

This is what makes it a fix rather than a note. #1812 states *"The PATH channel is
immune, and that is the shape of the fix … (measured: 1 read)"* — true only of a
direct navigation, measured **2** for a forwarding one. PR #1820's changeset says
*"all … now read once … pinned by the read-count table"*, while that table had **no
forwarding row** in either direction.

### Maintainability

- **Cost measured, because the issue asked for it.** Same-session A/B, medians of
  5 × 200k iterations after 40k warmup: a forwarding navigation goes
  **752.2 → 774.1 ns/op (+2.9 %)**; the direct-route control is
  631.0 → 633.4 ns (+0.4 %, noise). About +22 ns on the forwarding path only —
  one `normalizeChannel` pass in place of a `stripUndefined` pass, plus its
  allocation. Stated because the rejected variant was free: the seam's shape was
  bought at 3 % on one path, deliberately.
- **Provenance swept rather than assumed.** `mergeDefined`'s docblock warns this
  seam receives a bag from the caller **and from the matcher**, and that its
  `UNSAFE_KEY` skip is live because of the second — a skip removed once on a
  reachability argument that was false. Four vectors diffed against
  `origin/master`, all identical: `matchPath` through a forwarding URL,
  `__proto__` arriving **from a URL** through that route, a hop carrying only one
  of the two defaults, and `isActiveRoute`'s hierarchical arm.

## Test plan

- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes for `@real-router/core` — **4670** functional tests at 100% coverage, **462** property tests
- [x] `tests/functional/read-count-authority.test.ts` — **10** new rows: params and search at each of the four resolving doors, plus two controls on a hop that DOES carry defaults, which must keep reading once
- [x] `tests/functional/routes/hop-bag-read-once-1848.test.ts` (new) — **3** cells for the other half: an `undefined`-valued key never reaching an interceptor, the seam never handing back the caller's own object by identity, and the committed state and URL unchanged
- [x] Mutation-validated, and it is why there are two files: removing the `normalizeChannel` wrapper leaves **every count at 1 and the whole suite green** — what that wrapper buys is not a count, it is the seam's shape. Removing the wrapper reds 2, removing the skip reds 1, neither reds the other
- [x] `@real-router/persistent-params-plugin`, `browser-plugin`, `ssr-utils` and `validation-plugin` pass — the first because it intercepts the seam this touches
- [x] Full pre-push gate green: `turbo run build lint:package lint:types` across every non-example package, plus `test:stress`, `lint:changeset`, `lint:duplicates`, `lint:unused`, `lint:deps`, `lint:audit` and `lint:security`

Closes #1848
