### PR TITLE
fix(browser-env): history.state restores four channels and now validates four (#1837)

### DIFF
--- a/.changeset/history-state-browser-1837.md
+++ b/.changeset/history-state-browser-1837.md
@@ -1,0 +1,66 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+fix: `history.state` restores four channels and now validates four (#1837)
+
+`history.state` is the one input this plugin takes that a third party genuinely
+controls — a previous page, another script, or an entry written by an older
+version of your app. Four fixes to how a restored entry is screened and written
+back. They live in `shared/browser-env`, so `@real-router/hash-plugin` gets the
+same four.
+
+**1. The query channel is screened by value, like the path channel.** A restored
+`search` reached the frozen `state.search` with any value at all, while the
+IDENTICAL value in `params` was refused:
+
+```js
+// all six were ACCEPTED into state.search before; all six are refused now
+{ tab: () => 1 }   { tab: Symbol() }   { tab: 10n }
+{ tab: <cyclic> }  { tab: new Date() } { tab: new Map() }
+```
+
+Measured end to end: `state.search.tab` of type `function`, `buildPath` printing
+`?tab=()%20%3D%3E%201`, and a real `history.pushState` throwing
+`DataCloneError` on the next write.
+
+⚠ The query domain is unchanged — a repeated key still parses to an array and a
+bare `?flag` to `null`, and both still restore.
+
+⚠ **What finding 1 also takes.** A `search` whose object carries a custom
+prototype — a class instance, or `Object.create(someBag)` — was accepted before
+(as an empty bag, since only own keys are read) and is refused now, because
+`isParams` rejects a non-`Object.prototype` prototype exactly as it always has
+for `params`. The two channels agree, which is the point; and the shape cannot
+survive a real `history.pushState` round trip anyway, since structured
+deserialization yields plain objects. Reachable only from a synthetic
+`PopStateEvent`.
+
+**2. The guard's own reads no longer rethrow.** A `history.state` carrying an
+accessor, or a `get`-trapping Proxy, made `isState` throw out of a type guard.
+The popstate handler then took its non-`RouterError` path
+(`recoverFromCriticalError`) instead of falling back to `matchPath` — a wrong
+classification rather than a crash. An unreadable payload is now simply not
+restorable, the same answer any other malformed entry gets.
+
+**3. A persisted `UNKNOWN_ROUTE` answers to `allowNotFound`.** With
+`allowNotFound: false`, Back to an entry written while the option was `true`
+still committed the 404 the option forbids. Measured: the plugin itself writes
+`{"name":"@@router/UNKNOWN_ROUTE","params":{},"search":{},"path":"/nope"}` under
+`allowNotFound: true`, so the entry is ordinary, not adversarial. It now takes
+the same branch a live unmatched URL takes: `true` restores, `false` emits
+`ROUTE_NOT_FOUND` and rolls the URL back.
+
+**4. The URL rollback writes the four-channel projection.** It wrote the whole
+committed `State`, so `context` and `transition` went into `history.state` on
+a guard-rejected Back, a SAME_STATES popstate and a strict-mode unmatched URL —
+the first two through the handler's `RouterError` catch, the third through its
+own branch. ⚠ `context` is a public plugin slot this plugin does not control,
+and a real `replaceState` serialises: a plugin publishing a non-cloneable value
+made the rollback throw into an empty `catch`, so the URL was never rolled back
+at all.
+
+⚠ **If you read `history.state` yourself:** rollback entries now carry exactly
+`{ name, params, search, path }`, matching every other write site. Measured,
+ordinary entries always did — the two extra members appeared only on rollback
+ones.

--- a/.changeset/history-state-hash-1837.md
+++ b/.changeset/history-state-hash-1837.md
@@ -1,0 +1,68 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+fix: `history.state` restores four channels and now validates four (#1837)
+
+`history.state` is the one input this plugin takes that a third party genuinely
+controls — a previous page, another script, or an entry written by an older
+version of your app. Four fixes to how a restored entry is screened and written
+back.
+
+**1. The query channel is screened by value, like the path channel.** A restored
+`search` reached the frozen `state.search` with any value at all, while the
+IDENTICAL value in `params` was refused:
+
+```js
+// all six were ACCEPTED into state.search before; all six are refused now
+{ tab: () => 1 }   { tab: Symbol() }   { tab: 10n }
+{ tab: <cyclic> }  { tab: new Date() } { tab: new Map() }
+```
+
+Measured end to end: `state.search.tab` of type `function`, `buildPath` printing
+`?tab=()%20%3D%3E%201`, and a real `history.pushState` throwing
+`DataCloneError` on the next write.
+
+⚠ The query domain is unchanged — measured through a real restore, a repeated
+key still comes back as `[1, 2]` and a bare `?flag` as `null`.
+
+⚠ **What finding 1 also takes.** A `search` whose object carries a custom
+prototype — a class instance, or `Object.create(someBag)` — was accepted before
+(as an empty bag, since only own keys are read) and is refused now, because
+`isParams` rejects a non-`Object.prototype` prototype exactly as it always has
+for `params`. The two channels agree, which is the point; and the shape cannot
+survive a real `history.pushState` round trip anyway, since structured
+deserialization yields plain objects. Reachable only from a synthetic
+`PopStateEvent`.
+
+**2. The guard's own reads no longer rethrow.** A `history.state` carrying an
+accessor, or a `get`-trapping Proxy, made `isState` throw out of a type guard.
+The popstate handler then took its non-`RouterError` path
+(`recoverFromCriticalError`) instead of falling back to `matchPath` — a wrong
+classification rather than a crash. An unreadable payload is now simply not
+restorable, the same answer any other malformed entry gets.
+
+**3. A persisted `UNKNOWN_ROUTE` answers to `allowNotFound`.** With
+`allowNotFound: false`, Back to an entry written while the option was `true`
+still committed the 404 the option forbids — the guard accepts core's `@@`
+namespace, deliberately, because that is what `UNKNOWN_ROUTE` is, so the entry
+took the matched branch and skipped the gate. Measured: the plugin itself writes
+`{"name":"@@router/UNKNOWN_ROUTE","params":{},"search":{},"path":"/nope"}` under
+`allowNotFound: true`, so the entry is ordinary, not adversarial. It now takes
+the same branch a live unmatched URL takes: `true` restores, `false` emits
+`ROUTE_NOT_FOUND` and rolls the URL back.
+
+**4. The URL rollback writes the four-channel projection.** It wrote the whole
+committed `State`, so `context` and `transition` went into `history.state` on a
+guard-rejected Back, a SAME_STATES popstate and a strict-mode unmatched URL.
+⚠ `context` is a public plugin slot this plugin does not control, and a real
+`replaceState` serialises: a plugin publishing a non-cloneable value made the
+rollback throw into an empty `catch`, so the URL was never rolled back at all.
+
+⚠ **If you read `history.state` yourself:** rollback entries now carry exactly
+`{ name, params, search, path }`. Measured, ordinary entries always did — the
+two extra members appeared only on rollback ones.
+
+These fixes live in `shared/browser-env`, which this plugin consumes through the
+same `isState` guard and the same popstate handler as
+`@real-router/browser-plugin`, so both packages get them identically.

--- a/packages/browser-plugin/ARCHITECTURE.md
+++ b/packages/browser-plugin/ARCHITECTURE.md
@@ -410,7 +410,7 @@ Simple concatenation: `base + path`.
 
 Popstate event handling, critical error recovery, and deferred event processing live in `shared/browser-env/`:
 
-- `shared/browser-env/popstate-utils.ts` — `getRouteFromEvent` (validates `history.state` via `isStateStrict`, falls back to `api.matchPath(browser.getLocation())` when invalid), `updateBrowserState` (legacy), `createUpdateBrowserState` (mutable-buffer factory used by browser-plugin on the hot path)
+- `shared/browser-env/popstate-utils.ts` — `getRouteFromEvent` (validates `history.state` via `isStateStrict`, falls back to `api.matchPath(browser.getLocation())` when invalid), `updateBrowserState` (the four-channel projection `{ name, params, search, path }` — hash-plugin's writer, and since #1837 the URL rollback's too, so a rollback entry carries the same members every other write site does), `createUpdateBrowserState` (mutable-buffer factory used by browser-plugin on the hot path)
 - `shared/browser-env/popstate-handler.ts` — `createPopstateHandler` (deferred-queue, last-write-wins, `RouterError` vs critical-error split), `createPopstateLifecycle` (popstate listener add/remove + `cleanup` callback)
 - `historyState` is a subset of `State`: only `{ name, params, search, path }` are stored in `history.state` — `transition`, `context`, etc. are not persisted across reloads
 - Error categorization in `popstate-handler.ts`: `RouterError` instances are routed through `rollbackUrlToCurrentState()` (sync URL with current router state); anything else triggers `recoverFromCriticalError()` (warns + `replaceState` to last good URL)

--- a/packages/browser-plugin/CLAUDE.md
+++ b/packages/browser-plugin/CLAUDE.md
@@ -91,7 +91,31 @@ See [IMPLEMENTATION_NOTES.md](../../IMPLEMENTATION_NOTES.md) section "URL Fragme
 
 ### State Validation
 
-External code can corrupt `history.state`. Plugin validates structure via `isStateStrict` (from browser-env) and ignores invalid states gracefully.
+External code can corrupt `history.state` — a previous page, another script, or
+an entry written by an older version of the app. The plugin validates it via
+`isStateStrict` (from browser-env) and falls back to `matchPath(location)` when
+it does not hold up. Four things that guard does, each of which it did not
+before #1837 / #1838:
+
+- **Both restored channels are screened by VALUE.** `params` always was;
+  `search` was shape-only until #1837, so a function, Symbol, BigInt, cycle or
+  class instance rode into the frozen `state.search` while the identical value
+  in `params` was refused. The query domain is untouched — a repeated key still
+  restores as an array, a bare `?flag` as `null`.
+- **It answers, it does not throw.** The entry may carry accessors or be a
+  `get`-trapping Proxy; every read sits inside a boundary, so an unreadable
+  payload is simply not restorable instead of surfacing as a critical error.
+- **The entry is read ONCE per member.** The snapshot that is validated is the
+  snapshot that is committed, so an entry answering differently between reads
+  cannot have one shape approved and another one land.
+- **A persisted `UNKNOWN_ROUTE` is not special-cased past `allowNotFound`.** It
+  takes the same branch a live unmatched URL takes.
+
+⚠ Only the first of those is visible in a real browser without help:
+`history.pushState` serialises, so an accessor, a Proxy or a drifting entry
+cannot come back from a genuine popstate. They are reachable from a synthetic
+`PopStateEvent` and under jsdom, which stores the entry by identity — which is
+also why the test estate was blind to the `DataCloneError` half for so long.
 
 ### Popstate history-write skip (#1353)
 

--- a/packages/browser-plugin/tests/functional/browser-env/authority-1838.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/authority-1838.test.ts
@@ -146,4 +146,63 @@ describe("shared/browser-env authority (#1838)", () => {
 
     expect(writes).toStrictEqual([]);
   });
+
+  it("every member `RestorableEntry` declares is actually validated (#1837)", () => {
+    // The recurrence guard for the class #1838 and #1837 are both instances of:
+    // the guard declares a shape and checks a SUBSET of it.
+    //
+    //   #1838 — declared `value is State`, checked three of `State`'s six.
+    //   #1837 — checked `search`'s SHAPE and not its values, while the twin
+    //           channel `params` was screened by value.
+    //
+    // The next instance is a member added to `RestorableEntry` and not to the
+    // guard, and neither the type checker nor any behavioural test would say
+    // so: an unvalidated member is simply believed.
+    //
+    // Derived from the source, never listed — a hand-written member list is the
+    // thing that goes stale, and that is what let #1838 sit as long as it did.
+    const file = path.join(SRC, "state-guard.ts");
+    const source = parse(file);
+
+    const declared: string[] = [];
+    const validated = new Set<string>();
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isInterfaceDeclaration(node) &&
+        node.name.text === "RestorableEntry"
+      ) {
+        for (const member of node.members) {
+          if (member.name !== undefined && ts.isIdentifier(member.name)) {
+            declared.push(member.name.text);
+          }
+        }
+      }
+
+      // Every `obj.<member>` read, wherever it happens: `isStateStrict` reads
+      // some directly and delegates the rest to `isRequiredFields`, whose
+      // parameter carries the same name.
+      if (
+        ts.isPropertyAccessExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "obj"
+      ) {
+        validated.add(node.name.text);
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+
+    // Anti-vacuity on BOTH derivations: an empty `declared` makes the subset
+    // check trivially true, and an empty `validated` makes it trivially false
+    // in a way a reader might "fix" by shrinking the interface.
+    expect(declared.length).toBeGreaterThan(3);
+    expect(validated.size).toBeGreaterThan(3);
+
+    expect(declared.filter((member) => !validated.has(member))).toStrictEqual(
+      [],
+    );
+  });
 });

--- a/packages/browser-plugin/tests/functional/browser-env/restore-reads-once-1837.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/restore-reads-once-1837.test.ts
@@ -1,0 +1,161 @@
+// #1837, found by attacking the fix rather than by the issue — the entry that
+// is VALIDATED must be the entry that is COMMITTED.
+//
+// `getRouteFromEvent` read each member of `history.state` TWICE: once through
+// `isState`, and once again when building the arguments for `makeState`.
+// Measured before the fix, with a payload answering differently on the second
+// read of each key:
+//
+//     reads per member: { name: 2, params: 2, path: 2 }
+//     guard approved  : users.view  /users/view/1
+//     committed       : home        /TOTALLY/OTHER   { id: "SECOND" }
+//
+// The guard's verdict described one entry and the router committed another.
+//
+// ⚠ **Reachability, stated honestly.** A real browser runs
+// StructuredSerializeForStorage on `history.pushState`, so a `history.state`
+// that comes back from a genuine popstate is a plain deserialized object with
+// no accessors — drift is impossible there. It is reachable from a SYNTHETIC
+// `PopStateEvent` (app code, or a test harness) and under jsdom, which stores
+// `history.state` by identity.
+//
+// ⚑ That is exactly the reachability of the accessor defect one commit earlier,
+// and this is its sibling: both follow from "the entry may not be a plain
+// object". Fixing the throw and leaving the drift would be the false-completeness
+// shape — a fix whose sibling is one line away.
+import { createRouter } from "@real-router/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { browserPluginFactory } from "@real-router/browser-plugin";
+
+import {
+  createMockedBrowser,
+  routerConfig,
+  noop,
+} from "../../helpers/testUtils";
+
+import type { Router } from "@real-router/core";
+
+/** Answers `first` on read 1 of each key and `then` on every later read. */
+function driftingEntry(
+  first: Record<string, unknown>,
+  then: Record<string, unknown>,
+): { entry: Record<string, unknown>; reads: Record<string, number> } {
+  const reads: Record<string, number> = {};
+  const entry: Record<string, unknown> = {};
+
+  for (const key of Object.keys(first)) {
+    reads[key] = 0;
+
+    Object.defineProperty(entry, key, {
+      get(): unknown {
+        reads[key] += 1;
+
+        return reads[key] === 1 ? first[key] : (then[key] ?? first[key]);
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  return { entry, reads };
+}
+
+describe("#1837 — a restored entry is read ONCE per member", () => {
+  it("commits what the guard validated, not a later read", async () => {
+    vi.spyOn(console, "error").mockImplementation(noop);
+    vi.spyOn(console, "warn").mockImplementation(noop);
+
+    const browser = createMockedBrowser(noop);
+    const router: Router = createRouter(routerConfig, {
+      defaultRoute: "home",
+    });
+
+    router.usePlugin(browserPluginFactory({}, browser));
+    await router.start("/users/list");
+
+    const { entry, reads } = driftingEntry(
+      { name: "users.view", params: { id: "1" }, path: "/users/view/1" },
+      { name: "home", params: { id: "SECOND" }, path: "/TOTALLY/OTHER" },
+    );
+
+    globalThis.history.replaceState({}, "", "/users/view/1");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: entry }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // ⚑ ONE read per member is the property; the committed state is the
+    // consequence. Both are asserted, because the count alone would pass if the
+    // single read happened to be the wrong one.
+    expect(reads).toStrictEqual({ name: 1, params: 1, path: 1 });
+    expect({
+      name: router.getState()?.name,
+      path: router.getState()?.path,
+    }).toStrictEqual({ name: "users.view", path: "/users/view/1" });
+
+    router.stop();
+  });
+
+  it("CONTROL — a stable entry restores exactly as before", async () => {
+    // The snapshot must not change what a normal entry does; without this the
+    // cell above passes if the restore stopped working altogether.
+    const browser = createMockedBrowser(noop);
+    const router: Router = createRouter(routerConfig, {
+      defaultRoute: "home",
+      queryParamsMode: "loose",
+    });
+
+    router.usePlugin(browserPluginFactory({}, browser));
+    await router.start("/users/list");
+
+    globalThis.history.replaceState({}, "", "/users/view/9");
+    globalThis.dispatchEvent(
+      new PopStateEvent("popstate", {
+        state: {
+          name: "users.view",
+          params: { id: "9" },
+          search: { tab: "a" },
+          path: "/users/view/9",
+        },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(router.getState()?.name).toBe("users.view");
+    expect(router.getState()?.params).toStrictEqual({ id: "9" });
+    expect(router.getState()?.search).toStrictEqual({ tab: "a" });
+
+    router.stop();
+  });
+
+  it("CONTROL — a THROWING member still falls back rather than escaping", async () => {
+    // The snapshot is a read too, so it inherits the boundary question. It must
+    // not reintroduce the escape the previous commit closed.
+    vi.spyOn(console, "error").mockImplementation(noop);
+
+    const browser = createMockedBrowser(noop);
+    const router: Router = createRouter(routerConfig, {
+      defaultRoute: "home",
+    });
+
+    router.usePlugin(browserPluginFactory({}, browser));
+    await router.start("/users/list");
+
+    const entry = { params: {}, path: "/home" };
+
+    Object.defineProperty(entry, "name", {
+      get(): never {
+        throw new Error("from the entry");
+      },
+      enumerable: true,
+    });
+
+    globalThis.history.replaceState({}, "", "/home");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: entry }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Falls back to `matchPath("/home")`, which is the `home` route.
+    expect(router.getState()?.name).toBe("home");
+
+    router.stop();
+  });
+});

--- a/packages/browser-plugin/tests/functional/browser-env/state-guard-getter-safety-1837.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/state-guard-getter-safety-1837.test.ts
@@ -1,0 +1,169 @@
+// #1837 finding 2 — the guard reads a third party's object, so every read is a
+// call into code the plugin does not own.
+//
+// `isParams` has wrapped its walk in a try/catch since #1052 for exactly this
+// reason. The guard's OWN reads had no boundary: `obj.name`, `obj.path`,
+// `obj.search`, `obj.transition`, `obj.context` are plain property accesses on
+// a `history.state` payload, and a payload can carry accessors — an entry
+// written by another script, or a `get`-trapping Proxy.
+//
+// ⚠ The issue framed this as "two of the three reads", on the ground that
+// `isParams` covers `params`. Measured: it does not, and cannot. The getter
+// fires on the property READ, in `isRequiredFields`, BEFORE `isParams` is
+// entered — so `params` escaped exactly like `name` and `path`. All five reads
+// needed the boundary, not two.
+//
+// What it costs when it escapes: `onPopState` has a try, so the throw is
+// contained — but it is classified as `[browser-plugin] Critical error in
+// onPopState` instead of the correct "this entry is not restorable → fall back
+// to `matchPath`". A wrong classification, not a crash.
+import { describe, expect, it } from "vitest";
+
+import { isStateStrict } from "../../../src/browser-env/state-guard";
+
+const BOOM = new Error("from the entry's accessor");
+
+/** A `history.state` payload whose named member throws when read. */
+function throwingAt(member: string): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    name: "users.list",
+    params: {},
+    path: "/users/list",
+  };
+
+  return Object.defineProperty(base, member, {
+    get(): never {
+      throw BOOM;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+describe("#1837 — a throwing accessor on the entry is REFUSED, not rethrown", () => {
+  it("survives a throwing getter on every member the guard reads", () => {
+    // ⚑ ONE assertion over all five, so a member dropped from the list cannot
+    // pass by not being tested. `verdict` is `false` — an entry the guard
+    // cannot read is not restorable, which is the same answer it gives any
+    // other malformed payload.
+    const verdicts = ["name", "path", "params", "search", "transition"].map(
+      (member) => {
+        try {
+          return [member, isStateStrict(throwingAt(member))];
+        } catch (error) {
+          return [member, `RETHREW: ${(error as Error).message}`];
+        }
+      },
+    );
+
+    expect(verdicts).toStrictEqual([
+      ["name", false],
+      ["path", false],
+      ["params", false],
+      ["search", false],
+      ["transition", false],
+    ]);
+  });
+
+  it("survives a get-trapping Proxy over an otherwise valid entry", () => {
+    // The shape a reactive store or an instrumented page produces. Distinct
+    // from the accessor above: the trap fires for EVERY key, including ones the
+    // guard reaches only after the earlier ones passed.
+    const trapped = new Proxy(
+      { name: "users.list", params: {}, path: "/users/list" },
+      {
+        get(): never {
+          throw BOOM;
+        },
+      },
+    );
+
+    expect(() => isStateStrict(trapped)).not.toThrow();
+    expect(isStateStrict(trapped)).toBe(false);
+  });
+
+  it("survives a throwing getter INSIDE the params bag — the #1052 boundary", () => {
+    // The read is one level deeper than the cells above: `params.id`, a value
+    // INSIDE the bag, reached by `isParams`'s walk rather than by the guard's
+    // own five property reads.
+    //
+    // ⚠ This cell does NOT pin `isParams`'s own `catch` (the #1052 boundary),
+    // and the honest reason is worth more than the pretence. Measured twice:
+    // making that `catch` rethrow left all 421 tests GREEN before this file
+    // existed, and leaves them green WITH this cell — because the outer
+    // boundary added for #1837 subsumes it. Through `isStateStrict` the inner
+    // one is now unobservable BY CONSTRUCTION, so no test reachable from here
+    // can hold it.
+    //
+    // It stays where it is regardless: `isParams` is a byte-identical twin of
+    // validation-plugin's copy, which has no outer boundary of its own, and
+    // that copy is where the #1052 catch is still load-bearing.
+    //
+    // What this cell does pin is the OUTCOME — a nested throwing accessor is
+    // refused rather than rethrown — which is the property a consumer depends
+    // on and which survives whichever of the two boundaries catches it.
+    const bag: Record<string, unknown> = {};
+
+    Object.defineProperty(bag, "id", {
+      get(): never {
+        throw BOOM;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+
+    // The accessor is genuinely live — without this the cell is vacuous.
+    expect(() => bag.id).toThrow(BOOM);
+
+    expect(() =>
+      isStateStrict({ name: "users.view", params: bag, path: "/users/1" }),
+    ).not.toThrow();
+    expect(
+      isStateStrict({ name: "users.view", params: bag, path: "/users/1" }),
+    ).toBe(false);
+
+    // ...and the same one level down again, in `search`, which reaches the same
+    // validator since this issue's first commit.
+    expect(
+      isStateStrict({
+        name: "users.view",
+        params: {},
+        path: "/users/1",
+        search: bag,
+      }),
+    ).toBe(false);
+  });
+
+  it("CONTROL — a valid entry is still ACCEPTED, and a plain invalid one still refused", () => {
+    // Without this the cells above pass by refusing everything, which is what a
+    // `try { … } catch { return false }` around the whole body would do if it
+    // also swallowed the real verdict.
+    expect(
+      isStateStrict({ name: "users.list", params: {}, path: "/users/list" }),
+    ).toBe(true);
+    expect(
+      isStateStrict({
+        name: "users.list",
+        params: {},
+        path: "/users/list",
+        search: { tab: "a" },
+      }),
+    ).toBe(true);
+    expect(
+      isStateStrict({ name: "users.list", params: "bad", path: "/u" }),
+    ).toBe(false);
+    expect(isStateStrict(null)).toBe(false);
+  });
+
+  it("CONTROL — the accessor is genuinely reached, not skipped by an earlier refusal", () => {
+    // ⚠ The cell that stops the first one from being vacuous. A guard that
+    // refused `throwingAt("transition")` for some unrelated reason would look
+    // identical. Reading the member by hand must throw — i.e. the payload the
+    // guard was handed really does have a live accessor on it.
+    for (const member of ["name", "path", "params", "search", "transition"]) {
+      const entry = throwingAt(member);
+
+      expect(() => entry[member]).toThrow(BOOM);
+    }
+  });
+});

--- a/packages/browser-plugin/tests/functional/browser-env/state-guard-value-domain-1837.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/state-guard-value-domain-1837.test.ts
@@ -1,0 +1,126 @@
+// #1837 finding 1 — `history.state` restores FOUR channels and validates the
+// values of three.
+//
+// `history.state` is the one input in this codebase a third party genuinely
+// controls: a previous page, another script, an entry written by an older
+// version of the app. `popstate-utils` restores four channels from it —
+// `name`, `params`, `search`, `path` — and hands them straight to
+// `api.makeState`.
+//
+// ⚑ #1838 already closed the SHAPE half of this: `isOptionalBag` refuses a
+// `search` that is a string or an array, because both reach `makeState` as a bag
+// of numeric keys. What it does not do is look at the VALUES, and that is the
+// half this file covers. Measured before the fix, every one of these was
+// ACCEPTED into the frozen `state.search`:
+//
+//     {tab: () => 1}     {tab: Symbol()}   {tab: 10n}
+//     {tab: <cyclic>}    {tab: new Date()} {tab: new Map()}
+//
+// while the SAME values in `params` were all refused. That asymmetry is the
+// defect: two channels of one entry, opposite treatment, and `search` is the
+// only one of the two that no value-level guard screens.
+//
+// ⚠ The consequence is not cosmetic, and it needs a browser that SERIALISES on
+// write to see. jsdom's `history.replaceState` stores by identity, so the whole
+// test estate is blind to it. Measured end to end with a structured-cloning
+// mock: a function value gives `state.search.tab` of type `function`,
+// `buildPath` prints `/users/list?tab=()%20%3D%3E%201`, and `structuredClone`
+// of the committed state throws `DataCloneError` — which is what a real
+// `history.pushState` does.
+import { describe, expect, it } from "vitest";
+
+import { isStateStrict } from "../../../src/browser-env/state-guard";
+
+const BASE = { name: "users.list", params: {}, path: "/users/list" };
+
+/** Built here rather than inline: a cycle cannot be written as a literal. */
+function cyclicBag(): Record<string, unknown> {
+  const cyclic: Record<string, unknown> = {};
+
+  cyclic.self = cyclic;
+
+  return { tab: cyclic };
+}
+
+describe("#1837 — the query channel is screened like the path channel", () => {
+  it("refuses every value shape that cannot survive a history write", () => {
+    // ⚑ ONE assertion over a signature, not six `it`s: a shape that stopped
+    // being constructed would otherwise pass by running nothing.
+    const verdicts = [
+      ["function", { tab: (): number => 1 }],
+      ["symbol", { tab: Symbol("s") }],
+      ["bigint", { tab: 10n }],
+      ["cycle", cyclicBag()],
+      ["Date instance", { tab: new Date() }],
+      ["Map instance", { tab: new Map() }],
+    ].map(([label, search]) => [label, isStateStrict({ ...BASE, search })]);
+
+    expect(verdicts).toStrictEqual([
+      ["function", false],
+      ["symbol", false],
+      ["bigint", false],
+      ["cycle", false],
+      ["Date instance", false],
+      ["Map instance", false],
+    ]);
+  });
+
+  it("POSITIVE CONTROL — still accepts everything a real query string parses to", () => {
+    // ⚠ This is the cell that makes the fix a fix rather than a refusal. The
+    // query channel's value domain is NOT the path channel's: a repeated key
+    // parses to an ARRAY and a bare `?flag` to `null`. Measured through the
+    // matcher, `/list?a=1&a=2&tab=x&flag` yields
+    // `{"a":[1,2],"tab":"x","flag":null}` — all three must survive.
+    const accepted = [
+      { a: ["1", "2"] },
+      { a: [1, 2] },
+      { flag: null },
+      { tab: "x" },
+      { n: 5 },
+      { b: true },
+      { nested: { deep: "1" } },
+      {},
+    ].map((search) => isStateStrict({ ...BASE, search }));
+
+    expect(accepted).toStrictEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it("POSITIVE CONTROL — `search` stays OPTIONAL, so a pre-M2 entry still restores", () => {
+    // Entries written before RFC-4 M2 (#1548) carry no query channel at all;
+    // `makeState` reuses the frozen empty bag for them. Requiring `search`
+    // would break every Back to such an entry.
+    expect(isStateStrict(BASE)).toBe(true);
+    expect(isStateStrict({ ...BASE, search: undefined })).toBe(true);
+  });
+
+  it("CONTROL — the shape half #1838 closed is still closed", () => {
+    // Not a duplicate of `state-guard-mirror-1838`: it pins that those two are
+    // refused; this pins that the value-level check did not REPLACE the shape
+    // check when it composed with it.
+    expect(isStateStrict({ ...BASE, search: "NOT-AN-OBJECT" })).toBe(false);
+    expect(isStateStrict({ ...BASE, search: ["a", "b"] })).toBe(false);
+  });
+
+  it("CONTROL — the path channel is unchanged, and was never the defect", () => {
+    // The asymmetry ran one way: `params` already refused all of these.
+    const params = [
+      { id: (): number => 1 },
+      { id: 10n },
+      { id: Symbol("s") },
+    ].map((bag) => isStateStrict({ name: "u", path: "/u", params: bag }));
+
+    expect(params).toStrictEqual([false, false, false]);
+    expect(isStateStrict({ name: "u", path: "/u", params: { id: "1" } })).toBe(
+      true,
+    );
+  });
+});

--- a/packages/browser-plugin/tests/functional/popstate-persisted-not-found-1837.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate-persisted-not-found-1837.test.ts
@@ -1,0 +1,159 @@
+// #1837 finding 3 — a PERSISTED not-found answers to `allowNotFound` like a
+// live one.
+//
+// `allowNotFound: false` means "an unmatched URL is an error; do not commit
+// `UNKNOWN_ROUTE`". The popstate handler enforces it on exactly one of its two
+// entry paths:
+//
+//     const matched = getRouteFromEvent(evt, api, location);
+//     if (matched)                 -> navigateToState(...)     <- no gate
+//     else if (deps.allowNotFound) -> navigateToNotFound(...)  <- the gate
+//     else                         -> ROUTE_NOT_FOUND + rollback
+//
+// `getRouteFromEvent` returns a state whenever `isStateStrict` passes, and the
+// guard waves through a name starting with `@@` — core's system namespace,
+// deliberately, because that is what `UNKNOWN_ROUTE` is. So an entry whose
+// `history.state` says `@@router/UNKNOWN_ROUTE` takes the FIRST branch and
+// commits, whatever `allowNotFound` says.
+//
+// ⚠ Not an adversarial shape. It is what THIS PLUGIN writes: with
+// `allowNotFound: true` every unmatched URL persists such an entry. Flip the
+// option in the next deploy, and Back to that entry still commits the 404 the
+// option now forbids.
+//
+// ⚑ The fix routes a restored `UNKNOWN_ROUTE` through the same branch a LIVE
+// unmatched URL takes, rather than adding a second gate beside the first. One
+// rule, one place: whether the not-found arrived from the address bar or from
+// `history.state`, `allowNotFound` decides it.
+import { createRouter } from "@real-router/core";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { browserPluginFactory } from "@real-router/browser-plugin";
+
+import { createMockedBrowser, routerConfig, noop } from "../helpers/testUtils";
+
+import type { Browser } from "../../src/browser-env";
+import type { Router } from "@real-router/core";
+
+const PERSISTED_NOT_FOUND = {
+  name: "@@router/UNKNOWN_ROUTE",
+  params: {},
+  path: "/nope",
+};
+
+let mockedBrowser: Browser;
+let router: Router | undefined;
+
+async function startWith(allowNotFound: boolean): Promise<Router> {
+  const created = createRouter(routerConfig, {
+    defaultRoute: "home",
+    allowNotFound,
+  });
+
+  created.usePlugin(browserPluginFactory({}, mockedBrowser));
+  await created.start("/users/list");
+
+  return created;
+}
+
+async function popstateTo(state: unknown, url: string): Promise<void> {
+  globalThis.history.replaceState({}, "", url);
+  globalThis.dispatchEvent(new PopStateEvent("popstate", { state }));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe("#1837 — a persisted UNKNOWN_ROUTE answers to allowNotFound", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "error").mockImplementation(noop);
+    vi.spyOn(console, "warn").mockImplementation(noop);
+  });
+
+  beforeEach(() => {
+    mockedBrowser = createMockedBrowser(noop);
+    globalThis.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    router?.stop();
+    router = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("is REFUSED under allowNotFound:false, like a live unmatched URL", async () => {
+    router = await startWith(false);
+
+    const before = router.getState()?.name;
+
+    await popstateTo(PERSISTED_NOT_FOUND, "/nope");
+
+    // The committed state must not have moved to the persisted 404.
+    expect(router.getState()?.name).toBe(before);
+    expect(router.getState()?.name).not.toBe("@@router/UNKNOWN_ROUTE");
+  });
+
+  it("reports it through the SAME channel a live unmatched URL uses", async () => {
+    // Not just "does not commit": the strict-mode branch emits
+    // `ROUTE_NOT_FOUND` and re-syncs the URL. A refusal that went silent would
+    // pass the cell above and still be a different behaviour from the live one.
+    router = await startWith(false);
+
+    const errors: unknown[] = [];
+
+    router.usePlugin(() => ({
+      onTransitionError: (_t, _f, error) => errors.push(error),
+    }));
+
+    await popstateTo(PERSISTED_NOT_FOUND, "/nope");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: "ROUTE_NOT_FOUND" });
+  });
+
+  it("POSITIVE CONTROL — under allowNotFound:true it still restores", async () => {
+    // The cell that stops the fix from being "refuse it everywhere". This is
+    // the working scenario the plugin itself creates, and it must survive.
+    router = await startWith(true);
+
+    await popstateTo(PERSISTED_NOT_FOUND, "/nope");
+
+    expect(router.getState()?.name).toBe("@@router/UNKNOWN_ROUTE");
+    expect(router.getState()?.path).toBe("/nope");
+  });
+
+  it("CONTROL — an ordinary route entry is unaffected by either setting", async () => {
+    // The gate must key on the persisted 404, not on "came from history.state".
+    for (const allowNotFound of [true, false]) {
+      router?.stop();
+      router = await startWith(allowNotFound);
+
+      await popstateTo(
+        { name: "users.view", params: { id: "1" }, path: "/users/view/1" },
+        "/users/view/1",
+      );
+
+      expect(router.getState()?.name, `allowNotFound=${allowNotFound}`).toBe(
+        "users.view",
+      );
+    }
+  });
+
+  it("CONTROL — an ordinary NONEXISTENT name is still refused, as it was before", async () => {
+    // Already refused downstream by `navigateToState` (ROUTE_NOT_FOUND); the
+    // fix must not change it, and it is what makes `@@` the odd one out.
+    router = await startWith(false);
+
+    const before = router.getState()?.name;
+
+    await popstateTo({ name: "ghost", params: {}, path: "/nope2" }, "/nope2");
+
+    expect(router.getState()?.name).toBe(before);
+  });
+});

--- a/packages/browser-plugin/tests/functional/popstate.test.ts
+++ b/packages/browser-plugin/tests/functional/popstate.test.ts
@@ -128,8 +128,19 @@ describe("Browser Plugin — Popstate", () => {
 
       // State unchanged, URL re-synced to previous state
       expect(restrictedRouter.getState()).toStrictEqual(previousState);
+      // ⚠ The FOUR-CHANNEL projection, not the whole `State` (#1837). This
+      // asserted `previousState` — six members, `context` and `transition`
+      // among them — and so pinned the defect: `context` is a public plugin
+      // slot this plugin does not control, and a real `replaceState` runs
+      // StructuredSerializeForStorage, so a non-cloneable value there killed
+      // the rollback silently.
       expect(replaceSpy).toHaveBeenCalledWith(
-        previousState,
+        {
+          name: previousState.name,
+          params: previousState.params,
+          search: previousState.search,
+          path: previousState.path,
+        },
         expect.stringContaining(previousState.path),
       );
 
@@ -219,8 +230,19 @@ describe("Browser Plugin — Popstate", () => {
       // The plugin must have called replaceState with the previous state
       // and a URL containing the previous path — this is the actual URL
       // restoration that the gotcha promises but was previously untested.
+      // ⚠ The FOUR-CHANNEL projection, not the whole `State` (#1837). This
+      // asserted `previousState` — six members, `context` and `transition`
+      // among them — and so pinned the defect: `context` is a public plugin
+      // slot this plugin does not control, and a real `replaceState` runs
+      // StructuredSerializeForStorage, so a non-cloneable value there killed
+      // the rollback silently.
       expect(replaceSpy).toHaveBeenCalledWith(
-        previousState,
+        {
+          name: previousState.name,
+          params: previousState.params,
+          search: previousState.search,
+          path: previousState.path,
+        },
         expect.stringContaining(previousState.path),
       );
 
@@ -275,8 +297,19 @@ describe("Browser Plugin — Popstate", () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(guardedRouter.getState()).toStrictEqual(previousState);
+      // ⚠ The FOUR-CHANNEL projection, not the whole `State` (#1837). This
+      // asserted `previousState` — six members, `context` and `transition`
+      // among them — and so pinned the defect: `context` is a public plugin
+      // slot this plugin does not control, and a real `replaceState` runs
+      // StructuredSerializeForStorage, so a non-cloneable value there killed
+      // the rollback silently.
       expect(replaceSpy).toHaveBeenCalledWith(
-        previousState,
+        {
+          name: previousState.name,
+          params: previousState.params,
+          search: previousState.search,
+          path: previousState.path,
+        },
         "/users/list?tab=a&sort=z#anchor",
       );
 

--- a/packages/browser-plugin/tests/functional/rollback-projection-1837.test.ts
+++ b/packages/browser-plugin/tests/functional/rollback-projection-1837.test.ts
@@ -1,0 +1,161 @@
+// #1837 finding 4 — the URL rollback writes a PROJECTION, like every other
+// history write in the plugin.
+//
+// Every other write site goes through `updateBrowserState`, which persists four
+// channels: `{ name, params, search, path }`. The rollback did
+// `deps.browser.replaceState(currentState, url)` — the whole committed `State`,
+// which additionally carries `context` and `transition`.
+//
+// It fires on every guard-rejected Back, every SAME_STATES popstate and every
+// strict-mode unmatched URL, so this is not a rare path.
+//
+// ⚠ Why it matters, and it is not tidiness: `state.context` is a PUBLIC plugin
+// slot whose contents this plugin does not control. A real browser runs
+// StructuredSerializeForStorage inside `replaceState`, so a plugin publishing a
+// non-cloneable value into `context` makes the rollback throw — into the empty
+// `catch {}` that wraps it — and the URL is never rolled back at all. jsdom
+// stores by identity, which is why the estate never saw this.
+//
+// ⚑ `transition` is the second half and needs no such argument: it is
+// per-navigation metadata about a transition that already finished. Persisting
+// it means a Back to this entry restores a `transition` describing a DIFFERENT
+// navigation.
+import { createRouter } from "@real-router/core";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { browserPluginFactory } from "@real-router/browser-plugin";
+
+import { createMockedBrowser, routerConfig, noop } from "../helpers/testUtils";
+
+import type { Browser } from "../../src/browser-env";
+import type { Router } from "@real-router/core";
+
+let mockedBrowser: Browser;
+let router: Router | undefined;
+
+describe("#1837 — the rollback writes the four-channel projection", () => {
+  beforeAll(() => {
+    vi.spyOn(console, "error").mockImplementation(noop);
+    vi.spyOn(console, "warn").mockImplementation(noop);
+  });
+
+  beforeEach(() => {
+    mockedBrowser = createMockedBrowser(noop);
+    globalThis.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    router?.stop();
+    router = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("writes exactly {name, params, search, path} on a strict-mode rollback", async () => {
+    router = createRouter(routerConfig, {
+      defaultRoute: "home",
+      allowNotFound: false,
+    });
+    router.usePlugin(browserPluginFactory({}, mockedBrowser));
+    await router.start("/users/list");
+
+    const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+    globalThis.history.replaceState({}, "", "/nonexistent-path");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(replaceSpy).toHaveBeenCalled();
+
+    const written = replaceSpy.mock.calls.at(-1)?.[0] as Record<
+      string,
+      unknown
+    >;
+
+    // ⚑ The KEY SET is the assertion, not the values: `context` and
+    // `transition` are what must not be there, and asserting the values would
+    // pass with them present.
+    expect(
+      Object.keys(written).toSorted((a, b) => a.localeCompare(b)),
+    ).toStrictEqual(["name", "params", "path", "search"]);
+  });
+
+  it("POSITIVE CONTROL — the four channels still carry the surviving state", async () => {
+    // Without this the cell above passes if the rollback started writing `{}`.
+    router = createRouter(routerConfig, {
+      defaultRoute: "home",
+      allowNotFound: false,
+    });
+    router.usePlugin(browserPluginFactory({}, mockedBrowser));
+    await router.start("/users/view/7");
+
+    const surviving = router.getState();
+    const replaceSpy = vi.spyOn(mockedBrowser, "replaceState");
+
+    globalThis.history.replaceState({}, "", "/nonexistent-path");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const written = replaceSpy.mock.calls.at(-1)?.[0] as Record<
+      string,
+      unknown
+    >;
+
+    expect(written.name).toBe(surviving?.name);
+    expect(written.params).toStrictEqual(surviving?.params);
+    expect(written.path).toBe(surviving?.path);
+    // ...and the URL argument still names the surviving state's path.
+    expect(replaceSpy.mock.calls.at(-1)?.[1]).toContain(surviving?.path);
+  });
+
+  it("survives a non-cloneable value in the PUBLIC context slot", async () => {
+    // ⚠ The cell that needs a browser doing what a real one does. jsdom stores
+    // `history.state` by identity and accepts anything; a real
+    // `replaceState` runs StructuredSerializeForStorage and throws
+    // `DataCloneError`. With the whole `State` written, a plugin publishing a
+    // function into `state.context` killed the rollback silently — the throw
+    // landed in the handler's empty `catch {}` and the URL stayed wrong.
+    const cloning = createMockedBrowser(noop);
+    const thrown: unknown[] = [];
+
+    vi.spyOn(cloning, "replaceState").mockImplementation((state, url) => {
+      try {
+        structuredClone(state);
+      } catch (error) {
+        thrown.push(error);
+
+        throw error;
+      }
+
+      globalThis.history.replaceState(state, "", url);
+    });
+
+    router = createRouter(routerConfig, {
+      defaultRoute: "home",
+      allowNotFound: false,
+    });
+    router.usePlugin(browserPluginFactory({}, cloning));
+    // A plugin writing something un-cloneable into the shared context slot.
+    router.usePlugin(() => ({
+      onTransitionSuccess(toState) {
+        (toState.context as Record<string, unknown>).probe = {
+          notCloneable: () => 1,
+        };
+      },
+    }));
+    await router.start("/users/list");
+
+    globalThis.history.replaceState({}, "", "/nonexistent-path");
+    globalThis.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(thrown).toStrictEqual([]);
+  });
+});

--- a/packages/hash-plugin/CLAUDE.md
+++ b/packages/hash-plugin/CLAUDE.md
@@ -132,7 +132,31 @@ See [IMPLEMENTATION_NOTES.md](../../IMPLEMENTATION_NOTES.md) section "URL Fragme
 
 ### State Validation
 
-External code can corrupt `history.state`. Plugin validates structure via `isStateStrict` (from browser-env) and ignores invalid states gracefully.
+External code can corrupt `history.state` — a previous page, another script, or
+an entry written by an older version of the app. The plugin validates it via
+`isStateStrict` (from browser-env) and falls back to `matchPath(location)` when
+it does not hold up. Four things that guard does, each of which it did not
+before #1837 / #1838:
+
+- **Both restored channels are screened by VALUE.** `params` always was;
+  `search` was shape-only until #1837, so a function, Symbol, BigInt, cycle or
+  class instance rode into the frozen `state.search` while the identical value
+  in `params` was refused. The query domain is untouched — a repeated key still
+  restores as an array, a bare `?flag` as `null`.
+- **It answers, it does not throw.** The entry may carry accessors or be a
+  `get`-trapping Proxy; every read sits inside a boundary, so an unreadable
+  payload is simply not restorable instead of surfacing as a critical error.
+- **The entry is read ONCE per member.** The snapshot that is validated is the
+  snapshot that is committed, so an entry answering differently between reads
+  cannot have one shape approved and another one land.
+- **A persisted `UNKNOWN_ROUTE` is not special-cased past `allowNotFound`.** It
+  takes the same branch a live unmatched URL takes.
+
+⚠ Only the first of those is visible in a real browser without help:
+`history.pushState` serialises, so an accessor, a Proxy or a drifting entry
+cannot come back from a genuine popstate. They are reachable from a synthetic
+`PopStateEvent` and under jsdom, which stores the entry by identity — which is
+also why the test estate was blind to the `DataCloneError` half for so long.
 
 ### Popstate history-write skip (#1353)
 

--- a/packages/hash-plugin/README.md
+++ b/packages/hash-plugin/README.md
@@ -125,7 +125,7 @@ router.matchUrl("/path"); // returns undefined
 | Export | Description |
 |--------|-------------|
 | `Browser` | Browser interface type (from `browser-env`) — for custom browser implementations |
-| `isState` | Type guard to validate history state structure — `(value: unknown) => value is State` |
+| `isState` | Type guard for a RESTORABLE `history.state` entry — `(value: unknown) => value is RestorableEntry`. Narrowed from `State` in #1838: it validates the four channels an entry may carry, not all six members of `State`. Screens `params` AND `search` by value (#1837), and answers `false` rather than throwing when the entry's own accessors throw. |
 
 ## Documentation
 

--- a/scripts/twin-lockstep.test.mjs
+++ b/scripts/twin-lockstep.test.mjs
@@ -74,14 +74,17 @@ const LOCKSTEP = [
     exempt: {
       isOptionalBag:
         "Shared-only, and deliberately OUTSIDE `isRequiredFields` (#1838). It " +
-        "checks the three members `State` declares that a restored history entry " +
-        "may omit — `search`, `transition`, `context` — which the twin has no " +
-        "notion of: validation-plugin validates a State the router built, not a " +
-        "`history.state` payload. Putting it inside `isRequiredFields` would have " +
-        "forced a matching edit on the other side of a pair this registry exists " +
-        "to keep byte-identical. (The `RestorableEntry` interface it feeds needs " +
-        "no entry here: this registry enumerates functions and constants, and a " +
-        "type exemption is rejected as stale.)",
+        "checks the members `State` declares that a restored history entry may " +
+        "omit and which the twin has no notion of: validation-plugin validates a " +
+        "State the router built, not a `history.state` payload. Putting it inside " +
+        "`isRequiredFields` would have forced a matching edit on the other side " +
+        "of a pair this registry exists to keep byte-identical. (The " +
+        "`RestorableEntry` interface it feeds needs no entry here: this registry " +
+        "enumerates functions and constants, and a type exemption is rejected as " +
+        "stale.) ⚠ It read `search`, `transition`, `context` until #1837 — " +
+        "`search` moved to `isParams`, because it is the one of the three that is " +
+        "RESTORED into a channel and it was the only channel no value-level guard " +
+        "screened.",
       isStateStrict:
         "The subject of the twin, not a member of it: validation-plugin has no " +
         "isStateStrict — it composes its own state validation from the same " +

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -1,6 +1,6 @@
 import { errorCodes, RouterError, UNKNOWN_ROUTE } from "@real-router/core";
 
-import { getRouteFromEvent } from "./popstate-utils.js";
+import { getRouteFromEvent, updateBrowserState } from "./popstate-utils.js";
 
 import type { Browser, SharedFactoryState } from "./types.js";
 import type { Params, Plugin, Router, SearchParams } from "@real-router/core";
@@ -133,7 +133,28 @@ export function createPopstateHandler(
       ctxHash ? { hash: ctxHash } : undefined,
     );
 
-    deps.browser.replaceState(currentState, url);
+    // ⚑ The four-channel PROJECTION, through the owner every other history
+    // write in this plugin already uses (#1837). This wrote `currentState`
+    // itself — the whole committed `State`, so `context` and `transition` went
+    // into `history.state` too, on every guard-rejected Back, every SAME_STATES
+    // popstate and every strict-mode unmatched URL.
+    //
+    // ⚠ `context` is the half that BREAKS rather than bloats: it is a public
+    // plugin slot whose contents this plugin does not control, and a real
+    // `replaceState` runs StructuredSerializeForStorage. A plugin publishing a
+    // non-cloneable value made this throw into the empty `catch {}` around the
+    // call, so the URL was never rolled back at all — silently. jsdom stores by
+    // identity, which is why 360 tests never saw it.
+    //
+    // ⚠ `transition` is per-navigation metadata about a navigation that already
+    // finished; persisting it means a Back to this entry restores a
+    // `transition` describing a different one.
+    //
+    // ⚑ `updateBrowserState` rather than a third inline `{ name, params,
+    // search, path }`: `popstate-utils` already owns that projection twice (here
+    // and in `createUpdateBrowserState`'s reused buffer), and hash-plugin calls
+    // the same function. A copy N+1 is how the four writers would drift.
+    updateBrowserState(currentState, url, true, deps.browser);
   }
 
   function recoverFromCriticalError(error: unknown): void {

--- a/shared/browser-env/popstate-handler.ts
+++ b/shared/browser-env/popstate-handler.ts
@@ -169,7 +169,27 @@ export function createPopstateHandler(
     isTransitioning = true;
 
     try {
-      const matched = getRouteFromEvent(evt, deps.api, location);
+      const restored = getRouteFromEvent(evt, deps.api, location);
+
+      // ⚑ A restored entry naming `UNKNOWN_ROUTE` is a PERSISTED not-found, and
+      // it takes the same branch a LIVE one does (#1837). Before this it took
+      // the matched branch instead, because `isStateStrict` accepts a name in
+      // core's `@@` namespace — deliberately, since that is what `UNKNOWN_ROUTE`
+      // is — so `allowNotFound` was enforced on one of the two ways a 404
+      // reaches this handler and not the other.
+      //
+      // ⚠ The entry is not adversarial: it is what THIS PLUGIN writes. Under
+      // `allowNotFound: true` every unmatched URL persists one. Turn the option
+      // off in the next deploy and Back to that entry still committed the 404
+      // the option now forbids.
+      //
+      // ⚑ Routed rather than gated: adding a second `allowNotFound` check beside
+      // the first would leave two places to keep in step. Sending it down the
+      // existing branch means `allowNotFound: true` still restores (through
+      // `navigateToNotFound`, with the #1448 same-state short-circuit) and
+      // `false` reports `ROUTE_NOT_FOUND` and rolls the URL back — one rule,
+      // whichever way the not-found arrived.
+      const matched = restored?.name === UNKNOWN_ROUTE ? undefined : restored;
 
       if (matched) {
         // api.navigateToState — plugin-only entry point. Preserves

--- a/shared/browser-env/popstate-utils.ts
+++ b/shared/browser-env/popstate-utils.ts
@@ -43,12 +43,52 @@ export function getRouteFromEvent(
   api: PluginApi,
   location: string,
 ): State | undefined {
-  const state: unknown = "state" in evt ? evt.state : undefined;
+  const raw: unknown = "state" in evt ? evt.state : undefined;
 
-  if (isState(state)) {
+  // ⚑ ONE read per member, and the snapshot is what gets both VALIDATED and
+  // COMMITTED (#1837). This read each member twice — once through `isState`,
+  // once again building the `makeState` arguments — so on an entry that answers
+  // differently between them the guard's verdict described one state and the
+  // router committed another. Measured with a drifting payload: the guard
+  // approved `users.view` / `/users/view/1` and `home` / `/TOTALLY/OTHER`
+  // landed.
+  //
+  // ⚠ Reachability, stated rather than implied: a real browser runs
+  // StructuredSerializeForStorage on `pushState`, so a genuine `history.state`
+  // comes back plain and cannot drift. It is reachable from a SYNTHETIC
+  // `PopStateEvent` and under jsdom, which stores the entry by identity — the
+  // same reachability as the accessor escape the guard's boundary closes, and
+  // the reason both are closed together rather than one of them.
+  //
+  // The snapshot is itself a read, so it sits inside a `try`: a throwing
+  // accessor here must take the same `matchPath` fallback an unreadable entry
+  // takes, not escape into the handler's critical-error path.
+  let snapshot: unknown = raw;
+
+  if (raw !== null && typeof raw === "object") {
+    const entry = raw as Record<string, unknown>;
+
+    try {
+      snapshot = {
+        name: entry.name,
+        params: entry.params,
+        search: entry.search,
+        path: entry.path,
+      };
+    } catch {
+      snapshot = undefined;
+    }
+  }
+
+  if (isState(snapshot)) {
     // Restore the query channel too (RFC-4 M2 / #1548). Entries written before
     // M2 have no `search` — `makeState` reuses the frozen empty bag for them.
-    return api.makeState(state.name, state.params, state.search, state.path);
+    return api.makeState(
+      snapshot.name,
+      snapshot.params,
+      snapshot.search,
+      snapshot.path,
+    );
   }
 
   return api.matchPath(location);

--- a/shared/browser-env/state-guard.ts
+++ b/shared/browser-env/state-guard.ts
@@ -368,8 +368,30 @@ export function isStateStrict<P extends Params = Params>(
     return false;
   }
 
+  // ⚑ `search` is screened by VALUE, with the same validator the path channel
+  // uses (#1837). #1838 closed the SHAPE half here — a string or an array
+  // `search` reaches `makeState` as a bag of numeric keys — and stopped there,
+  // so a function, a Symbol, a BigInt, a cycle or a class instance rode into
+  // the frozen `state.search` while the IDENTICAL value in `params` was
+  // refused. Two channels of one entry, opposite treatment, and this is the
+  // only one of the two fed by a third party.
+  //
+  // ⚠ `isParams` SUBSUMES `isOptionalBag` for this member — it refuses
+  // non-objects, arrays and custom prototypes before it looks at any value — so
+  // the two are not composed, and the shape half is not lost. Pinned by the
+  // CONTROL cell in `state-guard-value-domain-1837.test.ts`.
+  //
+  // ⚠ And it is not a narrowing of the query domain, which was the risk worth
+  // measuring: a repeated query key parses to an ARRAY and a bare `?flag` to
+  // `null`, and `isParams` accepts both. Measured through the matcher,
+  // `/list?a=1&a=2&tab=x&flag` yields `{"a":[1,2],"tab":"x","flag":null}` and
+  // survives unchanged.
+  //
+  // `transition` / `context` keep the shape-only check: neither is restored
+  // into a channel — `popstate-utils` hands `makeState` four members and these
+  // are not among them.
   return (
-    isOptionalBag(obj.search) &&
+    (obj.search === undefined || isParams(obj.search)) &&
     isOptionalBag(obj.transition) &&
     isOptionalBag(obj.context)
   );

--- a/shared/browser-env/state-guard.ts
+++ b/shared/browser-env/state-guard.ts
@@ -360,39 +360,57 @@ export function isStateStrict<P extends Params = Params>(
 
   const obj = value as Record<string, unknown>;
 
-  // ⚠ `isRequiredFields` is a TWIN of validation-plugin's copy, locked in step
-  // by `scripts/twin-lockstep.test.mjs` — the extra members are checked HERE,
-  // outside it, so the pair stays byte-identical and this fix needs no change
-  // on the other side.
-  if (!isRequiredFields(obj)) {
+  // ⚑ EVERY read below is a call into code this plugin does not own (#1837).
+  // The subject is `history.state`: a previous page, another script, or an
+  // entry written by an older version of the app can put an accessor on it, or
+  // hand over a `get`-trapping Proxy. `isParams` has wrapped its own walk since
+  // #1052 for this reason; the guard's own five reads had no boundary.
+  //
+  // ⚠ Including `params` — the issue that reported this said `isParams` covered
+  // it. Measured: it cannot. The getter fires on the property READ inside
+  // `isRequiredFields`, before `isParams` is entered, so all five escaped alike.
+  //
+  // A payload the guard cannot READ is not restorable, so the verdict is the
+  // same `false` any other malformed entry gets, and `onPopState` takes the
+  // `matchPath` fallback instead of logging a critical error about someone
+  // else's accessor.
+  try {
+    // ⚠ `isRequiredFields` is a TWIN of validation-plugin's copy, locked in
+    // step by `scripts/twin-lockstep.test.mjs` — the extra members are checked
+    // HERE, outside it, so the pair stays byte-identical and neither this fix
+    // nor #1838's needs a change on the other side.
+    if (!isRequiredFields(obj)) {
+      return false;
+    }
+
+    // ⚑ `search` is screened by VALUE, with the same validator the path channel
+    // uses (#1837). #1838 closed the SHAPE half here — a string or an array
+    // `search` reaches `makeState` as a bag of numeric keys — and stopped there,
+    // so a function, a Symbol, a BigInt, a cycle or a class instance rode into
+    // the frozen `state.search` while the IDENTICAL value in `params` was
+    // refused. Two channels of one entry, opposite treatment, and this is the
+    // only one of the two fed by a third party.
+    //
+    // ⚠ `isParams` SUBSUMES `isOptionalBag` for this member — it refuses
+    // non-objects, arrays and custom prototypes before it looks at any value — so
+    // the two are not composed, and the shape half is not lost. Pinned by the
+    // CONTROL cell in `state-guard-value-domain-1837.test.ts`.
+    //
+    // ⚠ And it is not a narrowing of the query domain, which was the risk worth
+    // measuring: a repeated query key parses to an ARRAY and a bare `?flag` to
+    // `null`, and `isParams` accepts both. Measured through the matcher,
+    // `/list?a=1&a=2&tab=x&flag` yields `{"a":[1,2],"tab":"x","flag":null}` and
+    // survives unchanged.
+    //
+    // `transition` / `context` keep the shape-only check: neither is restored
+    // into a channel — `popstate-utils` hands `makeState` four members and these
+    // are not among them.
+    return (
+      (obj.search === undefined || isParams(obj.search)) &&
+      isOptionalBag(obj.transition) &&
+      isOptionalBag(obj.context)
+    );
+  } catch {
     return false;
   }
-
-  // ⚑ `search` is screened by VALUE, with the same validator the path channel
-  // uses (#1837). #1838 closed the SHAPE half here — a string or an array
-  // `search` reaches `makeState` as a bag of numeric keys — and stopped there,
-  // so a function, a Symbol, a BigInt, a cycle or a class instance rode into
-  // the frozen `state.search` while the IDENTICAL value in `params` was
-  // refused. Two channels of one entry, opposite treatment, and this is the
-  // only one of the two fed by a third party.
-  //
-  // ⚠ `isParams` SUBSUMES `isOptionalBag` for this member — it refuses
-  // non-objects, arrays and custom prototypes before it looks at any value — so
-  // the two are not composed, and the shape half is not lost. Pinned by the
-  // CONTROL cell in `state-guard-value-domain-1837.test.ts`.
-  //
-  // ⚠ And it is not a narrowing of the query domain, which was the risk worth
-  // measuring: a repeated query key parses to an ARRAY and a bare `?flag` to
-  // `null`, and `isParams` accepts both. Measured through the matcher,
-  // `/list?a=1&a=2&tab=x&flag` yields `{"a":[1,2],"tab":"x","flag":null}` and
-  // survives unchanged.
-  //
-  // `transition` / `context` keep the shape-only check: neither is restored
-  // into a channel — `popstate-utils` hands `makeState` four members and these
-  // are not among them.
-  return (
-    (obj.search === undefined || isParams(obj.search)) &&
-    isOptionalBag(obj.transition) &&
-    isOptionalBag(obj.context)
-  );
 }


### PR DESCRIPTION
## Summary

`history.state` is the one input these plugins take that a third party genuinely
controls — a previous page, another script, or an entry written by an older
version of the app. The guard restored four channels and validated the values of
one and a half of them.

⚠ **Three of the issue's seven findings were already closed** by later work and
are not in this PR. That is measured, not assumed — see Scope below.

### The four that were live

- **`search` is screened by VALUE, like `params`.** #1838 closed the SHAPE half
  (a string or an array `search` reaches `makeState` as a bag of numeric keys);
  values were untouched, so a function, Symbol, BigInt, cycle, `Date` or `Map`
  rode into the frozen `state.search` while the IDENTICAL value in `params` was
  refused. Two channels of one entry, opposite treatment.

  Consequence, reproduced end to end with a browser mock that structured-clones
  on write: `state.search.tab` of type `function` → `buildPath` printing
  `/users/list?tab=()%20%3D%3E%201` → `structuredClone` of the committed state
  throwing `DataCloneError`.

  **Root cause:** `isOptionalBag` answers "is it an object", and the query
  channel needed the question `params` already asks.

- **The guard's own reads no longer rethrow.** An accessor on the entry, or a
  `get`-trapping Proxy, threw out of a type guard; the handler then took its
  non-`RouterError` path instead of the `matchPath` fallback — a wrong
  classification. ⚠ The issue said "two of the three reads", on the ground that
  `isParams` covers `params`. Measured, it does not and cannot: the getter fires
  on the property READ inside `isRequiredFields`, before `isParams` is entered.
  **All five escaped.**

- **A persisted `UNKNOWN_ROUTE` answers to `allowNotFound`.** The guard accepts
  core's `@@` namespace deliberately — that is what `UNKNOWN_ROUTE` is — so a
  restored 404 took the matched branch and skipped the gate. Measured: the
  plugin itself writes such entries under `allowNotFound: true`, so turning the
  option off did not stop Back from committing the old ones.

  **Root cause:** `allowNotFound` was enforced on one of the two ways a 404
  reaches the handler. Fixed by ROUTING the restored one down the existing
  branch rather than adding a second gate beside the first.

- **The URL rollback writes the four-channel projection.** It wrote the whole
  `State`, so `context` and `transition` landed in `history.state`. ⚠ `context`
  is a public plugin slot these plugins do not control, and a real
  `replaceState` serialises — a plugin publishing a non-cloneable value made the
  rollback throw into an empty `catch`, so the URL was never rolled back at all.
  Fixed by calling `updateBrowserState`, the projection's existing owner, rather
  than writing a third inline copy.

### Found by attacking the fix, not by the issue

- **A restored entry is read ONCE per member.** `getRouteFromEvent` read each
  member twice — once through `isState`, once building the `makeState`
  arguments — so the entry that was VALIDATED was not the entry that got
  COMMITTED:

  ```
  reads per member: { name: 2, params: 2, path: 2 }
  guard approved  : users.view  /users/view/1
  committed       : home        /TOTALLY/OTHER   { id: "SECOND" }
  ```

  ⚠ Reachability is the same as the accessor escape above: a real
  `history.pushState` serialises, so neither can come back from a genuine
  popstate. Both are reachable from a synthetic `PopStateEvent` and under jsdom,
  which stores the entry by identity. Fixing one and leaving the other — on the
  same line of code — would have been the false-completeness shape.

- **The class-guard the recurrence needed.** #1838 and #1837 are two instances
  of one shape: *the guard declares more than it checks*. The next instance is a
  member added to `RestorableEntry` and not to the guard, and nothing would say
  so. `authority-1838.test.ts` — the suite that already owns this directory —
  now derives both sides from the source and requires the interface's members to
  be a subset of the validated ones.

### Scope

Three findings need no work, measured on HEAD before any RED was written:

| # | issue's finding | status |
| - | --------------- | ------ |
| 1 | `search` not validated | **half closed** by #1838 (shape); values were live |
| 5 | `safelyEncodePath` double-encodes | **CLOSED** — rewritten to preserve `%XX`; idempotent on all five inputs |
| 7 | the twin mirror is unguarded | **CLOSED** — `scripts/twin-lockstep.test.mjs` compares five members plus a coverage assertion |

Finding **6** (zero captured intrinsics in `shared/`) is deliberately deferred:
it is the `shared/` half that #1971 already names as "Boundary, undecided", and
#1971 waits on #1901's gate. Splitting one decision across two PRs would be the
worse outcome.

`@real-router/navigation-plugin` gets no changeset: it symlinks
`shared/browser-env` but imports only `sharedUrlPluginDefaults`, `UrlContext`,
`extractPathFromAbsoluteUrl` and `createWarnOnce` — neither the guard nor the
popstate handler.

### Maintainability

`methods`-style docs drift, fixed in the same pass: `hash-plugin/README.md`
documented `isState` as `value is State` (wrong since #1838 narrowed it to
`RestorableEntry`), and `browser-plugin/ARCHITECTURE.md` called
`updateBrowserState` "(legacy)" — it is hash-plugin's writer and now the
rollback's.

## Breaking changes

⚠ **Rollback entries in `history.state` now carry exactly
`{ name, params, search, path }`.** Measured: ordinary entries always did — the
two extra members appeared only on rollback ones.

⚠ **A `search` object with a custom prototype is refused.** A class instance or
`Object.create(bag)` was accepted before (as an empty bag, since only own keys
are read) and now is not, because `isParams` rejects a non-`Object.prototype`
prototype exactly as it always has for `params`. The shape cannot survive a real
`history.pushState` round trip.

## Test plan

- [x] `state-guard-value-domain-1837.test.ts` — six hostile value shapes, plus
      the POSITIVE CONTROL that every shape a real query string parses to still
      restores (`/list?a=1&a=2&tab=x&flag` → `{"a":[1,2],"tab":"x","flag":null}`)
- [x] `state-guard-getter-safety-1837.test.ts` — all five reads, a `get`-trapping
      Proxy, and a CONTROL proving the accessor is genuinely reached
- [x] `popstate-persisted-not-found-1837.test.ts` — both settings, the error
      channel, and controls for an ordinary route and an ordinary missing one
- [x] `rollback-projection-1837.test.ts` — the key set, the surviving values, and
      a cloning browser for the `DataCloneError` half
- [x] `restore-reads-once-1837.test.ts` — one read per member and the committed
      outcome, with controls for a stable entry and a throwing one
- [x] `authority-1838.test.ts` — the recurrence guard, killed by both an
      unvalidated new member and a legal rename of the interface
- [x] Mutation: 6/6 added terms killed individually; the FULL revert reds **16**
- [x] browser-plugin 434 · **100% coverage** · 85 property · 41 stress
- [x] hash-plugin 108 · navigation-plugin 226 · validation-plugin 774 · all 100%
- [x] `twin-lockstep` 0 · lint 0 · type-check 0 · 2 changesets valid
- [x] Wiki updated (`isState`'s signature had drifted a wave; `allowNotFound`)
- [ ] full `pnpm build` across the graph — delegated (project rule)
- [ ] perf — reading it from the CodSpeed report on this PR

Closes #1837

Related: #1838 (the previous wave on this guard), #1971 / #1901 (where finding 6
belongs), #1586, #1353, #1448.
