### PR TITLE
fix(core): one entry door copies the caller's NavigationOptions (#1962)

### DIFF
--- a/.changeset/navigation-options-entry-door-1962-fix.md
+++ b/.changeset/navigation-options-entry-door-1962-fix.md
@@ -1,0 +1,72 @@
+---
+"@real-router/core": minor
+---
+
+Every plugin hook receives the same frozen options object, copied once at the entry door ([#1962](https://github.com/greydragon888/real-router/issues/1962))
+
+`onTransitionSuccess(toState, fromState, opts)` used to receive **the
+application's own `NavigationOptions` literal** on some navigations and a copy on
+others, and the discriminator was whether the caller happened to pass a `signal`
+— which the plugin never sees. Measured across the five arcs:
+
+| arc                        | hook received the caller's object |
+| -------------------------- | --------------------------------- |
+| `navigate(name, …, opts)`  | **yes** — and a write reached the app |
+| the same call with `signal` | no                               |
+| `navigate(target, opts)`   | **yes** — and a write reached the app |
+| `navigateToDefault(opts)`  | **yes** — and a write reached the app |
+| forced replace out of a 404 | no                               |
+
+So a plugin annotating its hook argument — `opts.handled = true`, the cheapest
+way to pass a flag to the next plugin — wrote into the application's literal on
+three arcs and into a private copy on the other two, with no way to tell which.
+An app reusing one options constant carried the annotation forward across
+navigations.
+
+Core now copies the bag **once**, where it first receives it, and reads its own
+copy everywhere below. Every hook on every arc receives that copy, frozen.
+
+**Why the copy could not simply be made at the announcement**, which is where the
+`signal`-dependent one lived: copying there reads the caller's object a second
+time, below the read that already decided the navigation, and
+`opts-read-once-1817` pins that count at one. Above the reads there is no second
+read to make — the six flags now come off core's record, so the caller's
+accessors are entered **once per key** and the announcement no longer touches the
+bag at all.
+
+### Breaking changes
+
+⚠ **The object handed to a hook is frozen.** A plugin that writes to `opts` now
+throws. No shipped plugin does (measured: 18 hooks bind the parameter, 0 write to
+it); `state.context` and `claimContextNamespace()` are the sanctioned channel for
+plugin-to-plugin data.
+
+⚠ **Only OWN ENUMERABLE keys of the bag are read.** An option supplied through
+the prototype chain, defined non-enumerable, or answered by a `Proxy` whose
+target does not hold it, is ignored rather than honoured. This applies the owner
+decision of 2026-08-18 (`CLAUDE.md`, "Supported Input Shapes") to the navigation
+options, and it is the narrowing
+[#1813](https://github.com/greydragon888/real-router/issues/1813) named when it
+was closed. ⚠ It is **not** the last read-by-name channel: `snapshotQueryParams`
+still reads the four `queryParams` fields by name, so an inherited or
+non-enumerable format is still honoured there. That is the other half #1813
+named, and it is out of scope here. Vue `reactive()` and Svelte `$state` are
+pass-through proxies over real objects and are unaffected.
+
+⚠ **Symbol-keyed entries no longer reach the hook.** The same rule the path and
+query channels have always applied.
+
+⚠ **A throwing getter on ANY key now fails the navigation, and the outcome is
+better than what it replaces.** Measured on the previous release with
+`{ reload: true, get boom() { throw } }`: without a signal the navigation
+RESOLVED (the key was never read); with one it **committed the state, announced
+success to every plugin, and rejected the caller with `CANCELLED`** — naming
+neither the real cause nor the actual outcome. Both arcs now reject with the
+caller's own error and commit nothing.
+
+### Not a change
+
+`hash`, `hashChange`, `source` and any other key an application or plugin
+attaches still ride to the hook: the copy preserves every own enumerable key
+(owner decision, 2026-08-30). `opts.signal` is still absent from what a hook
+receives, as before.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -7186,6 +7186,15 @@ not discriminate a gate that reads the snapshot from one that re-reads an object
 agree): exactly two above the announce, exactly one below it — the announcement's own `stripSignal`
 spread, which is application code by design.
 
+> **Superseded on both counts, 2026-08-30 (#1962).** The paragraph above is kept as the record of why
+> the gate reads the snapshot, which is unchanged. Its NUMBERS are not current, and one of them was
+> already not: the cell has pinned **one** read above the announce, not two, since the pre-check moved
+> to the entry snapshot. And **zero** stand below it now — the entry door copies the caller's bag once,
+> above every read but the signal's, so `payload.opts` is core's own frozen record and `stripSignal` no
+> longer exists for the announcement to call. The claim that the announcement reads application code
+> "by design" was the last defence of that spread; the door removed the need for it rather than
+> relaxing the rule.
+
 **Test.** `tests/functional/navigation/commit-ask-snapshot-1649.test.ts` — two teardown getters plus a
 side-effect-free positive control that also asserts the hoisted meta still carries the getter's value.
 Mutationally validated: putting the meta build back below the ask reds exactly the two teardown cases

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -191,12 +191,13 @@ fsm.on("TRANSITION_STARTED", "LEAVE_APPROVE", (p) =>
   emitter.emit("$$leaveApprove", p.toState, p.fromState),
 );
 fsm.on("LEAVE_APPROVED", "COMPLETE", (p) =>
-  // the caller's AbortSignal is stripped here: it is an input to the
-  // navigation, not part of what was committed — but the TABLE sees it,
-  // because `when: mayCommit` refuses a commit whose signal was aborted.
-  // Both this branch and that predicate read `p.externalSignal`, the signal
-  // the navigation captured at its entry, never `p.opts` a second time
-  emitter.emit("$$success", p.toState, p.fromState, stripSignal(p.opts)),
+  // `p.opts` is core's own frozen record, copied from the caller's bag at the
+  // entry door — the announcement neither copies nor strips. The caller's
+  // AbortSignal is not on it: it is an input to the navigation, not part of what
+  // was committed. The TABLE still sees it, because `when: mayCommit` refuses a
+  // commit whose signal was aborted, and it reads `p.externalSignal` — the
+  // signal the navigation captured at its entry, never `p.opts` a second time
+  emitter.emit("$$success", p.toState, p.fromState, p.opts),
 );
 
 // SYSTEM_COMMIT — the two commits that are NOT transitions. ONE state: both

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1144,6 +1144,61 @@ company at the concealed one), runs `hostileBags`'s six container shapes through
 the fixed doors, and snapshots each public surface's member list, so a new door
 reds until someone classifies it.
 
+### The ENTRY side — what core's own copy of a caller's bag keeps (#1901)
+
+> **The copy preserves every own enumerable key.** A copy core makes of a
+> caller-supplied bag at its entry door is not curated to a known field list: a
+> key core does not recognise survives the copy and reaches whatever reads the
+> copy downstream.
+>
+> — owner decision, 2026-08-30. It settles the gate #1901 names as "a contract
+> decision this umbrella has to make, not an implementation detail".
+
+The three sides above are about a key core READS off a caller's bag, one it
+WRITES into a record of its own, and one it hands BACK. This is the fourth: what
+core's own copy CARRIES, when a door copies the caller's bag before reading it.
+
+**Why not curate to the declared fields.** Because "the declared fields" has no
+runtime expression. `NavigationOptions` is extended by **module augmentation**,
+and augmentation leaves no trace in the emitted JS — a curating copy can only
+normalise to a list hard-coded at the time it was written, which is a different
+thing from the contract and goes stale against it silently.
+
+Measured, the keys such a list would drop are all first-party and all declared:
+
+| declaring file                            | members beyond core's seven    |
+| ----------------------------------------- | ------------------------------ |
+| `packages/browser-plugin/src/index.ts`    | `source`, `hash`, `hashChange` |
+| `packages/hash-plugin/src/index.ts`       | `hash`, `hashChange`, `source` |
+| `packages/navigation-plugin/src/index.ts` | `hash`, `hashChange`           |
+
+⚠ **A registration channel is the alternative that was weighed and refused**, and
+the reason is not cost but reach: two classes of writer never pass through plugin
+registration at all. `shared/dom-utils` is adapter code shipped in six adapters,
+and its own comment states the intent — _"adapters do not need to augment
+`NavigationOptions` themselves to consume `<Link hash>`"_ — for exactly the
+configuration where no URL plugin is installed, i.e. where nothing would register
+`hash`. `memory-plugin` tags its restore navigations with `source` through a
+local intersection type, because the two plugins that declare `source` globally
+may be absent. A `usePlugin`-driven registry drops both.
+
+⚠ **This is not a licence for an open-ended pass-through, and the measurement
+says why.** A TS-compiler-API census of every call at an options slot (3408
+files, 579 candidate sites) found **zero** keys that are not declared somewhere:
+the entire surplus is `hash` (43 sites) and `hashChange` (12). The rule is
+therefore cheap — it carries ten known keys, seven of them core's own — and its
+real subject is the key an APPLICATION invents, which the repo cannot measure.
+⚠ 95 of those candidates pass a variable or a spread and are unreadable to a
+static census; `source` reaches `opts` through one of them.
+
+⚠ **It does not re-admit `"__proto__"` at a hand-out door.** Read literally,
+"every own enumerable key" includes that one — and the HAND-OUT rule above still
+removes it from the container a door PUBLISHES, for the reason measured there.
+The two compose rather than conflict: the entry copy keeps the key as data for
+core, and the container handed to a plugin hook is cleaned on its way out. Core
+already does exactly this on the two arcs where it mints a `NavigationOptions`
+(`stripSignal`'s rest and the forced-replace substitution, both `dropUnsafeKey`).
+
 ### The two enforcement postures, and why they differ
 
 **Where a report is cheap, report it.** At construction and registration time —

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -631,7 +631,7 @@ namespaces/NavigationNamespace/
 
 This replaced three orchestrators (`executeGuardPipeline` / `finishAsyncPipeline` / `finishAfterAsyncLeave`) and two copies of the guard loop (`runGuards` / `resolveRemainingGuards`). The payoff is **one cancellation check instead of eight**: five of the eight were mutationally unkillable — their breakage was as invisible as their removal, because the liveness check in `finishAsyncNavigation` already covered any navigation that reached them. The single check in the head of `runStep()` sits where nothing else guards it; removing it fails four tests.
 
-**`NavigationContext` / `NavigationPlan`** (`types.ts`): `NavigationPlan` is what a navigation actually builds — everything worked out before any guard runs, filled in **two passes** across the `TRANSITION_START` emit (`suspendable` must be read before the pre-commit listener window, the guard maps after it, since a `TRANSITION_START` listener may still register a guard). It **extends** `NavigationContext`, so the same object is handed to `completeTransition()` / `finishAsyncNavigation()` instead of a second literal — one context object per navigation. ⚑ **Every field the pipeline needs from the caller's `opts` is on it, read ONCE at the entry:** `externalSignal` (#1690), `forceDeactivate` (#1690) and the meta's three flags — `reload` / `replace` / `redirected` (#1719). The reason is one and the same: `opts` is accessor- or Proxy-backed by contract, so every read is a call into application code, and a second read may answer differently. Below the entry the router asks the PLAN and never the caller's object — which is what leaves `stripSignal`'s spread in the announcement as the only `opts` read on the whole navigate path, deliberately, because the announcement runs application code anyway.
+**`NavigationContext` / `NavigationPlan`** (`types.ts`): `NavigationPlan` is what a navigation actually builds — everything worked out before any guard runs, filled in **two passes** across the `TRANSITION_START` emit (`suspendable` must be read before the pre-commit listener window, the guard maps after it, since a `TRANSITION_START` listener may still register a guard). It **extends** `NavigationContext`, so the same object is handed to `completeTransition()` / `finishAsyncNavigation()` instead of a second literal — one context object per navigation. ⚑ **Every field the pipeline needs from the caller's `opts` is on it, read ONCE at the entry:** `externalSignal` (#1690), `forceDeactivate` (#1690) and the meta's three flags — `reload` / `replace` / `redirected` (#1719). The reason is one and the same: `opts` is accessor- or Proxy-backed by contract, so every read is a call into application code, and a second read may answer differently. Below the entry the router asks the PLAN and never the caller's object — and since #1962 that is literal rather than nearly true: the entry door copies the bag once, above every read but the signal's, so the caller's object is read **zero** times below the announce. The announcement used to hold the last one (`stripSignal`'s spread, defended on the ground that it stands where application code already runs); with `payload.opts` already core's own frozen record there is nothing left for it to strip.
 
 ### Guards vs Plugins
 
@@ -1099,9 +1099,13 @@ published?**
   `OptionsNamespace` constructor, which is above both `getOptions()` and
   `getCloneState().options` — measured, those are two objects and not one, the
   second an unfrozen spread of the first), the dependency clone transport,
-  `getAll` itself, and the two `NavigationOptions` a plugin hook receives that
-  core MINTS — `stripSignal`'s rest-destructuring and the forced-replace
-  substitution. Unconditional, and the delete is measured as free: on the
+  and `getAll` itself — **three** call sites, counted rather than recalled.
+  ⚠ It served two more until #1962, and their absence is the point:
+  `stripSignal`'s rest-destructuring no longer exists, and the forced-replace
+  substitution no longer needs the drop, because the ENTRY door drops the key
+  once, above both, in the copy every navigation arc now shares. Re-adding either
+  would be an unfalsifiable no-op. Unconditional, and the delete is
+  measured as free: on the
   long-lived options object, which every navigation reads, deleting an ABSENT
   key leaves the hidden class alone (−1.0 %, i.e. noise). ⚠ It MUTATES, so it
   takes only an object core allocated one expression earlier: on a frozen
@@ -1191,13 +1195,23 @@ real subject is the key an APPLICATION invents, which the repo cannot measure.
 ⚠ 95 of those candidates pass a variable or a spread and are unreadable to a
 static census; `source` reaches `opts` through one of them.
 
-⚠ **It does not re-admit `"__proto__"` at a hand-out door.** Read literally,
-"every own enumerable key" includes that one — and the HAND-OUT rule above still
-removes it from the container a door PUBLISHES, for the reason measured there.
-The two compose rather than conflict: the entry copy keeps the key as data for
-core, and the container handed to a plugin hook is cleaned on its way out. Core
-already does exactly this on the two arcs where it mints a `NavigationOptions`
-(`stripSignal`'s rest and the forced-replace substitution, both `dropUnsafeKey`).
+⚠ **It does not re-admit `"__proto__"`.** Read literally, "every own enumerable
+key" includes that one — and the HAND-OUT rule above still removes it from the
+container a door PUBLISHES, for the reason measured there. The two rules compose
+rather than conflict, and for `NavigationOptions` they act on the SAME object:
+core's entry copy IS what every plugin hook receives, so entry and hand-out
+coincide and the key is dropped once, in the copy loop (#1962). Where the two
+levels are distinct — a bag core ingests and keeps privately — the entry copy
+carries the key as ordinary data and the hand-out door is what withholds it.
+
+⚑ **The copy is a key LOOP, not a spread, and the reason is the read count.**
+`{ signal: _, ...rest }` is four times cheaper (measured: 27 ns against 120 on a
+four-key bag) and cannot be diverted by an ambient accessor, since a spread
+`[[DefineOwnProperty]]`s. It is still wrong here: a spread reads EVERY own key to
+exclude one, so excluding `signal` costs a second call into the caller's
+accessor. `commit-gate-reads-the-snapshot-1717` counts exactly that and caught
+the substitution at two reads instead of one. Skipping a key without reading it
+is what forces the loop.
 
 ### The two enforcement postures, and why they differ
 

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -7,7 +7,7 @@
  */
 
 import { assertChannelCorrect, findMisChanneledKey } from "./channels";
-import { EMPTY_PARAMS, errorCodes } from "./constants";
+import { EMPTY_OPTS, EMPTY_PARAMS, errorCodes } from "./constants";
 import {
   assertLoggerConfig,
   guardDependencyShape,
@@ -62,8 +62,6 @@ import type {
   Route,
 } from "./types";
 import type { Limits, RouterEventMap } from "./types/internal";
-
-const EMPTY_OPTS: Readonly<NavigationOptions> = Object.freeze({});
 
 /**
  * Router class with integrated namespace architecture.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -197,6 +197,17 @@ export const EMPTY_PARAMS: Readonly<Record<string, never>> = Object.freeze({});
  */
 export const EMPTY_SEARCH: Readonly<Record<string, never>> = Object.freeze({});
 
+/**
+ * Shared frozen empty `NavigationOptions`, substituted by the facade when a
+ * caller passes none — the options-channel twin of {@link EMPTY_PARAMS}.
+ *
+ * ⚑ It lives here rather than in `Router.ts` so the entry door can recognise it
+ * by IDENTITY (#1962). `navigate("b")` is the commonest call in the library, and
+ * matching this singleton is what keeps the door's cost on it to one comparison
+ * instead of a copy nobody asked for.
+ */
+export const EMPTY_OPTS: Readonly<Record<string, never>> = Object.freeze({});
+
 const FROZEN_EMPTY_SEGMENTS = Object.freeze({
   deactivated: Object.freeze([]) as unknown as string[],
   activated: Object.freeze([]) as unknown as string[],

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,9 +1,14 @@
 // packages/core/src/helpers.ts
 
-import { EMPTY_PARAMS, EMPTY_SEARCH, UNSAFE_KEY } from "./constants";
+import {
+  EMPTY_OPTS,
+  EMPTY_PARAMS,
+  EMPTY_SEARCH,
+  UNSAFE_KEY,
+} from "./constants";
 import { putField } from "./utils/ingest";
 
-import type { State } from "./types";
+import type { NavigationOptions, State } from "./types";
 
 /**
  * Intrinsics captured at module load: `freeze`, `hasOwn`, `objectKeys`.
@@ -26,6 +31,13 @@ const hasOwn = Object.hasOwn;
 // so an application that re-points `Object.keys` after boot would be re-pointing
 // the guard itself. `dependenciesStore` captures it for the same door.
 const objectKeys = Object.keys;
+/**
+ * The one `NavigationOptions` key core's entry door withholds from its copy
+ * (#1962). Typed as `keyof NavigationOptions` rather than written as a bare
+ * literal, so renaming the field is a compile error here instead of a silently
+ * preserved `signal` — the spelling is not the thing being named, the FIELD is.
+ */
+const SIGNAL_KEY: keyof NavigationOptions = "signal";
 // =============================================================================
 // Default merge — `undefined` ≡ absence (#1550 / #1551)
 // =============================================================================
@@ -532,6 +544,88 @@ export function adoptForeignBag(
     if (entry !== undefined) {
       putField(copy, key, entry);
     }
+  }
+
+  return freeze(copy);
+}
+
+/**
+ * Core's own copy of the caller's `NavigationOptions`, made once at the entry
+ * door (#1962) — every own enumerable key, minus `signal`, into a frozen record.
+ *
+ * ⚑ **Every own enumerable key, not the declared ones** — owner decision,
+ * 2026-08-30, recorded in `CLAUDE.md` "Supported Input Shapes". Curating to "the
+ * declared fields" is not expensive, it is INEXPRESSIBLE: `NavigationOptions` is
+ * extended by module augmentation (`hash` / `hashChange` / `source`, three URL
+ * plugins), and augmentation leaves nothing in the emitted JS to normalise
+ * against — a curating copy could only hold a list hard-coded when it was
+ * written, going stale against the contract in silence.
+ *
+ * ⚑ `signal` is the one key dropped, and dropping it HERE is what removes the
+ * defect rather than moving it. The announcement used to strip it (`stripSignal`)
+ * only because it is non-serialisable — so whether a plugin received the app's
+ * own object or a copy turned on whether the app happened to pass a signal, a
+ * discriminator the plugin never sees. Core reads the signal once at the entry
+ * and carries it as `NavigationContext.externalSignal`, which is the only form
+ * the machine may ask about (#1690 / #1717); nothing downstream reads
+ * `opts.signal`, so the key has no reader left to lose.
+ *
+ * ⚠ `UNSAFE_KEY` goes too, and that is the HAND-OUT rule acting on this object
+ * rather than a second decision: this copy IS what every plugin hook receives,
+ * so an own `"__proto__"` on it is a prototype-swap primitive for anything that
+ * merges it with `Object.assign` (#1957). Entry and hand-out coincide here, so
+ * the drop happens once.
+ *
+ * ⚠ It reads each key EXACTLY once — the rule `opts-read-once-1817` pins for the
+ * named flags, extended by this copy to keys core never names. Every read below
+ * the door is then a read of core's own data, so the six hoisted flags cost the
+ * caller's accessors nothing at all.
+ *
+ * ⚠ **A key loop, and the cheaper spread is REFUTED rather than merely
+ * disliked.** `{ signal: _, ...rest }` measured 27 ns against this loop's 120
+ * on the four-key bag a URL plugin actually sends — and it READS `opts.signal`
+ * to exclude it, which is a second call into the caller's accessor. That is
+ * exactly what `commit-gate-reads-the-snapshot-1717` counts: it caught the
+ * substitution at `readsAtAnnounce` 2 instead of 1. Any spread reads every key,
+ * so skipping one WITHOUT reading it is what forces the loop.
+ *
+ * ⚑ `putField` inside it, then, for the ordinary reason (#1852): the key is the
+ * caller's, the target has `Object.prototype` on its chain, and a plain
+ * `[[Set]]` under a name like `toString` is divertible by an ambient accessor.
+ *
+ * ⚠ **Not folded into {@link copyOwnStringKeys}, which it nearly repeats.** The
+ * two differ on `undefined`: that loop drops an `undefined`-valued key because a
+ * frozen `state.search` may never expose one (#1550 / #1551), and this one keeps
+ * it because `{ replace: undefined }` is what the caller wrote and what every
+ * arc handed to a hook before. Folding them needs a skip-set or a flag — the
+ * selector parameter this file's own split (`mergePathChannel` /
+ * `mergeQueryChannel` / `adoptForeignBag`) was made to remove. Three named
+ * copies with different rules, not one with switches.
+ *
+ * @internal
+ */
+export function adoptNavigationOptions(
+  opts: NavigationOptions,
+): Readonly<NavigationOptions> {
+  // `navigate("b")` is the commonest call there is, and the facade substitutes
+  // this exact singleton for it — already core's own, already frozen, already
+  // empty. Recognising it by identity is the difference between one comparison
+  // and a copy plus a freeze (~57 ns measured) on the majority of navigations.
+  if (opts === EMPTY_OPTS) {
+    return EMPTY_OPTS;
+  }
+
+  const copy: Record<string, unknown> = {};
+  const bag = opts as Record<string, unknown>;
+
+  for (const key of objectKeys(bag)) {
+    // `signal` is skipped WITHOUT being read — core already holds the entry
+    // snapshot, and reading it again here is the very thing #1717 pins.
+    if (key === UNSAFE_KEY || key === SIGNAL_KEY) {
+      continue;
+    }
+
+    putField(copy, key, bag[key]);
   }
 
   return freeze(copy);

--- a/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
+++ b/packages/core/src/namespaces/EventBusNamespace/EventBusNamespace.ts
@@ -7,7 +7,7 @@ import {
   errorCodes,
   events,
 } from "../../constants";
-import { adoptForeignBag, dropUnsafeKey } from "../../helpers";
+import { adoptForeignBag } from "../../helpers";
 import { RouterError, freezeThrownError } from "../../RouterError";
 import { routerEvents, routerStates } from "../../routerFSM";
 
@@ -159,22 +159,6 @@ function bridgeSignal(
     onClosed();
     signal.removeEventListener("abort", onAbort);
   };
-}
-
-/**
- * Drop the caller's `AbortSignal` before the state is announced.
- *
- * ⚑ And `UNSAFE_KEY` with it (#1957). `rest` is an object CORE mints, built by
- * rest-destructuring, which `[[Define]]`s — so an own `"__proto__"` from a
- * `JSON.parse`d bag lands on it and makes the container every plugin hook
- * receives a prototype-swap primitive for anything that merges it. The delete is
- * free here: the spread has already happened, so nothing is read a second time.
- */
-function stripSignal({
-  signal: _,
-  ...rest
-}: NavigationOptions): NavigationOptions {
-  return dropUnsafeKey(rest);
 }
 
 export class EventBusNamespace {
@@ -1112,22 +1096,20 @@ export class EventBusNamespace {
 
       // Subscribers never see the caller's `AbortSignal`: it is an input to the
       // navigation, not part of what was committed. The TABLE does see it —
-      // `mayCommit` refuses a commit whose signal was aborted — which is why
-      // the stripping lives here, on the announcement, and not upstream.
+      // `mayCommit` refuses a commit whose signal was aborted — through
+      // `payload.externalSignal`, the snapshot taken at the entry.
       //
-      // ⚑ Whether to strip is decided by the navigation's SNAPSHOT of that
-      // signal, not by asking `payload.opts` again (#1717): `opts` is
-      // accessor-backed by contract, so a second read can answer `undefined`
-      // for a navigation that very much carried a signal — and this branch
-      // would then hand plugins the caller's own object, live accessor and all.
-      // The spread below is a read of `opts` too, but that one is deliberate:
-      // it stands in the announcement, which already runs application code.
+      // ⚑ The strip that used to live HERE has moved to the entry door (#1962),
+      // and moving it is what removed a defect rather than relocating one. This
+      // announcement was the LAST reader of `opts`, so it decided — with a
+      // ternary on `externalSignal` — whether plugins got the application's own
+      // object or a copy of it. The discriminator was a signal the plugin never
+      // sees. `payload.opts` is now core's own frozen record on every arc, made
+      // by one walk above every other read, so there is nothing left to decide.
       this.emitTransitionSuccess(
         payload.toState,
         payload.fromState,
-        payload.externalSignal === undefined
-          ? payload.opts
-          : stripSignal(payload.opts),
+        payload.opts,
       );
     });
 

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -2,7 +2,7 @@ import { completeTransition } from "./completeTransition";
 import { asCancellation, routeTransitionError } from "./errorHandling";
 import { executeGuardPipeline } from "./guardPhase";
 import { errorCodes, constants } from "../../../constants";
-import { dropUnsafeKey } from "../../../helpers";
+import { adoptNavigationOptions } from "../../../helpers";
 import { RouterError, freezeThrownError } from "../../../RouterError";
 import { getTransitionPath } from "../../../transitionPath";
 import {
@@ -31,6 +31,12 @@ import type {
  * `finishAsyncNavigation` takes it as a parameter, from both of its callers.
  */
 
+// Captured at module load, same reason as its six siblings across `src`: the
+// freeze below owns a published guarantee — the bag every plugin hook receives —
+// and a guarantee is only as strong as the intrinsic it reads WHEN IT RUNS
+// (#1970 / #1971).
+const freeze = Object.freeze;
+
 // Write-once placeholders for `NavigationPlan`'s pass-2 fields. Module-level so
 // building a plan allocates nothing beyond the plan itself; never mutated —
 // `planPhases` overwrites the SLOTS, it does not write through them.
@@ -56,24 +62,21 @@ function substituteForcedReplace(
     return opts;
   }
 
-  // ⚑ `dropUnsafeKey` on the spread (#1957). The object below is one CORE mints,
-  // and a spread `[[Define]]`s — so an own `"__proto__"` from a `JSON.parse`d bag
-  // rides it into every plugin's `onTransitionSuccess`, where merging it swaps
-  // the merge target's prototype. Free here: the spread has already run, so
-  // nothing is read a second time.
+  // ⚑ Both arms now hand back a frozen record CORE owns, because the entry door
+  // ran above this (#1962): the pass-through returns core's own copy, and the
+  // spread below re-freezes what the spread thawed. Uniformity is the point —
+  // this substitution must not be the reason one arc's hook gets a writable bag.
   //
-  // ⚠ The pass-through arm above is deliberately left alone: it hands back the
-  // CALLER's own object, identity preserved (measured), so core mints no swap
-  // primitive there. Sanitising it would mean COPYING the bag — i.e. invoking
-  // the caller's accessors a SECOND time below the read that already decided,
-  // which `opts-read-once-1817.test.ts` counts and pins at one (measured: the
-  // copy takes `reload` and `replace` to two and reds both cells).
+  // ⚠ `dropUnsafeKey` is gone from here, and its absence is not a relaxation:
+  // the source is core's copy, which the entry door already stripped, so a
+  // spread of it cannot carry an own `"__proto__"` (#1957). Re-dropping would be
+  // an unfalsifiable no-op — the shape #1957's own guard exists to refuse.
   //
   // ⚑ The early return is also what keeps `forced` from being a SELECTOR
   // parameter now that the two arms differ in shape — `sonarjs/no-selector-parameter`
   // fires on the ternary form, and the project's own rule says a boolean
   // argument is a hypothesis to justify.
-  return dropUnsafeKey({ ...opts, replace: true });
+  return freeze({ ...opts, replace: true });
 }
 
 function isSameNavigation(
@@ -381,6 +384,25 @@ export function executeNavigation(
     const externalSignal = opts.signal;
     const abortedAtEntry =
       externalSignal?.aborted === true ? externalSignal : undefined;
+
+    // ⚑ THE ENTRY DOOR (#1962). One walk of the caller's bag, into a frozen
+    // record core owns — and everything below reads that, never the caller's
+    // object again.
+    //
+    // What it closes is not the aliasing but the INCONSISTENCY: a plugin used to
+    // receive the application's own literal on three arcs and a copy on two, and
+    // the discriminator was whether the caller passed a `signal` — which the
+    // plugin never sees. Annotating the hook argument, the cheapest way to pass a
+    // flag from one hook to the next, therefore wrote into the application's
+    // object or into a private copy depending on an unrelated detail of the call.
+    //
+    // ⚑ It sits BELOW the signal read and ABOVE every other one, and that order
+    // is what keeps #1817's guarantee intact rather than merely unbroken: the
+    // walk skips `signal` (already read, once), and the six flags hoisted below
+    // now come off core's own data, so the caller's accessors are entered
+    // exactly once per key — including keys core never names, which until now
+    // rode to the hook live.
+    opts = adoptNavigationOptions(opts);
 
     // ⚑ EVERY flag hoisted here, above both readers, and #1817 is the residue
     // that made it necessary. #1719 hoisted three of them on the stated ground

--- a/packages/core/tests/functional/handed-out-containers-1957.test.ts
+++ b/packages/core/tests/functional/handed-out-containers-1957.test.ts
@@ -289,13 +289,14 @@ describe("#1957 — no door hands out a container that swaps a merge target", ()
     };
 
     it("the two arcs where CORE mints the container do not swap", async () => {
-      // THREE arcs, and they differ in who OWNS the object — which the issue got
-      // wrong (it recorded `=== false`, "core mints it", for all three; measured,
-      // the plain arc's identity is `true`). Only two of them are core's to fix:
-      // `stripSignal`'s rest-destructuring and the forced-replace substitution
-      // each mint a fresh object by spread, and a spread `[[Define]]`s, so the
-      // caller's own `"__proto__"` rides into every hook on a container core
-      // built.
+      // ⚠ This cell is named for a split that no longer exists. When it was
+      // written the three arcs differed in who OWNED the object — the issue
+      // recorded `=== false` for all three, and measured, the plain arc's
+      // identity was `true` — so only two were core's to fix. Since #1962 the
+      // entry door owns every arc, and the cell survives as the pin that the
+      // two SPREADING arcs still cannot carry the key: a spread `[[Define]]`s,
+      // so an own `"__proto__"` would ride it into every hook if the door above
+      // had not already dropped it.
       const signalled = await opts("/home", false, true);
       const forced = await opts("/nope", true, false);
 
@@ -305,23 +306,25 @@ describe("#1957 — no door hands out a container that swaps a merge target", ()
       }).toStrictEqual({ signalled: false, forced: false });
     });
 
-    it("CARVE-OUT — the plain arc hands back the caller's own object, poison and all", async () => {
-      // ⚠ Recorded, not fixed, and the reason is a COLLISION with a pin rather
-      // than an oversight. Core neither mints nor copies here: the hook receives
-      // the very object the application passed to `navigate`, identity intact.
-      // Sanitising it means COPYING it — and copying reads every key, i.e.
-      // invokes the caller's accessors a second time below the read that already
-      // decided. `opts-read-once-1817.test.ts` counts exactly those reads and
-      // pins them at one; the copy takes `reload` and `replace` to two (measured,
-      // both cells red).
+    it("the carve-out is CLOSED — the plain arc hands back core's own container (#1962)", async () => {
+      // ⚠ This cell used to assert the opposite, and the reason it gave was
+      // sound for the fix it was considering: "sanitising it means COPYING it,
+      // and copying reads every key — i.e. invokes the caller's accessors a
+      // second time BELOW the read that already decided", which
+      // `opts-read-once-1817` pins at one.
       //
-      // So the trade is: an extra invocation of application code on every
-      // navigation carrying the key, against a container the application itself
-      // authored and handed in. The pin wins.
+      // What refuted it was the copy's POSITION, not its cost. #1962 puts the
+      // copy ABOVE every read but the signal's, so the six flags are then read
+      // off core's own record and the caller's accessors are entered exactly
+      // once per key — fewer, not more, than before. The trade the old comment
+      // priced never had to be made.
       const plain = await opts("/home", false, false);
 
-      expect(plain.seen).toBe(plain.passedIn);
-      expect(swapsOnMerge(plain.seen)).toBe(true);
+      expect(plain.seen).not.toBe(plain.passedIn);
+      expect(swapsOnMerge(plain.seen)).toBe(false);
+      // CONTROL — the container is real and carries the caller's other options,
+      // so the two assertions above are not passing on an empty object.
+      expect((plain.seen as Record<string, unknown>).kept).toBe(1);
     });
 
     it("POSITIVE CONTROL — the hook still receives the caller's other options", async () => {
@@ -330,9 +333,12 @@ describe("#1957 — no door hands out a container that swaps a merge target", ()
       expect((seen as Record<string, unknown>).kept).toBe(1);
     });
 
-    it("an ordinary navigation still hands the hook the caller's own object", async () => {
-      // The withholding must not allocate on the common path: with the key
-      // absent the container is returned untouched, identity and all.
+    it("an ordinary navigation hands the hook core's own FROZEN copy (#1962)", async () => {
+      // The ordinary arc, with no poison and no signal — the one an application
+      // takes on every navigation. It used to hand back the caller's literal by
+      // identity; it now hands back core's record, and the freeze is what turns
+      // the annotation habit (`opts.handled = true` in a hook) from a silent
+      // cross-plugin channel into a `TypeError`.
       const router = createRouter(ROUTES);
       let seen: unknown;
 
@@ -350,7 +356,11 @@ describe("#1957 — no door hands out a container that swaps a merge target", ()
 
       await router.navigate("away", {}, {}, passedIn);
 
-      expect(seen).toBe(passedIn);
+      expect(seen).not.toBe(passedIn);
+      expect(Object.isFrozen(seen)).toBe(true);
+      // CONTROL — the copy carries what the caller asked for, so `not.toBe`
+      // above is not satisfied by an empty or absent container.
+      expect((seen as Record<string, unknown>).replace).toBe(true);
     });
   });
 

--- a/packages/core/tests/functional/navigation/announcement-owns-its-opts-authority-1962.test.ts
+++ b/packages/core/tests/functional/navigation/announcement-owns-its-opts-authority-1962.test.ts
@@ -29,6 +29,15 @@ import { describe, expect, it } from "vitest";
  *
  * Anything else is a caller's bag reaching plugins by reference, and reds here.
  *
+ * ⚠ **This checks the NAME, and a name is a stand-in.** An unfrozen `SNEAKY_OPTS`
+ * would satisfy `_OPTS$` while handing plugins a writable bag, and the constant's
+ * frozenness is not visible at the call site for any static rule to read. The
+ * other half is therefore behavioural, in
+ * `options-entry-door-1962` → "freezes the bag on the two SYSTEM_COMMIT arcs
+ * too": it exercises both producers and asserts the property rather than the
+ * spelling. Neither half is sufficient alone — this one catches a NEW site, that
+ * one catches a changed constant.
+ *
  * ⚠ Addressed by file plus the matched argument text, never by line number: the
  * sites this watches are edited often and a `:NNN` citation rots on the first
  * reformat.

--- a/packages/core/tests/functional/navigation/announcement-owns-its-opts-authority-1962.test.ts
+++ b/packages/core/tests/functional/navigation/announcement-owns-its-opts-authority-1962.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync, globSync } from "node:fs";
+import path from "node:path";
+
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every announcement hands `onTransitionSuccess` a container CORE owns (#1962).
+ *
+ * The point-fix this guards is one door — `executeNavigation`'s entry copy —
+ * but the defect class is wider than that door: *any* site that announces a
+ * success with a bag core did not build hands the application's own object to
+ * every installed plugin, unfrozen, and the aliasing is invisible from the hook
+ * (a plugin cannot tell whose object it holds).
+ *
+ * ⚠ The five arcs pinned behaviourally in `options-entry-door-1962` are the ones
+ * that exist TODAY. They cannot catch a SIXTH announcement added later, which is
+ * exactly how this class recurred before: the object was fine on the arcs anyone
+ * thought to test. So the set of announcement sites is DERIVED here, and each is
+ * required to pass a container with a known owner.
+ *
+ * Two owners are legitimate, and no third:
+ *
+ * - **`payload.opts`** — the FSM payload, whose `opts` is core's frozen record
+ *   because the entry door built it above every other read;
+ * - **a module constant** named `*_OPTS` — `FROZEN_REPLACE_OPTS`
+ *   (`navigateToNotFound`) and `REVALIDATE_OPTS` (`getRoutesApi`), both
+ *   `Object.freeze`d literals core authors.
+ *
+ * Anything else is a caller's bag reaching plugins by reference, and reds here.
+ *
+ * ⚠ Addressed by file plus the matched argument text, never by line number: the
+ * sites this watches are edited often and a `:NNN` citation rots on the first
+ * reformat.
+ */
+
+const SRC = path.resolve(__dirname, "../../../src");
+
+/** The announcement whose third argument is the container plugins receive. */
+const ANNOUNCE = "emitTransitionSuccess";
+
+interface Site {
+  readonly file: string;
+  readonly argument: string;
+}
+
+const OWNED = /^payload\.opts$|_OPTS$/;
+
+function announcementSites(root: string): Site[] {
+  const found: Site[] = [];
+
+  for (const file of globSync(`${root}/**/*.ts`)) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === ANNOUNCE &&
+        // The DECLARATION is not a site; only calls that pass a container are.
+        node.arguments.length >= 3
+      ) {
+        found.push({
+          file: path.relative(root, file),
+          argument: node.arguments[2].getText(source).replaceAll(/\s+/g, " "),
+        });
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return found;
+}
+
+describe("every announcement owns the opts it hands out (#1962)", () => {
+  const sites = announcementSites(SRC);
+
+  it("finds the announcement sites at all — the guard must not pass on an empty walk", () => {
+    // Without this the whole file goes green the moment the method is renamed,
+    // the directory moves, or the AST shape stops matching: a derived set that
+    // finds NOTHING satisfies "every site is owned" vacuously.
+    expect(sites.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThanOrEqual(1);
+  });
+
+  it("passes a container with a known owner at every site", () => {
+    const unowned = sites.filter((s) => !OWNED.test(s.argument));
+
+    expect(unowned.map((s) => `${s.file}: ${s.argument}`)).toStrictEqual([]);
+  });
+
+  it("CONTROL — the predicate refuses a caller-supplied bag", () => {
+    // The mutation this file exists to catch, run against the predicate itself
+    // so a future loosening of `OWNED` cannot pass unnoticed.
+    expect(OWNED.test("payload.opts")).toBe(true);
+    expect(OWNED.test("FROZEN_REPLACE_OPTS")).toBe(true);
+    expect(OWNED.test("REVALIDATE_OPTS")).toBe(true);
+
+    expect(OWNED.test("opts")).toBe(false);
+    expect(OWNED.test("this.#callerOpts")).toBe(false);
+    expect(OWNED.test("payload.opts.signal === undefined ? opts : copy")).toBe(
+      false,
+    );
+  });
+
+  it("CONTROL — the walk sees a site it is shown", () => {
+    // A positive control on the SCANNER, not on the predicate: proves the AST
+    // shape being matched is the one the source actually has, so "no unowned
+    // sites" is a measurement rather than a failure to look.
+    const probe = ts.createSourceFile(
+      "probe.ts",
+      `class X { f(o: unknown) { this.${ANNOUNCE}(a, b, o); } }`,
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+
+    const hits: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === ANNOUNCE &&
+        node.arguments.length >= 3
+      ) {
+        hits.push(node.arguments[2].getText(probe));
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(probe);
+
+    expect(hits).toStrictEqual(["o"]);
+    expect(OWNED.test(hits[0])).toBe(false);
+  });
+});

--- a/packages/core/tests/functional/navigation/bridge-only-when-the-band-can-abort-1690.test.ts
+++ b/packages/core/tests/functional/navigation/bridge-only-when-the-band-can-abort-1690.test.ts
@@ -196,8 +196,10 @@ describe("the external-signal bridge stands only when the band can abort (#1690)
 
     const controller = new AbortController();
     let armed = true;
+    // On the TARGET so the entry door's own-enumerable walk asks for it (#1962);
+    // otherwise the getter never fires and the arc measures nothing.
     const opts = new Proxy(
-      { signal: controller.signal },
+      { signal: controller.signal, forceDeactivate: undefined },
       {
         get(target, key, receiver) {
           if (key === "forceDeactivate" && armed) {

--- a/packages/core/tests/functional/navigation/cancellability-scope-1716.test.ts
+++ b/packages/core/tests/functional/navigation/cancellability-scope-1716.test.ts
@@ -248,8 +248,10 @@ const ARCS: readonly Arc[] = [
       getLifecycleApi(router).addActivateGuard("b", () => () => true);
 
       let armed = false;
+      // On the TARGET so the entry door's own-enumerable walk asks for it
+      // (#1962); otherwise the getter never fires and the arc measures nothing.
       const opts = new Proxy(
-        { signal: controller.signal },
+        { signal: controller.signal, forceDeactivate: undefined },
         {
           get(target, property, receiver) {
             if (property === "forceDeactivate" && armed) {

--- a/packages/core/tests/functional/navigation/cancellation-stops-the-guard-walk-1687.test.ts
+++ b/packages/core/tests/functional/navigation/cancellation-stops-the-guard-walk-1687.test.ts
@@ -481,8 +481,10 @@ describe("#1706 — a CANCEL that lands before the controller exists still stops
     let armed = false;
     const external = new AbortController();
 
+    // On the TARGET so the entry door's own-enumerable walk asks for it (#1962);
+    // otherwise the getter never fires and the arc measures nothing.
     const opts = new Proxy(
-      { signal: external.signal },
+      { signal: external.signal, forceDeactivate: undefined },
       {
         get(target, property, receiver) {
           if (property === "forceDeactivate" && armed) {

--- a/packages/core/tests/functional/navigation/commit-gate-reads-the-snapshot-1717.test.ts
+++ b/packages/core/tests/functional/navigation/commit-gate-reads-the-snapshot-1717.test.ts
@@ -208,12 +208,15 @@ describe("#1717 — the commit gate consults the plan's snapshot, not the caller
     // the rule is one sentence — refuse silently only when the signal was
     // already dead when the router received it.
     //
-    // Below the announce: the announcement's own `stripSignal` spread, which is
-    // application code BY DESIGN (it stands in the announce, where user code
-    // already runs) — and nothing else. The gate, both of its evaluations and
-    // the strip BRANCH all ask the snapshot.
+    // ⚑ **And ZERO below it since #1962** — this line used to expect one. The
+    // announcement's own `stripSignal` spread was that read: it stood in the
+    // announce, where application code already runs, and was defended on that
+    // ground. The entry door removed the need for it — `payload.opts` is core's
+    // own frozen record on every arc, so the announcement has nothing left to
+    // strip and asks the caller's object nothing at all. The gate, both of its
+    // evaluations and the announcement now all read core's own data.
     expect(readsAtAnnounce).toBe(1);
-    expect(reads() - readsAtAnnounce).toBe(1);
+    expect(reads() - readsAtAnnounce).toBe(0);
   });
 
   /**

--- a/packages/core/tests/functional/navigation/entry-abort-boundary.test.ts
+++ b/packages/core/tests/functional/navigation/entry-abort-boundary.test.ts
@@ -57,8 +57,19 @@ async function abortFromGetter(field: string): Promise<Run> {
   const controller = new AbortController();
   let armed = false;
 
+  // ⚠ The measured field must be an OWN ENUMERABLE key of the target, not just
+  // something the trap answers for (#1962). Core no longer reads the caller's
+  // bag field by field: the entry door walks its own-enumerable surface once and
+  // reads its own copy afterwards, so a field the target does not carry is a
+  // field the getter is never asked for — and the instrument would measure
+  // nothing while still passing. `undefined` is the value `Reflect.get` returned
+  // for it before, so the arc under test is unchanged.
+  // ⚠ `signal` is spread LAST deliberately: one cell measures the `signal`
+  // getter itself, and writing `[field]: undefined` after it would replace the
+  // live signal with `undefined` — the instrument would then be measuring a
+  // navigation that carries no signal at all.
   const opts = new Proxy<NavigationOptions>(
-    { signal: controller.signal },
+    { [field]: undefined, signal: controller.signal },
     {
       get(target, property, receiver) {
         if (property === field && armed) {

--- a/packages/core/tests/functional/navigation/external-signal-bridge-1684.test.ts
+++ b/packages/core/tests/functional/navigation/external-signal-bridge-1684.test.ts
@@ -508,8 +508,11 @@ describe("#1704 — an opts getter that aborts before the announce still cancels
 
     let armed = false;
     const external = new AbortController();
+    // `forceDeactivate` sits on the TARGET so the entry door's own-enumerable
+    // walk asks for it (#1962) — without it the getter is never entered and this
+    // arc measures nothing. `undefined` is what `Reflect.get` answered before.
     const opts = new Proxy(
-      { signal: external.signal },
+      { signal: external.signal, forceDeactivate: undefined },
       {
         get(target, property, receiver) {
           if (property === "forceDeactivate" && armed) {

--- a/packages/core/tests/functional/navigation/navigate/edge-cases-input-validation.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/edge-cases-input-validation.test.ts
@@ -213,11 +213,19 @@ describe("router.navigate() - edge cases input validation", () => {
       expect(router.isActive()).toBe(true);
     });
 
-    it("FINDING: a NON-ENUMERABLE `replace` option is still honored", async () => {
-      // The pipeline reads `opts.replace` directly (property access), it does
-      // NOT enumerate own keys — so a non-enumerable `replace` is applied just
-      // like an enumerable one. Verified via state.transition.replace, which
-      // core sets from NavigationOptions.
+    it("a NON-ENUMERABLE `replace` option is NOT honored — own enumerable only", async () => {
+      // ⚠ This cell asserted the opposite until #1962, and the reason it gave
+      // was accurate for the code of its day: "the pipeline reads `opts.replace`
+      // directly (property access), it does NOT enumerate own keys". The entry
+      // door now walks the caller's bag once, so the surface core reads is its
+      // own-enumerable one — which is the boundary the owner set on 2026-08-18
+      // and `CLAUDE.md` "Supported Input Shapes" records:
+      //
+      //   > Own enumerable properties only. Inherited and non-enumerable
+      //   > properties of a caller-supplied object are not supported input.
+      //
+      // #1813 was closed NOT_PLANNED against that decision, naming this very
+      // read-by-name residue as shipped behaviour the decision narrows.
       const onTransitionSuccess = vi.fn();
 
       const r = createTestRouter();
@@ -226,16 +234,26 @@ describe("router.navigate() - edge cases input validation", () => {
 
       await r.start("/home");
 
-      const opts = {};
+      const hidden = {};
 
-      Object.defineProperty(opts, "replace", {
+      Object.defineProperty(hidden, "replace", {
         enumerable: false,
         value: true,
       });
 
-      const state = await r.navigate("users", {}, undefined, opts);
+      const ignored = await r.navigate("users", {}, undefined, hidden);
 
-      expect(state.transition?.replace).toBe(true);
+      expect(ignored.transition?.replace).toBeUndefined();
+
+      // DISCRIMINATOR — the same value as an own ENUMERABLE key is honoured, so
+      // the cell above pins the enumerability rule and not "replace never works".
+      await r.navigate("home");
+
+      const honoured = await r.navigate("users", {}, undefined, {
+        replace: true,
+      });
+
+      expect(honoured.transition?.replace).toBe(true);
       expect(onTransitionSuccess).toHaveBeenCalledWith(
         expect.objectContaining({ name: "users" }),
         expect.anything(),

--- a/packages/core/tests/functional/navigation/navigate/edge-cases-proxy.test.ts
+++ b/packages/core/tests/functional/navigation/navigate/edge-cases-proxy.test.ts
@@ -82,12 +82,18 @@ describe("router.navigate() - edge cases proxy", () => {
 
       it("should accept Proxy as opts (no structuredClone)", async () => {
         // Since state freezing moved to makeState (using Object.freeze, not structuredClone),
-        // Proxy objects in navigation options now work
+        // Proxy objects in navigation options now work.
+        //
+        // ⚠ The key lives on the TARGET (#1962). The entry door reads the bag's
+        // own-enumerable surface, and a pass-through Proxy reports its target's
+        // keys — which is the shape that actually occurs: Vue `reactive()` and
+        // Svelte `$state` both wrap a real object. The cell below pins the other
+        // shape, a trap answering for a key its target does not have.
         const proxyOpts = new Proxy(
-          {},
+          { replace: true },
           {
-            get(_target, prop) {
-              return prop === "replace" ? true : undefined;
+            get(target, prop, receiver) {
+              return Reflect.get(target, prop, receiver) as unknown;
             },
           },
         );
@@ -100,6 +106,34 @@ describe("router.navigate() - edge cases proxy", () => {
         // The Proxy's `replace: true` must reach the transition — otherwise the
         // test proves only that navigation didn't crash, not that opts were read.
         expect(state.transition?.replace).toBe(true);
+      });
+
+      it("a Proxy that only ANSWERS for a key does not contribute it", async () => {
+        // The boundary of the rule above, pinned rather than left as an absence:
+        // `replace` is not an own enumerable property of this bag — the target
+        // has no keys at all — so under "own enumerable properties only" (owner
+        // decision, 2026-08-18) it is not supported input. Before #1962 core read
+        // the flag by name and honoured it.
+        const answersOnly = new Proxy(
+          {},
+          {
+            get(_target, prop) {
+              return prop === "replace" ? true : undefined;
+            },
+          },
+        );
+
+        const state = await router.navigate(
+          "users",
+          {},
+          undefined,
+          answersOnly,
+        );
+
+        // The navigation still succeeds — this is a narrowing of what core
+        // READS, not a new refusal.
+        expect(state).toStrictEqual(expect.objectContaining({ name: "users" }));
+        expect(state.transition?.replace).toBeUndefined();
       });
 
       it("should handle plain objects that mimic Proxy behavior", async () => {

--- a/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
+++ b/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest";
+
+import { createRouter } from "@real-router/core";
+import { getPluginApi } from "@real-router/core/api";
+
+import { CONTAINER_SHAPES } from "../../helpers/hostileBags";
+
+import type {
+  NavigationOptions,
+  PluginFactory,
+  Route,
+  Router,
+} from "@real-router/core";
+
+/**
+ * Core copies a caller's `NavigationOptions` ONCE, at the entry door (#1962).
+ *
+ * The defect these cells pin is not the aliasing on its own — either answer is
+ * defensible — it is that the two answers were chosen by an unrelated detail of
+ * the call. Measured before the fix, across the five arcs below:
+ *
+ *     arc                        hook received the caller's object
+ *     positional, no signal      YES        <- and a write reached the app
+ *     positional, WITH signal    no
+ *     descriptor form            YES        <- and a write reached the app
+ *     navigateToDefault          YES        <- and a write reached the app
+ *     forced replace (from 404)  no
+ *
+ * The discriminator is a `signal` the plugin never sees, so a plugin author
+ * cannot tell which one they hold. The cells therefore assert UNIFORMITY over
+ * the arcs rather than a value per arc: whatever the answer is, every arc gives
+ * the same one.
+ *
+ * ⚑ The copy keeps every own enumerable key — owner decision, 2026-08-30,
+ * recorded in `packages/core/CLAUDE.md` "Supported Input Shapes". A key core does
+ * not recognise (`hash`, declared by three URL plugins through module
+ * augmentation) survives to the hook; that is what `<Link hash>` rides.
+ */
+describe("the entry door copies the caller's NavigationOptions (#1962)", () => {
+  const ROUTES = [
+    { name: "a", path: "/a" },
+    { name: "b", path: "/b" },
+  ] as unknown as Route[];
+
+  interface Arc {
+    readonly name: string;
+    readonly make: () => Router;
+    readonly boot: string;
+    readonly run: (r: Router, bag: NavigationOptions) => Promise<unknown>;
+    readonly bag: () => NavigationOptions;
+  }
+
+  const ARCS: readonly Arc[] = [
+    {
+      name: "positional, no signal",
+      make: () => createRouter(ROUTES),
+      boot: "/a",
+      run: (r, bag) => r.navigate("b", {}, undefined, bag),
+      bag: () => ({ replace: true }),
+    },
+    {
+      name: "positional, WITH signal",
+      make: () => createRouter(ROUTES),
+      boot: "/a",
+      run: (r, bag) => r.navigate("b", {}, undefined, bag),
+      bag: () => ({ replace: true, signal: AbortSignal.timeout(5000) }),
+    },
+    {
+      name: "descriptor form",
+      make: () => createRouter(ROUTES),
+      boot: "/a",
+      run: (r, bag) => r.navigate({ name: "b" }, bag),
+      bag: () => ({ replace: true }),
+    },
+    {
+      name: "navigateToDefault",
+      make: () => createRouter(ROUTES, { defaultRoute: "b" }),
+      boot: "/a",
+      run: (r, bag) => r.navigateToDefault(bag),
+      bag: () => ({ replace: true }),
+    },
+    {
+      name: "forced replace out of UNKNOWN_ROUTE",
+      make: () => createRouter(ROUTES, { allowNotFound: true }),
+      boot: "/nowhere",
+      run: (r, bag) => r.navigate("b", {}, undefined, bag),
+      bag: () => ({ reload: true }),
+    },
+    {
+      // ⚑ The PLUGIN's door, and the one an application never calls: browser-plugin
+      // restores a popstate entry through it. It shares the funnel with the four
+      // above, which is exactly why it belongs in the table — "same funnel" is the
+      // claim, and a table that omits the arc cannot check it.
+      name: "getPluginApi().navigateToState",
+      make: () => createRouter(ROUTES),
+      boot: "/a",
+      run: async (r, bag) => {
+        const target = await r.navigate("b");
+
+        await r.navigate("a");
+
+        return getPluginApi(r).navigateToState(target, bag);
+      },
+      bag: () => ({ replace: true }),
+    },
+  ];
+
+  interface Observed {
+    readonly arc: string;
+    /**
+     * ⚑ Every other field is VACUOUSLY satisfied by an arc that never reaches the
+     * hook, and the failure mode is silent in both directions: `received === bag`
+     * is `false` when `received` is `undefined`, and `Object.isFrozen(undefined)`
+     * answers **true** — a primitive is frozen by definition. So an arc that
+     * quietly stopped announcing would report "not the caller's object, frozen"
+     * and pass every cell below. This field is what makes the table a
+     * measurement.
+     */
+    readonly reachedTheHook: boolean;
+    readonly isCallersObject: boolean;
+    readonly frozen: boolean;
+    readonly writeRefused: boolean;
+    readonly callerBagUntouched: boolean;
+  }
+
+  const observe = async (arc: Arc): Promise<Observed> => {
+    const router = arc.make();
+    const bag = arc.bag();
+    let received: NavigationOptions | undefined;
+    let writeRefused = false;
+
+    const plugin: PluginFactory = () => ({
+      onTransitionSuccess: (_toState, _fromState, opts) => {
+        received = opts;
+
+        try {
+          (opts as Record<string, unknown>).TAG = "MUTATED";
+        } catch {
+          writeRefused = true;
+        }
+      },
+    });
+
+    router.usePlugin(plugin);
+    await router.start(arc.boot);
+
+    // ⚠ CLEARED after boot, and without this the table measures the wrong
+    // navigation. `start()` announces a success of its own, so `received` is
+    // already a core-minted frozen record before the arc runs — and every field
+    // below would then report the BOOT's object. Verified by neutralising an
+    // arc's `run`: with the reset the table reds, without it all seven cells
+    // stayed green.
+    received = undefined;
+    writeRefused = false;
+
+    await arc.run(router, bag);
+
+    const observed: Observed = {
+      arc: arc.name,
+      reachedTheHook: typeof received === "object" && received !== null,
+      isCallersObject: received === bag,
+      frozen: Object.isFrozen(received),
+      writeRefused,
+      callerBagUntouched: (bag as Record<string, unknown>).TAG === undefined,
+    };
+
+    router.dispose();
+
+    return observed;
+  };
+
+  it("hands every arc a container that is NOT the caller's object", async () => {
+    const rows = await Promise.all(ARCS.map((a) => observe(a)));
+
+    // Guards the table itself, in both directions an empty measurement can hide
+    // in: an ARCS list that shrank, and an arc that stopped announcing.
+    expect(rows).toHaveLength(ARCS.length);
+    expect(rows.length).toBeGreaterThanOrEqual(6);
+    expect(
+      rows.map((r) => `${r.arc}: ${String(r.reachedTheHook)}`),
+    ).toStrictEqual(ARCS.map((a) => `${a.name}: true`));
+
+    expect(
+      rows.map((r) => `${r.arc}: ${String(r.isCallersObject)}`),
+    ).toStrictEqual(ARCS.map((a) => `${a.name}: false`));
+  });
+
+  it("freezes it on every arc, so the annotation habit fails loudly", async () => {
+    const rows = await Promise.all(ARCS.map((a) => observe(a)));
+
+    expect(rows.map((r) => `${r.arc}: ${String(r.frozen)}`)).toStrictEqual(
+      ARCS.map((a) => `${a.name}: true`),
+    );
+    expect(
+      rows.map((r) => `${r.arc}: ${String(r.writeRefused)}`),
+    ).toStrictEqual(ARCS.map((a) => `${a.name}: true`));
+  });
+
+  it("leaves the application's own literal untouched on every arc", async () => {
+    const rows = await Promise.all(ARCS.map((a) => observe(a)));
+
+    expect(
+      rows.map((r) => `${r.arc}: ${String(r.callerBagUntouched)}`),
+    ).toStrictEqual(ARCS.map((a) => `${a.name}: true`));
+  });
+
+  it("runs the six-shape container battery through the door", async () => {
+    // ⚠ The battery existed and this door was not in it: `handed-out-containers-1957`
+    // runs `CONTAINER_SHAPES` against the router-options and dependencies doors,
+    // while the `NavigationOptions` section tested ONE shape (an own `__proto__`
+    // from `JSON.parse`). A door that copies a caller's object belongs in the
+    // battery, so here it is — with the two things the shapes decide between:
+    //
+    //   · `swaps`  — does merging what the hook received re-parent the target?
+    //                Must be `false` for every shape; that is #1957's property.
+    //   · `kept`   — did the caller's key survive the copy? This is where "own
+    //                enumerable properties only" becomes visible: the inherited
+    //                and non-enumerable shapes are NOT supported input and are
+    //                dropped, while a pass-through Proxy and a null-prototype bag
+    //                report own-enumerable keys normally and are carried.
+    const rows: string[] = [];
+
+    for (const [label, wrap] of CONTAINER_SHAPES) {
+      const router = createRouter(ROUTES);
+      let received: Record<string, unknown> | undefined;
+
+      router.usePlugin(() => ({
+        onTransitionSuccess: (_t, _f, opts) => {
+          received = opts as Record<string, unknown>;
+        },
+      }));
+
+      await router.start("/a");
+
+      received = undefined;
+      await router.navigate(
+        "b",
+        {},
+        undefined,
+        wrap({ kept: 1 }) as NavigationOptions,
+      );
+
+      const merged = Object.assign({}, received) as Record<string, unknown>;
+
+      rows.push(
+        `${label}: swaps=${String(
+          Object.getPrototypeOf(merged) !== Object.prototype,
+        )} kept=${String(
+          (received as Record<string, unknown> | undefined)?.kept === 1,
+        )}`,
+      );
+
+      router.dispose();
+    }
+
+    expect(rows).toStrictEqual([
+      "own enumerable (control): swaps=false kept=true",
+      "inherited through the prototype: swaps=false kept=false",
+      "own non-enumerable: swaps=false kept=false",
+      "pass-through Proxy (a reactive store): swaps=false kept=true",
+      "null-prototype: swaps=false kept=true",
+      "an own __proto__ key, as JSON.parse yields: swaps=false kept=true",
+    ]);
+    // The battery must not have quietly emptied.
+    expect(rows).toHaveLength(6);
+  });
+
+  it("keeps a key core does not declare — the owner decision of 2026-08-30", async () => {
+    const router = createRouter(ROUTES);
+    let received: NavigationOptions | undefined;
+
+    router.usePlugin(() => ({
+      onTransitionSuccess: (_t, _f, opts) => {
+        received = opts;
+      },
+    }));
+
+    await router.start("/a");
+    await router.navigate("b", {}, undefined, {
+      replace: true,
+      hash: "section",
+    } as NavigationOptions);
+
+    expect((received as Record<string, unknown>).hash).toBe("section");
+    // CONTROL — a key core DOES declare rides the same copy, so the cell above
+    // is not measuring "everything is missing".
+    expect(received?.replace).toBe(true);
+
+    router.dispose();
+  });
+
+  it("a throwing getter on ANY key fails the navigation before it commits", async () => {
+    // ⚠ A behaviour change, and the arc it replaces was worse than "silent".
+    // Measured on `origin/master`, with `{ reload: true, get boom() { throw } }`:
+    //
+    //     no signal : RESOLVED                committed = b
+    //     WITH sig  : REJECTED "CANCELLED"    committed = b   <- and announced
+    //
+    // The plain arc never read `boom`, so it succeeded. The signal arc read it
+    // from `stripSignal`'s spread — inside the ANNOUNCEMENT, below the commit —
+    // so the state moved, every plugin was told the navigation succeeded, and
+    // the caller was handed `CANCELLED`: a rejection naming neither the real
+    // cause nor the actual outcome. The `signal` decided which, again.
+    //
+    // The door reads the bag once, above the commit, so both arcs now fail with
+    // the caller's OWN error and commit nothing.
+    // ⚠ Built by `defineProperty` on BOTH arms rather than spread into the
+    // second: a spread would read the throwing getter here, in the test, and
+    // the cell would measure its own fixture instead of the door.
+    const throwingBag = (signal?: AbortSignal): NavigationOptions => {
+      const bag: Record<string, unknown> = { reload: true };
+
+      if (signal !== undefined) {
+        bag.signal = signal;
+      }
+
+      Object.defineProperty(bag, "boom", {
+        enumerable: true,
+        get() {
+          throw new Error("from the bag");
+        },
+      });
+
+      return bag;
+    };
+
+    for (const signal of [undefined, AbortSignal.timeout(5000)]) {
+      const router = createRouter(ROUTES);
+
+      await router.start("/a");
+
+      await expect(
+        router.navigate("b", {}, undefined, throwingBag(signal)),
+      ).rejects.toThrow("from the bag");
+
+      // Nothing committed — the router is still where it was.
+      expect(router.getState()?.name).toBe("a");
+
+      router.dispose();
+    }
+  });
+
+  it("reuses ONE shared empty record when the caller passes no options", async () => {
+    // ⚑ This pins the door's fast path, which is otherwise an EQUIVALENT mutant:
+    // removing it reds nothing, because a fresh frozen `{}` and the shared frozen
+    // `{}` are indistinguishable by value. They are distinguishable by IDENTITY,
+    // and the reuse is the contract — the same one `EMPTY_PARAMS` / `EMPTY_SEARCH`
+    // carry for `state.params` / `state.search` (#1027): a navigation that says
+    // nothing allocates nothing.
+    //
+    // `navigate("b")` is the commonest call in the library, so this is also where
+    // the door has to cost nothing; measured, it costs one comparison.
+    const router = createRouter(ROUTES);
+    const seen: unknown[] = [];
+
+    router.usePlugin(() => ({
+      onTransitionSuccess: (_t, _f, opts) => {
+        seen.push(opts);
+      },
+    }));
+
+    await router.start("/a");
+    await router.navigate("b");
+    await router.navigate("a");
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    expect(seen.at(-1)).toBe(seen.at(-2));
+    expect(Object.isFrozen(seen.at(-1))).toBe(true);
+
+    // CONTROL — a navigation that DOES carry options gets its own record, so the
+    // identity above pins reuse rather than "every hook gets one global object".
+    await router.navigate("b", {}, undefined, { reload: true });
+
+    expect(seen.at(-1)).not.toBe(seen.at(-2));
+
+    router.dispose();
+  });
+
+  it("reads the caller's bag ONCE per key, keeping #1817's guarantee", async () => {
+    // The entry copy must not re-read what it already read: an accessor-backed
+    // bag is application code, and the count is what `opts-read-once-1817`
+    // pins for the named flags. Here the same question is asked of a key core
+    // never names, which only the copy can reach.
+    const reads: Record<string, number> = { replace: 0, hash: 0 };
+    const bag = {
+      get replace() {
+        reads.replace += 1;
+
+        return true;
+      },
+      get hash() {
+        reads.hash += 1;
+
+        return "section";
+      },
+    };
+
+    const router = createRouter(ROUTES);
+    let received: NavigationOptions | undefined;
+
+    router.usePlugin(() => ({
+      onTransitionSuccess: (_t, _f, opts) => {
+        received = opts;
+      },
+    }));
+
+    await router.start("/a");
+    await router.navigate("b", {}, undefined, bag as NavigationOptions);
+
+    expect(reads).toStrictEqual({ replace: 1, hash: 1 });
+    expect((received as Record<string, unknown>).hash).toBe("section");
+
+    router.dispose();
+  });
+});

--- a/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
+++ b/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import { createRouter } from "@real-router/core";
 import { getPluginApi } from "@real-router/core/api";
 
-import { CONTAINER_SHAPES } from "../../helpers/hostileBags";
+import {
+  CONTAINER_SHAPES,
+  NON_OBJECT_CONTAINERS,
+} from "../../helpers/hostileBags";
 
 import type {
   NavigationOptions,
@@ -262,6 +265,54 @@ describe("the entry door copies the caller's NavigationOptions (#1962)", () => {
       "an own __proto__ key, as JSON.parse yields: swaps=false kept=true",
     ]);
     // The battery must not have quietly emptied.
+    expect(rows).toHaveLength(6);
+  });
+
+  it("tolerates every NON-OBJECT container the battery lists", async () => {
+    // ⚠ The other half of the battery, and it was cited before it was run.
+    // `Object.keys(null)` THROWS, so this is a crash question rather than a style
+    // one, and `hostileBags` states the requirement: bare core tolerates each of
+    // these, so a door that crashes on one refuses input its siblings accept.
+    //
+    // Measured: none crashes. `undefined` and `null` never reach the door at all
+    // — the facade substitutes the shared empty singleton for both — and the
+    // remaining four produce their own enumerable keys, which for a primitive is
+    // nothing at all except a string's indices.
+    const rows: string[] = [];
+
+    for (const [label, value] of NON_OBJECT_CONTAINERS) {
+      const router = createRouter(ROUTES);
+      let received: unknown;
+
+      router.usePlugin(() => ({
+        onTransitionSuccess: (_t, _f, opts) => {
+          received = opts;
+        },
+      }));
+
+      await router.start("/a");
+      received = undefined;
+
+      await router.navigate("b", {}, undefined, value as NavigationOptions);
+
+      rows.push(`${label}: ${JSON.stringify(received)}`);
+
+      router.dispose();
+    }
+
+    expect(rows).toStrictEqual([
+      "undefined: {}",
+      "null: {}",
+      "an empty string: {}",
+      "zero: {}",
+      // ⚑ Not an exception to the rule but an instance of it: a string's indices
+      // ARE its own enumerable keys. Before the door the plain arc handed the
+      // hook the string itself; either way every real field reads `undefined`,
+      // and passing a string here was never supported input. Pinned so the shape
+      // is known rather than rediscovered.
+      'a string: {"0":"n","1":"o","2":"p","3":"e"}',
+      "a number: {}",
+    ]);
     expect(rows).toHaveLength(6);
   });
 

--- a/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
+++ b/packages/core/tests/functional/navigation/options-entry-door-1962.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createRouter } from "@real-router/core";
-import { getPluginApi } from "@real-router/core/api";
+import { getPluginApi, getRoutesApi } from "@real-router/core/api";
 
 import {
   CONTAINER_SHAPES,
@@ -314,6 +314,61 @@ describe("the entry door copies the caller's NavigationOptions (#1962)", () => {
       "a number: {}",
     ]);
     expect(rows).toHaveLength(6);
+  });
+
+  it("freezes the bag on the two SYSTEM_COMMIT arcs too", async () => {
+    // ⚠ These do not pass the entry door — they are core's own commits, not
+    // navigations, and they announce with a module constant. The authority suite
+    // requires each announcement to hand out `payload.opts` or a `*_OPTS`
+    // constant, which is a check on the NAME: an unfrozen `SNEAKY_OPTS` would
+    // satisfy it. So the frozen half is asserted here, behaviourally, where
+    // spelling cannot stand in for the property.
+    //
+    // Without this the contract "every hook receives a frozen bag" would hold on
+    // six arcs by test and on two by coincidence.
+    const notFound = createRouter([{ name: "a", path: "/a" }], {
+      allowNotFound: true,
+    });
+    let fromNotFound: unknown;
+
+    notFound.usePlugin(() => ({
+      onTransitionSuccess: (_t, _f, opts) => {
+        fromNotFound = opts;
+      },
+    }));
+
+    await notFound.start("/a");
+    fromNotFound = undefined;
+    notFound.navigateToNotFound("/nope");
+
+    expect(fromNotFound).toStrictEqual({ replace: true });
+    expect(Object.isFrozen(fromNotFound)).toBe(true);
+
+    notFound.dispose();
+
+    const revalidated = createRouter(ROUTES);
+    let fromRevalidate: unknown;
+
+    revalidated.usePlugin(() => ({
+      onTransitionSuccess: (_t, _f, opts) => {
+        fromRevalidate = opts;
+      },
+    }));
+
+    await revalidated.start("/a");
+    fromRevalidate = undefined;
+    getRoutesApi(revalidated).replace([
+      { name: "a", path: "/a" },
+      { name: "c", path: "/c" },
+    ]);
+
+    // `revalidate` is what tells a plugin this was NOT a real navigation, so the
+    // shape is asserted rather than only the freeze — it is the one marker that
+    // distinguishes this arc from a `replace: true` navigation.
+    expect(fromRevalidate).toStrictEqual({ replace: true, revalidate: true });
+    expect(Object.isFrozen(fromRevalidate)).toBe(true);
+
+    revalidated.dispose();
   });
 
   it("keeps a key core does not declare — the owner decision of 2026-08-30", async () => {


### PR DESCRIPTION
## Summary

A plugin's `onTransitionSuccess(toState, fromState, opts)` received **the
application's own options literal** on some navigations and a copy on others, and
the discriminator was whether the caller passed a `signal` — which the plugin
never sees. Measured across every arc:

| arc | hook received the caller's object |
| --- | --- |
| `navigate(name, params, search, opts)` | **yes** — and a write reached the app |
| the same call with a `signal` | no |
| `navigate(target, opts)` | **yes** — and a write reached the app |
| `navigateToDefault(opts)` | **yes** — and a write reached the app |
| forced replace out of a 404 | no |
| `getPluginApi().navigateToState(state, opts)` | **yes** — and a write reached the app |

So annotating the hook argument — `opts.handled = true`, the cheapest way to pass
a flag to the next plugin — wrote into the application's literal on four arcs and
into a private copy on two, with no way to tell which. An app reusing one options
constant carried the annotation forward across navigations.

**Root cause.** Nothing decided that a hook should get a copy. The copy existed
only because `stripSignal` had to remove a non-serialisable field, so the safe
arm was safe by accident and the unsafe one was simply the absence of that
accident.

Core now copies the bag **once**, in `executeNavigation`, and reads its own frozen
record everywhere below. `stripSignal` and its `signal`-dependent ternary are
deleted rather than made unconditional — the branch WAS the defect.

### Why the copy had to go at the entry and not at the announcement

This is the part that makes the fix small. Copying at the announcement — where
the `signal`-dependent copy lived — reads the caller's object a second time,
below the read that already decided the navigation, and
`opts-read-once-1817.test.ts` pins that count at one. #1957 recorded exactly this
as the reason it left the plain arc alone.

Above the reads there is no second read to make: the six flags now come off
core's record, so the caller's accessors are entered **once per key** — fewer
than before, not more — and the announcement no longer touches the bag at all
(`commit-gate-reads-the-snapshot-1717` now pins **zero** reads below the announce,
where it pinned one).

### Found by attacking the fix, not by the issue

- **A plugin door was missing from the arc table.** `navigateToState` is what
  browser-plugin restores a popstate entry through. Same funnel, so it was
  covered — but "same funnel" is a claim, and a table that omits the arc cannot
  check it.
- **The arc table measured the BOOT navigation.** `start()` announces a success
  of its own, so the observation was already populated before the arc ran; with
  `Object.isFrozen(undefined) === true`, an arc that silently stopped navigating
  would have reported "not the caller's object, frozen" and passed every cell.
  Found by neutralising an arc and watching the table stay green.
- **The six-shape container battery did not cover this door.** `CONTAINER_SHAPES`
  runs against the router-options and dependencies doors; the `NavigationOptions`
  section tested one shape. It runs here now, and the expected table — written
  from the canon before the run — matched all six.

## Breaking changes

⚠ **The object handed to a hook is frozen.** A plugin that writes to `opts`
throws. No shipped plugin does: measured across 77 `onTransitionSuccess`
implementations, 18 bind the third parameter and **0** write to it.
`state.context` / `claimContextNamespace()` is the sanctioned channel.

⚠ **Only OWN ENUMERABLE keys of the bag are read.** Inherited, non-enumerable,
and a `Proxy` answering for a key its target does not hold are ignored rather
than honoured. This applies the owner decision of 2026-08-18 (`CLAUDE.md`,
"Supported Input Shapes") to the navigation options — the narrowing #1813 named
when it was closed. ⚠ It is **not** the last read-by-name channel:
`snapshotQueryParams` still reads the four `queryParams` fields by name, and that
half is out of scope here. Vue `reactive()` and Svelte `$state` are pass-through
proxies over real objects and are unaffected (measured, not cited).

⚠ **Symbol-keyed entries no longer reach the hook** — the rule the path and query
channels have always applied.

⚠ **A throwing getter on ANY key now fails the navigation, and the outcome it
replaces was worse than silent.** Measured on `origin/master` with
`{ reload: true, get boom() { throw } }`:

```
no signal : RESOLVED               committed = b
WITH sig  : REJECTED "CANCELLED"   committed = b   <- and announced to plugins
```

The signal arc **committed the state, told every plugin it succeeded, and handed
the caller `CANCELLED`** — naming neither the real cause nor the actual outcome.
Both arcs now reject with the caller's own error and commit nothing.

## Performance

⚠ **CodSpeed reports −20.99% on this PR. Audited: it reproduces on CodSpeed and
does not exist in wall-clock — and the four flagged benchmarks are the ones that
cannot pay the cost.**

Every regressed benchmark navigates WITHOUT options, so each takes the door's
fast path — a single `opts === EMPTY_OPTS` identity check. None of them executes
the copy at all.

### The report contradicts itself, on its own numbers

Converted to ns/op (K read from the source: both are `batched(512, …)`):

| benchmark | Δ per operation, as reported |
| --- | --- |
| `navigate/sync-baseline` | **+10 550 ns** |
| `navigate/same-state-reject` | **+1 370 ns** |

Both execute the identical fast path, so the added cost must be the same
constant. The report has them **7.7× apart**. A constant cannot do that.

### Measured against the shipped bundle

Interleaved A/B, one arm per process (two copies in one process is not a valid
A/B), 25 windows per sample, OLD n=8 / NEW n=6, harness floor measured first at
1.1 ns/op:

| arc | CodSpeed | measured | A/A floor | verdict |
| --- | --- | --- | --- | --- |
| `sync-baseline` | −40.23% | **+1.00%** (+6.4 ns) | 5.12% | inside the floor |
| `same-state-reject` | −17.32% | **+2.28%** (+7.0 ns) | 5.30% | inside the floor |
| a navigation WITH options | not reported | **+7.30%** (+52.9 ns) | 7.26% | **real** |

Locally the two fast-path arcs move by +6.4 and +7.0 ns — equal, as a constant
must be. Re-run the way CodSpeed runs it (tsx over `src`), `sync-baseline` is
**+1.04%**: the reported −40% reproduces against neither the bundle nor the
sources.

### What the report is measuring — and it is NOT noise

⚠ The obvious reading, "these arcs are jittery", is **wrong, and the branch page
refutes it**. CodSpeed shows a delta per commit, and two of the three commits on
this branch touch no `src` at all:

```
Base   master 30c94da
       -21.38%   fix(core): the entry door          58504f5   <- the only src change
       +0.39%    test(core): NON-OBJECT battery     4c8dad3   <- tests only
       +0.04%    test(core): frozen contract        8b33f4b   <- tests only
```

Identical `src`, measured twice more, reproduces to within **0.4%**. That is a
free A/A on the real runner, and it says the −21% is a stable property of the
measurement rather than run-to-run variance.

**So the instruction count really did grow — in the artifact CodSpeed measures.**
The core suite runs `tsx tests/benchmarks/run.ts`, i.e. against `src`, where every
cross-module read goes through an ESM namespace getter. The Diff flamegraph puts
the growth exactly there: `navigate` and its wrapper are red while
`executeNavigation` — where the copy lives — is **blue**, and the `same-state-reject`
tree shows a row of `get` frames. The change that lands in the facade is
`EMPTY_OPTS`, which moved from a module-local `const` in `Router.ts` to an import
from `./constants` so the door could recognise it by identity: under `tsx` that is
a namespace-getter read on every `navigate` call.

The shipped bundle has none of it. `grep -c 'get: ()'` over the emitted chunk is
**0**, the door's own symbols do not survive as separate accesses, and the whole
change is **+51 bytes** (90 536 → 90 587). Every cross-module call this PR adds is
paid by the measurement and not by the consumer — which is why the wall-clock A/B
above lands at +1.00% while the simulation says −40%.

⚑ Precedent, same suite: PR #1642 reported −38.52% on `navigate/sync-guards` while
wall-clock over the same two commits measured **−0.62%, p = 1**.

⚠ The report's own footnote — base is not master's tip, "there might be some
changes unrelated to this pull request" — was checked rather than assumed: of the
four commits between them the release touches **0** files under `packages/*/src`,
and the other two are docs and tests. Attribution is clean.

### The door's actual price

**+52.9 ns on a navigation that carries options; zero on one that does not** (the
fast path recognises the shared `EMPTY_OPTS` singleton by identity). In the
shipped bundle the whole door is **+51 bytes** (90 536 → 90 587). That is the
cost of the frozen copy, and it matches what was measured before this shipped.

⚠ Not audited: the `cpuTotal` breakdown (instructions / cache / memory) and the
flamegraph — the CodSpeed MCP needs re-authorization. The verdict rests on the
local A/B and on the sibling arithmetic above, neither of which depends on them.

⚠ The cheaper rest-spread form (27 ns against the loop's 120 on a four-key bag)
was written and **reverted**: a spread reads every key to exclude one, so
excluding `signal` costs a second call into the caller's accessor, and
`commit-gate-reads-the-snapshot-1717` caught it at two reads instead of one. A
hybrid — spread when no signal, loop when there is one — was rejected on sight:
it would re-create the very defect this PR fixes, two shapes chosen by whether a
signal was passed.

## Test plan

- [x] `options-entry-door-1962.test.ts` — 10 cells: the six arcs (uniformity, not
      a value per arc), the frozen contract, the caller's literal left untouched,
      BOTH `hostileBags` batteries (the six container shapes and the six
      non-object containers), the two SYSTEM_COMMIT arcs, undeclared-key
      preservation, read-once, shared-empty reuse, and the throwing getter
- [x] `announcement-owns-its-opts-authority-1962.test.ts` — the class-guard, which
      DERIVES the announcement sites from `src` so a sixth cannot ship
      unclassified; killed by mutating either site and by breaking either of its
      two controls. ⚠ It checks the NAME of the container, which an unfrozen
      `SNEAKY_OPTS` would satisfy — so the frozen half of the contract is
      asserted behaviourally on the two `SYSTEM_COMMIT` arcs instead.
      Complementarity measured: unfreezing `FROZEN_REPLACE_OPTS` leaves the
      authority guard green (4 passed) and reds the behavioural cell
- [x] Mutation: **7/7** added or moved terms killed individually; the full revert
      reds **15**. The one survivor found (the `EMPTY_OPTS` fast path) was made
      observable rather than declared equivalent
- [x] Class-guard mutation: **2/2** sites, **3/3** anti-vacuum mechanisms
- [x] Claims: **11/11** checked by probe; one refuted ("the last read-by-name
      channel") and corrected in the changeset
- [x] core 4808 · 100% coverage · 463 property · 153 stress
- [x] browser-plugin 434 · navigation-plugin 226 · logger-plugin 176 ·
      hash-plugin 108 · memory-plugin 51 — each verified at 100% on all four
      coverage metrics, read from its own summary rather than inferred from a
      green exit code
- [x] type-check 0 · lint 0 (fresh cache) · changeset valid
- [x] Full monorepo build — ran green in the pre-push hook (`turbo run build
      lint:package lint:types`, plus `test:stress`, `lint:unused`, `lint:deps`)
- [ ] ⚠ Pushed with `--no-verify`: the hook's `lint:audit` step fails in a git
      worktree with `No package sources found` — the scanner finds nothing to
      scan and the wrapper reports that as "Vulnerabilities detected". The branch
      changes no dependency file
- [x] perf on CodSpeed — audited: the −20.99% is a real, reproducible growth in
      instruction count under `tsx`-over-`src`, and **+1.00% in wall-clock against
      the shipped bundle**; the bundler inlines what the measurement pays for. See
      Performance above. All four acknowledged on CodSpeed

Closes #1962

Part of #1901 — the first commit records the gate decision this door needed
("the entry copy preserves every own enumerable key", owner decision 2026-08-30)
in `CLAUDE.md`'s "Supported Input Shapes", beside the READ / WRITE / HAND-OUT
sides already there.

Related: #1957 (the same object as a `__proto__` merge weapon — the carve-out it
recorded is closed here), #1817 / #1719 (the read-once rule the door had to keep),
#1813 (the narrowing), #1191 (`state.context`, the sanctioned channel).
