### PR TITLE
fix(core): RouterError field access answers about OWN fields only (#1829) + withhold `__proto__` from every container core hands out (#1957)

### DIFF
--- a/.changeset/handed-out-containers-proto.md
+++ b/.changeset/handed-out-containers-proto.md
@@ -1,0 +1,63 @@
+---
+"@real-router/core": patch
+---
+
+fix: what core hands out is no longer a prototype-swap primitive (#1957)
+
+An own `"__proto__"` on a container is inert while it sits there and becomes a
+prototype swap the moment a consumer merges it with `Object.assign` or a `for…in`
+copy — both `[[Set]]` that name on the TARGET, where `Object.prototype`'s
+accessor replaces the target's prototype instead of adding an entry. (A spread
+is safe: it defines rather than sets.) `JSON.parse` and
+`Object.fromEntries(new URLSearchParams(…))` both mint the key, so no
+adversarial construction is involved.
+
+`getDependenciesApi(router).getAll()` was hardened this way at #1823. Four more
+doors had the same shape and no such withholding:
+
+```js
+const r = createRouter(routes, JSON.parse('{"defaultRoute":"home","__proto__":{"pwned":"YES"}}'));
+
+Object.assign({}, getPluginApi(r).getOptions()).pwned; // was "YES" -> now undefined
+```
+
+- `getPluginApi(router).getOptions()` — and with it
+  `getInternals(router).getCloneState().options`, so a clone's options were
+  polluted too. One fix covers both because it is applied at the SOURCE, in the
+  `OptionsNamespace` constructor: the two doors are not one object (the second
+  is an unfrozen spread of the first).
+- `getInternals(router).getCloneState().dependencies`.
+- `getInternals(router).getMetaForState(name)` for a route named `__proto__`.
+- the `NavigationOptions` a plugin's `onTransitionSuccess` receives, on the two
+  arcs where core MINTS the object (`stripSignal`, and the forced replace out of
+  `UNKNOWN_ROUTE`).
+
+Two shapes, picked by one question — does core read that key back off the very
+object it published?
+
+- **No → the key is dropped.** The copy exists only to be handed out.
+- **Yes → the key is withheld from ENUMERATION** (a non-enumerable own
+  property), at exactly one site: the route-meta record. Dropping is not a
+  milder fix there but a wrong one — core reads `meta[segmentName]` on every
+  navigation, so with the entry gone the read reaches the inherited accessor and
+  answers `Object.prototype`, an object with no keys, i.e. "params unchanged".
+  Measured: a route named `__proto__` stops re-activating when its `:id`
+  changes.
+
+⚠ **Behaviour change.** A dependency literally named `__proto__` is still held
+by the base router and still answered by `get()`, but it no longer reaches a
+`cloneRouter` clone. That is the trade #1823 already took at `getAll()`: a
+single read hands back a VALUE, a door hands back a CONTAINER someone will
+merge, and only the second is withheld.
+
+⚠ The fix reaches the TOP level of each container and no further. One level
+down are the caller's own objects, handed back by reference under core's
+one-level copy model (#1958) — `getOptions().defaultParams` and a dependency's
+value still carry whatever the caller put there. Pinned, not assumed.
+
+Five doors stay exempt, each with a measured reason recorded in
+`tests/functional/handed-out-containers-1957.test.ts`: `state.context` (#1191)
+and a route's custom fields (#1788), both prior owner decisions; `forwardState`'s
+bags and the un-forced `NavigationOptions` arc, where the container is the
+caller's own object and core minted nothing; and the internals handle, which
+exists to hand out core's live stores.

--- a/.changeset/router-error-own-fields.md
+++ b/.changeset/router-error-own-fields.md
@@ -1,0 +1,33 @@
+---
+"@real-router/core": patch
+---
+
+fix: `RouterError.hasField` / `getField` answer about OWN fields only (#1829)
+
+Both walked the prototype chain — `key in this` and `this[key]` — so an error
+carrying ONE custom field answered `true` for eighteen names and handed back native
+methods for most of them:
+
+```js
+const err = new RouterError("SOME_CODE", { userId: "u1" });
+
+err.hasField("toString");        // was true  -> now false
+typeof err.getField("toString"); // was "function" -> now "undefined"
+err.hasField("constructor");     // was true  -> now false
+err.hasField("userId");          // true, unchanged
+```
+
+Twelve of those are `Object.prototype`'s members and six are the class's own
+methods. `toString` and `constructor` are ordinary strings — they arrive from a
+config key, a route param name, a serialized payload.
+
+Every field the JSDoc promises still answers: `code`, `segment`, `path` and any
+custom field are OWN properties, so `Object.hasOwn` keeps all four worked
+examples while removing all eighteen false positives.
+
+⚠ Behaviour change for a consumer that relied on the chain: `hasField` /
+`getField` no longer reach `Object.prototype` members or the class's methods.
+Both are public API with no call site in any `src/`, so this is a contract
+correction rather than an internal one. The property tier did exercise them —
+but its "non-existent field" generator prefixes and suffixes the random key, so
+10 000 runs could never produce `toString`; the reachable half was added.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1071,6 +1071,79 @@ cannot see, and it was hiding two live sites in the matcher's junction walk.
   rule is the plugin author's too — four shipped plugins were copying a caller's
   bag into records of their own.
 
+### The HAND-OUT side, and the one question that picks the fix (#1957)
+
+The two sides above are about a key core READS off a caller's bag and a key core
+WRITES into a record of its own. The third is what core hands BACK: a container
+carrying an own `"__proto__"` is inert while it sits there and becomes a
+prototype-swap primitive the moment a consumer merges it with `Object.assign` or
+a `for…in` copy — both `[[Set]]` that name on the TARGET, where
+`Object.prototype`'s accessor replaces the target's prototype.
+
+⚠ A SPREAD is **not** one of them. `{ ...container }` performs
+`CreateDataProperty`, so it never reaches an inherited accessor — measured on a
+`JSON.parse`d bag, a null-prototype carrier and a pass-through Proxy, it swaps in
+none of the three. #1823 stated the pair correctly and a first revision of this
+section widened it to include the spread; the hazard is real and narrower than
+that. It is also why the derived guard measures with `Object.assign` only.
+
+⚠ The SOURCE's own prototype decides nothing — measured, an
+`Object.create(null)` container swaps the merge target exactly the same — so
+`emptyRecord` is not a fix at a hand-out door and never was. Only two things
+work: remove the key, or remove it from ENUMERATION. Which one is decided by a
+single question — **does core read that key back off the very object it
+published?**
+
+- **No → `dropUnsafeKey`** (`src/helpers.ts`), the shape `getAll` found at
+  #1823, now serving four doors: the router options at their SOURCE (the
+  `OptionsNamespace` constructor, which is above both `getOptions()` and
+  `getCloneState().options` — measured, those are two objects and not one, the
+  second an unfrozen spread of the first), the dependency clone transport,
+  `getAll` itself, and the two `NavigationOptions` a plugin hook receives that
+  core MINTS — `stripSignal`'s rest-destructuring and the forced-replace
+  substitution. Unconditional, and the delete is measured as free: on the
+  long-lived options object, which every navigation reads, deleting an ABSENT
+  key leaves the hidden class alone (−1.0 %, i.e. noise). ⚠ It MUTATES, so it
+  takes only an object core allocated one expression earlier: on a frozen
+  container carrying the key it throws (measured, and the right failure — a
+  silent no-op would publish the key).
+- **Yes → `concealUnsafeKey`** (`src/utils/ingest.ts`), used at exactly one
+  site: the matcher's route-meta record, whose keys are ROUTE NAMES and which
+  `segmentParamsEqual` reads by key on every navigation. Deleting is not a
+  milder fix there but a WRONG one — the read then reaches the inherited
+  accessor and answers `Object.prototype`, an object with no keys, i.e. "params
+  unchanged", so a route named `__proto__` stops re-activating when its `:id`
+  changes (measured: `["__proto__"]` → `[]`).
+
+⚠ **Consequence worth knowing:** a dependency named `__proto__` is held by the
+base router and answered by `get()`, but does NOT reach a clone. The same trade
+#1823 took at `getAll`, one door over.
+
+⚠ **Five doors are EXEMPT, each with a measured reason** — the two prior owner
+decisions (`state.context` #1191, a route's custom fields #1788), the two
+PASS-THROUGHS where the container is the caller's own object with identity
+intact (`forwardState`'s bags on the no-default fast path, and the un-forced
+`NavigationOptions` arc), and the internals handle, whose whole purpose is to
+hand out the live stores. Sanitising a pass-through means COPYING the caller's
+bag, which invokes its accessors a second time below the read that already
+decided — `opts-read-once-1817.test.ts` counts exactly those and pins them at
+one.
+
+⚠ **The level closed is the container a door RETURNS, and no further.** One
+level down are the caller's own objects, handed back by reference under core's
+one-level copy model (#1958) — `getOptions().defaultParams`,
+`get(name).defaultParams` and a dependency's value all still swap, measured, and
+`getOptions().defaultParams` IS the caller's object by identity. That is the
+pass-through answer again, one level lower, and it is pinned rather than left as
+an absence.
+
+The set is DERIVED, not listed:
+`tests/functional/handed-out-containers-1957.test.ts` measures every
+container-returning door on the swap itself (never on the own key — the two part
+company at the concealed one), runs `hostileBags`'s six container shapes through
+the fixed doors, and snapshots each public surface's member list, so a new door
+reds until someone classifies it.
+
 ### The two enforcement postures, and why they differ
 
 **Where a report is cheap, report it.** At construction and registration time —

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -13,7 +13,7 @@ import {
   guardDependencyShape,
   guardRouteStructure,
 } from "./guards";
-import { normalizeChannel } from "./helpers";
+import { dropUnsafeKey, normalizeChannel } from "./helpers";
 import {
   createInterceptable,
   createTernaryInterceptable,
@@ -402,7 +402,22 @@ export class Router<
       // Clone support (issue #173)
       getCloneState: () => ({
         options: { ...this.#options.get() },
-        dependencies: { ...this.#dependenciesStore.dependencies },
+        // ⚑ The same withholding `getAll` performs one door over (#1823),
+        // extended here because this door had the identical spread and no
+        // delete (#1957). The store is `Object.create(null)`, so an own
+        // `"__proto__"` sits there as an ORDINARY key — legitimate, and
+        // `get("__proto__")` still answers — but a spread re-defines it on a
+        // normal object and makes THIS container a prototype-swap primitive for
+        // whoever merges it. `getCloneState` is reachable from the published
+        // `@real-router/core/validation` subpath.
+        //
+        // ⚠ Consequence, and it is the one #1823 already took at `getAll`: a
+        // dependency literally named `__proto__` does not reach a clone. The
+        // base still holds it; the clone re-ingests this container, and the key
+        // is no longer in it.
+        dependencies: dropUnsafeKey({
+          ...this.#dependenciesStore.dependencies,
+        }),
         pluginFactories: this.#plugins.getAll(),
         // `logger` is a const in this constructor's scope (a RouterLogger class
         // instance), so getConfig() yields the resolved config a clone inherits

--- a/packages/core/src/RouterError.ts
+++ b/packages/core/src/RouterError.ts
@@ -5,6 +5,14 @@ import { putField } from "./utils/ingest";
 
 // Pre-compute Set of error code values for O(1) lookup in setCode()
 // This avoids creating array and doing linear search on every setCode() call
+// ⚑ Captured at module load, for the reason `helpers.ts` states over its own
+// three: an application can re-point `Object.hasOwn` after boot, and this one
+// gates a PUBLIC read (#1829). ⚠ The file's four other intrinsic reads are still
+// raw — #1971 owns that sweep, and a point fix here would be the N+1 it exists
+// to prevent; capturing the read this commit ADDS is not the same thing as
+// sweeping the ones it found.
+const hasOwn = Object.hasOwn;
+
 const errorCodeValues = new Set(Object.values(errorCodes));
 
 // Reserved built-in properties - throw error if user tries to set these
@@ -280,7 +288,19 @@ export class RouterError extends Error {
    * ```
    */
   hasField(key: string): boolean {
-    return key in this;
+    // ⚑ `hasOwn`, not `in` (#1829). `in` walks the prototype chain, so this
+    // answered `true` for `Object.prototype`'s twelve members and for the
+    // class's own six methods — eighteen names for an error carrying ONE field
+    // and `toString` / `constructor` are ordinary strings arriving from a config
+    // key, a route param name or a serialized payload.
+    //
+    // ⚠ NOT `toJSON`'s `excludeKeys`, which the issue proposed. Measured against
+    // the docstring above: that set keeps 1 of its 4 worked examples — it
+    // excludes `code`, `segment` and `path`, which this method documents as
+    // answering `true`. The two functions ask different questions (what to
+    // SERIALIZE vs what the error CARRIES), so agreeing on those three is the
+    // contract and diverging on `message` / `stack` / `name` is not drift.
+    return hasOwn(this, key);
   }
 
   /**
@@ -304,7 +324,10 @@ export class RouterError extends Error {
    * ```
    */
   getField(key: string): unknown {
-    return this[key];
+    // Reachable without `hasField` — a consumer may just read — so the same gate
+    // stands here rather than being implied by the predicate (#1829). Before
+    // this, `getField("toString")` handed back the native function.
+    return hasOwn(this, key) ? this[key] : undefined;
   }
 
   /**

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -1,6 +1,6 @@
 import { throwIfDisposed } from "./helpers";
-import { UNSAFE_KEY } from "../constants";
 import { ingestDependencies } from "../guards";
+import { dropUnsafeKey } from "../helpers";
 import { getInternals } from "../internals";
 
 import type { DependenciesApi } from "./types";
@@ -182,7 +182,7 @@ export function getDependenciesApi<
       return value as Dependencies[typeof name];
     },
     getAll: () => {
-      // ⚑ A spread, then `UNSAFE_KEY` deleted (#1823). The store is
+      // ⚑ A spread, then `dropUnsafeKey` (#1823 / #1957). The store is
       // `Object.create(null)`, so an own `"__proto__"` is an ORDINARY key there
       // — but a spread re-defines it on a normal object, and the result is then
       // a prototype-swap primitive for any consumer that merges it with
@@ -202,21 +202,19 @@ export function getDependenciesApi<
       // happens to carry as an accessor throws instead of storing (#1852). The
       // first draft of this fix used the loop and turned an already-immune site
       // into a member of that class — measured, `getAll()` threw.
-      const all: Record<string, unknown> = { ...source };
-
+      //
       // The one key a spread cannot be trusted with: `source` is built with
       // `Object.create(null)`, so `"__proto__"` can sit there as an ORDINARY own
       // key. Spreading defines it as an own key here too — harmless in `all`
       // itself, but it makes the returned object a prototype-swap primitive for
       // any consumer that merges it with `Object.assign` or a `for…in` copy.
       //
-      // ⚠ UNCONDITIONAL, and deliberately. Guarding it with
-      // `Object.hasOwn(source, UNSAFE_KEY)` decides nothing — deleting an
-      // absent key is a no-op in every observable respect, measured — while
-      // putting a re-pointable intrinsic read in front of the one line that
-      // neutralises the hazard. `hasOwn` shimmed to `false` restored the whole
-      // primitive.
-      delete all[UNSAFE_KEY];
+      // ⚠ The delete is UNCONDITIONAL, and `dropUnsafeKey`'s docblock carries
+      // the measurement that says why (a `hasOwn` gate in front of the one line
+      // that neutralises the hazard is an intrinsic read an application can
+      // re-point). This site is where that reasoning was FOUND (#1823); it now
+      // serves three doors (#1957) and lives with the primitive.
+      const all: Record<string, unknown> = dropUnsafeKey({ ...source });
 
       return all as ReturnType<DependenciesApi<Dependencies>["getAll"]>;
     },

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -124,6 +124,26 @@ export const UNKNOWN_ROUTE = "@@router/UNKNOWN_ROUTE";
  * `UNSAFE_KEY`, deliberately. It is also why `getAll` is this constant's other
  * consumer: the key is admitted on the way IN and withheld on the way OUT,
  * because that door hands back a normal object someone will merge.
+ *
+ * ⚑ **That last sentence is a RULE, and `getAll` is no longer its only case
+ * (#1957).** Every door that hands back a container core built withholds the key
+ * — router options (and with them the clone transport, one object), the
+ * dependency clone transport, and the two `NavigationOptions` a plugin hook
+ * receives that core MINTS. `dropUnsafeKey` (`helpers.ts`) is the one primitive;
+ * the derived table is
+ * `tests/functional/handed-out-containers-1957.test.ts`.
+ *
+ * ⚠ There is a SECOND shape, for the one container core hands out AND reads
+ * back by key: the route-meta record is withheld from ENUMERATION instead
+ * (`concealUnsafeKey`, `utils/ingest.ts`), because deleting the entry sends
+ * core's own read to the inherited accessor and a route named `__proto__` stops
+ * re-activating on a param change — measured.
+ *
+ * ⚠ Five doors stay EXEMPT, each with a measured reason in that table: the two
+ * prior owner decisions (`state.context` #1191, a route's custom fields #1788),
+ * the two PASS-THROUGHS where the container is the caller's own object
+ * (`forwardState`'s bags, and the un-forced `NavigationOptions` arc), and the
+ * internals handle, which exists to hand out the live stores.
  */
 export const UNSAFE_KEY = "__proto__";
 

--- a/packages/core/src/engine/path-matcher/registration/index.ts
+++ b/packages/core/src/engine/path-matcher/registration/index.ts
@@ -21,7 +21,11 @@ import {
   throwSegmentGrammarError,
 } from "./errors";
 import { insertIntoTrie, insertSlashChildIntoTrie } from "./trie";
-import { emptyRecord, publishRecord } from "../../../utils/ingest";
+import {
+  concealUnsafeKey,
+  emptyRecord,
+  publishRecord,
+} from "../../../utils/ingest";
 
 import type { CompiledRoute, MatcherInputNode } from "../types";
 
@@ -205,9 +209,23 @@ function buildMeta(
     meta[segment.fullName] = segment.paramTypeMap;
   }
 
+  // ⚑ `concealUnsafeKey` between the publish and the freeze (#1957). The keys
+  // here are ROUTE NAMES and core accepts one spelled `__proto__` (#1801), so
+  // `publishRecord`'s spread — which restores `Object.prototype` on purpose —
+  // hands out a record whose own `"__proto__"` swaps the prototype of anything
+  // that merges it. The value is a `paramTypeMap`, an object, so this one is a
+  // genuine swap primitive rather than the entry-loss near-miss `buildParamMeta`
+  // carries.
+  //
+  // ⚠ Withheld from ENUMERATION, not deleted, and the difference is measured:
+  // this record is core's own working table (`segmentParamsEqual` reads
+  // `meta[segmentName]` per navigation), so a delete sends that read to the
+  // INHERITED accessor, which answers `Object.prototype` — an object with no
+  // keys, i.e. "params unchanged". A `:id` change then stops re-activating the
+  // segment.
   return meta === undefined
     ? EMPTY_ROUTE_META
-    : Object.freeze(publishRecord(meta));
+    : Object.freeze(concealUnsafeKey(publishRecord(meta)));
 }
 
 // Allocation-free emptiness probe for a segment's paramTypeMap (Object.keys

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -687,6 +687,50 @@ export function normalizeChannel<T extends Record<string, unknown>>(
  * Returns the input untouched, with no allocation, when the key is absent —
  * which is every ordinary URL, so the common path pays one `hasOwn`.
  */
+/**
+ * Remove `UNSAFE_KEY` from an object core JUST allocated for a hand-out (#1957).
+ *
+ * The sibling of {@link withoutUnsafeKey}, and the split between them is which
+ * of the two questions the call site has already answered:
+ *
+ *   - {@link withoutUnsafeKey} is handed a bag it does NOT own, so it gates on
+ *     `hasOwn` and copies only when it must. That gate is the price of not
+ *     allocating on a path where the key is almost always absent.
+ *   - this one is handed the RESULT of a spread core just performed, so there
+ *     is nothing to copy and nothing to preserve — and the delete is therefore
+ *     UNCONDITIONAL. `getAll` recorded why (#1823) and the reason generalises:
+ *     guarding it with `hasOwn` decides nothing (deleting an absent key is a
+ *     no-op in every observable respect, measured) while putting a re-pointable
+ *     intrinsic read in front of the one line that neutralises the hazard.
+ *     Capturing `hasOwn` at module load does not close that either — a shim
+ *     evaluated BEFORE this module, the ordinary polyfill order, still wins.
+ *
+ * ⚠ Only ever call this on an object core allocated in the same expression. It
+ * MUTATES, and a caller's own bag is not core's to edit.
+ *
+ * ⚠ That precondition is the CONTRACT and the type cannot express it, so here
+ * is what breaking it costs, measured: `delete` on a FROZEN container carrying
+ * the key, or on a non-configurable own key, throws
+ * `TypeError: Cannot delete property '__proto__'` — every module is strict. An
+ * absent key is a no-op even under a freeze, which is why no shipped site can
+ * reach the throw by accident (all four hand over a spread made one expression
+ * earlier). The throw is the right failure mode rather than a flaw: a silent
+ * no-op would leave the key on a published container with nobody the wiser.
+ * Not pinned by a test — no public door can hand this a frozen bag, and a
+ * functional test may not reach `src` to try.
+ *
+ * ⚠ The three sites it serves all SPREAD rather than copy key by key, and that
+ * is load-bearing (#1852): a spread `[[Define]]`s, while `dst[key] = value`
+ * dispatches into whatever `Object.prototype` carries under an ordinary
+ * dependency or option name. The first draft of #1823's fix used the loop and
+ * turned an already-immune door into a member of that class.
+ */
+export function dropUnsafeKey<T extends object>(fresh: T): T {
+  delete (fresh as Record<string, unknown>)[UNSAFE_KEY];
+
+  return fresh;
+}
+
 export function withoutUnsafeKey<T extends Record<string, unknown>>(bag: T): T {
   if (!hasOwn(bag, UNSAFE_KEY)) {
     return bag;

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -7,7 +7,7 @@ import {
   errorCodes,
   events,
 } from "../../constants";
-import { adoptForeignBag } from "../../helpers";
+import { adoptForeignBag, dropUnsafeKey } from "../../helpers";
 import { RouterError, freezeThrownError } from "../../RouterError";
 import { routerEvents, routerStates } from "../../routerFSM";
 
@@ -161,12 +161,20 @@ function bridgeSignal(
   };
 }
 
-/** Drop the caller's `AbortSignal` before the state is announced. */
+/**
+ * Drop the caller's `AbortSignal` before the state is announced.
+ *
+ * ⚑ And `UNSAFE_KEY` with it (#1957). `rest` is an object CORE mints, built by
+ * rest-destructuring, which `[[Define]]`s — so an own `"__proto__"` from a
+ * `JSON.parse`d bag lands on it and makes the container every plugin hook
+ * receives a prototype-swap primitive for anything that merges it. The delete is
+ * free here: the spread has already happened, so nothing is read a second time.
+ */
 function stripSignal({
   signal: _,
   ...rest
 }: NavigationOptions): NavigationOptions {
-  return rest;
+  return dropUnsafeKey(rest);
 }
 
 export class EventBusNamespace {

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -2,6 +2,7 @@ import { completeTransition } from "./completeTransition";
 import { asCancellation, routeTransitionError } from "./errorHandling";
 import { executeGuardPipeline } from "./guardPhase";
 import { errorCodes, constants } from "../../../constants";
+import { dropUnsafeKey } from "../../../helpers";
 import { RouterError, freezeThrownError } from "../../../RouterError";
 import { getTransitionPath } from "../../../transitionPath";
 import {
@@ -51,7 +52,28 @@ function substituteForcedReplace(
   opts: NavigationOptions,
   forced: boolean,
 ): NavigationOptions {
-  return forced ? { ...opts, replace: true } : opts;
+  if (!forced) {
+    return opts;
+  }
+
+  // ⚑ `dropUnsafeKey` on the spread (#1957). The object below is one CORE mints,
+  // and a spread `[[Define]]`s — so an own `"__proto__"` from a `JSON.parse`d bag
+  // rides it into every plugin's `onTransitionSuccess`, where merging it swaps
+  // the merge target's prototype. Free here: the spread has already run, so
+  // nothing is read a second time.
+  //
+  // ⚠ The pass-through arm above is deliberately left alone: it hands back the
+  // CALLER's own object, identity preserved (measured), so core mints no swap
+  // primitive there. Sanitising it would mean COPYING the bag — i.e. invoking
+  // the caller's accessors a SECOND time below the read that already decided,
+  // which `opts-read-once-1817.test.ts` counts and pins at one (measured: the
+  // copy takes `reload` and `replace` to two and reds both cells).
+  //
+  // ⚑ The early return is also what keeps `forced` from being a SELECTOR
+  // parameter now that the two arms differ in shape — `sonarjs/no-selector-parameter`
+  // fires on the ternary form, and the project's own rule says a boolean
+  // argument is a hypothesis to justify.
+  return dropUnsafeKey({ ...opts, replace: true });
 }
 
 function isSameNavigation(

--- a/packages/core/src/namespaces/OptionsNamespace/OptionsNamespace.ts
+++ b/packages/core/src/namespaces/OptionsNamespace/OptionsNamespace.ts
@@ -3,6 +3,7 @@
 import { defaultOptions } from "./constants";
 import { deepFreeze } from "./helpers";
 import { validateOptionsIsObject } from "./validators";
+import { dropUnsafeKey } from "../../helpers";
 
 import type { DefaultDependencies, Options } from "../../types";
 
@@ -12,10 +13,32 @@ export class OptionsNamespace<
   readonly #options: Readonly<Options<Dependencies>>;
 
   constructor(initialOptions: Partial<Options<Dependencies>> = {}) {
-    this.#options = deepFreeze({
-      ...defaultOptions,
-      ...initialOptions,
-    });
+    // ⚑ `dropUnsafeKey` on the spread, before the freeze (#1957). The caller's
+    // bag reaches this literal by a spread, which `[[Define]]`s — so an own
+    // `"__proto__"` from `JSON.parse` or
+    // `Object.fromEntries(new URLSearchParams(…))` lands as an own key on the
+    // object core is about to hand to every plugin through
+    // `getPluginApi(router).getOptions()` and to every clone through
+    // `getCloneState().options`. There it is a prototype-swap primitive for any
+    // consumer that merges it.
+    //
+    // Nothing is lost: `Options` has a closed shape and `"__proto__"` names none
+    // of it, so unlike the dependency store one door over there is no value
+    // here to withhold from — only an unknown key that would have been dead
+    // config.
+    //
+    // ⚠ A THROW would be the wrong shape. `validateOptionsIsObject` accepts any
+    // object and unknown option keys are tolerated everywhere else, so refusing
+    // this one name while ignoring its eleven `Object.prototype` siblings would
+    // be a rule with no reason a caller could infer. (`options.logger` throws on
+    // it, but that is an allow-listed SUB-bag with a closed key set — a
+    // different contract, not a precedent for the parent.)
+    this.#options = deepFreeze(
+      dropUnsafeKey({
+        ...defaultOptions,
+        ...initialOptions,
+      }),
+    );
   }
 
   static validateOptionsIsObject(

--- a/packages/core/src/utils/ingest.ts
+++ b/packages/core/src/utils/ingest.ts
@@ -25,7 +25,14 @@
 // namespace, because those are not containers a consumer merges. See `putField`'s
 // docblock for that split.
 //
-// ⚠ These are WRITE-side primitives only, and the boundary is deliberate. A
+//   `concealUnsafeKey` (#1957) is the one member of this file that DOES decide
+//     that — for exactly one record, `buildMeta`'s, which core both hands out
+//     and reads back by key. It withholds the name from ENUMERATION rather than
+//     removing it, because removing it is a measured behaviour loss there. The
+//     doors that only hand a container OUT drop the key instead
+//     (`dropUnsafeKey`, `helpers.ts`).
+//
+// ⚠ The rest are WRITE-side primitives only, and the boundary is deliberate. A
 // READ-side primitive that walks a caller's prototype chain was written here,
 // wired, measured — and removed: `CLAUDE.md` "Supported Input Shapes" settles
 // that axis already ("own enumerable properties only", owner decision
@@ -37,6 +44,8 @@
 //
 // So what is left is the half the canon does not cover: what happens when core
 // writes into a record of its own under a key it did not choose.
+
+import { UNSAFE_KEY } from "../constants";
 
 /**
  * The target discipline: a record with NO prototype.
@@ -93,6 +102,66 @@ export function publishRecord<V>(source: Record<string, V>): Record<string, V> {
  */
 const defineProperty = Object.defineProperty;
 const hasOwn = Object.hasOwn;
+
+/**
+ * Withhold `UNSAFE_KEY` from ENUMERATION on a record core hands out AND reads
+ * back by key (#1957).
+ *
+ * ⚑ The hazard is the CONSUMER's merge, not core's own write. `Object.assign`
+ * and a `for…in` copy `[[Set]]` each own ENUMERABLE key on the TARGET, where
+ * `Object.prototype`'s `"__proto__"` accessor replaces that target's prototype
+ * instead of adding an entry.
+ *
+ * ⚠ A SPREAD is not in that list, and an earlier revision of this docblock said
+ * it was. `{ ...source }` performs `CreateDataProperty`, i.e.
+ * `[[DefineOwnProperty]]`, which never reaches an inherited accessor — measured
+ * on the poisoned bag, on a null-prototype carrier and through a pass-through
+ * Proxy, a spread swaps in none of the three. #1823 had the list right
+ * ("`Object.assign` or a `for…in` copy") and this widened it by mistake. The
+ * hazard is real and narrower than that sentence claimed.
+ *
+ * So the SOURCE's own prototype decides nothing either — measured, an
+ * `Object.create(null)` source swaps the target exactly the same — and the only
+ * two fixes are removing the key or removing it from enumeration.
+ *
+ * ⚠ **Dropping is not a milder fix here, it is a WRONG one.** The route-meta
+ * record is core's working table: `segmentParamsEqual` reads `meta[segmentName]`
+ * on every navigation, so with the entry gone the read reaches the INHERITED
+ * accessor and answers `Object.prototype` — an object, whose `Object.keys` is
+ * `[]`, so the segment reports "params unchanged". Measured end to end on a
+ * route named `__proto__`: `/p/1` → `/p/2` activates `["__proto__"]` today and
+ * `[]` with the entry deleted. Core accepts that name (#1801), so the loss is
+ * real and silent.
+ *
+ * Non-enumerable keeps the read exact for core AND for a consumer asking by
+ * key, while `Object.assign` / a spread / `for…in` skip it — measured, all
+ * three.
+ *
+ * ⚠ NOT applied by {@link publishRecord} itself. Its other caller is
+ * `buildParamMeta`, whose map core ENUMERATES (`Object.keys` in
+ * `segmentParamsEqual`, `for…in` in `hasAnyParam`) and which is not a swap
+ * primitive anyway: a param's value is the string `"url"` / `"query"`, and the
+ * inherited setter ignores primitives.
+ *
+ * Returns the input untouched, with no descriptor write, when the key is absent
+ * — which is every ordinary route.
+ */
+export function concealUnsafeKey<V>(
+  record: Record<string, V>,
+): Record<string, V> {
+  if (!hasOwn(record, UNSAFE_KEY)) {
+    return record;
+  }
+
+  defineProperty(record, UNSAFE_KEY, {
+    value: record[UNSAFE_KEY],
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  return record;
+}
 
 /**
  * Write one field of a record core BUILDS under a key it did not choose.

--- a/packages/core/tests/functional/chain-walk-authority.test.ts
+++ b/packages/core/tests/functional/chain-walk-authority.test.ts
@@ -1015,14 +1015,14 @@ describe("where core walks a chain it does not own", () => {
       // an anonymous crash one line later — #1798's shape, one namespace over.
       'namespaces/RoutesNamespace/RoutesNamespace.ts · "name" in toState':
         "in-on-param",
-      // `hasField`'s built-ins do NOT live on the prototype. Measured on
-      // `new RouterError("ERR", { segment: "users" })`, every field its JSDoc
-      // names — `code`, `message`, `segment`, plus `name` and `stack` — answers
-      // `Object.hasOwn === true`. So the chain walk buys the documented feature
-      // nothing; what it adds is `hasField("toString") === true`,
-      // `hasField("hasField") === true` and `hasField("constructor") === true`,
-      // against a JSDoc example that says `hasField("unknown") === false`.
-      "RouterError.ts · key in this": "in-on-param",
+      // ⚑ `RouterError.ts · key in this` stood here as a DEFECT and is GONE
+      // (#1829): `hasField` asks `Object.hasOwn` now, and `getField` gates on the
+      // same answer. The measurement this row carried is what settled the fix —
+      // every field the JSDoc names already answers `hasOwn === true`, so the
+      // chain walk bought the documented feature nothing. It also refutes the
+      // fix the issue PROPOSED (reuse `toJSON`'s `excludeKeys`), which would
+      // have dropped `code` / `segment` / `path` — three of that JSDoc's four
+      // worked examples.
 
       // ── EXEMPT, with the reason ──────────────────────────────────────────
 

--- a/packages/core/tests/functional/dependencies/plain-object-guard-1858.test.ts
+++ b/packages/core/tests/functional/dependencies/plain-object-guard-1858.test.ts
@@ -67,16 +67,9 @@ describe("the plain-object guard judges the prototype (#1858)", () => {
   });
 
   it("CONTROL — the other reserved-looking names survive too", () => {
-    // `__proto__` is in the list deliberately: it is the one name with
-    // `getAll()`'s `UNSAFE_KEY` deletion behind it (#1823), so it takes a
-    // different route through the rebuild doors than its neighbours.
-    for (const name of [
-      "toString",
-      "valueOf",
-      "hasOwnProperty",
-      "__proto__",
-      "ordinary",
-    ]) {
+    // ⚠ `__proto__` used to be in this list and is now its own cell below: since
+    // #1957 it is the one name that does NOT reach a clone.
+    for (const name of ["toString", "valueOf", "hasOwnProperty", "ordinary"]) {
       const router = createRouter(ROUTES);
       const api = getDependenciesApi(router);
 
@@ -92,6 +85,33 @@ describe("the plain-object guard judges the prototype (#1858)", () => {
       clone.dispose();
       router.dispose();
     }
+  });
+
+  it("`__proto__` is held by the base and does NOT reach a clone (#1957)", () => {
+    // The clone transport is `getCloneState().dependencies` — a container core
+    // spreads out of the null-prototype store, on the published
+    // `@real-router/core/validation` surface. A spread `[[Define]]`s, so the key
+    // landed there as an own key and made that container a prototype-swap
+    // primitive for anyone merging it; it is deleted now, exactly as `getAll()`
+    // deletes it one door over (#1823).
+    //
+    // ⚠ The consequence is this cell, and it is the trade #1823 already took:
+    // `getAll()` withholds the key from the container while `get()` still
+    // answers, so preservation loses to the merge hazard. `UNSAFE_KEY`'s own
+    // docblock records why the other direction was shipped once and reverted —
+    // `Object.assign` drops the key even in the safe string case, so "the user's
+    // data is kept" holds for exactly one hop.
+    const router = createRouter(ROUTES);
+
+    getDependenciesApi(router).set("__proto__" as never, "V" as never);
+
+    const clone = cloneRouter(router);
+
+    expect(getDependenciesApi(router).get("__proto__" as never)).toBe("V");
+    expect(getDependenciesApi(clone).get("__proto__" as never)).toBeUndefined();
+
+    clone.dispose();
+    router.dispose();
   });
 
   it("accepts a null-prototype bag, which the old spelling refused", () => {

--- a/packages/core/tests/functional/error/field-access-own-only-1829.test.ts
+++ b/packages/core/tests/functional/error/field-access-own-only-1829.test.ts
@@ -1,0 +1,150 @@
+// #1829 — `hasField` / `getField` answer about the error's OWN fields, and
+// nothing else.
+//
+// Both walked the prototype chain (`key in this`, `this[key]`), so an error with
+// ONE custom field answered `true` for eighteen names and handed back native
+// methods for most of them. `toString` and `constructor` are ordinary strings —
+// they arrive from a config key, a route param name, a serialized payload.
+//
+// ⚑ The whole surface is external: `RouterError` is a root export and neither
+// method has a call site in any `src/` in the monorepo, so nothing in-repo was
+// WRONG. That is what makes it a contract defect rather than a latent one.
+//
+// ⚠ It does not follow that nothing in-repo covered them, and an earlier
+// revision of this line said "no call site inside the monorepo" — measured,
+// there are ~20, all in TESTS, including a whole property file. What that file
+// could not do is reach the defect: its "non-existent field" generator builds
+// `__non_existent_${randomKey}__`, prefixed AND suffixed, so no `fc.string()`
+// ever produces `toString`. 10 000 runs, zero coverage of this axis. The
+// reachable half now lives beside it (`methods.properties.ts`).
+//
+// ⚠ **The fix is NOT the one the issue proposes.** It suggested reusing
+// `toJSON`'s `excludeKeys`, on the ground that the two would otherwise disagree
+// about one instance. Measured against the methods' own docstrings, that set
+// keeps 1 of 4 documented promises:
+//
+//     rule                        segment/path/code/userId   false positives
+//     `key in this` (before)      1111                       18
+//     `Object.hasOwn`             1111                        0
+//     hasOwn minus toJSON's set   0001                        0   <- the proposal
+//
+// `hasField("segment") // true` and `getField("code") // "ERR" (built-in field)`
+// are worked examples in the JSDoc above each method. The two functions answer
+// DIFFERENT questions — `toJSON` says what to serialize, these say what the
+// error carries — so agreeing on `code` / `segment` / `path` (they do) is the
+// contract, and diverging on `message` / `stack` / `name` is not drift.
+import { describe, expect, it } from "vitest";
+
+import { RouterError } from "@real-router/core";
+
+/**
+ * Derived at runtime, never written out: a hand-written enumeration of
+ * `Object.prototype`'s members is what the sibling sweep #1798 got wrong, and
+ * the set grows with the engine.
+ */
+const INHERITED = Object.getOwnPropertyNames(Object.prototype);
+
+/** The class's own methods, read off the prototype rather than listed. */
+const METHODS = Object.getOwnPropertyNames(
+  Object.getPrototypeOf(new RouterError("SOME_CODE")) as object,
+).filter((name) => name !== "constructor");
+
+interface FieldAccess {
+  hasField: (key: string) => boolean;
+  getField: (key: string) => unknown;
+}
+
+function makeError(): FieldAccess {
+  return new RouterError("ROUTE_NOT_FOUND", {
+    segment: "users",
+    path: "/users",
+    userId: "u1",
+  });
+}
+
+describe("#1829 — field access is own-only", () => {
+  it("COUNTS what the old rule got wrong, so the prose cannot drift from it", () => {
+    // ⚠ This cell exists because the number DID drift: the changeset, the commit
+    // message, this file's header and `RouterError.ts`'s comment all said
+    // "twenty", derived from "twelve inherited + six methods" — which is
+    // eighteen. `constructor` is on BOTH lists and counts once. Nothing was
+    // wrong with the fix; the arithmetic was invented and repeated four times,
+    // which is what an uncounted number in prose does.
+    const err = makeError();
+    const own = new Set(Object.getOwnPropertyNames(err));
+    const falsePositives = [...new Set([...INHERITED, ...METHODS])].filter(
+      (name) => !own.has(name),
+    );
+
+    expect(INHERITED).toHaveLength(12);
+    expect(METHODS).toHaveLength(6);
+    expect(falsePositives).toHaveLength(18);
+
+    // ...and every one of them answers correctly NOW. Without this line the
+    // count above is trivia; with it, the count is the size of what was closed.
+    expect(falsePositives.filter((name) => err.hasField(name))).toStrictEqual(
+      [],
+    );
+  });
+
+  it("answers false / undefined for every INHERITED name", () => {
+    const err = makeError();
+
+    // Before: twelve of twelve, and `getField` returned the native function.
+    expect(INHERITED.filter((name) => err.hasField(name))).toStrictEqual([]);
+    expect(
+      INHERITED.filter((name) => err.getField(name) !== undefined),
+    ).toStrictEqual([]);
+  });
+
+  it("answers false / undefined for the class's OWN METHOD names", () => {
+    const err = makeError();
+
+    // Derived, so a seventh method added later is covered without an edit.
+    expect(METHODS.length).toBeGreaterThan(3);
+    expect(METHODS.filter((name) => err.hasField(name))).toStrictEqual([]);
+    expect(
+      METHODS.filter((name) => err.getField(name) !== undefined),
+    ).toStrictEqual([]);
+  });
+
+  it("POSITIVE CONTROL — still answers for every field the docstrings promise", () => {
+    // Without this column the cell above passes by refusing everything, which is
+    // exactly what the issue's proposed fix would have done to three of these.
+    const err = makeError();
+
+    expect({
+      userId: err.hasField("userId"),
+      segment: err.hasField("segment"),
+      path: err.hasField("path"),
+      code: err.hasField("code"),
+    }).toStrictEqual({
+      userId: true,
+      segment: true,
+      path: true,
+      code: true,
+    });
+
+    expect(err.getField("userId")).toBe("u1");
+    expect(err.getField("code")).toBe("ROUTE_NOT_FOUND");
+    expect(err.getField("segment")).toBe("users");
+  });
+
+  it("NEGATIVE CONTROL — a name the error does not carry is still false", () => {
+    const err = makeError();
+
+    expect(err.hasField("unknown")).toBe(false);
+    expect(err.getField("unknown")).toBeUndefined();
+  });
+
+  it("`getField` is not a back door around `hasField`", () => {
+    // The two are reachable independently — a consumer may call `getField`
+    // without asking first — so the read needed the change as much as the
+    // predicate did.
+    const err = makeError();
+
+    for (const name of [...INHERITED, ...METHODS]) {
+      expect(err.getField(name), `getField(${name})`).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/tests/functional/handed-out-containers-1957.test.ts
+++ b/packages/core/tests/functional/handed-out-containers-1957.test.ts
@@ -1,0 +1,749 @@
+// #1957 — what core HANDS OUT may not be a prototype-swap primitive.
+//
+// The discriminator, and it is about the CONSUMER's merge rather than core's own
+// write: an own `"__proto__"` on a container is inert while it sits there, and
+// becomes a swap the moment anyone merges it with `Object.assign` or a `for…in`
+// copy — both `[[Set]]` that name on the TARGET, where `Object.prototype`'s
+// accessor replaces the target's prototype instead of adding an entry.
+//
+// ⚠ A SPREAD is NOT one of them, and an earlier revision of this header said it
+// was. `{ ...container }` performs `CreateDataProperty`, so it can never swap —
+// measured on three carrier shapes. #1823's pin had the list right and this
+// widened it; the hazard is real and narrower. `swapsOnMerge` below is
+// `Object.assign` only for exactly that reason.
+//
+// The SOURCE's own prototype decides nothing either (measured: a null-prototype
+// source swaps the target exactly the same), so the only two fixes are removing
+// the key or removing it from ENUMERATION.
+//
+// ⚑ Which of the two, per door, is decided by ONE question: does core read that
+// key back off the very object it published?
+//
+//   • No  → DROP it (`getAll`'s shape, #1823): the copy exists only to be handed
+//     out, so the key carries nothing. Unconditional, because a `hasOwn` gate in
+//     front of the one line that neutralises the hazard is an intrinsic read an
+//     application can re-point.
+//   • Yes → CONCEAL it (non-enumerable own property): the meta record IS core's
+//     working table, read by key on every navigation. Dropping is not a milder
+//     fix there, it is a WRONG one — measured below.
+//
+// ⚠ FIVE doors are listed as CARVE-OUTS rather than fixed, each with its
+// measured reason, in the last block. Two are prior owner decisions
+// (`state.context` #1191, `getRouteConfig` #1788); two are PASS-THROUGHS, where
+// the container is the caller's own object and core minted nothing; one is the
+// internals handle, which exists to hand out core's live stores. They are
+// recorded so each exemption is a statement someone can disagree with, not a
+// door nobody looked at.
+//
+// ⚠ The issue named FOUR doors. A deep walk of every door's object graph found
+// seven containers that swap, so three of the carve-outs below are additions to
+// its list — which is the argument for deriving the set rather than listing it.
+import { describe, expect, it } from "vitest";
+
+import { createRouter, getNavigator, RouterError } from "@real-router/core";
+import {
+  cloneRouter,
+  getDependenciesApi,
+  getLifecycleApi,
+  getPluginApi,
+  getRoutesApi,
+} from "@real-router/core/api";
+import { getInternals } from "@real-router/core/validation";
+
+import { CONTAINER_SHAPES } from "../helpers/hostileBags";
+
+import type { Router } from "@real-router/core/types";
+
+/**
+ * The property every row is measured on: merging this container into a fresh
+ * object replaces THAT object's prototype.
+ *
+ * Deliberately not `Object.hasOwn(container, "__proto__")`. The own key is the
+ * mechanism, the swap is the harm — and the two part company at exactly the door
+ * the conceal fixes, where the key stays and the swap goes.
+ */
+function swapsOnMerge(container: unknown): boolean {
+  if (container === null || typeof container !== "object") {
+    return false;
+  }
+
+  // ⚠ `Object.assign`, and ONLY `Object.assign`. It uses `[[Set]]`, which is the
+  // mechanism under test; a spread performs `CreateDataProperty`, i.e.
+  // `[[DefineOwnProperty]]`, which cannot reach the inherited accessor at all.
+  //
+  // ⚑ This carried a second `{ ...container }` arm OR-ed onto the result, added
+  // for symmetry with the doors' own spreads. It is an equivalent mutant:
+  // measured on the poisoned bag, on a null-prototype carrier and through a
+  // pass-through Proxy, the spread arm reports `false` in all three — it can
+  // never fire. #1823's own pin already warns about this axis from the other
+  // side (`eslint --fix` once rewrote its `Object.assign` into a spread and
+  // silently removed the point of the cell); the "instrument" block below is
+  // what would red if that happened here.
+  return (
+    Object.getPrototypeOf(Object.assign({}, container)) !== Object.prototype
+  );
+}
+
+const parse = (json: string): Record<string, unknown> =>
+  JSON.parse(json) as Record<string, unknown>;
+
+/** `JSON.parse` mints the own key. No adversarial construction is involved. */
+const POISON = '{"kept":1,"__proto__":{"pwned":"YES"}}';
+const POISONED_OPTIONS = '{"defaultRoute":"home","__proto__":{"pwned":"YES"}}';
+
+const ROUTES = [
+  { name: "home", path: "/home" },
+  { name: "away", path: "/away" },
+];
+
+describe("#1957 — no door hands out a container that swaps a merge target", () => {
+  describe("the instrument", () => {
+    it("swapsOnMerge fires on the shape, and on nothing else", () => {
+      // Without this the whole table can pass by measuring nothing.
+      expect(swapsOnMerge(parse(POISON))).toBe(true);
+      expect(swapsOnMerge({ kept: 1 })).toBe(false);
+      expect(swapsOnMerge({ __proto__: { pwned: "YES" } })).toBe(false);
+      expect(swapsOnMerge(undefined)).toBe(false);
+    });
+
+    it("a null-prototype source swaps the target just the same", () => {
+      // The reason `Object.create(null)` is not a fix at a hand-out door, and
+      // the reason `getAll` deletes rather than relying on its own store.
+      const source: Record<string, unknown> = Object.create(null) as Record<
+        string,
+        unknown
+      >;
+
+      source.__proto__ = { pwned: "YES" };
+
+      expect(Object.getPrototypeOf(source)).toBeNull();
+      expect(swapsOnMerge(source)).toBe(true);
+    });
+  });
+
+  describe("options — `getOptions()` and the clone transport read one object", () => {
+    it("neither door swaps a merge target", () => {
+      const router = createRouter(ROUTES, parse(POISONED_OPTIONS));
+
+      expect({
+        getOptions: swapsOnMerge(getPluginApi(router).getOptions()),
+        cloneState: swapsOnMerge(getInternals(router).getCloneState().options),
+      }).toStrictEqual({ getOptions: false, cloneState: false });
+    });
+
+    it("a CLONE's options are clean too, because the fix is ABOVE both doors", () => {
+      // The issue's own line: "It survives cloneRouter — the clone's
+      // getOptions() is polluted too."
+      //
+      // ⚠ NOT because the two doors share an object — measured, they do not:
+      // `getCloneState()` returns `{ ...this.#options.get() }`, a fresh and
+      // (unlike `getOptions()`'s) UNFROZEN spread, identity `false`. An earlier
+      // revision of this comment, of `CLAUDE.md` and of the commit message all
+      // said "the same object"; the fix covers both for a stronger reason —
+      // it is applied at the SOURCE, in the `OptionsNamespace` constructor, so
+      // every door downstream spreads an object that never had the key.
+      const router = createRouter(ROUTES, parse(POISONED_OPTIONS));
+
+      expect(getInternals(router).getCloneState().options as unknown).not.toBe(
+        getPluginApi(router).getOptions(),
+      );
+
+      const clone = cloneRouter(router);
+
+      expect(swapsOnMerge(getPluginApi(clone).getOptions())).toBe(false);
+      expect(
+        (getPluginApi(clone).getOptions() as unknown as Record<string, unknown>)
+          .defaultRoute,
+      ).toBe("home");
+
+      clone.dispose();
+      router.dispose();
+    });
+
+    it("POSITIVE CONTROL — the rest of the poisoned bag is still the router's options", () => {
+      // The drop must not be a refusal: `createRouter` accepts an options bag
+      // with unknown keys, and every other key on this one still lands.
+      const router = createRouter(ROUTES, parse(POISONED_OPTIONS));
+      const options = getPluginApi(router).getOptions() as unknown as Record<
+        string,
+        unknown
+      >;
+
+      expect(options.defaultRoute).toBe("home");
+      expect(options.trailingSlash).toBeDefined();
+    });
+  });
+
+  describe("dependencies — the clone transport, beside the door #1823 already closed", () => {
+    it("neither door swaps a merge target", () => {
+      const router = createRouter(ROUTES);
+
+      getDependenciesApi(router).setAll(parse(POISON));
+
+      expect({
+        getAll: swapsOnMerge(getDependenciesApi(router).getAll()),
+        cloneState: swapsOnMerge(
+          getInternals(router).getCloneState().dependencies,
+        ),
+      }).toStrictEqual({ getAll: false, cloneState: false });
+    });
+
+    it("POSITIVE CONTROL — the store still HOLDS the name, and a single read answers", () => {
+      // The asymmetry #1823 recorded and this extends: a single read hands back
+      // a VALUE, a door hands back a CONTAINER someone will merge. Only the
+      // second is withheld.
+      const router = createRouter(ROUTES);
+
+      getDependenciesApi(router).setAll(parse(POISON));
+
+      const deps = getDependenciesApi(router) as unknown as {
+        has: (name: string) => boolean;
+        get: (name: string) => unknown;
+      };
+
+      expect(deps.has("__proto__")).toBe(true);
+      expect(deps.get("__proto__")).toStrictEqual({ pwned: "YES" });
+      expect(getDependenciesApi(router).getAll()).toStrictEqual({ kept: 1 });
+    });
+  });
+
+  describe("route meta — the one door where DROPPING is the wrong fix", () => {
+    const metaRouter = (): Router =>
+      createRouter([{ name: "__proto__", path: "/p/:id" }]);
+
+    it("the published record does not swap a merge target", () => {
+      const router = metaRouter();
+
+      expect(
+        swapsOnMerge(getInternals(router).getMetaForState("__proto__")),
+      ).toBe(false);
+    });
+
+    it("an ORDINARY route's meta gains no own `__proto__` at all", () => {
+      // Found by mutation: deleting the conceal's `hasOwn` gate reds NOTHING
+      // otherwise. Ungated, the read `record[UNSAFE_KEY]` reaches the inherited
+      // accessor and answers `Object.prototype`, which then gets DEFINED as an
+      // own (non-enumerable) key on every parameterised route's meta — a
+      // descriptor write per route at registration, for a name nobody used.
+      // Invisible to the swap rows above and to `toStrictEqual`, which does not
+      // compare non-enumerable properties.
+      const router = createRouter([{ name: "plain", path: "/plain/:id" }]);
+      const meta = getInternals(router).getMetaForState("plain");
+
+      expect(Object.getOwnPropertyNames(meta!)).toStrictEqual(["plain"]);
+    });
+
+    it("DISCRIMINATOR — the entry is still there, and still read by key", () => {
+      // A `delete`-shaped fix passes the row above and reds this one. Core reads
+      // `meta[segmentName]` on every navigation, so with the entry gone the read
+      // reaches the INHERITED accessor and answers `Object.prototype` — an
+      // object, whose `Object.keys` is `[]`, so `segmentParamsEqual` reports the
+      // segment unchanged. Measured, both halves.
+      const router = metaRouter();
+      const meta = getInternals(router).getMetaForState("__proto__");
+
+      expect(meta?.__proto__).toStrictEqual({ id: "url" });
+    });
+
+    it("DISCRIMINATOR — a param change still re-activates the segment", async () => {
+      // The end-to-end consequence of the same read. On the drop this is `[]`.
+      const router = metaRouter();
+
+      await router.start("/p/1");
+
+      const state = await router.navigate("__proto__", { id: "2" });
+
+      expect(state.transition?.segments.activated).toStrictEqual(["__proto__"]);
+    });
+  });
+
+  describe("NavigationOptions — the object a plugin hook receives", () => {
+    const opts = async (
+      boot: string,
+      allowNotFound: boolean,
+      withSignal: boolean,
+    ): Promise<{ seen: unknown; passedIn: Record<string, unknown> }> => {
+      const router = createRouter(ROUTES, { allowNotFound });
+      let seen: unknown;
+
+      router.usePlugin(() => ({
+        onTransitionSuccess(_toState, _fromState, received) {
+          if (received !== undefined) {
+            seen = received;
+          }
+        },
+      }));
+
+      await router.start(boot);
+
+      const passedIn = parse(POISON);
+
+      if (withSignal) {
+        passedIn.signal = new AbortController().signal;
+      }
+
+      seen = undefined;
+      await router.navigate("away", {}, {}, passedIn);
+
+      return { seen, passedIn };
+    };
+
+    it("the two arcs where CORE mints the container do not swap", async () => {
+      // THREE arcs, and they differ in who OWNS the object — which the issue got
+      // wrong (it recorded `=== false`, "core mints it", for all three; measured,
+      // the plain arc's identity is `true`). Only two of them are core's to fix:
+      // `stripSignal`'s rest-destructuring and the forced-replace substitution
+      // each mint a fresh object by spread, and a spread `[[Define]]`s, so the
+      // caller's own `"__proto__"` rides into every hook on a container core
+      // built.
+      const signalled = await opts("/home", false, true);
+      const forced = await opts("/nope", true, false);
+
+      expect({
+        signalled: swapsOnMerge(signalled.seen),
+        forced: swapsOnMerge(forced.seen),
+      }).toStrictEqual({ signalled: false, forced: false });
+    });
+
+    it("CARVE-OUT — the plain arc hands back the caller's own object, poison and all", async () => {
+      // ⚠ Recorded, not fixed, and the reason is a COLLISION with a pin rather
+      // than an oversight. Core neither mints nor copies here: the hook receives
+      // the very object the application passed to `navigate`, identity intact.
+      // Sanitising it means COPYING it — and copying reads every key, i.e.
+      // invokes the caller's accessors a second time below the read that already
+      // decided. `opts-read-once-1817.test.ts` counts exactly those reads and
+      // pins them at one; the copy takes `reload` and `replace` to two (measured,
+      // both cells red).
+      //
+      // So the trade is: an extra invocation of application code on every
+      // navigation carrying the key, against a container the application itself
+      // authored and handed in. The pin wins.
+      const plain = await opts("/home", false, false);
+
+      expect(plain.seen).toBe(plain.passedIn);
+      expect(swapsOnMerge(plain.seen)).toBe(true);
+    });
+
+    it("POSITIVE CONTROL — the hook still receives the caller's other options", async () => {
+      const { seen } = await opts("/home", false, false);
+
+      expect((seen as Record<string, unknown>).kept).toBe(1);
+    });
+
+    it("an ordinary navigation still hands the hook the caller's own object", async () => {
+      // The withholding must not allocate on the common path: with the key
+      // absent the container is returned untouched, identity and all.
+      const router = createRouter(ROUTES);
+      let seen: unknown;
+
+      router.usePlugin(() => ({
+        onTransitionSuccess(_toState, _fromState, received) {
+          if (received !== undefined) {
+            seen = received;
+          }
+        },
+      }));
+
+      await router.start("/home");
+
+      const passedIn = { replace: true };
+
+      await router.navigate("away", {}, {}, passedIn);
+
+      expect(seen).toBe(passedIn);
+    });
+  });
+
+  describe("doors that were already safe — the controls for the table", () => {
+    it("nothing else in the sweep swaps", async () => {
+      const router = createRouter(
+        [
+          parse(
+            '{"name":"__proto__","path":"/p/:__proto__","__proto__":{"pwned":"YES"}}',
+          ) as never,
+          { name: "away", path: "/away" },
+        ],
+        { queryParamsMode: "loose" },
+      );
+      const internals = getInternals(router);
+
+      await router.start("/p/1");
+
+      const matched = internals.matchPath(
+        "/p/9?__proto__=1",
+        getPluginApi(router).getOptions(),
+      );
+
+      expect({
+        getTree: swapsOnMerge(getPluginApi(router).getTree()),
+        routeConfig: swapsOnMerge(getRoutesApi(router).get("__proto__")),
+        matchedParams: swapsOnMerge(matched?.params),
+        matchedSearch: swapsOnMerge(matched?.search),
+        stateParams: swapsOnMerge(router.getState()?.params),
+        stateSearch: swapsOnMerge(router.getState()?.search),
+        transition: swapsOnMerge(router.getState()?.transition),
+        navigator: swapsOnMerge(getNavigator(router)),
+        lifecycleApi: swapsOnMerge(getLifecycleApi(router)),
+        routesApi: swapsOnMerge(getRoutesApi(router)),
+        error: swapsOnMerge(
+          new RouterError("ROUTE_NOT_FOUND", parse(POISON) as never),
+        ),
+        errorJson: swapsOnMerge(
+          new RouterError("ROUTE_NOT_FOUND", parse(POISON) as never).toJSON(),
+        ),
+      }).toStrictEqual({
+        getTree: false,
+        routeConfig: false,
+        matchedParams: false,
+        matchedSearch: false,
+        stateParams: false,
+        stateSearch: false,
+        transition: false,
+        navigator: false,
+        lifecycleApi: false,
+        routesApi: false,
+        error: false,
+        errorJson: false,
+      });
+    });
+  });
+
+  describe("the CARVE-OUTS, measured rather than skipped", () => {
+    // ⚑ Found by a DEEP walk of every door's object graph, not from the issue's
+    // list — which named four doors and missed three of the five below. The
+    // walk is what makes "every container-returning door" a derivation instead
+    // of an enumeration, and the three it added split cleanly into the two
+    // shapes core does not owe a copy for:
+    //
+    //   PASS-THROUGH — the container is the CALLER's own object, identity
+    //     intact, so core minted no swap primitive and sanitising it would mean
+    //     copying a bag on the render path (`forwardState`, and the plain arc of
+    //     `NavigationOptions` above).
+    //   LIVE STORE — the container IS core's mutable state, handed out through
+    //     the internals handle whose entire purpose is that (`routeGetStore`,
+    //     `dependenciesGetStore`). Withholding a key there withholds it from the
+    //     router, not from a consumer.
+    //
+    // Both are stated so a later reader can disagree with the reason rather
+    // than rediscover the door.
+
+    it("`forwardState` hands the CALLER's own bags back, poison and all", () => {
+      // Its siblings normalise (`makeState().params` is clean, measured), and
+      // the URL direction is scrubbed one layer up by `withoutUnsafeKey`
+      // (#1904). What is left is the fast path, where the seam has no default to
+      // layer and returns exactly what it was given.
+      const router = createRouter(ROUTES);
+      const bag = parse(POISON);
+      const out = getPluginApi(router).forwardState(
+        "home",
+        bag as never,
+        bag as never,
+      );
+
+      expect(out.params).toBe(bag);
+      expect(swapsOnMerge(out.params)).toBe(true);
+
+      // The CONTROL that says this is a pass-through and not a leak in the
+      // merge: give the route a default and the copy drops the key.
+      const withDefault = createRouter([
+        parse(
+          '{"name":"home","path":"/home","defaultParams":{"__proto__":{"pwned":"YES"}}}',
+        ) as never,
+      ]);
+
+      expect(
+        swapsOnMerge(
+          getPluginApi(withDefault).forwardState(
+            "home",
+            {} as never,
+            {} as never,
+          ).params,
+        ),
+      ).toBe(false);
+    });
+
+    it("the internals handle hands out the LIVE stores", () => {
+      // `dependenciesGetStore()` / `routeGetStore()` return core's own mutable
+      // objects — writing to them corrupts the router outright, which is a
+      // larger licence than merging them. They are not copies made for a
+      // caller, so there is nothing here to withhold from.
+      const router = createRouter(ROUTES);
+
+      getDependenciesApi(router).setAll(parse(POISON));
+
+      const internals = getInternals(router);
+
+      expect(swapsOnMerge(internals.dependenciesGetStore().dependencies)).toBe(
+        true,
+      );
+
+      // ...and the COPY door beside it is the one that was fixed.
+      expect(swapsOnMerge(getDependenciesApi(router).getAll())).toBe(false);
+    });
+
+    it("`getRouteConfig` still carries a route's `__proto__` custom field", () => {
+      // #1788's carve-out, and its premise is "the record does not escape to a
+      // MERGING consumer" — re-measured in the issue against all three shipped
+      // consumers (`lifecycle-plugin`, `preload-plugin`, `search-schema-plugin`),
+      // which read by key. That is a statement about in-repo plugins, not a
+      // structural fact about third-party ones.
+      const router = createRouter([
+        parse('{"name":"home","path":"/home","__proto__":{"pwned":"YES"}}'),
+      ] as never);
+
+      expect(swapsOnMerge(getPluginApi(router).getRouteConfig("home"))).toBe(
+        true,
+      );
+    });
+
+    it("`state.context` still carries a plugin's `__proto__` namespace", async () => {
+      // #1191 stores every namespace name as ordinary data, deliberately: the
+      // record is a plugin's own and core does not merge it.
+      //
+      // ⚠ What this cell records is that the premise has a TRANSPORT.
+      // `JSON.stringify(getState())` emits the name, a client `JSON.parse`
+      // re-creates the own key, and the merge on the far side swaps — so "not a
+      // container a consumer merges" is true of core and not of SSR. Left as it
+      // stands because reversing #1191 is a decision about `claimContextNamespace`,
+      // not about this door; the cell exists so the exemption cannot be mistaken
+      // for a door nobody measured.
+      const router = createRouter(ROUTES);
+      const claim = getPluginApi(router).claimContextNamespace("__proto__");
+
+      await router.start("/home");
+      claim.write(router.getState()!, { pwned: "YES" });
+
+      expect(swapsOnMerge(router.getState()?.context)).toBe(true);
+
+      // The JSON hop is the point: `structuredClone` preserves the own key
+      // without going through a string, so it does not model the SSR transport
+      // this cell measures (serialize on the server, `JSON.parse` on the
+      // client).
+      const serialized = JSON.stringify(router.getState()?.context);
+      const roundTripped = JSON.parse(serialized) as object;
+
+      expect(swapsOnMerge(roundTripped)).toBe(true);
+    });
+  });
+
+  describe("the LEVEL this closes, and the one above it", () => {
+    it("the fix reaches the TOP level of a container and no further", () => {
+      // ⚑ The recurring failure this cell exists to prevent is not "the fix is
+      // wrong" but "the fix is one level below the hole". So: the level closed
+      // is the container a door RETURNS. One level down are the caller's own
+      // objects, handed back by reference — core's documented one-level copy
+      // model (#1958, `config-aliasing-authority-1958.test.ts`) — and they are
+      // NOT cleaned, measured on four doors at once.
+      //
+      // That is the same answer the pass-through carve-outs get, for the same
+      // reason: core owns no copy there. Stated here so the boundary is a
+      // measurement rather than an absence.
+      const nested = parse('{"__proto__":{"pwned":"YES"},"id":"1"}');
+      const router = createRouter(
+        [{ name: "home", path: "/home", defaultParams: nested }] as never,
+        { defaultParams: nested } as never,
+        { svc: nested },
+      );
+      const options = getPluginApi(router).getOptions() as unknown as Record<
+        string,
+        unknown
+      >;
+      const routeConfig = getRoutesApi(router).get("home") as unknown as Record<
+        string,
+        unknown
+      >;
+      const all = getDependenciesApi(router).getAll() as Record<
+        string,
+        unknown
+      >;
+
+      expect({
+        optionsTop: swapsOnMerge(options),
+        dependenciesTop: swapsOnMerge(all),
+        optionsDefaultParams: swapsOnMerge(options.defaultParams),
+        routeDefaultParams: swapsOnMerge(routeConfig.defaultParams),
+        dependencyValue: swapsOnMerge(all.svc),
+      }).toStrictEqual({
+        optionsTop: false,
+        dependenciesTop: false,
+        // One level down: the caller's own object, by reference.
+        optionsDefaultParams: true,
+        routeDefaultParams: true,
+        dependencyValue: true,
+      });
+
+      // ...and it IS the caller's object, not a copy core made and left dirty.
+      expect(options.defaultParams).toBe(nested);
+    });
+  });
+
+  describe("VECTOR 0 — the adversarial container battery, at the fixed doors", () => {
+    // `hostileBags.ts`'s six shapes are the forms a caller-supplied bag
+    // legitimately arrives in. The fix reads and copies caller-supplied objects,
+    // so the battery belongs in the same commit rather than in a transcript.
+    it("every shape passes the fixed doors clean, and none of them throws", () => {
+      // ⚑ ONE assertion over a signature per shape, the form
+      // `hostile-bags-battery.test.ts` argues for: an `it.each` branching on the
+      // label puts a conditional inside a test, and a shape that silently
+      // stopped being constructed would then pass by running nothing.
+      const signature = CONTAINER_SHAPES.map(([label, wrap]) => {
+        const bag = wrap({ kept: 1 });
+
+        const optionsRouter = createRouter(
+          [{ name: "home", path: "/home" }],
+          bag as never,
+        );
+        const depsRouter = createRouter(
+          [{ name: "home", path: "/home" }],
+          {},
+          bag,
+        );
+
+        const row = [
+          label,
+          swapsOnMerge(getPluginApi(optionsRouter).getOptions()),
+          swapsOnMerge(getInternals(optionsRouter).getCloneState().options),
+          swapsOnMerge(getInternals(depsRouter).getCloneState().dependencies),
+          swapsOnMerge(getDependenciesApi(depsRouter).getAll()),
+        ];
+
+        optionsRouter.dispose();
+        depsRouter.dispose();
+
+        return row;
+      });
+
+      expect(signature).toStrictEqual(
+        CONTAINER_SHAPES.map(([label]) => [label, false, false, false, false]),
+      );
+      // The battery must not have quietly emptied — a zero-row table compares
+      // equal to a zero-row expectation.
+      expect(signature.length).toBeGreaterThan(5);
+    });
+
+    it("a `__proto__` whose VALUE is a string is dropped too, though it never swapped", () => {
+      // The battery's own poison shape carries `"from-the-wire"`, a STRING — and
+      // the inherited setter ignores primitives, so that form was never a swap
+      // primitive. The withholding is value-blind, exactly as `getAll`'s
+      // unconditional delete is, and this cell says so rather than leaving a
+      // reader to assume the drop is conditioned on the hazard.
+      const router = createRouter(
+        [{ name: "home", path: "/home" }],
+        parse('{"kept":1,"__proto__":"from-the-wire"}') as never,
+      );
+      const options = getPluginApi(router).getOptions() as unknown as Record<
+        string,
+        unknown
+      >;
+
+      expect(Object.hasOwn(options, "__proto__")).toBe(false);
+      expect(options.kept).toBe(1);
+    });
+  });
+
+  describe("a NEW door cannot ship unclassified", () => {
+    it("every public surface has exactly the members this table walked", () => {
+      // The table above is a list, and a list cannot notice a fifth door. This
+      // cell is what makes one answer the question: add a member to any surface
+      // and it reds, so the author has to classify it — fixed, or carve-out with
+      // a reason.
+      const router = createRouter(ROUTES);
+      const members = (surface: object): string[] =>
+        Object.keys(surface).toSorted((a, b) => a.localeCompare(b));
+
+      expect({
+        routes: members(getRoutesApi(router)),
+        dependencies: members(getDependenciesApi(router)),
+        lifecycle: members(getLifecycleApi(router)),
+        plugin: members(getPluginApi(router)),
+        navigator: members(getNavigator(router)),
+        internals: members(getInternals(router) as unknown as object),
+      }).toStrictEqual({
+        routes: [
+          "add",
+          "clear",
+          "get",
+          "has",
+          "remove",
+          "replace",
+          "subscribeChanges",
+          "update",
+        ],
+        dependencies: [
+          "get",
+          "getAll",
+          "has",
+          "remove",
+          "reset",
+          "set",
+          "setAll",
+        ],
+        lifecycle: [
+          "addActivateGuard",
+          "addDeactivateGuard",
+          "removeActivateGuard",
+          "removeDeactivateGuard",
+        ],
+        plugin: [
+          "addEventListener",
+          "addInterceptor",
+          "buildNavigationState",
+          "claimContextNamespace",
+          "emitTransitionError",
+          "extendRouter",
+          "forwardState",
+          "getOptions",
+          "getRootPath",
+          "getRouteConfig",
+          "getTree",
+          "makeState",
+          "matchPath",
+          "navigateToState",
+          "setRootPath",
+        ],
+        navigator: [
+          "canNavigateTo",
+          "getState",
+          "isActiveRoute",
+          "isLeaveApproved",
+          "navigate",
+          "subscribe",
+          "subscribeLeave",
+        ],
+        internals: [
+          "addEventListener",
+          "buildPath",
+          "buildStateResolved",
+          "contextClaimRecords",
+          "dependenciesGetStore",
+          "emitTransitionError",
+          "forwardState",
+          "getCloneState",
+          "getMetaForState",
+          "getOptions",
+          "getQueryParams",
+          "getRootPath",
+          "getStateName",
+          "getTree",
+          "hydrationState",
+          "interceptors",
+          "isDisposed",
+          "isTransitioning",
+          "logger",
+          "makeState",
+          "matchPath",
+          "navigateToNotFound",
+          "navigateToState",
+          "port",
+          "routeGetStore",
+          "routerExtensions",
+          "setRootPath",
+          "start",
+          "systemCommit",
+          "treeChanged",
+          "validator",
+        ],
+      });
+    });
+  });
+});

--- a/packages/core/tests/property/error/methods.properties.ts
+++ b/packages/core/tests/property/error/methods.properties.ts
@@ -1,5 +1,5 @@
 import { fc, test } from "@fast-check/vitest";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { RouterError } from "@real-router/core";
 
@@ -263,38 +263,106 @@ describe("RouterError Methods Properties", () => {
   });
 
   describe("hasField / getField", () => {
-    test.prop([errorCodeArbitrary, fc.string()], { numRuns: 10_000 })(
+    // ⚑ The key generator is the whole point of this property, and it used to be
+    // `__non_existent_${randomKey}__` — prefixed AND suffixed, so no
+    // `fc.string()` could ever produce `toString`, `constructor` or any other
+    // name the old `key in this` answered `true` for. It ran 10 000 times
+    // against the #1829 defect and could not see it: a vacuous guard on exactly
+    // the axis it names.
+    //
+    // Widening the GENERATOR is the fix rather than adding a second cell beside
+    // it — the names are non-existent fields, which is what this property is
+    // about, and a non-generative twin here would only duplicate
+    // `tests/functional/error/field-access-own-only-1829.test.ts`.
+    //
+    // Derived, never listed: a hand-written enumeration of `Object.prototype`
+    // is what the sibling sweep #1798 got wrong, and the set grows with the
+    // engine.
+    const CHAIN_ONLY_NAMES = [
+      ...new Set([
+        ...Object.getOwnPropertyNames(Object.prototype),
+        ...Object.getOwnPropertyNames(
+          Object.getPrototypeOf(new RouterError("SOME_CODE")) as object,
+        ),
+      ]),
+    ];
+
+    const absentKeyArbitrary = fc.oneof(
+      fc.string().map((randomKey) => `__non_existent_${randomKey}__`),
+      fc.constantFrom(...CHAIN_ONLY_NAMES),
+    );
+
+    test.prop([errorCodeArbitrary, absentKeyArbitrary], { numRuns: 10_000 })(
       "hasField returns false for non-existent fields",
-      (code, randomKey) => {
+      (code, absentKey) => {
         const err = new RouterError(code);
 
-        // Generate random key that definitely doesn't exist
-        const nonExistentKey = `__non_existent_${randomKey}__`;
-
-        expect(err.hasField(nonExistentKey)).toBe(false);
-        expect(err.getField(nonExistentKey)).toBeUndefined();
+        expect(err.hasField(absentKey)).toBe(false);
+        expect(err.getField(absentKey)).toBeUndefined();
       },
     );
+
+    it("CONTROL — the generator actually reaches the chain names", () => {
+      // Without this the widening above can be reverted, or the arbitrary can
+      // start producing only its random half, and the property goes back to
+      // guarding nothing while still passing.
+      expect(CHAIN_ONLY_NAMES).toContain("toString");
+      expect(CHAIN_ONLY_NAMES).toContain("constructor");
+      expect(CHAIN_ONLY_NAMES).toContain("hasField");
+      expect(CHAIN_ONLY_NAMES.length).toBeGreaterThan(15);
+
+      const samples = fc.sample(absentKeyArbitrary, 500);
+
+      expect(samples.some((key) => CHAIN_ONLY_NAMES.includes(key))).toBe(true);
+      expect(samples.some((key) => key.startsWith("__non_existent_"))).toBe(
+        true,
+      );
+
+      // ⚑ The PRECONDITION the property leans on, asserted rather than assumed:
+      // a field-less error carries none of these as an OWN property, so every
+      // generated key really is absent and the property never has to skip one.
+      //
+      // ⚠ A `if (Object.hasOwn(err, absentKey)) return;` guard stood in the
+      // property body instead, justified by "`message`, `stack` and `name` are
+      // own properties of every Error" — true, and irrelevant: none of those
+      // three is on `Object.prototype` or on the class prototype, so none is in
+      // this set. Measured across four codes, the guard swallowed NOTHING. A
+      // dead branch with a plausible comment on it is worse than no comment.
+      const probe = new RouterError("SOME_CODE");
+
+      expect(
+        CHAIN_ONLY_NAMES.filter((name) => Object.hasOwn(probe, name)),
+      ).toStrictEqual([]);
+    });
 
     test.prop([errorCodeArbitrary, customFieldsArbitrary], { numRuns: 10_000 })(
       "hasField/getField are consistent",
       (code, fields) => {
         const err = new RouterError(code, fields);
 
+        // ⚑ The six reserved METHOD names used to be skipped here by a
+        // hard-coded list. The skip was DEAD: `customFieldsArbitrary` already
+        // filters exactly those names (plus `__proto__` / `constructor` /
+        // `prototype` and the reserved data keys), so the condition was true on
+        // every run. It read as compensation for the old `key in this` — which
+        // did answer `true` for all six — and survived because a dead branch in
+        // a test costs nothing visible.
+        //
+        // ⚠ Replacing it with `if (reserved) expect(false) else expect(true)`
+        // was tried and is equally dead, for the same reason. The generator owns
+        // the exclusion; re-deriving it here duplicates it. The reserved names
+        // are pinned where a generator CAN reach them — the chain-only property
+        // above, which reds on the `key in this` mutant.
+        //
+        // ⚠ Two SIBLINGS in this file carry the identical dead skip ("adds
+        // arbitrary fields", "multiple calls accumulate fields") and are left
+        // alone deliberately: they predate #1829 and cleaning them is not this
+        // fix's business. Recorded because measuring something and saying
+        // nothing is how it stays. ("does not overwrite methods" is NOT one of
+        // them — it injects the reserved keys itself, so its list is live.)
         for (const [key, value] of Object.entries(fields)) {
-          if (
-            ![
-              "setCode",
-              "toJSON",
-              "hasField",
-              "getField",
-              "setAdditionalFields",
-              "setErrorInstance",
-            ].includes(key)
-          ) {
-            expect(err.hasField(key)).toBe(true);
-            expect(err.getField(key)).toBe(value);
-          }
+          expect(err.hasField(key)).toBe(true);
+          expect(err.getField(key)).toBe(value);
         }
       },
     );


### PR DESCRIPTION
## Summary

Two defects on the same axis: what `@real-router/core` hands BACK to a consumer.
Both are contract corrections on public API, neither has a production call site
in the monorepo, and neither would have gone red in the existing suite.

### #1829 — `RouterError.hasField` / `getField` answer about OWN fields only

Both walked the prototype chain (`key in this`, `this[key]`), so an error
carrying ONE custom field answered `true` for **eighteen** names and handed back
native methods for most of them:

```js
const err = new RouterError("SOME_CODE", { userId: "u1" });

err.hasField("toString");        // was true      -> now false
typeof err.getField("toString"); // was "function" -> now "undefined"
err.hasField("userId");          // true, unchanged
```

`toString` and `constructor` are ordinary strings — they arrive from a config
key, a route param name, a serialized payload.

- **Root cause:** the membership test was `in`, which is a chain walk, where the
  documented question is about the error's own fields. Both methods now gate on
  a module-load-captured `Object.hasOwn`.
- ⚠ **Not the fix the issue proposes.** It suggested reusing `toJSON`'s
  `excludeKeys`. Measured against the methods' own docstrings, that set keeps
  **1 of 4** worked examples:

  | rule                     | segment/path/code/userId | false positives |
  | ------------------------ | ------------------------ | --------------- |
  | `key in this` (before)   | 1111                     | 18              |
  | `Object.hasOwn`          | 1111                     | 0               |
  | hasOwn minus toJSON's    | 0001                     | 0 ← the proposal |

  The verdict was already on record: `chain-walk-authority.test.ts` carried this
  site as a DEFECT row whose own measurement said the chain walk "buys the
  documented feature nothing". That row is replaced by a note, and the table is
  scan-driven — restoring `key in this` reds it (verified).

### #1957 — no door hands out a prototype-swap primitive

An own `"__proto__"` on a container is inert while it sits there and becomes a
swap the moment a consumer merges it with `Object.assign` or a `for…in` copy.
`JSON.parse` and `Object.fromEntries(new URLSearchParams(…))` both mint the key,
so no adversarial construction is involved.

```js
const r = createRouter(routes, JSON.parse('{"defaultRoute":"home","__proto__":{"pwned":"YES"}}'));

Object.assign({}, getPluginApi(r).getOptions()).pwned; // was "YES" -> now undefined
```

- **Root cause:** `getAll()` was hardened at #1823 and the rule stopped there.
  Four more doors spread a caller's bag into an object core allocates and handed
  it out — `getOptions()` (and with it `getCloneState().options`, so clones were
  polluted too), `getCloneState().dependencies`, `getMetaForState(name)` for a
  route named `__proto__`, and the `NavigationOptions` a plugin hook receives.
- **Two shapes, one question** — does core read that key back off the very
  object it published? **No → drop it** (`dropUnsafeKey`, `getAll`'s shape, now
  one primitive at four sites). **Yes → conceal it** from enumeration
  (`concealUnsafeKey`, exactly one site: the route-meta record). Dropping is not
  a milder fix there but a wrong one — core reads `meta[segmentName]` per
  navigation, so with the entry gone the read reaches the inherited accessor and
  answers `Object.prototype`, an object with no keys, i.e. "params unchanged".
  Measured end to end: a route named `__proto__` stops re-activating on a `:id`
  change.

### Corrections the attack phase forced on this PR's own claims

Every one of these was written by me and disproved by measurement before
shipping, so the record here is what survived:

- **A spread is safe.** `{ ...container }` performs `CreateDataProperty` and can
  never swap — measured on three carrier shapes. A first revision said
  "`Object.assign` and a spread both `[[Set]]`" in five places, and the guard's
  own instrument carried the same dead arm OR-ed into it.
- **The two options doors are not one object.** `getCloneState()` returns
  `{ ...this.#options.get() }` — a fresh, unfrozen spread, identity `false`. One
  fix covers both because it sits at the SOURCE, in the `OptionsNamespace`
  constructor.
- **Eighteen, not twenty.** 12 inherited + 6 class methods, `constructor`
  counting once. The wrong arithmetic had been repeated four times.
- **The level closed is the container a door RETURNS**, no further. One level
  down are the caller's own objects by reference (#1958's one-level copy model);
  `getOptions().defaultParams` still swaps and IS the caller's object by
  identity. Pinned rather than left as an absence.

### Maintainability

- `hostileBags`'s six container shapes now run against the fixed doors in the
  same commit (no defect found).
- `methods.properties.ts`: the "non-existent field" generator built
  `` `__non_existent_${randomKey}__` `` — prefixed AND suffixed — so 10 000 runs
  could never produce `toString`. It named the axis this PR fixes and guarded
  nothing on it. The generator is widened (it reds on the `key in this` mutant)
  and a CONTROL cell reds if it is narrowed back. Two sibling properties carry
  the same dead skip and are deliberately left alone — they predate this.

## Breaking changes

⚠ A dependency literally named `__proto__` is still held by the base router and
still answered by `get()`, but it no longer reaches a `cloneRouter` clone. That
is the trade #1823 already took at `getAll()`: a single read hands back a VALUE,
a door hands back a CONTAINER someone will merge, and only the second is
withheld.

⚠ `hasField` / `getField` no longer reach `Object.prototype` members or the
class's own methods.

## Test plan

- [x] `tests/functional/error/field-access-own-only-1829.test.ts` — inherited
      names, class methods (both derived at runtime), a counting cell so the
      prose cannot drift, positive/negative controls, and `getField` as an
      independent door. Fails before, passes after.
- [x] `tests/functional/handed-out-containers-1957.test.ts` (24 cells) — every
      container-returning door measured on the SWAP itself, the `hostileBags`
      battery, the level-boundary pin, five carve-outs each with a measured
      reason, and a per-surface member snapshot so a new door reds until
      someone classifies it (verified on two differently-built surfaces).
- [x] Mutation-validated: each of the six fix sites reds the guard file
      individually; reverting the whole fix reds 11 tests across 4 files; both
      branches of each new primitive are killed.
- [x] core — 4792 functional, 463 property, 153 stress, **100% coverage**
- [x] consumers — validation-plugin 774, browser-plugin 412,
      persistent-params 152, preload 86, ssr-utils 78, search-schema 78,
      lifecycle 37
- [x] `lint` 0, `type-check` 0, knip, semgrep, jscpd, coverage-scope,
      doc-anchors, syncpack, changeset gates all clean
- [ ] full `pnpm build` across the graph — delegated (project rule)
- [ ] perf — reading it from the CodSpeed report on this PR

Closes #1829
Closes #1957

Related: #1986 (three further doors found by the deep walk, recorded as
carve-outs pending an owner decision), #1823, #1904, #1801, #1788, #1191, #1901.
