### PR TITLE
fix(core): executeNavigation reads each opts flag once (#1817)

### DIFF
--- a/.changeset/opts-read-once-1817.md
+++ b/.changeset/opts-read-once-1817.md
@@ -1,0 +1,36 @@
+---
+"@real-router/core": minor
+---
+
+`executeNavigation` reads each `opts` flag once (#1817)
+
+#1719 hoisted the navigation meta's flags at the entry, on the stated ground that
+`opts` is accessor- or Proxy-backed by contract and every read is a call into
+application code. Two readers stayed behind, and each is a place where the value
+that DECIDED and the value RECORDED in `state.transition` were different reads of
+the caller's object:
+
+- `isSameNavigation` re-read `opts.reload` (and read `opts.force`) to decide the
+  `SAME_STATES` short-circuit;
+- `forceReplaceFromUnknown`'s predicate read `opts.replace` before the hoist did.
+
+Both now take the hoisted values. Measured on a `reload` answering `true` then
+`false`, navigating to the route already committed: the reload used to be refused
+as `SAME_STATES`; the mirror direction used to navigate while recording
+`transition.reload: false`. Out of `UNKNOWN_ROUTE`, a `replace` answering `true`
+then `false` used to commit `transition.replace: false` — losing the forced
+replace whose whole purpose is keeping 404 entries out of the history.
+
+⚠ **This is not a hardening change.** Making two reads disagree needs a getter
+that answers differently between them, and the accessor-backed bags that occur in
+practice — Vue's `reactive()`, Svelte 5's `$props()` — are pass-through and
+stable. What it does is finish a rule the codebase already states about itself.
+
+⚠ **`force` moves from a lazy read to an unconditional one.** `isSameNavigation`'s
+`&&` short-circuited, so it was reached only when a `fromState` existed and
+`reload` was falsy. The total reads per navigation are never higher (4 → 4, and
+6 → 4 out of `UNKNOWN_ROUTE`), but the distribution changes.
+
+Nothing else moves: `state.transition`'s shape is identical for every option
+shape measured, including non-boolean `replace` values, which pass through
+unchanged.

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -36,26 +36,31 @@ import type {
 const NO_SEGMENTS: string[] = Object.freeze([]) as unknown as string[];
 const NO_GUARDS = new Map<string, GuardFn>();
 
-function forceReplaceFromUnknown(
+/**
+ * The substituting half of the UNKNOWN_ROUTE force, taking the DECISION rather
+ * than making it (#1817).
+ *
+ * It used to decide too — `fromState?.name === UNKNOWN_ROUTE && !opts.replace` —
+ * which read the caller's `replace` one read BEFORE the entry hoisted it. On a
+ * drifting getter the two disagreed and the forced replace was LOST: the
+ * predicate saw `true` ("the caller already asked, nothing to substitute") while
+ * the meta recorded `false`, so a URL plugin reading `transition.replace` pushes
+ * a history entry where this mechanism exists to replace one.
+ */
+function substituteForcedReplace(
   opts: NavigationOptions,
-  fromState: State | undefined,
+  forced: boolean,
 ): NavigationOptions {
-  return fromState?.name === constants.UNKNOWN_ROUTE && !opts.replace
-    ? { ...opts, replace: true }
-    : opts;
+  return forced ? { ...opts, replace: true } : opts;
 }
 
 function isSameNavigation(
   fromState: State | undefined,
-  opts: NavigationOptions,
+  reload: boolean | undefined,
+  force: boolean | undefined,
   toState: State,
 ): boolean {
-  return (
-    !!fromState &&
-    !opts.reload &&
-    !opts.force &&
-    fromState.path === toState.path
-  );
+  return !!fromState && !reload && !force && fromState.path === toState.path;
 }
 
 /**
@@ -355,15 +360,51 @@ export function executeNavigation(
     const abortedAtEntry =
       externalSignal?.aborted === true ? externalSignal : undefined;
 
-    opts = forceReplaceFromUnknown(opts, fromState);
-
-    // Read AFTER the force: it substitutes the object, setting `replace: true`.
+    // ⚑ EVERY flag hoisted here, above both readers, and #1817 is the residue
+    // that made it necessary. #1719 hoisted three of them on the stated ground
+    // that `opts` is accessor- or Proxy-backed BY CONTRACT, so each read is a
+    // call into application code — and left two readers behind:
+    // `forceReplaceFromUnknown`'s predicate, which ran BEFORE the hoist, and
+    // `isSameNavigation`, which re-read `reload` and read `force` after it. So
+    // the value that DECIDED and the value RECORDED in `state.transition` were
+    // two different reads of the caller's object.
+    //
+    // ⚠ What this is and is not. It finishes a rule the codebase already states
+    // about itself, and adds no check. It is NOT a safety fix: making two reads
+    // disagree needs a getter that answers differently between them, and the
+    // accessor-backed bags that occur in practice (Vue `reactive()`, Svelte
+    // `$props()`) are pass-through and stable. The drift is the INSTRUMENT the
+    // guard cells use to make the read count observable, exactly as a stable
+    // `toString` measures nothing in the route-name family.
+    //
+    // ⚠ `force` moves from a LAZY read to an unconditional one, so the count is
+    // not uniformly lower — measured per arc:
+    //
+    //     arc                         before                after
+    //     to a different route        reload 2, force 0     reload 1, force 1
+    //     same route, reload: true    reload 2, force 0     reload 1, force 1
+    //     same route, reload: false   reload 2, force 1     reload 1, force 1
+    //     out of UNKNOWN_ROUTE        reload 2, replace 2   reload 1, replace 1
+    //
+    // `isSameNavigation`'s `&&` short-circuited, so `force` was reached only when
+    // a `fromState` existed and `reload` was falsy. The TOTAL per navigation is
+    // never higher (4 -> 4, and 6 -> 4 out of UNKNOWN_ROUTE), and one read per
+    // field at the entry is the rule this file is held to — reproducing the
+    // short-circuit would put the hoist back in the business of knowing what the
+    // pre-check does internally, which is the coupling #1719 was undoing.
     const reload = opts.reload;
-    const replace = opts.replace;
+    const force = opts.force;
+    const replaceRequested = opts.replace;
     const redirected = opts.redirected;
     const forceDeactivate = opts.forceDeactivate === true;
 
-    if (isSameNavigation(fromState, opts, toState)) {
+    const forcedReplace =
+      fromState?.name === constants.UNKNOWN_ROUTE && !replaceRequested;
+    const replace = forcedReplace || replaceRequested;
+
+    opts = substituteForcedReplace(opts, forcedReplace);
+
+    if (isSameNavigation(fromState, reload, force, toState)) {
       deps.emitTransitionError(toState, fromState, CACHED_SAME_STATES_ERROR);
 
       return CACHED_SAME_STATES_REJECTION;

--- a/packages/core/tests/functional/navigation/entry-reads-opts-once.test.ts
+++ b/packages/core/tests/functional/navigation/entry-reads-opts-once.test.ts
@@ -98,9 +98,16 @@ describe("the caller's `opts` is read at the entry, once", () => {
     expect(reads.beginTransition ?? []).toStrictEqual([]);
   });
 
-  it("only the entry and the two pre-checks read it, and each field once", () => {
-    // A closed set, keyed by function — a read appearing in a THIRD place is a
+  it("ONLY the entry reads it, and each field once", () => {
+    // A closed set, keyed by function — a read appearing in a SECOND place is a
     // failure, not a re-sort.
+    //
+    // ⚑ It used to be three functions, and the other two were this guard's own
+    // residue (#1817). `forceReplaceFromUnknown` read `replace` in its predicate
+    // BEFORE the entry hoisted it, and `isSameNavigation` re-read `reload` and
+    // read `force` after — so the value that DECIDED and the value recorded in
+    // `state.transition` were two different reads of the caller's object. Both
+    // now take parameters, and the entry is the only site.
     const sites = Object.fromEntries(
       Object.entries(reads).map(([fn, fields]) => [
         fn,
@@ -109,11 +116,11 @@ describe("the caller's `opts` is read at the entry, once", () => {
     );
 
     expect(sites).toStrictEqual({
-      // The pre-checks, which run before the entry snapshot exists.
-      forceReplaceFromUnknown: ["replace"],
-      isSameNavigation: ["force", "reload"],
-      // The entry itself: every value the pipeline carries downstream.
+      // The entry, and nothing else: every value the pipeline carries
+      // downstream, plus `force`, which only the same-state pre-check needs and
+      // which is now handed to it rather than fetched by it.
       executeNavigation: [
+        "force",
         "forceDeactivate",
         "redirected",
         "reload",

--- a/packages/core/tests/functional/navigation/opts-read-once-1817.test.ts
+++ b/packages/core/tests/functional/navigation/opts-read-once-1817.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+
+import type { Route } from "@real-router/core/types";
+
+/**
+ * `executeNavigation` reads each `opts` flag ONCE (#1817, residual of #1719).
+ *
+ * #1719 hoisted `reload` / `replace` / `redirected` at the entry, on the stated
+ * ground that `opts` is accessor- or Proxy-backed BY CONTRACT and every read is a
+ * call into application code. Two readers stayed behind:
+ *
+ *   • `isSameNavigation`, which re-read `opts.reload` (and read `opts.force`) to
+ *     decide the `SAME_STATES` short-circuit — so the flag that DECIDED and the
+ *     flag that was RECORDED in `state.transition` were two different reads;
+ *   • `forceReplaceFromUnknown`, whose predicate read `opts.replace` before the
+ *     hoist did.
+ *
+ * ⚑ The rule these cells encode is the one this family has settled on: a door
+ * answers as its FIRST read names.
+ */
+describe("executeNavigation reads each opts flag once (#1817)", () => {
+  const ROUTES = [
+    { name: "a", path: "/a" },
+    { name: "b", path: "/b" },
+  ] as unknown as Route[];
+
+  /** An `opts` whose named flags answer from a per-key script, one entry per read. */
+  const driftingOpts = (
+    script: Readonly<Record<string, readonly unknown[]>>,
+  ): { opts: object; reads: Record<string, number> } => {
+    const reads: Record<string, number> = {};
+
+    for (const key of Object.keys(script)) {
+      reads[key] = 0;
+    }
+
+    const opts = new Proxy(
+      {},
+      {
+        get(_target, key) {
+          if (typeof key !== "string" || !(key in script)) {
+            return;
+          }
+
+          const answers = script[key];
+
+          reads[key] += 1;
+
+          return answers[Math.min(reads[key] - 1, answers.length - 1)];
+        },
+        has: (_target, key) => typeof key === "string" && key in script,
+        ownKeys: () => Object.keys(script),
+        getOwnPropertyDescriptor: () => ({
+          enumerable: true,
+          configurable: true,
+        }),
+      },
+    );
+
+    return { opts, reads };
+  };
+
+  it("a reload requested by the FIRST read is honoured", async () => {
+    // Measured before the fix: rejected `SAME_STATES`. The hoist read `true` and
+    // built the meta from it; `isSameNavigation` read `false` a moment later and
+    // refused. The caller asked for a reload and was silently declined.
+    const router = createRouter(ROUTES);
+
+    await router.start("/a");
+
+    const { opts, reads } = driftingOpts({ reload: [true, false] });
+    const state = await router.navigate("a", {}, {}, opts as never);
+
+    expect(state.name).toBe("a");
+    expect(state.transition?.reload).toBe(true);
+    expect(reads.reload, "one read decides and records").toBe(1);
+
+    router.dispose();
+  });
+
+  it("a reload DENIED by the first read stays denied", async () => {
+    // The mirror, and it used to succeed while recording `reload: false` — the
+    // committed `transition` carried the value that did NOT decide.
+    const router = createRouter(ROUTES);
+
+    await router.start("/a");
+
+    const { opts, reads } = driftingOpts({ reload: [false, true] });
+
+    await expect(
+      router.navigate("a", {}, {}, opts as never),
+    ).rejects.toMatchObject({ code: "SAME_STATES" });
+
+    expect(reads.reload).toBe(1);
+
+    router.dispose();
+  });
+
+  it("the forced replace out of UNKNOWN_ROUTE is not lost to a second read", async () => {
+    // ⚠ Not in the issue's body beyond "read twice", and it is the sharpest of
+    // the three: `forceReplaceFromUnknown` exists so a 404 entry does not
+    // pollute history. Its predicate saw `true` — "the caller already asked for
+    // replace, nothing to substitute" — and the meta then recorded `false`, so a
+    // URL plugin reading `transition.replace` pushes where it must replace.
+    const router = createRouter(ROUTES, { allowNotFound: true });
+
+    await router.start("/nowhere");
+
+    expect(router.getState()?.name).toBe("@@router/UNKNOWN_ROUTE");
+
+    const { opts, reads } = driftingOpts({ replace: [true, false] });
+    const state = await router.navigate("b", {}, {}, opts as never);
+
+    expect(state.transition?.replace).toBe(true);
+    expect(reads.replace, "the predicate and the meta share one read").toBe(1);
+
+    router.dispose();
+  });
+
+  it("CONTROL — stable opts behave exactly as before, on every arm", async () => {
+    const router = createRouter(ROUTES, { allowNotFound: true });
+
+    await router.start("/a");
+
+    const reloaded = await router.navigate("a", {}, {}, { reload: true });
+
+    expect(reloaded.transition?.reload).toBe(true);
+
+    await expect(
+      router.navigate("a", {}, {}, { reload: false }),
+    ).rejects.toMatchObject({ code: "SAME_STATES" });
+
+    const moved = await router.navigate("b", {}, {}, { replace: true });
+
+    expect(moved.transition?.replace).toBe(true);
+
+    router.dispose();
+  });
+
+  it("CONTROL — force short-circuits the same-state check, from one read", async () => {
+    // `opts.force` was read ONLY inside `isSameNavigation`, so it has no
+    // second read to disagree with — but it moves to the hoist with the others,
+    // and this pins that its meaning is unchanged.
+    const router = createRouter(ROUTES);
+
+    await router.start("/a");
+
+    const forced = await router.navigate("a", {}, {}, {
+      force: true,
+    } as never);
+
+    expect(forced.name).toBe("a");
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/read-count-authority.test.ts
+++ b/packages/core/tests/functional/read-count-authority.test.ts
@@ -924,7 +924,11 @@ describe("how many times core reads a caller-owned key", () => {
       // the SAME_STATES short-circuit. `packages/core/CLAUDE.md` asserts this is
       // 1. It is not, and `state.transition.reload` can record the value that did
       // NOT decide the outcome.
-      "navigate · opts.reload": 2,
+      // ⚑ Was 2, and the table pinned the defect rather than the rule (#1817):
+      // the entry hoisted `reload` and `isSameNavigation` read it again, so the
+      // flag that DECIDED the SAME_STATES short-circuit and the flag recorded in
+      // `state.transition` were two different reads of the caller's object.
+      "navigate · opts.reload": 1,
 
       // #1899 / #1789 — ONE read per own key, since registration snapshots the
       // batch (`snapshotRouteBatch`). These two rows are


### PR DESCRIPTION
## Summary

`executeNavigation` read two of the caller's `opts` flags twice, so the value
that **decided** a navigation and the value **recorded** in `state.transition`
could be two different reads.

- **A requested reload is no longer silently refused**, and the committed `transition.reload` is the flag that actually decided.
- **The forced replace out of `UNKNOWN_ROUTE` cannot be lost**, so a 404 entry cannot slip into the history as a push.
- Each `opts` field is read exactly once, at the entry, and the structural guard that says so no longer carries exceptions.

### #1817 — Root cause

#1719 hoisted the meta's flags at the entry, on the stated ground that `opts` is
accessor- or Proxy-backed **by contract**. Two readers stayed behind — and
#1719's own guard, `entry-reads-opts-once.test.ts`, listed them as legal
exceptions, so the residue was written down as intended:

```
forceReplaceFromUnknown: ["replace"]           <- predicate, ran BEFORE the hoist
isSameNavigation:        ["force", "reload"]   <- ran after it
```

Measured, router on `/a`, navigating to `a`:

| `reload` answers | before | after |
| --- | --- | --- |
| `true` then `false` | rejected `SAME_STATES` | navigates, `transition.reload: true` |
| `false` then `true` | navigates, records `transition.reload: false` | rejected `SAME_STATES` |

Both directions are one defect from opposite ends.

⚑ **The third arc is sharper than the issue states**, which names it only as
"read twice". Out of `UNKNOWN_ROUTE`, a `replace` answering `true` then `false`
committed `transition.replace: false`. `forceReplaceFromUnknown` exists so a 404
entry does not pollute history; its predicate saw `true` — "the caller already
asked, nothing to substitute" — and the meta recorded `false`, so a URL plugin
reading that flag pushes where the mechanism exists to replace.

### What this is not

**Not a hardening change.** Making two reads disagree needs a getter that answers
differently between them, and the accessor-backed bags that occur in practice —
Vue's `reactive()`, Svelte 5's `$props()` — are pass-through and stable. What it
does is finish a rule the codebase already states about itself, and take a read
off the navigate path. The drifting getter is the **instrument** the guard cells
need: a stable bag answers the same twice and measures nothing, exactly as a
stable `toString` does in the route-name family.

### Maintainability

⚠ **`force` moves from a lazy read to an unconditional one**, so the count is not
uniformly lower:

| arc | before | after |
| --- | --- | --- |
| to a different route | reload 2, force 0 | reload 1, force 1 |
| same route, `reload: true` | reload 2, force 0 | reload 1, force 1 |
| same route, `reload: false` | reload 2, force 1 | reload 1, force 1 |
| out of `UNKNOWN_ROUTE` | reload 2, replace 2 | reload 1, replace 1 |

`isSameNavigation`'s `&&` short-circuited, so `force` was reached only when a
`fromState` existed and `reload` was falsy. The total per navigation is never
higher (4 → 4, and 6 → 4 out of `UNKNOWN_ROUTE`). Reproducing the short-circuit
would put the hoist back in the business of knowing what the pre-check does
internally — the coupling #1719 was undoing — so it is recorded rather than
restored.

## Test plan

- [x] `pnpm type-check && pnpm lint && pnpm test -- --run` passes for `@real-router/core` — **4675** functional tests at 100% coverage, **462** property tests
- [x] `tests/functional/navigation/opts-read-once-1817.test.ts` (new) — **5** cells: one per damage direction, the `UNKNOWN_ROUTE` arc, and two controls on stable opts
- [x] `entry-reads-opts-once.test.ts` — its expected map loses both exceptions. ⚠ Relaxing a guard's expectations demands proof it still guards: re-introducing the `isSameNavigation` reader reds **4** cells, the `replace` predicate **2**
- [x] `read-count-authority.test.ts` — the row pinned `"navigate · opts.reload": 2`, i.e. the table recorded the defect as the rule. It is 1
- [x] Behaviour diffed against `origin/master` rather than assumed: `state.transition`'s shape is identical across six option shapes, including non-boolean `replace` (`1`, `"yes"`, `0` pass through unchanged; `0` out of `UNKNOWN_ROUTE` still forces `true`), and `opts.signal`'s read count is untouched
- [x] The seven packages that consume `transition.replace` or pass `opts`: browser-plugin **412**, hash-plugin **108**, navigation-plugin **226**, memory-plugin **51**, ssr-utils **78**, validation-plugin **774**, persistent-params-plugin **152**
- [x] Full pre-push gate green: `turbo run build lint:package lint:types` across every non-example package, plus `test:stress`, `lint:changeset`, `lint:duplicates`, `lint:unused`, `lint:deps`, `lint:audit` and `lint:security`

Closes #1817
