### PR TITLE
perf(core): bind the navigation hot path's imports locally at module load (#1962)

### DIFF
--- a/.changeset/empty-opts-local-binding-1962-perf.md
+++ b/.changeset/empty-opts-local-binding-1962-perf.md
@@ -1,0 +1,24 @@
+---
+"@real-router/core": patch
+---
+
+Bind the navigation hot path's imported values locally at module load ([#1962](https://github.com/greydragon888/real-router/issues/1962))
+
+No behaviour changes and no consumer-visible effect: the shipped bundle inlines
+an imported binding and a locally-aliased one identically, so this is byte-for-byte
+the same work for anyone who installs the package.
+
+What it changes is what the repository's own benchmark suite MEASURES. That suite
+runs `tsx` over `src`, where an imported binding is a property access on the module
+namespace — a getter call — rather than a local. Three such accesses sit on every
+navigation after the entry door landed:
+
+- `Router.navigate` reads `EMPTY_OPTS` (moved from a module-local `const` into
+  `constants.ts` so the door could recognise it by identity);
+- `adoptNavigationOptions` reads the same singleton for its fast path;
+- `executeNavigation` calls `adoptNavigationOptions` across a module boundary.
+
+Each is now read once at module load and used as a local. The singleton is
+aliased, never re-declared — the entry door matches it by IDENTITY, and two
+objects would silently disable the fast path (pinned by
+`options-entry-door-1962` → "reuses ONE shared empty record").

--- a/packages/core/src/Router.ts
+++ b/packages/core/src/Router.ts
@@ -7,7 +7,11 @@
  */
 
 import { assertChannelCorrect, findMisChanneledKey } from "./channels";
-import { EMPTY_OPTS, EMPTY_PARAMS, errorCodes } from "./constants";
+import {
+  EMPTY_OPTS as SHARED_EMPTY_OPTS,
+  EMPTY_PARAMS,
+  errorCodes,
+} from "./constants";
 import {
   assertLoggerConfig,
   guardDependencyShape,
@@ -80,6 +84,22 @@ import type { Limits, RouterEventMap } from "./types/internal";
  *
  * @internal This class implementation is internal. Use createRouter() instead.
  */
+/**
+ * ⚠ A module-LOCAL binding to the shared singleton, and it must stay one.
+ *
+ * `EMPTY_OPTS` lives in `constants.ts` because the entry door recognises it by
+ * IDENTITY (#1962) — the two must be the same object, so it cannot simply be
+ * re-declared here. What this alias changes is not the value but the READ: under
+ * the benchmark's `tsx`-over-`src` build an imported binding is a property access
+ * on the module namespace, i.e. a getter call, and `navigate` performs it on
+ * every call. Read once at module load, it is a local from then on.
+ *
+ * ⚑ In the shipped bundle this is a no-op — tsdown inlines both forms — so do
+ * NOT "simplify" it back to a bare import: the simplification is invisible to
+ * consumers and visible to every measurement this repository takes.
+ */
+const EMPTY_OPTS: Readonly<Record<string, never>> = SHARED_EMPTY_OPTS;
+
 export class Router<
   Dependencies extends DefaultDependencies = DefaultDependencies,
 > implements RouterInterface<Dependencies> {

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,7 +1,7 @@
 // packages/core/src/helpers.ts
 
 import {
-  EMPTY_OPTS,
+  EMPTY_OPTS as SHARED_EMPTY_OPTS,
   EMPTY_PARAMS,
   EMPTY_SEARCH,
   UNSAFE_KEY,
@@ -31,6 +31,15 @@ const hasOwn = Object.hasOwn;
 // so an application that re-points `Object.keys` after boot would be re-pointing
 // the guard itself. `dependenciesStore` captures it for the same door.
 const objectKeys = Object.keys;
+/**
+ * ⚠ Read ONCE at module load, for the same reason the three intrinsics above
+ * are: an imported binding is a namespace read on every access under the
+ * benchmark's `tsx`-over-`src` build, and the entry door performs it on every
+ * navigation. The value is the shared singleton either way — identity is what
+ * {@link adoptNavigationOptions} matches on, so this must alias and never
+ * re-declare (#1962).
+ */
+const EMPTY_OPTS = SHARED_EMPTY_OPTS;
 /**
  * The one `NavigationOptions` key core's entry door withholds from its copy
  * (#1962). Typed as `keyof NavigationOptions` rather than written as a bare

--- a/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/executeNavigation.ts
@@ -2,7 +2,7 @@ import { completeTransition } from "./completeTransition";
 import { asCancellation, routeTransitionError } from "./errorHandling";
 import { executeGuardPipeline } from "./guardPhase";
 import { errorCodes, constants } from "../../../constants";
-import { adoptNavigationOptions } from "../../../helpers";
+import { adoptNavigationOptions as sharedAdoptNavigationOptions } from "../../../helpers";
 import { RouterError, freezeThrownError } from "../../../RouterError";
 import { getTransitionPath } from "../../../transitionPath";
 import {
@@ -36,6 +36,15 @@ import type {
 // and a guarantee is only as strong as the intrinsic it reads WHEN IT RUNS
 // (#1970 / #1971).
 const freeze = Object.freeze;
+/**
+ * ⚠ Bound locally at module load, same reason as the freeze above and as the
+ * `EMPTY_OPTS` alias in `helpers.ts`: under the benchmark's `tsx`-over-`src`
+ * build an imported binding is a namespace getter, and this one is called on
+ * EVERY navigation. The shipped bundle inlines both forms, so the alias costs
+ * consumers nothing and stops the measurement charging for a boundary that does
+ * not exist in the artifact anyone runs (#1962).
+ */
+const adoptNavigationOptions = sharedAdoptNavigationOptions;
 
 // Write-once placeholders for `NavigationPlan`'s pass-2 fields. Module-level so
 // building a plan allocates nothing beyond the plan itself; never mutated —


### PR DESCRIPTION
## Summary

**An experiment with a falsification condition stated before the run, not a
cleanup.** Merge it only if CodSpeed confirms the prediction below.

#1962's entry door landed with CodSpeed reporting **−21%**, and that number is
confirmed independently: comparing master to master (`30c94da` → `1ff2fc2`, same
runner, only that change between them) reproduces the four regressions with
identical figures.

A local A/B against the **shipped bundle** disagrees by an order of magnitude:

| arc | CodSpeed | measured against `dist` | A/A floor |
| --- | --- | --- | --- |
| `navigate/sync-baseline` | −40.23% | **+1.00%** (+6.4 ns) | 5.12% |
| `navigate/same-state-reject` | −17.32% | **+2.28%** (+7.0 ns) | 5.30% |

⚠ That disagreement is not self-resolving, and this repository has a recorded
precedent of resolving it the WRONG way: on #1689 the same shape (CodSpeed
−10…−44% on `navigate/*`, local wall-clock ±0.6%) was called an artifact and
acknowledged — and the regressions were real. Apple Silicon's wide out-of-order
core absorbs instruction growth that callgrind on x86-64 charges in full.

## The hypothesis this PR tests

The core suite runs `tsx tests/benchmarks/run.ts`, i.e. against `src`, where an
imported binding is a property access on the module namespace — a getter call —
while the shipped bundle inlines it. #1962 added **three** such accesses to every
navigation:

- `Router.navigate` reads `EMPTY_OPTS`, which used to be a module-local `const`
  and moved into `constants.ts` so the entry door could recognise it by identity;
- `adoptNavigationOptions` reads the same singleton for its fast path;
- `executeNavigation` **calls** `adoptNavigationOptions` across a module boundary.

Each is now bound once at module load and used as a local.

Supporting evidence already in hand: the Diff flamegraph puts the growth in
`navigate` and its wrapper (red) while `executeNavigation` — where the copy
actually runs — is **blue**, and `same-state-reject`'s call tree carries a row of
`get` frames. In the emitted chunk, `grep -c 'get: ()'` is **0** and the entire
door is **+51 bytes**.

## ⚑ Falsification, declared before the run

**If CodSpeed still reports ~−20% on this branch, the mechanism is refuted.** The
cost would then be real work inside the door, which would mean the four
acknowledgements on #1991 were wrong and the door needs its price reduced rather
than its measurement corrected.

A null result here is as useful as a positive one. What must not happen is
reading the outcome after the fact in whichever direction is convenient — hence
this section.

## What this is not

⚠ **Not a consumer-visible change.** tsdown inlines an imported binding and a
locally-aliased one identically, so installed packages get byte-for-byte the same
work. If the experiment succeeds, the lesson belongs to the instrument — the
suite measures an artifact nobody ships, and will over-charge every future PR
that adds an import to a hot path — not to this constant.

⚠ **The singleton is ALIASED, never re-declared.** The door matches it by
identity; two objects would disable the fast path in silence.
`options-entry-door-1962` → "reuses ONE shared empty record" pins exactly that
and stays green.

⚠ Each alias carries a comment telling the next reader not to simplify it back.
The change is invisible to consumers and visible to every measurement this
repository takes, which is precisely the shape that gets "cleaned up".

## Test plan

- [x] core 4808 · 100% coverage — no behaviour change, no test changes
- [x] type-check 0 · lint 0 (fresh cache) · changeset valid
- [x] The identity contract is pinned by an existing cell rather than by argument
- [ ] ⚠ **The result of this PR's own CodSpeed run is the deliverable.** Merge on
      confirmation; close on refutation and reopen the cost question on #1962

Related: #1962 (the door), #1991 (where the regression was reported and
acknowledged), #1689 (the precedent for getting this disagreement wrong).
