### PR TITLE
fix: every deciding intrinsic is read from a module-load capture (#1971)

### DIFF
--- a/.changeset/captured-intrinsics-angular-1971-fix.md
+++ b/.changeset/captured-intrinsics-angular-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/angular": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-browser-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-browser-plugin-1971-fix.md
@@ -1,0 +1,33 @@
+---
+"@real-router/browser-plugin": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/browser-env`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+⚠ **Three of the reads in `shared/browser-env` FAIL OPEN**, which is what makes
+this half sharper than core's. Measured by re-pointing each after boot:
+
+```
+Object.getPrototypeOf -> null   a Date instance ACCEPTED into state.params
+Object.values         -> []     a nested function ACCEPTED
+Object.keys           -> []     base:"/a/../b" accepted, the '..' rule bypassed
+```
+
+The guard's verdict flipped to *valid* for input it exists to reject, rather than
+degrading toward refusal.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-core-1971-fix.md
+++ b/.changeset/captured-intrinsics-core-1971-fix.md
@@ -1,0 +1,40 @@
+---
+"@real-router/core": patch
+---
+
+Every deciding intrinsic is read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+`guards.ts` states the rule and the measurement behind it — *"a guard is only as
+strong as the intrinsic it reads WHEN IT RUNS"*, after one naive `Object.hasOwn`
+polyfill walked through five sibling readers while the single captured guard
+held. Of the 32 files touching a deciding intrinsic, 17 captured one and 20 read
+one raw — and five did BOTH, including
+`utils/ingest.ts`, which owns the write discipline and captured two intrinsics
+two hundred lines above a raw `Object.entries` — both in the same commit.
+
+All 52 raw reads in `packages/core/src` now go through a capture. Seven
+intrinsics are in scope, the ones that answer *"what is on this object"* for a
+value the module did not build: `hasOwn`, `keys`, `entries`, `values`,
+`getOwnPropertyDescriptor`, `getOwnPropertyNames`, `getPrototypeOf`.
+
+Measured, a re-pointed intrinsic changed a verdict:
+
+```
+copyFields with a shimmed Object.entries   {"id":"7","tab":"a"} -> {"tab":"a"}
+```
+
+The key dropped silently — no throw, no warning, the bag copied "successfully".
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.
+
+The convention is now derived rather than remembered:
+`captured-intrinsics-authority-1971.test.ts` walks core and `shared/` and fails
+on any unclassified raw read, so the sweep does not have to run a third time.

--- a/.changeset/captured-intrinsics-core-1971-fix.md
+++ b/.changeset/captured-intrinsics-core-1971-fix.md
@@ -7,10 +7,12 @@ Every deciding intrinsic is read from a module-load capture ([#1971](https://git
 `guards.ts` states the rule and the measurement behind it — *"a guard is only as
 strong as the intrinsic it reads WHEN IT RUNS"*, after one naive `Object.hasOwn`
 polyfill walked through five sibling readers while the single captured guard
-held. Of the 32 files touching a deciding intrinsic, 17 captured one and 20 read
-one raw — and five did BOTH, including
-`utils/ingest.ts`, which owns the write discipline and captured two intrinsics
-two hundred lines above a raw `Object.entries` — both in the same commit.
+held. Of the 28 files in `packages/core/src` touching a deciding intrinsic, 11
+captured one and 20 read one raw — and THREE did both, including
+`utils/ingest.ts`, which owns the write discipline and captured `hasOwn` two
+hundred lines above a raw `Object.entries` — both in the same commit. The
+overlap is the finding: this was never "some files follow the rule and others do
+not".
 
 All 52 raw reads in `packages/core/src` now go through a capture. Seven
 intrinsics are in scope, the ones that answer *"what is on this object"* for a

--- a/.changeset/captured-intrinsics-hash-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-hash-plugin-1971-fix.md
@@ -31,3 +31,5 @@ already requires script execution.
 
 No behaviour change in a healthy environment: an intrinsic nobody touched answers
 the same either way.
+
+⚑ 1 further read in this package's own `src` was swept in the same pass.

--- a/.changeset/captured-intrinsics-hash-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-hash-plugin-1971-fix.md
@@ -1,0 +1,33 @@
+---
+"@real-router/hash-plugin": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/browser-env`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+⚠ **Three of the reads in `shared/browser-env` FAIL OPEN**, which is what makes
+this half sharper than core's. Measured by re-pointing each after boot:
+
+```
+Object.getPrototypeOf -> null   a Date instance ACCEPTED into state.params
+Object.values         -> []     a nested function ACCEPTED
+Object.keys           -> []     base:"/a/../b" accepted, the '..' rule bypassed
+```
+
+The guard's verdict flipped to *valid* for input it exists to reject, rather than
+degrading toward refusal.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-logger-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-logger-plugin-1971-fix.md
@@ -10,9 +10,12 @@ can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
 by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
 
-The reads are in `internal/params-diff.ts`, which decides what CHANGED between
-two params bags — a re-pointed `keys` or `entries` makes the diff report a
-change that did not happen, or miss one that did.
+The reads are in `internal/params-diff.ts`, and they split by role.
+`entries` and `hasOwn` decide the diff's CONTENT — walking both bags and asking
+whether the other one holds the key — so a re-pointed one makes the log miss a
+change that happened, or invent a removal and an addition for a key that never
+moved. `keys` is the emptiness test that gates whether the diff is printed at
+all, so re-pointing it silences a real diff rather than corrupting it.
 
 ⚠ **What capture does NOT buy**, stated because the doctrine states it: it
 narrows the window from "any time after boot" to "before the module loads". A

--- a/.changeset/captured-intrinsics-logger-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-logger-plugin-1971-fix.md
@@ -1,0 +1,25 @@
+---
+"@real-router/logger-plugin": patch
+---
+
+Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+7 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+`getPrototypeOf` in this package went to the live global, where an application
+can re-point them after boot. They are now read once at module load — the
+doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
+by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
+
+The reads are in `internal/params-diff.ts`, which decides what CHANGED between
+two params bags — a re-pointed `keys` or `entries` makes the diff report a
+change that did not happen, or miss one that did.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-navigation-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-navigation-plugin-1971-fix.md
@@ -1,0 +1,33 @@
+---
+"@real-router/navigation-plugin": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/browser-env`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+⚠ **Three of the reads in `shared/browser-env` FAIL OPEN**, which is what makes
+this half sharper than core's. Measured by re-pointing each after boot:
+
+```
+Object.getPrototypeOf -> null   a Date instance ACCEPTED into state.params
+Object.values         -> []     a nested function ACCEPTED
+Object.keys           -> []     base:"/a/../b" accepted, the '..' rule bypassed
+```
+
+The guard's verdict flipped to *valid* for input it exists to reject, rather than
+degrading toward refusal.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
@@ -10,8 +10,12 @@ can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
 by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
 
-The reads decide which params persist across a navigation. A re-pointed `keys`
-empties that set, so the plugin silently stops persisting anything.
+`factory.ts` derives the persisted set from the config —
+`Array.isArray(params) ? params : objectKeys(params)` — so a re-pointed `keys`
+empties it and the plugin silently persists nothing. ⚠ Only for the OBJECT form
+of the config; the array form (`persistentParamsPlugin(["lang"])`) never reaches
+that read. The rest of the reads are `entries` and `hasOwn` in the per-navigation
+merge, where an empty answer drops the carried params instead.
 
 ⚠ **What capture does NOT buy**, stated because the doctrine states it: it
 narrows the window from "any time after boot" to "before the module loads". A

--- a/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
@@ -10,12 +10,25 @@ can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
 by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
 
-`factory.ts` derives the persisted set from the config —
+The 14 fall into three groups, with three different consequences.
+
+`factory.ts` (1) derives the persisted set from the config —
 `Array.isArray(params) ? params : objectKeys(params)` — so a re-pointed `keys`
 empties it and the plugin silently persists nothing. ⚠ Only for the OBJECT form
 of the config; the array form (`persistentParamsPlugin(["lang"])`) never reaches
-that read. The rest of the reads are `entries` and `hasOwn` in the per-navigation
-merge, where an empty answer drops the carried params instead.
+that read.
+
+`param-utils.ts` and `plugin.ts` (10) are the per-navigation merge, all `entries`
+and `hasOwn`, where an empty answer drops the carried params instead of losing
+the set that defines them.
+
+`validation.ts` (3) splits again. `getPrototypeOf` is the plain-object test
+(`!== Object.prototype`, rejecting a `Date` or a `Map`) and `entries` feeds the
+`.every()` that checks each key and value — and `.every()` on an empty array is
+`true`, so a re-pointed `entries` makes the plugin ACCEPT any config it exists to
+refuse. The third, `keys`, is in a different function: it derives the names to
+test for `UNPUBLISHABLE_PARAM_KEY`, so re-pointing it skips that warning rather
+than admitting anything.
 
 ⚠ **What capture does NOT buy**, stated because the doctrine states it: it
 narrows the window from "any time after boot" to "before the module loads". A

--- a/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-persistent-params-plugin-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/persistent-params-plugin": patch
+---
+
+Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+14 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+`getPrototypeOf` in this package went to the live global, where an application
+can re-point them after boot. They are now read once at module load — the
+doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
+by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
+
+The reads decide which params persist across a navigation. A re-pointed `keys`
+empties that set, so the plugin silently stops persisting anything.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-preact-1971-fix.md
+++ b/.changeset/captured-intrinsics-preact-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/preact": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-react-1971-fix.md
+++ b/.changeset/captured-intrinsics-react-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/react": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-rsc-server-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-rsc-server-plugin-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/rsc-server-plugin": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/ssr`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-search-schema-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-search-schema-plugin-1971-fix.md
@@ -1,0 +1,25 @@
+---
+"@real-router/search-schema-plugin": patch
+---
+
+Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+6 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+`getPrototypeOf` in this package went to the live global, where an application
+can re-point them after boot. They are now read once at module load — the
+doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
+by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
+
+The reads walk the schema and the incoming query bag; a re-pointed `entries`
+means a declared key is never seen, and the value it should have coerced rides
+through unvalidated.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-search-schema-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-search-schema-plugin-1971-fix.md
@@ -10,9 +10,12 @@ can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
 by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
 
-The reads walk the schema and the incoming query bag; a re-pointed `entries`
-means a declared key is never seen, and the value it should have coerced rides
-through unvalidated.
+The reads are the plugin's two rebuild loops — `#writeBack`, which reassembles
+`params` and `search` from the validated result, and `omitKeys`. Both BUILD a
+fresh bag from what they enumerate, so a re-pointed `entries` does not let a key
+through unvalidated: it makes the key vanish. The schema runs, reports success,
+and its coerced output reaches neither `state.search` nor the URL — while the
+caller's own untouched keys are dropped alongside it.
 
 ⚠ **What capture does NOT buy**, stated because the doctrine states it: it
 narrows the window from "any time after boot" to "before the module loads". A

--- a/.changeset/captured-intrinsics-solid-1971-fix.md
+++ b/.changeset/captured-intrinsics-solid-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/solid": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-sources-1971-fix.md
+++ b/.changeset/captured-intrinsics-sources-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/sources": patch
+---
+
+Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+1 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+`getPrototypeOf` in this package went to the live global, where an application
+can re-point them after boot. They are now read once at module load — the
+doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
+by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
+
+`canonicalJson` sorts a bag's keys to produce the cache key every subscription
+compares on. A re-pointed `keys` collapses distinct states to one key.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-sources-1971-fix.md
+++ b/.changeset/captured-intrinsics-sources-1971-fix.md
@@ -4,7 +4,7 @@
 
 Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
 
-1 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+1 read of `Object.keys` / `hasOwn` / `entries` / `values` /
 `getPrototypeOf` in this package went to the live global, where an application
 can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository

--- a/.changeset/captured-intrinsics-ssr-data-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-ssr-data-plugin-1971-fix.md
@@ -22,3 +22,5 @@ already requires script execution.
 
 No behaviour change in a healthy environment: an intrinsic nobody touched answers
 the same either way.
+
+⚑ 1 further read in this package's own `src` was swept in the same pass.

--- a/.changeset/captured-intrinsics-ssr-data-plugin-1971-fix.md
+++ b/.changeset/captured-intrinsics-ssr-data-plugin-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/ssr-data-plugin": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/ssr`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-ssr-utils-1971-fix.md
+++ b/.changeset/captured-intrinsics-ssr-utils-1971-fix.md
@@ -10,9 +10,14 @@ can re-point them after boot. They are now read once at module load — the
 doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
 by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
 
-The reads walk route tables for `getStaticPaths` and serialise router state for
-hydration — a re-pointed intrinsic drops paths from a static build, or ships a
-hydration payload missing fields the client expects.
+Two different consequences, one per file. In `serializeRouterState` the read
+builds the hydration payload, so an empty answer ships a payload missing fields
+the client expects. In `getStaticPaths` the reads are the LOST-KEY detector — it
+round-trips each entry through `matchPath` and reports a supplied key that did
+not survive — so a re-pointed `entries` or `keys` does not drop a path: it makes
+the detector go silent, and a manifest quietly missing pages ships without the
+warning that exists to catch it. That is this issue's own failure mode, in a
+guard.
 
 ⚠ **What capture does NOT buy**, stated because the doctrine states it: it
 narrows the window from "any time after boot" to "before the module loads". A

--- a/.changeset/captured-intrinsics-ssr-utils-1971-fix.md
+++ b/.changeset/captured-intrinsics-ssr-utils-1971-fix.md
@@ -1,0 +1,25 @@
+---
+"@real-router/ssr-utils": patch
+---
+
+Deciding intrinsics are read from a module-load capture ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+4 reads of `Object.keys` / `hasOwn` / `entries` / `values` /
+`getPrototypeOf` in this package went to the live global, where an application
+can re-point them after boot. They are now read once at module load — the
+doctrine `@real-router/core`'s `guards.ts` states, extended across the repository
+by the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971).
+
+The reads walk route tables for `getStaticPaths` and serialise router state for
+hydration — a re-pointed intrinsic drops paths from a static build, or ships a
+hydration payload missing fields the client expects.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-svelte-1971-fix.md
+++ b/.changeset/captured-intrinsics-svelte-1971-fix.md
@@ -22,3 +22,5 @@ already requires script execution.
 
 No behaviour change in a healthy environment: an intrinsic nobody touched answers
 the same either way.
+
+⚑ 1 further read in this package's own `src` was swept in the same pass.

--- a/.changeset/captured-intrinsics-svelte-1971-fix.md
+++ b/.changeset/captured-intrinsics-svelte-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/svelte": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-twin-1971-fix.md
+++ b/.changeset/captured-intrinsics-twin-1971-fix.md
@@ -24,7 +24,7 @@ already requires script execution.
 No behaviour change in a healthy environment: an intrinsic nobody touched answers
 the same either way.
 
-⚑ Its own validators were swept in the same pass — **17** further reads across
+⚑ Its own validators were swept in the same pass — **18** further reads across
 six files, including `retrospective.ts`, where `Object.keys` and
 `Object.getOwnPropertyDescriptor` form the walk-and-check pair core documents as
 having to answer about the same property set: with `keys` re-pointed the loop is

--- a/.changeset/captured-intrinsics-twin-1971-fix.md
+++ b/.changeset/captured-intrinsics-twin-1971-fix.md
@@ -23,3 +23,12 @@ already requires script execution.
 
 No behaviour change in a healthy environment: an intrinsic nobody touched answers
 the same either way.
+
+⚑ Its own validators were swept in the same pass — **17** further reads across
+six files, including `retrospective.ts`, where `Object.keys` and
+`Object.getOwnPropertyDescriptor` form the walk-and-check pair core documents as
+having to answer about the same property set: with `keys` re-pointed the loop is
+empty and the getter check approves a dependency bag it exists to refuse. And
+`dependencies.ts` was reading `Object.keys(...).length` for the dependency-limit
+count while already capturing `keys` three lines above — re-point it and the
+limit stops limiting.

--- a/.changeset/captured-intrinsics-twin-1971-fix.md
+++ b/.changeset/captured-intrinsics-twin-1971-fix.md
@@ -1,0 +1,25 @@
+---
+"@real-router/validation-plugin": patch
+---
+
+The state-guard twin captures its deciding intrinsics ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+`type-guards/guards/params.ts` is one half of a byte-identical pair with
+`shared/browser-env/state-guard.ts` (`scripts/twin-lockstep.test.mjs` compares
+`isPlainContainer`, `pushChildren` and `isParamsUnsafe` among others). The
+shared half was capturing its intrinsics as part of [#1971](https://github.com/greydragon888/real-router/issues/1971), and a capture on
+one side only would leave one twin reading the live global while the other reads
+its saved copy — so the same transformation was applied to both from one source.
+
+The three captures are compared by the lockstep registry rather than exempted
+from it, which is what makes "identical bodies" mean "identical behaviour".
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/.changeset/captured-intrinsics-vue-1971-fix.md
+++ b/.changeset/captured-intrinsics-vue-1971-fix.md
@@ -1,0 +1,24 @@
+---
+"@real-router/vue": patch
+---
+
+Deciding intrinsics in the shared sources are captured at module load ([#1971](https://github.com/greydragon888/real-router/issues/1971))
+
+This package bundles `shared/dom-utils`, whose reads of
+`Object.keys` / `hasOwn` / `entries` / `values` / `getPrototypeOf` went to the
+live global and can be re-pointed after boot. They are now read once at module
+load, the doctrine `guards.ts` states for core and the sweep in [#1971](https://github.com/greydragon888/real-router/issues/1971) extended
+to the shared half.
+
+The reads decide what is on an object the module did not build, so a re-pointed
+intrinsic changes a verdict rather than a value.
+
+⚠ **What capture does NOT buy**, stated because the doctrine states it: it
+narrows the window from "any time after boot" to "before the module loads". A
+shim evaluated ahead of the module still wins ([#1798](https://github.com/greydragon888/real-router/issues/1798)).
+This is robustness against polyfills, RUM/APM instrumentation, browser extensions
+and test doubles — not a security boundary, since re-pointing `Object.keys`
+already requires script execution.
+
+No behaviour change in a healthy environment: an intrinsic nobody touched answers
+the same either way.

--- a/packages/angular/src/dom-utils/link-utils.ts
+++ b/packages/angular/src/dom-utils/link-utils.ts
@@ -8,6 +8,20 @@ import type {
 } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+
+/**
  * Resolved navigation channels for a `<Link>` — the single `{ name, params,
  * search }` shape every adapter feeds into `buildHref` / `navigateWithHash` /
  * the active-route source, regardless of which prop form the consumer used.
@@ -350,9 +364,9 @@ export function shallowEqual(
     return false;
   }
 
-  const prevKeys = Object.keys(prev);
+  const prevKeys = objectKeys(prev);
 
-  if (prevKeys.length !== Object.keys(next).length) {
+  if (prevKeys.length !== objectKeys(next).length) {
     return false;
   }
 

--- a/packages/angular/src/dom-utils/scroll-restore.ts
+++ b/packages/angular/src/dom-utils/scroll-restore.ts
@@ -1,5 +1,19 @@
 import type { Router, State } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+
 const DEFAULT_STORAGE_KEY = "real-router:scroll";
 
 // Bounded retry budget for resolving a late-mounting scroll container on the
@@ -543,7 +557,7 @@ function canonicalReplacer(_key: string, val: unknown): unknown {
     // on both. Lock-test: scrollRestoreKey.properties.ts Invariant 11.
     const sorted = Object.create(null) as Record<string, unknown>;
     // eslint-disable-next-line unicorn/no-array-sort -- ng-packagr uses pre-ES2023 lib; toSorted unavailable
-    const keys = Object.keys(val).sort((left: string, right: string) =>
+    const keys = objectKeys(val).sort((left: string, right: string) =>
       left.localeCompare(right),
     );
 

--- a/packages/browser-plugin/tests/functional/browser-env/authority-1838.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/authority-1838.test.ts
@@ -101,10 +101,21 @@ const CHAIN_WALK_REASONS: Record<string, string> = {
     "prototype — measured in jsdom, `Object.hasOwn(new PopStateEvent('popstate'), " +
     '"state")` is false while `"state" in evt` is true. Own-only would break every ' +
     "popstate restore.",
-  "state-guard.ts:256":
-    "SAFE. `for…in` over a caller's object, guarded by `Object.hasOwn` on the " +
-    "next line — the own-ness question is answered, not skipped.",
+  "state-guard.ts:283":
+    "SAFE. `for…in` over a caller's object, guarded by the CAPTURED `hasOwn` on " +
+    "the next line — the own-ness question is answered, not skipped, and since " +
+    "#1971 it is answered by an intrinsic read at module load rather than off " +
+    "the live global.",
 };
+
+// ⚠ This registry addresses by `file:line`, and #1971 moved every line in
+// `state-guard.ts` by inserting a capture block at its head — so the key above
+// rotted on an edit that changed nothing about the site it describes. The
+// repository's own rule for derived guards is to address by file plus the
+// MATCHED TEXT precisely because `:NNN` does this. Left as line-keyed here
+// rather than reworked mid-sweep: changing the addressing scheme is a change to
+// what this guard IS, and it deserves its own diff instead of riding in on one
+// that is about intrinsics.
 
 describe("shared/browser-env authority (#1838)", () => {
   it("the scanner sees the symlinked dir at all", () => {

--- a/packages/browser-plugin/tests/functional/browser-env/captured-intrinsics-1971.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/captured-intrinsics-1971.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { browserPluginFactory, isState } from "@real-router/browser-plugin";
+
+/**
+ * `shared/browser-env` decides with UNCAPTURED intrinsics, and three of them
+ * FAIL OPEN (#1971).
+ *
+ * The doctrine these cells enforce is stated in core's `guards.ts`: *"a guard is
+ * only as strong as the intrinsic it reads WHEN IT RUNS, and an application can
+ * re-point any of these AFTER boot"*. Core captures in seventeen files;
+ * `shared/` captures in none, and carries sixteen raw deciding reads.
+ *
+ * ⚑ What makes this half worth its own cells rather than a line in the sweep:
+ * core's raw reads mostly degrade toward refusal or a wrong-but-loud outcome,
+ * while here the guard's verdict flips to **"valid"** for input it exists to
+ * reject. Same convention, different severity.
+ *
+ * ⚠ Honest framing: an attacker who can re-point `Object.getPrototypeOf` already
+ * has script execution, so this is not a security boundary. It is robustness
+ * against polyfills, RUM/APM instrumentation, browser extensions and test
+ * doubles — the case the doctrine itself rests on.
+ *
+ * ⚠ And the doctrine's own limit, carried over verbatim: capture narrows the
+ * window from "any time after boot" to "before core loads". It does not close
+ * it — a shim evaluated ahead of the module still wins (#1798).
+ */
+describe("shared/browser-env decides with captured intrinsics (#1971)", () => {
+  const realGetPrototypeOf = Object.getPrototypeOf;
+  const realValues = Object.values;
+  const realKeys = Object.keys;
+
+  afterEach(() => {
+    Object.getPrototypeOf = realGetPrototypeOf;
+    Object.values = realValues;
+    Object.keys = realKeys;
+  });
+
+  const entryWith = (params: unknown): unknown => ({
+    name: "users",
+    params,
+    path: "/users",
+  });
+
+  it("refuses a Date in params even when getPrototypeOf is re-pointed", () => {
+    const entry = entryWith({ when: new Date() });
+
+    // CONTROL — the guard genuinely refuses this shape, so the cell below
+    // measures the intrinsic and not a guard that never worked.
+    expect(isState(entry)).toBe(false);
+
+    Object.getPrototypeOf = (() => null) as typeof Object.getPrototypeOf;
+
+    // Every object now looks like a plain container, so `isPlainContainer`
+    // waves a class instance through and the Date lands in `state.params`.
+    expect(isState(entry)).toBe(false);
+  });
+
+  it("refuses a nested function in params even when values is re-pointed", () => {
+    const entry = entryWith({ nested: { fn: () => "x" } });
+
+    // CONTROL — refused for real before the shim.
+    expect(isState(entry)).toBe(false);
+
+    Object.values = (() => []) as unknown as typeof Object.values;
+
+    // With no children pushed onto the work-stack the walk inspects nothing
+    // below the top level, so the function is never seen.
+    expect(isState(entry)).toBe(false);
+  });
+
+  it("refuses a '..' base even when keys is re-pointed", () => {
+    // CONTROL — the rule fires for real.
+    expect(() => browserPluginFactory({ base: "/a/../b" })).toThrow(
+      /must not contain '\.\.' segments/,
+    );
+
+    Object.keys = (() => []) as unknown as typeof Object.keys;
+
+    // The validator's loop is `for (const key of Object.keys(opts))`, so an
+    // empty answer validates NOTHING — not this rule, not any other.
+    expect(() => browserPluginFactory({ base: "/a/../b" })).toThrow(
+      /must not contain '\.\.' segments/,
+    );
+  });
+
+  it("CONTROL — the shims are genuinely installed and reached", () => {
+    // Without this the three cells above could pass by the shim silently
+    // failing to take effect, which is indistinguishable from a fix.
+    Object.getPrototypeOf = (() => null) as typeof Object.getPrototypeOf;
+    Object.values = (() => []) as unknown as typeof Object.values;
+    Object.keys = (() => []) as unknown as typeof Object.keys;
+
+    expect(Object.getPrototypeOf({})).toBeNull();
+    expect(Object.values({ a: 1 })).toStrictEqual([]);
+    expect(Object.keys({ a: 1 })).toStrictEqual([]);
+  });
+});

--- a/packages/browser-plugin/tests/functional/browser-env/captured-intrinsics-1971.test.ts
+++ b/packages/browser-plugin/tests/functional/browser-env/captured-intrinsics-1971.test.ts
@@ -62,7 +62,7 @@ describe("shared/browser-env decides with captured intrinsics (#1971)", () => {
     // CONTROL — refused for real before the shim.
     expect(isState(entry)).toBe(false);
 
-    Object.values = (() => []) as unknown as typeof Object.values;
+    Object.values = (() => []) as typeof Object.values;
 
     // With no children pushed onto the work-stack the walk inspects nothing
     // below the top level, so the function is never seen.
@@ -75,7 +75,7 @@ describe("shared/browser-env decides with captured intrinsics (#1971)", () => {
       /must not contain '\.\.' segments/,
     );
 
-    Object.keys = (() => []) as unknown as typeof Object.keys;
+    Object.keys = () => [];
 
     // The validator's loop is `for (const key of Object.keys(opts))`, so an
     // empty answer validates NOTHING — not this rule, not any other.
@@ -88,8 +88,8 @@ describe("shared/browser-env decides with captured intrinsics (#1971)", () => {
     // Without this the three cells above could pass by the shim silently
     // failing to take effect, which is indistinguishable from a fix.
     Object.getPrototypeOf = (() => null) as typeof Object.getPrototypeOf;
-    Object.values = (() => []) as unknown as typeof Object.values;
-    Object.keys = (() => []) as unknown as typeof Object.keys;
+    Object.values = (() => []) as typeof Object.values;
+    Object.keys = () => [];
 
     expect(Object.getPrototypeOf({})).toBeNull();
     expect(Object.values({ a: 1 })).toStrictEqual([]);

--- a/packages/core/src/RouterError.ts
+++ b/packages/core/src/RouterError.ts
@@ -3,6 +3,9 @@
 import { errorCodes, UNSAFE_KEY } from "./constants";
 import { putField } from "./utils/ingest";
 
+const objectEntries = Object.entries;
+const objectValues = Object.values;
+
 // Pre-compute Set of error code values for O(1) lookup in setCode()
 // This avoids creating array and doing linear search on every setCode() call
 // ⚑ Captured at module load, for the reason `helpers.ts` states over its own
@@ -13,7 +16,7 @@ import { putField } from "./utils/ingest";
 // sweeping the ones it found.
 const hasOwn = Object.hasOwn;
 
-const errorCodeValues = new Set(Object.values(errorCodes));
+const errorCodeValues = new Set(objectValues(errorCodes));
 
 // Reserved built-in properties - throw error if user tries to set these
 const reservedProperties = new Set(["code", "segment", "path"]);
@@ -117,7 +120,7 @@ export class RouterError extends Error {
 
     // Assign custom fields, checking reserved properties and filtering out reserved method names
     // Issue #39: Throw for reserved properties to match setAdditionalFields behavior
-    for (const [key, value] of Object.entries(rest)) {
+    for (const [key, value] of objectEntries(rest)) {
       if (reservedProperties.has(key)) {
         throw new TypeError(
           `[RouterError] Cannot set reserved property "${key}"`,
@@ -237,7 +240,7 @@ export class RouterError extends Error {
    */
   setAdditionalFields(fields: Record<string, unknown>): void {
     // Assign fields, throwing for reserved properties, silently ignoring methods
-    for (const [key, value] of Object.entries(fields)) {
+    for (const [key, value] of objectEntries(fields)) {
       if (reservedProperties.has(key)) {
         throw new TypeError(
           `[RouterError.setAdditionalFields] Cannot set reserved property "${key}"`,
@@ -386,7 +389,7 @@ export class RouterError extends Error {
     ]);
 
     for (const key in this) {
-      if (Object.hasOwn(this, key) && !excludeKeys.has(key)) {
+      if (hasOwn(this, key) && !excludeKeys.has(key)) {
         // ⚑ `putField` (#1852): `result` is a fresh literal and the keys are the
         // user's own error fields. Measured, a setter under one of them made the
         // field vanish from the serialized output with no error at all.

--- a/packages/core/src/api/cloneRouter.ts
+++ b/packages/core/src/api/cloneRouter.ts
@@ -227,11 +227,30 @@ export function cloneRouter<
       // spread skips a NON-ENUMERABLE own key while the resolved bag carries the
       // materialised default for it. Pinned.
       //
-      // `Object.keys` does not invoke the bag's accessors, so #1880 still holds:
-      // the VALUES all come from `sourceLimits`, which the base resolved once.
-      // (`OptionsNamespace` also deep-freezes the caller's bag before
+      // `Object.keys` does not invoke the bag's accessors, so #1880 still holds
+      // for the VALUES: they all come from `sourceLimits`, which the base
+      // resolved once.
+      //
+      // ⚠ The KEY SET is a different question, and the answer this comment used
+      // to give — "`OptionsNamespace` deep-freezes the caller's bag before
       // `createLimits` runs, so the second enumeration cannot see a different
-      // key set from the first.)
+      // key set from the first" — is FALSE for two ordinary shapes (#1961).
+      // `deepFreeze` recurses only when `value.constructor === Object`, so an
+      // `Object.create(null)` bag and a class instance are never frozen at all.
+      // Measured on both, with `{ maxListeners: 3 }`: the base enforces 3, a
+      // clone taken before a post-boot `delete` enforces 3, and a clone taken
+      // after it enforces NOTHING — 40 subscriptions accepted where the base
+      // throws at 3. Under SSR that is a per-request clone with a different
+      // listener cap from its base, which is #1880's own shape reopened through
+      // the key set instead of the values.
+      //
+      // ⚠ The issue's own reproduction uses a plain literal and does NOT
+      // reproduce — that one IS frozen, so the `delete` throws. The defect needs
+      // a bag the `constructor` test misses. Not fixed here: the fix is to
+      // snapshot the passed key set at construction beside `sourceLimits`, which
+      // is a behaviour change with its own changeset. What is corrected here is
+      // the false safety property this comment asserted, so the next reader does
+      // not build on it.
       //
       // ⚠ `Object.hasOwn`, NOT `key in sourceLimits`. `in` walks the prototype
       // chain, so it answers true for `"__proto__"`, `"constructor"`,

--- a/packages/core/src/api/cloneRouter.ts
+++ b/packages/core/src/api/cloneRouter.ts
@@ -17,6 +17,23 @@ import type {
 } from "../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
+
+/**
  * Per-clone overrides beyond dependencies.
  */
 export interface CloneOptions {
@@ -235,8 +252,8 @@ export function cloneRouter<
       // carries it, and the clone resolves it to the same defaults the base did.
       ...(options.limits != null && {
         limits: Object.fromEntries(
-          Object.keys(options.limits)
-            .filter((key) => Object.hasOwn(sourceLimits, key))
+          objectKeys(options.limits)
+            .filter((key) => hasOwn(sourceLimits, key))
             .map((key) => [
               key,
               sourceLimits[key as keyof typeof sourceLimits],
@@ -314,21 +331,21 @@ export function cloneRouter<
   const [definitionDeactivate, definitionActivate] = definitionFactories;
   const [externalDeactivate, externalActivate] = externalFactories;
 
-  for (const [name, handler] of Object.entries(definitionDeactivate)) {
+  for (const [name, handler] of objectEntries(definitionDeactivate)) {
     newLifecycleNamespace.addCanDeactivate(name, handler, true);
   }
 
-  for (const [name, handler] of Object.entries(definitionActivate)) {
+  for (const [name, handler] of objectEntries(definitionActivate)) {
     newLifecycleNamespace.addCanActivate(name, handler, true);
   }
 
   const lifecycle = getLifecycleApi(newRouter);
 
-  for (const [name, handler] of Object.entries(externalDeactivate)) {
+  for (const [name, handler] of objectEntries(externalDeactivate)) {
     lifecycle.addDeactivateGuard(name, handler);
   }
 
-  for (const [name, handler] of Object.entries(externalActivate)) {
+  for (const [name, handler] of objectEntries(externalActivate)) {
     lifecycle.addActivateGuard(name, handler);
   }
 

--- a/packages/core/src/api/getDependenciesApi.ts
+++ b/packages/core/src/api/getDependenciesApi.ts
@@ -9,6 +9,21 @@ import type { DefaultDependencies, Router } from "../types";
 import type { RouterValidator } from "../types/RouterValidator";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
+/**
  * One `ToPropertyKey`, at the door (#1843).
  *
  * A dependency name is used as a PROPERTY KEY, so every bare
@@ -86,7 +101,7 @@ function setDependency(
   // uses below asked the name FOUR times, and each was a `ToPropertyKey` call
   // into application code.
   const key = asKey(dependencyName);
-  const isNewKey = !Object.hasOwn(target, key);
+  const isNewKey = !hasOwn(target, key);
 
   if (isNewKey) {
     // Only check limit when adding new keys (overwrites don't increase count)
@@ -131,7 +146,7 @@ function setMultipleDependencies(
   // string, an array, a class instance, a `Map` and an own enumerable getter all
   // went straight in, the last of them RUNNING the caller's code.
   ingestDependencies(deps, (key, value) => {
-    if (Object.hasOwn(target, key)) {
+    if (hasOwn(target, key)) {
       overwrittenKeys.push(key);
     } else {
       validator?.dependencies.validateDependencyCount(store, "setDependencies");
@@ -271,7 +286,7 @@ export function getDependenciesApi<
       // `beta`.
       const key = asKey(name);
 
-      if (!Object.hasOwn(store.dependencies, key)) {
+      if (!hasOwn(store.dependencies, key)) {
         ctx.validator?.dependencies.warnRemoveNonExistent(String(key));
       }
 
@@ -286,7 +301,7 @@ export function getDependenciesApi<
     has: (name) => {
       ctx.validator?.dependencies.validateDependencyName(name, "hasDependency");
 
-      return Object.hasOwn(ctx.dependenciesGetStore().dependencies, name);
+      return hasOwn(ctx.dependenciesGetStore().dependencies, name);
     },
   };
 }

--- a/packages/core/src/api/getPluginApi.ts
+++ b/packages/core/src/api/getPluginApi.ts
@@ -17,6 +17,21 @@ import type {
   State,
 } from "../types";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
 // Cache the assembled PluginApi per router — mirrors getNavigator() (#525):
 // avoids re-allocating the closure-bag on each call (plugins call this once
 // at init, but tests + nested plugins poll it), and gives spy/stub helpers
@@ -230,7 +245,7 @@ export function getPluginApi<
     extendRouter: (extensions: Record<string, unknown>) => {
       throwIfDisposed(ctx.isDisposed);
 
-      const keys = Object.keys(extensions);
+      const keys = objectKeys(extensions);
 
       for (const key of keys) {
         if (key in router) {

--- a/packages/core/src/api/getRoutesApi.ts
+++ b/packages/core/src/api/getRoutesApi.ts
@@ -53,6 +53,21 @@ import type {
   Route,
 } from "../types";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -110,14 +125,14 @@ function clearRouteConfigurations<
   const [canDeactivateFactories, canActivateFactories] =
     lifecycleNamespace.getFactories();
 
-  for (const name of Object.keys(canActivateFactories)) {
+  for (const name of objectKeys(canActivateFactories)) {
     if (shouldClear(name)) {
       // Route removed from the tree — both origin slots go (route no longer exists).
       lifecycleNamespace.clearCanActivate(name, "both");
     }
   }
 
-  for (const name of Object.keys(canDeactivateFactories)) {
+  for (const name of objectKeys(canDeactivateFactories)) {
     if (shouldClear(name)) {
       lifecycleNamespace.clearCanDeactivate(name, "both");
     }
@@ -1054,7 +1069,7 @@ export function getRoutesApi<
       if (ctx.treeChanged.listenerCount() > 0) {
         const patch = buildStructuralPatch<Dependencies>(structural);
 
-        if (Object.keys(patch).length > 0) {
+        if (objectKeys(patch).length > 0) {
           emitChange({ op: "update", name, patch });
         }
       }

--- a/packages/core/src/channels/defaults.ts
+++ b/packages/core/src/channels/defaults.ts
@@ -5,6 +5,8 @@ import { putField } from "../utils/ingest";
 
 import type { Params, SearchParams } from "../types";
 
+const objectEntries = Object.entries;
+
 /**
  * Intrinsics captured at module load: `hasOwn`.
  *
@@ -61,7 +63,7 @@ export function withholdFilledSlots(
   let kept: Record<string, unknown> | undefined;
   let dropped = false;
 
-  for (const [key, value] of Object.entries(defaults)) {
+  for (const [key, value] of objectEntries(defaults)) {
     // `Object.hasOwn` before the read, exactly as `findMisChanneledKey` does in
     // `./guard` and for the same reason: a bare `params[key]` walks
     // the PROTOTYPE, so a route declaring `?toString` / `?constructor` /
@@ -157,7 +159,7 @@ export function assertRouteDefaultChannels(
   queryNamesOf: (name: string) => readonly string[],
   method: string,
 ): void {
-  for (const [name, defaults] of Object.entries(defaultParams)) {
+  for (const [name, defaults] of objectEntries(defaultParams)) {
     assertChannelCorrect(
       method,
       name,

--- a/packages/core/src/channels/modeGate.ts
+++ b/packages/core/src/channels/modeGate.ts
@@ -5,6 +5,8 @@ import { putField } from "../utils/ingest";
 
 import type { SearchParams } from "../types";
 
+const objectEntries = Object.entries;
+
 // ⚑ Captured at module load, for the reason `helpers.ts` states over its own
 // three: a guarantee is only as strong as the intrinsic it reads WHEN IT RUNS,
 // and an application can re-point `Object.freeze` after boot. Measured with the
@@ -68,7 +70,7 @@ export function admittedSearch<S extends SearchParams>(
   // `Object.entries` (own enumerable only) rather than `for…in` + `Object.hasOwn`
   // — the same idiom the deleted `separateChannels` used, and it keeps the guard branch
   // out of the file instead of leaving one no test can reach.
-  for (const [key, value] of Object.entries(search)) {
+  for (const [key, value] of objectEntries(search)) {
     if (queryNames.includes(key)) {
       admitted ??= {};
       // ⚑ The key is one the ROUTE declares with `?`, so it is exactly the kind

--- a/packages/core/src/engine/path-matcher/registration/index.ts
+++ b/packages/core/src/engine/path-matcher/registration/index.ts
@@ -31,6 +31,21 @@ import type { CompiledRoute, MatcherInputNode } from "../types";
 
 export type { RegistrationState } from "./context";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
 export function registerNode(
   state: RegistrationState,
   node: MatcherInputNode,
@@ -234,7 +249,7 @@ function hasAnyParam(
   paramTypeMap: Readonly<Record<string, "url" | "query">>,
 ): boolean {
   for (const key in paramTypeMap) {
-    if (Object.hasOwn(paramTypeMap, key)) {
+    if (hasOwn(paramTypeMap, key)) {
       return true;
     }
   }

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -17,6 +17,24 @@ import type { RouterValidator } from "./types/RouterValidator";
  * reproduces #1798 verbatim (`buildPath` prints the native method into the
  * URL). Two earlier revisions of this header said "before any application
  * code can run", which is the sentence a future reader would have trusted.
+ *
+ * ⚑ **This file states the doctrine; it no longer states it alone (#1971).** It
+ * held here and in sixteen other files while twenty read the live global — and
+ * FIVE of those twenty were among the seventeen,
+ * including `utils/ingest.ts`, which OWNS the write discipline and captured two
+ * intrinsics two hundred lines above a raw `Object.entries` — both landed in the
+ * same commit. Scattered discipline is precisely what this header's own
+ * "five sibling readers" measurement says does not hold, so the convention is now
+ * DERIVED rather than remembered:
+ * `tests/functional/captured-intrinsics-authority-1971.test.ts` walks core and
+ * `shared/` for any call to one of the seven DECIDING intrinsics outside a
+ * capture, and requires a written reason for anything that survives.
+ *
+ * ⚑ `shared/` is in that walk deliberately, and it is where the convention pays
+ * most: measured there, three of its raw reads FAIL OPEN — a re-pointed
+ * `getPrototypeOf` admits a `Date` into `state.params`, `values` admits a nested
+ * function, `keys` skips option validation entirely. Core's raw reads mostly
+ * degrade toward refusal; that half flipped the verdict to "valid".
  */
 const objectKeys = Object.keys;
 const hasOwn = Object.hasOwn;

--- a/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
+++ b/packages/core/src/namespaces/NavigationNamespace/transition/errorHandling.ts
@@ -8,6 +8,21 @@ import type { State } from "../../../types";
 import type { NavigationDependencies } from "../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+
+/**
  * Is this thrown value already the router's quiet-cancel outcome?
  *
  * Asked by {@link handleGuardError} (a guard signalling a quiet cancel by
@@ -184,7 +199,7 @@ export function wrapSyncError(
   if (thrown && typeof thrown === "object") {
     const filtered: Record<string, unknown> = {};
 
-    for (const [key, value] of Object.entries(thrown)) {
+    for (const [key, value] of objectEntries(thrown)) {
       // Skip reserved / hazardous keys: #39 (constructor TypeError on code/
       // segment/path) and #947 (`then` would make the error thenable).
       // ⚑ `UNSAFE_KEY` skipped, the same decision the state channels take and for

--- a/packages/core/src/namespaces/PluginsNamespace/constants.ts
+++ b/packages/core/src/namespaces/PluginsNamespace/constants.ts
@@ -8,6 +8,21 @@ import {
 import type { EventName } from "../../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Maps plugin method names to router event names.
  */
 export const EVENTS_MAP = {
@@ -27,7 +42,7 @@ export const EVENTS_MAP = {
 /**
  * Plugin method names that correspond to router events.
  */
-export const EVENT_METHOD_NAMES = Object.keys(
+export const EVENT_METHOD_NAMES = objectKeys(
   EVENTS_MAP,
 ) as (keyof typeof EVENTS_MAP)[];
 

--- a/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/RoutesNamespace.ts
@@ -42,6 +42,21 @@ import type {
 } from "../../types";
 import type { RouteLifecycleNamespace } from "../RouteLifecycleNamespace";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
 function createRouteState<P extends RouteParams = RouteParams>(
   matchResult: {
     readonly segments: readonly { fullName: string }[];
@@ -609,7 +624,7 @@ export class RoutesNamespace<
     // singleton when absent.
     const resolvedSearch = (search ?? EMPTY_SEARCH) as S;
 
-    if (Object.hasOwn(this.#store.config.forwardFnMap, name)) {
+    if (hasOwn(this.#store.config.forwardFnMap, name)) {
       const dynamicForward = this.#store.config.forwardFnMap[name];
       const { target, chain } = this.#resolveDynamicForward(
         name,
@@ -624,7 +639,7 @@ export class RoutesNamespace<
 
     if (
       staticForward !== name &&
-      Object.hasOwn(this.#store.config.forwardFnMap, staticForward)
+      hasOwn(this.#store.config.forwardFnMap, staticForward)
     ) {
       const targetDynamicForward =
         this.#store.config.forwardFnMap[staticForward];
@@ -763,8 +778,8 @@ export class RoutesNamespace<
     // maintained beside `resolvedForwardMap`, never separately.
     if (
       !this.#store.hasAnyForward ||
-      (!Object.hasOwn(this.#store.config.forwardMap, name) &&
-        !Object.hasOwn(this.#store.config.forwardFnMap, name))
+      (!hasOwn(this.#store.config.forwardMap, name) &&
+        !hasOwn(this.#store.config.forwardFnMap, name))
     ) {
       return false;
     }
@@ -1004,7 +1019,7 @@ export class RoutesNamespace<
     const chain: string[] = [];
     let current = name;
 
-    while (Object.hasOwn(this.#store.config.forwardMap, current)) {
+    while (hasOwn(this.#store.config.forwardMap, current)) {
       chain.push(current);
       current = this.#store.config.forwardMap[current];
     }
@@ -1198,7 +1213,7 @@ export class RoutesNamespace<
 
       visited.add(current);
 
-      if (Object.hasOwn(this.#store.config.forwardFnMap, current)) {
+      if (hasOwn(this.#store.config.forwardFnMap, current)) {
         const fn = this.#store.config.forwardFnMap[
           current
         ] as ForwardToCallback<Dependencies>;

--- a/packages/core/src/namespaces/RoutesNamespace/helpers.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/helpers.ts
@@ -16,6 +16,21 @@ import type {
 } from "../../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Creates an empty RouteConfig.
  */
 export function createEmptyConfig(): RouteConfig {
@@ -47,8 +62,8 @@ export function createEmptyConfig(): RouteConfig {
  */
 export function anyForwardConfigured(config: RouteConfig): boolean {
   return (
-    Object.keys(config.forwardMap).length > 0 ||
-    Object.keys(config.forwardFnMap).length > 0
+    objectKeys(config.forwardMap).length > 0 ||
+    objectKeys(config.forwardFnMap).length > 0
   );
 }
 
@@ -65,7 +80,7 @@ export function assignConfigEntries(
   target: RouteConfig,
   source: RouteConfig,
 ): void {
-  for (const key of Object.keys(source) as (keyof RouteConfig)[]) {
+  for (const key of objectKeys(source) as (keyof RouteConfig)[]) {
     Object.assign(target[key], source[key]);
   }
 }
@@ -189,7 +204,7 @@ export function clearConfigEntries<T>(
   config: Record<string, T>,
   matcher: (key: string) => boolean,
 ): void {
-  for (const key of Object.keys(config)) {
+  for (const key of objectKeys(config)) {
     if (matcher(key)) {
       delete config[key];
     }

--- a/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
+++ b/packages/core/src/namespaces/RoutesNamespace/routesStore.ts
@@ -39,6 +39,9 @@ import type {
 } from "../../types";
 import type { RouteLifecycleNamespace } from "../RouteLifecycleNamespace";
 
+const objectEntries = Object.entries;
+const objectKeys = Object.keys;
+
 /**
  * Intrinsics captured at module load: `defineProperty`.
  *
@@ -268,7 +271,7 @@ export function adoptForwardState<Dependencies extends DefaultDependencies>(
 export function refreshForwardMap(config: RouteConfig): Record<string, string> {
   const map = Object.create(null) as Record<string, string>;
 
-  for (const fromRoute of Object.keys(config.forwardMap)) {
+  for (const fromRoute of objectKeys(config.forwardMap)) {
     map[fromRoute] = resolveForwardChain(fromRoute, config.forwardMap);
   }
 
@@ -363,10 +366,10 @@ function registerSingleRouteHandlers<Dependencies extends DefaultDependencies>(
   logger: RouterLogger,
 ): void {
   const customFields = fromEntries(
-    Object.entries(route).filter(([key]) => !STANDARD_ROUTE_KEYS.has(key)),
+    objectEntries(route).filter(([key]) => !STANDARD_ROUTE_KEYS.has(key)),
   );
 
-  if (Object.keys(customFields).length > 0) {
+  if (objectKeys(customFields).length > 0) {
     routeCustomFields[fullName] = customFields;
   }
 
@@ -1155,7 +1158,7 @@ export function commitRouteUpdate<Dependencies extends DefaultDependencies>(
   // is needed — the next read sees the new value; the caller's emit stays
   // structural-only by design (О-7).
   if (nextCustomFields !== undefined) {
-    if (Object.keys(nextCustomFields).length > 0) {
+    if (objectKeys(nextCustomFields).length > 0) {
       store.routeCustomFields[name] = nextCustomFields;
     } else {
       delete store.routeCustomFields[name];
@@ -1277,8 +1280,8 @@ function prepareCustomFields<
   // `update`'s destructuring — are not re-invoked. `Object.entries` would read
   // every value eagerly, double-invoking a `defaultParams`/`forwardTo` getter
   // and breaking the "user getter called once" invariant.
-  // eslint-disable-next-line unicorn/prefer-object-iterable-methods -- see above
-  for (const key of Object.keys(updates)) {
+
+  for (const key of objectKeys(updates)) {
     if (STANDARD_ROUTE_KEYS.has(key)) {
       continue;
     }

--- a/packages/core/src/namespaces/StateNamespace/StateNamespace.ts
+++ b/packages/core/src/namespaces/StateNamespace/StateNamespace.ts
@@ -10,6 +10,21 @@ import type { RouterFSMContext } from "../../routerFSM";
 import type { Params, SearchParams, State } from "../../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * State SERVICE — no longer the owner of the state.
  *
  * The two cells live in the FSM context (plan §11.A2); this class keeps a
@@ -211,9 +226,9 @@ function recordsShallowEqual(
   left: Readonly<Record<string, unknown>>,
   right: Readonly<Record<string, unknown>>,
 ): boolean {
-  const leftKeys = Object.keys(left);
+  const leftKeys = objectKeys(left);
 
-  if (leftKeys.length !== Object.keys(right).length) {
+  if (leftKeys.length !== objectKeys(right).length) {
     return false;
   }
 

--- a/packages/core/src/pipeline/buildURL.ts
+++ b/packages/core/src/pipeline/buildURL.ts
@@ -6,6 +6,21 @@ import type { RouteResolver } from "./port";
 import type { Canonical } from "./types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Stage ⑤a — the URL of a canonical intent. Accepts nothing but a
  * {@link Canonical}, so "print a URL out of un-defaulted channels" cannot be
  * expressed: the query string is printed from `canonical.query` alone, never from a
@@ -68,10 +83,10 @@ export function buildURLForCommit(
     return buildURL(canonical, port);
   }
 
-  const keysBefore = Object.keys(canonical.path).length;
+  const keysBefore = objectKeys(canonical.path).length;
   const url = buildURL(canonical, port);
 
-  if (Object.keys(canonical.path).length > keysBefore) {
+  if (objectKeys(canonical.path).length > keysBefore) {
     diagnoseUndeclaredKeys(
       port,
       canonical.name,

--- a/packages/core/src/pipeline/canonicalize.ts
+++ b/packages/core/src/pipeline/canonicalize.ts
@@ -13,6 +13,21 @@ import type { Canonical } from "./types";
 import type { Params, SearchParams } from "../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Options for {@link canonicalize}. Both flags are opt-in, and both are read as
  * a ROLE rather than inferred from the shape of the call — the reasons differ
  * per flag and are recorded on each.
@@ -90,7 +105,7 @@ export function diagnoseUndeclaredKeys(
     return;
   }
 
-  for (const key of Object.keys(pathBag)) {
+  for (const key of objectKeys(pathBag)) {
     if (!declaredQuery.includes(key) && !declaredPath.includes(key)) {
       report(resolvedName, key);
     }

--- a/packages/core/src/transitionPath.ts
+++ b/packages/core/src/transitionPath.ts
@@ -3,6 +3,21 @@
 import type { State } from "./types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Per-segment param-source map for a route name — `{ segment: { param: "url" |
  * "query" } }`. Resolved from the live matcher via `RoutesNamespace.getMetaForState`
  * (RFC-4 M2 / #1548: this replaced the removed `stateMetaStore` WeakMap — ownership
@@ -102,7 +117,7 @@ function segmentParamsEqual(
     return true;
   }
 
-  for (const key of Object.keys(keys)) {
+  for (const key of objectKeys(keys)) {
     const toVal = toState.params[key];
     const fromVal = fromState.params[key];
 

--- a/packages/core/src/utils/fsm/fsm.ts
+++ b/packages/core/src/utils/fsm/fsm.ts
@@ -6,6 +6,23 @@ import type {
 } from "./types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+const objectValues = Object.values;
+
+/**
  * The NORMALIZED edge: every entry is an object, so the hot-path property load
  * in `send()` sees ONE shape. The string form stays first-class in the config —
  * it is widened here, once per distinct table (cached), not per send.
@@ -93,13 +110,13 @@ function normalizeTable(table: object): NormTable<string> {
   const raw = table as Record<string, Record<string, string | RawEdge>>;
   const out = Object.create(null) as NormTable<string>;
 
-  for (const [state, rawEdges] of Object.entries(raw)) {
+  for (const [state, rawEdges] of objectEntries(raw)) {
     const edges = Object.create(null) as Record<
       string,
       NormEdge<string, never, never> | undefined
     >;
 
-    for (const [event, declaration] of Object.entries(rawEdges)) {
+    for (const [event, declaration] of objectEntries(rawEdges)) {
       // An explicit `undefined` is the declared "no transition" no-op — skipped,
       // not a dangling target.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard for JS / cast callers, whose table may carry explicit undefined
@@ -111,8 +128,8 @@ function normalizeTable(table: object): NormTable<string> {
     out[state] = edges;
   }
 
-  for (const edges of Object.values(out)) {
-    for (const edge of Object.values(edges)) {
+  for (const edges of objectValues(out)) {
+    for (const edge of objectValues(edges)) {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `Object.values` widens to include the record's `| undefined` member
       if (edge !== undefined && out[edge.target] === undefined) {
         throw new Error(
@@ -329,7 +346,7 @@ export class FSM<
     // object. That is true today (`Object.create(null)` below) — which is
     // exactly why the `in` form passes its test — but it makes this guard depend
     // on a distant detail of `normalizeTable` instead of on itself.
-    if (!Object.hasOwn(edges, event)) {
+    if (!hasOwn(edges, event)) {
       throw new Error(
         `[FSM.on] event "${event}" has no edge from state "${from}"`,
       );

--- a/packages/core/src/utils/ingest.ts
+++ b/packages/core/src/utils/ingest.ts
@@ -47,6 +47,8 @@
 
 import { UNSAFE_KEY } from "../constants";
 
+const objectEntries = Object.entries;
+
 /**
  * The target discipline: a record with NO prototype.
  *
@@ -387,7 +389,7 @@ export function copyFields<V>(
   target: Record<string, V>,
   source: Record<string, V>,
 ): void {
-  for (const [key, value] of Object.entries(source)) {
+  for (const [key, value] of objectEntries(source)) {
     putField(target, key, value);
   }
 }

--- a/packages/core/src/utils/logger/RouterLogger.ts
+++ b/packages/core/src/utils/logger/RouterLogger.ts
@@ -11,6 +11,21 @@ import type {
 } from "../../types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
+/**
  * Internal config type with required callbackIgnoresLevel
  * (always initialized to false)
  */
@@ -126,7 +141,7 @@ export class RouterLogger {
 
     // `hasOwn`, not `!== undefined`: an explicit `callback: undefined` CLEARS
     // the sink, and the normalised record carries presence for exactly that.
-    if (Object.hasOwn(validated, "callback")) {
+    if (hasOwn(validated, "callback")) {
       this.#config.callback = validated.callback;
     }
 

--- a/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
+++ b/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
@@ -1,0 +1,258 @@
+import { readFileSync, globSync } from "node:fs";
+import path from "node:path";
+
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every DECIDING intrinsic is read from a module-load capture, in core and in
+ * `shared/` (#1971).
+ *
+ * `guards.ts` states the doctrine and the measurement behind it: *"a guard is
+ * only as strong as the intrinsic it reads WHEN IT RUNS"* — one naive
+ * `Object.hasOwn` polyfill walked through five sibling readers while the single
+ * captured guard held. Before this suite 32 files in core touched a deciding
+ * intrinsic: 17 captured one, 20 read one raw, and ⚠ FIVE did both — including
+ * `ingest.ts`, which OWNS the write discipline and captured two intrinsics two
+ * hundred lines above a raw `Object.entries`. The overlap is the point: this was
+ * never "some files follow the rule and others do not".
+ *
+ * ⚑ **Deciding, not every intrinsic.** The seven below answer "what is on this
+ * object" for a value the module did not build, so a re-pointed one changes a
+ * VERDICT. `freeze` / `create` / `assign` decide nothing and are out of scope
+ * here — `freeze` has its own reason to be captured (a published guarantee,
+ * #1984) and its own sites.
+ *
+ * ⚠ **What capture does not buy**, carried verbatim from the doctrine rather
+ * than quietly dropped: it narrows the window from "any time after boot" to
+ * "before this module loads". A shim evaluated ahead of core still wins (#1798).
+ * The convention is robustness against polyfills, instrumentation, extensions
+ * and test doubles — not a security boundary, since re-pointing `Object.keys`
+ * already requires script execution.
+ *
+ * ⚠ **Addressed by file and matched TEXT, never by `:NNN`.** Three sibling
+ * registries in this repository are line-keyed, and #1971's own capture blocks
+ * rotted all three by inserting lines above their sites. This one derives the
+ * set and reports the text, so a reformat cannot make it lie.
+ */
+
+const CORE_SRC = path.resolve(__dirname, "../../src");
+const SHARED = path.resolve(__dirname, "../../../../shared");
+/**
+ * ⚠ The third root, and it is a COPY rather than a symlink — which is exactly
+ * why it needs naming. `packages/angular/src/dom-utils` is `shared/dom-utils`
+ * re-materialised by angular's `prebundle` script (ng-packagr does not follow
+ * symlinks the way tsdown does), so it is the same source shipped twice.
+ *
+ * ⚑ Measured, not assumed: with only the two roots above, planting a raw
+ * `Object.keys` in that copy left this suite GREEN. The convention held in core
+ * and in `shared/` and had a hole precisely where the shared source is
+ * duplicated — the one place a sweep of either root cannot reach.
+ */
+const ANGULAR_DOM_UTILS = path.resolve(
+  __dirname,
+  "../../../angular/src/dom-utils",
+);
+
+/** Intrinsics that answer "what is on this object". */
+const DECIDING = new Set([
+  "hasOwn",
+  "keys",
+  "entries",
+  "values",
+  "getOwnPropertyDescriptor",
+  "getOwnPropertyNames",
+  "getPrototypeOf",
+]);
+
+interface Site {
+  readonly file: string;
+  readonly text: string;
+}
+
+/**
+ * Sites that may read the live global, each with a written reason. The registry
+ * is the ONLY way a read escapes, so an empty reason is not accepted.
+ */
+const EXEMPT: Record<string, string> = {};
+
+function rawReads(roots: readonly string[]): Site[] {
+  const found: Site[] = [];
+
+  for (const root of roots) {
+    for (const file of globSync(`${root}/**/*.ts`)) {
+      if (file.includes("node_modules") || file.includes("/dist/")) {
+        continue;
+      }
+
+      const source = ts.createSourceFile(
+        file,
+        readFileSync(file, "utf8"),
+        ts.ScriptTarget.ESNext,
+        true,
+      );
+
+      const visit = (node: ts.Node): void => {
+        // A CAPTURE is the cure, not a read: `const hasOwn = Object.hasOwn`.
+        if (
+          ts.isVariableDeclaration(node) &&
+          node.initializer &&
+          ts.isPropertyAccessExpression(node.initializer) &&
+          ts.isIdentifier(node.initializer.expression) &&
+          node.initializer.expression.text === "Object"
+        ) {
+          return;
+        }
+
+        if (
+          ts.isCallExpression(node) &&
+          ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === "Object" &&
+          DECIDING.has(node.expression.name.text)
+        ) {
+          found.push({
+            file: path.basename(file),
+            text: node.getText(source).split("\n", 1)[0].slice(0, 70),
+          });
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      visit(source);
+    }
+  }
+
+  return found;
+}
+
+describe("every deciding intrinsic is captured (#1971)", () => {
+  const sites = rawReads([CORE_SRC, SHARED, ANGULAR_DOM_UTILS]);
+
+  it("finds source to walk at all — the guard must not pass on an empty scan", () => {
+    // Without this the file goes green the moment a directory moves, the glob
+    // stops matching, or the AST shape changes: "no raw reads" and "nothing was
+    // read" are the same answer to a broken scanner.
+    const files = globSync(`${CORE_SRC}/**/*.ts`).length;
+    const sharedFiles = globSync(`${SHARED}/**/*.ts`).length;
+    const copiedFiles = globSync(`${ANGULAR_DOM_UTILS}/**/*.ts`).length;
+
+    expect(files).toBeGreaterThan(100);
+    expect(sharedFiles).toBeGreaterThan(10);
+    expect(copiedFiles).toBeGreaterThan(5);
+  });
+
+  it("leaves no unclassified raw read in core or shared", () => {
+    const unclassified = sites.filter(
+      (s) => EXEMPT[`${s.file}: ${s.text}`] === undefined,
+    );
+
+    expect(unclassified.map((s) => `${s.file}: ${s.text}`)).toStrictEqual([]);
+  });
+
+  it("keeps every exemption honest — no empty reasons, no stale entries", () => {
+    for (const [key, reason] of Object.entries(EXEMPT)) {
+      expect(
+        reason.trim().length,
+        `exemption ${key} needs a real written reason — it is the only way a read escapes`,
+      ).toBeGreaterThan(30);
+      expect(
+        sites.some((s) => `${s.file}: ${s.text}` === key),
+        `stale exemption: ${key} no longer matches a read — drop it`,
+      ).toBe(true);
+    }
+  });
+
+  it("CONTROL — every intrinsic in DECIDING is one the scanner actually looks for", () => {
+    // ⚠ Without this the guard's own list is the unguarded part of it: drop
+    // `values` from DECIDING and the suite stays green while silently no longer
+    // watching `Object.values` anywhere. The set is data, and data is mutated by
+    // REMOVAL — so each member gets a synthetic read it must be found in.
+    for (const name of DECIDING) {
+      const probe = ts.createSourceFile(
+        "probe.ts",
+        `function f(o: object) { return Object.${name}(o); }`,
+        ts.ScriptTarget.ESNext,
+        true,
+      );
+
+      let found = false;
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isCallExpression(node) &&
+          ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === "Object" &&
+          DECIDING.has(node.expression.name.text)
+        ) {
+          found = true;
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      visit(probe);
+
+      expect(
+        found,
+        `Object.${name} is in DECIDING but the scan misses it`,
+      ).toBe(true);
+    }
+
+    // And the set is the SEVEN this issue scoped — a member added without a
+    // decision, or one quietly dropped, changes what the sweep means.
+    expect(
+      [...DECIDING].toSorted((left, right) => left.localeCompare(right)),
+    ).toStrictEqual([
+      "entries",
+      "getOwnPropertyDescriptor",
+      "getOwnPropertyNames",
+      "getPrototypeOf",
+      "hasOwn",
+      "keys",
+      "values",
+    ]);
+  });
+
+  it("CONTROL — the scanner sees a read, and counts neither a capture nor a comment", () => {
+    const probe = ts.createSourceFile(
+      "probe.ts",
+      `const hasOwn = Object.hasOwn;
+       // Object.keys(x) in a comment is not a read
+       const s = "Object.values(y)";
+       function f(o: object) { return Object.entries(o); }`,
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+
+    const hits: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        node.initializer &&
+        ts.isPropertyAccessExpression(node.initializer) &&
+        ts.isIdentifier(node.initializer.expression) &&
+        node.initializer.expression.text === "Object"
+      ) {
+        return;
+      }
+
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === "Object" &&
+        DECIDING.has(node.expression.name.text)
+      ) {
+        hits.push(node.expression.name.text);
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(probe);
+
+    expect(hits).toStrictEqual(["entries"]);
+  });
+});

--- a/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
+++ b/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
@@ -5,17 +5,29 @@ import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 /**
- * Every DECIDING intrinsic is read from a module-load capture, in core and in
- * `shared/` (#1971).
+ * Every DECIDING intrinsic is read from a module-load capture, everywhere the
+ * repository ships source: every package's `src`, and `shared/` (#1971).
  *
  * `guards.ts` states the doctrine and the measurement behind it: *"a guard is
  * only as strong as the intrinsic it reads WHEN IT RUNS"* — one naive
  * `Object.hasOwn` polyfill walked through five sibling readers while the single
- * captured guard held. Before this suite 32 files in core touched a deciding
- * intrinsic: 17 captured one, 20 read one raw, and ⚠ FIVE did both — including
- * `ingest.ts`, which OWNS the write discipline and captured two intrinsics two
- * hundred lines above a raw `Object.entries`. The overlap is the point: this was
- * never "some files follow the rule and others do not".
+ * captured guard held. Measured by AST on this sweep's base commit:
+ *
+ *     scope     raw reads   files reading raw   files capturing   BOTH
+ *     core             52                  20                11      3
+ *     shared/          16                   7                 0      0
+ *     elsewhere        57                  20                 1      1
+ *
+ * The overlap column is the point: this was never "some files follow the rule
+ * and others do not". `ingest.ts`, which OWNS the write discipline, captured
+ * `hasOwn` and read `Object.entries` raw two hundred lines below it.
+ *
+ * ⚠ **"Capturing" counts a DECIDING intrinsic, and the distinction is not
+ * pedantry.** Counted as "captures any `Object.x`" the core column reads 17 and
+ * 5, because `modeGate.ts` and `routesStore.ts` capture `freeze` — which decides
+ * nothing and is out of scope by the very next paragraph. Those inflated numbers
+ * shipped in this sweep's first commit message; they are corrected here, and
+ * the smaller ones are the load-bearing claim.
  *
  * ⚑ **Deciding, not every intrinsic.** The seven below answer "what is on this
  * object" for a value the module did not build, so a re-pointed one changes a
@@ -30,25 +42,23 @@ import { describe, expect, it } from "vitest";
  * and test doubles — not a security boundary, since re-pointing `Object.keys`
  * already requires script execution.
  *
- * ⚠ **Addressed by file and matched TEXT, never by `:NNN`.** Three sibling
- * registries in this repository are line-keyed, and #1971's own capture blocks
- * rotted all three by inserting lines above their sites. This one derives the
- * set and reports the text, so a reformat cannot make it lie.
+ * ⚠ **Addressed by REPO-RELATIVE PATH and matched TEXT, never by `:NNN`.** Three
+ * sibling registries in this repository are line-keyed, and #1971's own capture
+ * blocks rotted all three by inserting lines above their sites. This one derives
+ * the set and reports the text, so a reformat cannot make it lie.
+ *
+ * ⚠ The path is what distinguishes two sites, and a BASENAME does not: measured
+ * over this scan's roots, 212 of 436 files share a basename with at least one
+ * other (`index.ts` 57×, `types.ts` 43×, `validation.ts` 8×). Since the text is
+ * matched too, and a text like `Object.keys(opts)` repeats freely, a basename
+ * key would let one written exemption silently cover a site nobody classified.
+ * The narrow core+`shared/` roots this suite started with hid that; the
+ * repository-wide roots below do not.
  */
 
 const PACKAGES = path.resolve(__dirname, "../../..");
-const SHARED = path.resolve(PACKAGES, "../shared");
-/**
- * ⚠ The third root, and it is a COPY rather than a symlink — which is exactly
- * why it needs naming. `packages/angular/src/dom-utils` is `shared/dom-utils`
- * re-materialised by angular's `prebundle` script (ng-packagr does not follow
- * symlinks the way tsdown does), so it is the same source shipped twice.
- *
- * ⚑ Measured, not assumed: with only the two roots above, planting a raw
- * `Object.keys` in that copy left this suite GREEN. The convention held in core
- * and in `shared/` and had a hole precisely where the shared source is
- * duplicated — the one place a sweep of either root cannot reach.
- */
+const REPO = path.resolve(PACKAGES, "..");
+const SHARED = path.resolve(REPO, "shared");
 
 /** Intrinsics that answer "what is on this object". */
 const DECIDING = new Set([
@@ -108,7 +118,7 @@ function rawReads(roots: readonly string[]): Site[] {
           DECIDING.has(node.expression.name.text)
         ) {
           found.push({
-            file: path.basename(file),
+            file: path.relative(REPO, file),
             text: node.getText(source).split("\n", 1)[0].slice(0, 70),
           });
         }
@@ -132,9 +142,12 @@ describe("every deciding intrinsic is captured (#1971)", () => {
     // read" are the same answer to a broken scanner.
     const packageFiles = globSync(`${PACKAGES}/*/src/**/*.ts`).length;
     const sharedFiles = globSync(`${SHARED}/**/*.ts`).length;
-    // The angular COPY is inside `packages/*/src`, so the wildcard reaches it —
-    // but only as long as it is still a copy rather than a symlink, and only as
-    // long as the walk descends there at all. Asserted by name, not assumed.
+    // ⚠ `packages/angular/src/dom-utils` is `shared/dom-utils` re-materialised by
+    // angular's `prebundle` (ng-packagr does not follow symlinks the way tsdown
+    // does), so it is the same source shipped twice — and it was a hole while
+    // the roots were core + `shared/` alone: planting a raw `Object.keys` there
+    // left this suite GREEN. The `packages/*/src` wildcard reaches it now, but
+    // only while the walk descends there at all, so it is asserted by name.
     const copied = globSync(`${PACKAGES}/angular/src/dom-utils/**/*.ts`).length;
 
     expect(packageFiles).toBeGreaterThan(300);
@@ -142,7 +155,7 @@ describe("every deciding intrinsic is captured (#1971)", () => {
     expect(copied).toBeGreaterThan(5);
   });
 
-  it("leaves no unclassified raw read in core or shared", () => {
+  it("leaves no unclassified raw read anywhere the repository ships source", () => {
     const unclassified = sites.filter(
       (s) => EXEMPT[`${s.file}: ${s.text}`] === undefined,
     );

--- a/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
+++ b/packages/core/tests/functional/captured-intrinsics-authority-1971.test.ts
@@ -36,8 +36,8 @@ import { describe, expect, it } from "vitest";
  * set and reports the text, so a reformat cannot make it lie.
  */
 
-const CORE_SRC = path.resolve(__dirname, "../../src");
-const SHARED = path.resolve(__dirname, "../../../../shared");
+const PACKAGES = path.resolve(__dirname, "../../..");
+const SHARED = path.resolve(PACKAGES, "../shared");
 /**
  * ⚠ The third root, and it is a COPY rather than a symlink — which is exactly
  * why it needs naming. `packages/angular/src/dom-utils` is `shared/dom-utils`
@@ -49,10 +49,6 @@ const SHARED = path.resolve(__dirname, "../../../../shared");
  * and in `shared/` and had a hole precisely where the shared source is
  * duplicated — the one place a sweep of either root cannot reach.
  */
-const ANGULAR_DOM_UTILS = path.resolve(
-  __dirname,
-  "../../../angular/src/dom-utils",
-);
 
 /** Intrinsics that answer "what is on this object". */
 const DECIDING = new Set([
@@ -128,19 +124,22 @@ function rawReads(roots: readonly string[]): Site[] {
 }
 
 describe("every deciding intrinsic is captured (#1971)", () => {
-  const sites = rawReads([CORE_SRC, SHARED, ANGULAR_DOM_UTILS]);
+  const sites = rawReads([`${PACKAGES}/*/src`, SHARED]);
 
   it("finds source to walk at all — the guard must not pass on an empty scan", () => {
     // Without this the file goes green the moment a directory moves, the glob
     // stops matching, or the AST shape changes: "no raw reads" and "nothing was
     // read" are the same answer to a broken scanner.
-    const files = globSync(`${CORE_SRC}/**/*.ts`).length;
+    const packageFiles = globSync(`${PACKAGES}/*/src/**/*.ts`).length;
     const sharedFiles = globSync(`${SHARED}/**/*.ts`).length;
-    const copiedFiles = globSync(`${ANGULAR_DOM_UTILS}/**/*.ts`).length;
+    // The angular COPY is inside `packages/*/src`, so the wildcard reaches it —
+    // but only as long as it is still a copy rather than a symlink, and only as
+    // long as the walk descends there at all. Asserted by name, not assumed.
+    const copied = globSync(`${PACKAGES}/angular/src/dom-utils/**/*.ts`).length;
 
-    expect(files).toBeGreaterThan(100);
+    expect(packageFiles).toBeGreaterThan(300);
     expect(sharedFiles).toBeGreaterThan(10);
-    expect(copiedFiles).toBeGreaterThan(5);
+    expect(copied).toBeGreaterThan(5);
   });
 
   it("leaves no unclassified raw read in core or shared", () => {

--- a/packages/core/tests/functional/captured-intrinsics-behaviour-1971.test.ts
+++ b/packages/core/tests/functional/captured-intrinsics-behaviour-1971.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { copyFields, putField } from "@real-router/core/utils";
+
+/**
+ * The BEHAVIOURAL half of #1971 — what the capture actually buys in core.
+ *
+ * `captured-intrinsics-authority-1971` derives the site set and proves no raw
+ * read remains; it says nothing about what a raw read would have DONE. This file
+ * is the other half, and it exists because the sweep's own reproduction was run
+ * once, before the fix, and then deleted: a defect measured but never pinned is
+ * a defect the next refactor restores in silence.
+ *
+ * ⚑ The subject is `copyFields`, published through `@real-router/core/utils`
+ * "because the rule is the plugin author's too" — and the file it lives in,
+ * `utils/ingest.ts`, OWNS the write discipline: it captured `defineProperty` and
+ * `hasOwn` at module load and then walked a caller's bag with the uncaptured
+ * `Object.entries` two hundred lines below, both in the same commit (#1852).
+ *
+ * ⚠ Not a security boundary: re-pointing `Object.entries` already requires
+ * script execution. It is robustness against polyfills, RUM/APM instrumentation,
+ * browser extensions and test doubles.
+ */
+describe("core's deciding intrinsics are captured — behaviour (#1971)", () => {
+  const realEntries = Object.entries;
+  const realHasOwn = Object.hasOwn;
+
+  afterEach(() => {
+    Object.entries = realEntries;
+    Object.hasOwn = realHasOwn;
+    delete (Object.prototype as Record<string, unknown>).hijacked;
+  });
+
+  it("copyFields keeps every key when Object.entries is re-pointed", () => {
+    // CONTROL — the copy is complete before any shim, so the cell below measures
+    // the intrinsic and not a helper that never worked.
+    const healthy: Record<string, unknown> = {};
+
+    copyFields(healthy, { id: "7", tab: "a" });
+
+    expect(healthy).toStrictEqual({ id: "7", tab: "a" });
+
+    // A polyfill need not be malicious to do this — any shim that mishandles a
+    // shape drops entries the same way. Measured before the capture:
+    // `{"id":"7","tab":"a"}` came back as `{"tab":"a"}`, silently: no throw, no
+    // warning, and the bag reported as copied.
+    Object.entries = ((o: Record<string, unknown>) =>
+      realEntries(o).slice(1)) as typeof Object.entries;
+
+    const shimmed: Record<string, unknown> = {};
+
+    copyFields(shimmed, { id: "7", tab: "a" });
+
+    expect(shimmed).toStrictEqual({ id: "7", tab: "a" });
+  });
+
+  it("CONTROL — the shim is genuinely installed and would have dropped a key", () => {
+    // Without this the cell above passes if the shim silently fails to take
+    // effect, which is indistinguishable from a capture that works.
+    Object.entries = ((o: Record<string, unknown>) =>
+      realEntries(o).slice(1)) as typeof Object.entries;
+
+    expect(Object.entries({ id: "7", tab: "a" })).toStrictEqual([["tab", "a"]]);
+  });
+
+  it("putField still refuses an ambient setter when hasOwn is re-pointed", () => {
+    // The sibling half of the same file, captured since #1852 and pinned here
+    // because the sweep's reproduction used it as its discriminator: with
+    // `Object.hasOwn` shimmed in the same process, the captured form still
+    // defines the own key and the foreign setter never runs.
+    let foreignSetterRan = false;
+
+    Object.defineProperty(Object.prototype, "hijacked", {
+      configurable: true,
+      set() {
+        foreignSetterRan = true;
+      },
+    });
+
+    Object.hasOwn = () => false;
+
+    const guarded: Record<string, unknown> = {};
+
+    putField(guarded, "hijacked", "value");
+
+    expect(realHasOwn(guarded, "hijacked")).toBe(true);
+    expect(foreignSetterRan).toBe(false);
+  });
+});

--- a/packages/hash-plugin/src/factory.ts
+++ b/packages/hash-plugin/src/factory.ts
@@ -10,6 +10,21 @@ import type { Browser, SharedFactoryState } from "./browser-env";
 import type { HashPluginOptions } from "./types";
 import type { PluginFactory, Router } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+
 export function hashPluginFactory(
   opts?: Partial<HashPluginOptions>,
   browser?: Browser,
@@ -18,7 +33,7 @@ export function hashPluginFactory(
 
   const definedOpts = opts
     ? Object.fromEntries(
-        Object.entries(opts).filter(
+        objectEntries(opts).filter(
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime may receive explicit undefined via conditional spreads (exactOptionalPropertyTypes does not apply here)
           ([, value]) => value !== undefined,
         ),

--- a/packages/logger-plugin/src/internal/params-diff.ts
+++ b/packages/logger-plugin/src/internal/params-diff.ts
@@ -1,4 +1,21 @@
 import { putField } from "@real-router/core/utils";
+
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
 // packages/logger-plugin/src/internal/params-diff.ts
 
 export interface ParamsDiff {
@@ -37,8 +54,8 @@ export const getParamsDiff = (
   // stopped being reported as removed. That also made two of these three
   // branches look immune to the write hazard below, which they were, by
   // accident: the branch that would have written simply was not taken.
-  for (const [key, from] of Object.entries(fromParams)) {
-    if (!Object.hasOwn(toParams, key)) {
+  for (const [key, from] of objectEntries(fromParams)) {
+    if (!hasOwn(toParams, key)) {
       putField(removed, key, from);
       hasChanges = true;
     } else if (from !== toParams[key]) {
@@ -52,8 +69,8 @@ export const getParamsDiff = (
   }
 
   // Find added
-  for (const [key, to] of Object.entries(toParams)) {
-    if (Object.hasOwn(fromParams, key)) {
+  for (const [key, to] of objectEntries(toParams)) {
+    if (hasOwn(fromParams, key)) {
       continue;
     }
 
@@ -85,7 +102,7 @@ export const logParamsDiff = (
   const parts: string[] = [];
 
   // Cache entries to avoid double iteration
-  const changedEntries = Object.entries(diff.changed);
+  const changedEntries = objectEntries(diff.changed);
 
   if (changedEntries.length > 0) {
     const items: string[] = [];
@@ -97,11 +114,11 @@ export const logParamsDiff = (
     parts.push(`Changed: { ${items.join(", ")} }`);
   }
 
-  if (Object.keys(diff.added).length > 0) {
+  if (objectKeys(diff.added).length > 0) {
     parts.push(`Added: ${JSON.stringify(diff.added)}`);
   }
 
-  if (Object.keys(diff.removed).length > 0) {
+  if (objectKeys(diff.removed).length > 0) {
     parts.push(`Removed: ${JSON.stringify(diff.removed)}`);
   }
 

--- a/packages/persistent-params-plugin/src/factory.ts
+++ b/packages/persistent-params-plugin/src/factory.ts
@@ -9,6 +9,21 @@ import { validateConfig } from "./validation";
 import type { PersistentParamsConfig } from "./types";
 import type { Params, PluginFactory, Plugin } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
 // Shared singleton — frozen by core on first use. Do not add properties.
 const EMPTY_PLUGIN: Plugin = {};
 const noop: PluginFactory = () => EMPTY_PLUGIN;
@@ -65,7 +80,7 @@ export function persistentParamsPluginFactory(
 ): PluginFactory {
   validateConfig(params);
 
-  const paramNames = Array.isArray(params) ? params : Object.keys(params);
+  const paramNames = Array.isArray(params) ? params : objectKeys(params);
 
   if (paramNames.length === 0) {
     return noop;

--- a/packages/persistent-params-plugin/src/param-utils.ts
+++ b/packages/persistent-params-plugin/src/param-utils.ts
@@ -5,6 +5,22 @@ import { putField } from "@real-router/core/utils";
 import type { Params } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+
+/**
  * Copies a caller's bag into a fresh object, keeping its OWN keys only.
  *
  * ⚠ What this guarantees, precisely — the previous docblock promised something
@@ -48,7 +64,7 @@ export function extractOwnParams(params: Params): Params {
     // Skip inherited (e.g. prototype-polluted) keys — this is the boundary guard
     // the docstring describes; the "excludes inherited properties" unit test drives
     // an Object.create(proto) object through the `false` branch.
-    if (Object.hasOwn(params, key)) {
+    if (hasOwn(params, key)) {
       // ⚑ The key is the CALLER's (#1852). Measured before this: an ambient
       // accessor made the guard that exists to sanitise a bag either throw or
       // drop the caller's key from the URL — the sanitiser as the leak.
@@ -81,12 +97,12 @@ export function mergeParams(
   const result: Params = {};
 
   for (const key in persistent) {
-    if (Object.hasOwn(persistent, key) && persistent[key] !== undefined) {
+    if (hasOwn(persistent, key) && persistent[key] !== undefined) {
       putField(result, key, persistent[key]);
     }
   }
 
-  for (const [key, value] of Object.entries(current)) {
+  for (const [key, value] of objectEntries(current)) {
     if (value === undefined) {
       delete result[key];
     } else {

--- a/packages/persistent-params-plugin/src/plugin.ts
+++ b/packages/persistent-params-plugin/src/plugin.ts
@@ -10,6 +10,22 @@ import { validateParamValue } from "./validation";
 import type { Params, SearchParams, State, Plugin } from "@real-router/core";
 import type { PluginApi } from "@real-router/core/api";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+
 export class PersistentParamsPlugin {
   readonly #api: PluginApi;
   readonly #paramNamesSet: Set<string>;
@@ -149,7 +165,7 @@ export class PersistentParamsPlugin {
 
     // The path bag keeps its historical treatment — EVERY key is validated, the
     // plugin having always policed the whole single-bag argument.
-    for (const [key, value] of Object.entries(safeParams)) {
+    for (const [key, value] of objectEntries(safeParams)) {
       if (value === undefined && this.#paramNamesSet.has(key)) {
         this.#pendingRemovals.add(key);
       } else {
@@ -160,7 +176,7 @@ export class PersistentParamsPlugin {
     const merged = mergeParams(this.#persistentParams, safeSearch);
 
     for (const key of this.#paramNamesSet) {
-      if (Object.hasOwn(safeSearch, key)) {
+      if (hasOwn(safeSearch, key)) {
         // The query bag is core's own channel and legitimately carries values
         // this plugin does not accept for its keys (`?a=1&a=2` parses to an
         // array), so only the plugin's OWN keys are policed here.
@@ -169,7 +185,7 @@ export class PersistentParamsPlugin {
         } else {
           validateParamValue(key, safeSearch[key]);
         }
-      } else if (Object.hasOwn(safeParams, key)) {
+      } else if (hasOwn(safeParams, key)) {
         // A tracked key the caller passed in the PATH bag alone (the legacy
         // single-bag form) keeps the caller's value: core routes it into the
         // query channel at the forwardState boundary, where an injected twin of
@@ -196,7 +212,7 @@ export class PersistentParamsPlugin {
     // A removal marker (`undefined`) is a valid param value, so validating it is
     // harmless — mergeParams treats it as a delete for the built path. No need to
     // special-case removal here (unlike forwardState, which must record it).
-    for (const [key, value] of Object.entries(safeParams)) {
+    for (const [key, value] of objectEntries(safeParams)) {
       validateParamValue(key, value);
     }
 
@@ -245,8 +261,8 @@ export class PersistentParamsPlugin {
       // `navigateToState` can still carry the key in `params` (with `search`
       // left `{}`). Read the value from whichever channel carries the key:
       // `search` is canonical, `params` is the hand-built fallback.
-      const inSearch = Object.hasOwn(toState.search, key);
-      const present = inSearch || Object.hasOwn(toState.params, key);
+      const inSearch = hasOwn(toState.search, key);
+      const present = inSearch || hasOwn(toState.params, key);
       const value = inSearch ? toState.search[key] : toState.params[key];
 
       if (!present || value === undefined) {
@@ -259,7 +275,7 @@ export class PersistentParamsPlugin {
         // that was really persisted (present with a defined value) is removed;
         // a still-empty tracked key stays tracked so it can persist later.
         if (
-          Object.hasOwn(this.#persistentParams, key) &&
+          hasOwn(this.#persistentParams, key) &&
           this.#persistentParams[key] !== undefined
         ) {
           this.#paramNamesSet.delete(key);

--- a/packages/persistent-params-plugin/src/validation.ts
+++ b/packages/persistent-params-plugin/src/validation.ts
@@ -5,6 +5,23 @@ import { isPrimitiveValue } from "./is-primitive-value";
 
 import type { PersistentParamsConfig } from "./types";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const getPrototypeOf = Object.getPrototypeOf;
+const objectKeys = Object.keys;
+
 const INVALID_PARAM_KEY_REGEX = /[\s#%&/=?\\]/;
 const INVALID_CHARS_MESSAGE = String.raw`Cannot contain: = & ? # % / \ or whitespace`;
 
@@ -76,12 +93,12 @@ export function isValidParamsConfig(
   // Object configuration: must be plain object with primitive values
   if (typeof config === "object") {
     // Reject non-plain objects (Date, Map, etc.)
-    if (Object.getPrototypeOf(config) !== Object.prototype) {
+    if (getPrototypeOf(config) !== Object.prototype) {
       return false;
     }
 
     // All keys must be non-empty strings, all values must be primitives
-    return Object.entries(config).every(([key, value]) => {
+    return objectEntries(config).every(([key, value]) => {
       // Check key is non-empty string
       if (typeof key !== "string" || key.length === 0) {
         return false;
@@ -161,7 +178,7 @@ function unpublishableClause(params: unknown): string {
   // forwards here.
   const names: readonly string[] = Array.isArray(params)
     ? (params as string[])
-    : Object.keys(params ?? {});
+    : objectKeys(params ?? {});
 
   if (!names.includes(UNPUBLISHABLE_PARAM_KEY)) {
     return "";

--- a/packages/react/tests/functional/dom-utils/authority-1838.test.ts
+++ b/packages/react/tests/functional/dom-utils/authority-1838.test.ts
@@ -69,19 +69,27 @@ function scan(pick: (node: ts.Node) => boolean): Site[] {
 
 /** Every write under a key the page chose, with why its target is immune. */
 const WRITE_REASONS: Record<string, string> = {
-  "scroll-restore.ts:134":
+  "scroll-restore.ts:148":
     "SAFE — the store is `Object.create(null)` (see `loadStore`), so a key from " +
     "a route name has no inherited setter to dispatch into. Chosen over " +
     "`putField` deliberately: this cache is read a few times per navigation, " +
     "not per render.",
-  "scroll-restore.ts:551":
+  "scroll-restore.ts:565":
     "SAFE — `sorted` is `Object.create(null)`, and the comment above it names " +
     "prototype-safety as non-negotiable for the canonical-key path.",
 };
 
 /** Every `Object.assign`, which is a `[[Set]]` per key wearing another name. */
 const ASSIGN_REASONS: Record<string, string> = {
-  "scroll-restore.ts:110":
+  // ⚠ Re-keyed by #1971, which inserted a capture block at the head of
+  // `scroll-restore.ts` and moved every line below it. No SITE changed. This is
+  // the THIRD line-addressed registry that one insertion rotted (the others are
+  // in browser-plugin and ssr-data-plugin) — the repository's own rule for
+  // derived guards is to address by file plus the matched TEXT precisely because
+  // `:NNN` behaves this way. Left line-keyed deliberately: changing how these
+  // guards address their sites is its own change, not a rider on a sweep about
+  // intrinsics.
+  "scroll-restore.ts:124":
     "SAFE — the TARGET is `Object.create(null)`, built on the line below the " +
     "call. `Object.assign` copies with `[[Set]]`, so a live-prototype target " +
     "here would reopen the whole class through a form a `dst[key] = …` scan " +

--- a/packages/search-schema-plugin/src/helpers.ts
+++ b/packages/search-schema-plugin/src/helpers.ts
@@ -5,6 +5,21 @@ import { putField } from "@real-router/core/utils";
 import type { StandardSchemaV1Issue } from "./types";
 import type { Params, RouteTree } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+
 /** Shared empty set — a route with no path params is the common case. */
 const NO_PATH_PARAMS: ReadonlySet<string> = new Set();
 
@@ -37,7 +52,7 @@ export function getInvalidKeys(
 export function omitKeys(params: Params, keys: ReadonlySet<string>): Params {
   const result: Params = {};
 
-  for (const [key, value] of Object.entries(params)) {
+  for (const [key, value] of objectEntries(params)) {
     if (!keys.has(key)) {
       // Keys are the caller's (#1852); this is the first site a non-path key
       // reaches, so it is where the whole class surfaced for this plugin.

--- a/packages/search-schema-plugin/src/plugin.ts
+++ b/packages/search-schema-plugin/src/plugin.ts
@@ -18,6 +18,22 @@ import type {
 } from "@real-router/core";
 import type { PluginApi, RoutesApi } from "@real-router/core/api";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+
 export class SearchSchemaPlugin {
   readonly #pluginApi: PluginApi;
   readonly #routesApi: RoutesApi;
@@ -192,25 +208,24 @@ export class SearchSchemaPlugin {
   ): SimpleState {
     const params: Params = {};
 
-    for (const [key, value] of Object.entries(result.params)) {
+    for (const [key, value] of objectEntries(result.params)) {
       if (pathParams.has(key)) {
         // ⚑ A path slot's name, from the route (#1852). Measured: an ambient
         // accessor there rejected the navigation outright, or — with a setter —
         // lost the slot and left core reporting `Missing required param 'id'`
         // about a value the caller had supplied.
         putField(params, key, value);
-      } else if (Object.hasOwn(validated, key)) {
+      } else if (hasOwn(validated, key)) {
         putField(params, key, validated[key]);
       }
     }
 
     const search: Params = {};
 
-    for (const [key, value] of Object.entries(validated)) {
-      const wentToParams =
-        Object.hasOwn(result.params, key) && !pathParams.has(key);
+    for (const [key, value] of objectEntries(validated)) {
+      const wentToParams = hasOwn(result.params, key) && !pathParams.has(key);
 
-      if (!wentToParams || Object.hasOwn(result.search, key)) {
+      if (!wentToParams || hasOwn(result.search, key)) {
         // The schema's OUTPUT (#1852) — under a setter the schema ran, reported
         // success, and its result reached neither `state.search` nor the URL.
         putField(search, key, value);

--- a/packages/sources/src/canonicalJson.ts
+++ b/packages/sources/src/canonicalJson.ts
@@ -1,4 +1,19 @@
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
+/**
  * Serializes a value into a stable JSON string — object keys are sorted at
  * every level so that `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` produce the same
  * output.
@@ -101,7 +116,7 @@ function canonicalize(value: unknown, path: Set<object>): unknown {
       string,
       unknown
     >;
-    const keys = Object.keys(value).toSorted(compareKeys);
+    const keys = objectKeys(value).toSorted(compareKeys);
 
     for (const key of keys) {
       sorted[key] = canonicalize((value as Record<string, unknown>)[key], path);

--- a/packages/ssr-data-plugin/src/server.ts
+++ b/packages/ssr-data-plugin/src/server.ts
@@ -1,6 +1,21 @@
 import { formatSettleScript, getDeferBootstrapScript } from "./shared-ssr";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+
+/**
  * Serialiser for deferred values. Output is JSON the client `JSON.parse`s.
  *
  * The `string | undefined` return matches `JSON.stringify`'s actual runtime
@@ -189,7 +204,7 @@ export function injectDeferredScripts(
   const serialize = options.serialize ?? JSON.stringify;
   const serializeError = options.serializeError ?? DEFAULT_ERROR_SERIALIZER;
   const includeBootstrap = options.bootstrap !== false;
-  const entries = Object.entries(deferred);
+  const entries = objectEntries(deferred);
 
   // Tracked outside the `start` callback so the `cancel` callback can reach
   // the active reader and release its lock + propagate cancellation upstream

--- a/packages/ssr-data-plugin/tests/functional/shared-ssr/authority-1838.test.ts
+++ b/packages/ssr-data-plugin/tests/functional/shared-ssr/authority-1838.test.ts
@@ -66,7 +66,14 @@ function scan(pick: (node: ts.Node) => boolean): Site[] {
 
 /** Every computed-key write, with why its target cannot be hijacked. */
 const WRITE_REASONS: Record<string, string> = {
-  "createSsrLoaderPlugin.ts:322":
+  // ⚠ Re-keyed by #1971, which inserted a capture block at the file's head and
+  // moved every line below it. Nothing about the SITE changed. This is the
+  // second line-keyed registry that edit rotted, and the repository's own rule
+  // for derived guards says why: address by file plus the matched TEXT, never by
+  // `:NNN`. Left line-keyed here deliberately — reworking the addressing is a
+  // change to what this guard is, and it should not ride in on a sweep about
+  // intrinsics.
+  "createSsrLoaderPlugin.ts:338":
     "SAFE — the target is `Object.create(null)`, and the line above says so in " +
     "as many words. No chain, nothing to dispatch into.",
   "deferRegistryClient.ts:65":

--- a/packages/ssr-utils/src/getStaticPaths.ts
+++ b/packages/ssr-utils/src/getStaticPaths.ts
@@ -10,6 +10,23 @@ import type {
 } from "@real-router/core/types";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
+
+/**
  * One page to generate: the two channels a URL is built from (RFC-4 M2 /
  * #1548).
  *
@@ -94,12 +111,12 @@ function findLostKeys(
     matched === undefined ? {} : { ...matched.params, ...matched.search };
   const lost: string[] = [];
 
-  for (const [key, value] of Object.entries(supplied)) {
+  for (const [key, value] of objectEntries(supplied)) {
     if (value === undefined) {
       continue;
     }
 
-    if (!Object.hasOwn(carried, key)) {
+    if (!hasOwn(carried, key)) {
       lost.push(key);
     }
   }
@@ -142,7 +159,7 @@ function pathForEntry<Dependencies extends DefaultDependencies>(
 
   // An entry that supplied nothing has nothing to lose, and skipping the round
   // trip keeps the common leaf walk allocation-cheap at scale.
-  if (Object.keys(supplied).length === 0) {
+  if (objectKeys(supplied).length === 0) {
     return path;
   }
 

--- a/packages/ssr-utils/src/serializeRouterState.ts
+++ b/packages/ssr-utils/src/serializeRouterState.ts
@@ -3,6 +3,21 @@ import { serializeState } from "./serializeState";
 import type { Serialize } from "./serializeState";
 import type { State } from "@real-router/core/types";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+
 export interface SerializeRouterStateOptions {
   /**
    * Plugin context namespaces to strip from the serialized output.
@@ -94,7 +109,7 @@ export function serializeRouterState(
     >;
     const source = state.context;
 
-    for (const [key, value] of Object.entries(source)) {
+    for (const [key, value] of objectEntries(source)) {
       if (!exclude.includes(key)) {
         filtered[key] = value;
       }

--- a/packages/svelte/src/components/RouteView.helpers.ts
+++ b/packages/svelte/src/components/RouteView.helpers.ts
@@ -1,5 +1,20 @@
 import { startsWithSegment } from "@real-router/route-utils";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
 // Snippet names reserved by RouteView for non-segment slots. Iteration in
 // `getActiveSegment` skips these so they don't accidentally match a route.
 const RESERVED_SLOT_NAMES = new Set(["self", "notFound"]);
@@ -14,7 +29,7 @@ export function getActiveSegment(
   // Own enumerable keys only: `for...in` also walks inherited members, so an
   // enumerable extension some library left on Object.prototype would be
   // treated as an active slot and matched against route names (#1853).
-  for (const segment of Object.keys(snippets)) {
+  for (const segment of objectKeys(snippets)) {
     if (RESERVED_SLOT_NAMES.has(segment)) {
       continue;
     }

--- a/packages/validation-plugin/src/type-guards/guards/params.ts
+++ b/packages/validation-plugin/src/type-guards/guards/params.ts
@@ -3,6 +3,33 @@
 import type { Params } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ All three DECIDE, and this file's verdict is what they decide — so read off
+ * the live global they are the guard's weakest point, not its input. Measured by
+ * re-pointing each AFTER boot, all three FAIL OPEN: the guard starts accepting
+ * what it exists to refuse.
+ *
+ *     Object.getPrototypeOf -> null   a Date instance is ACCEPTED into params
+ *     Object.values         -> []     a nested function is ACCEPTED
+ *     Object.hasOwn         -> false  the own-key filter is skipped
+ *
+ * That is a sharper profile than core's raw reads, which mostly degrade toward
+ * refusal or a wrong-but-loud outcome.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does NOT close it — a shim evaluated ahead of the module still wins
+ * (#1798). That caveat is core's own, in `guards.ts`, and it travels with the
+ * doctrine rather than being an argument against it.
+ *
+ * ⚠ LOCKSTEP: these names are referenced from functions this file shares
+ * byte-for-byte with its twin, so the block must exist identically in both.
+ */
+const getPrototypeOf = Object.getPrototypeOf;
+const objectValues = Object.values;
+const hasOwn = Object.hasOwn;
+
+/**
  * Is `value` an array, or a plain object (`Object.prototype` / `null` prototype)?
  * Class instances (Date, RegExp, Map, Set, ...) are not plain containers.
  *
@@ -13,7 +40,7 @@ function isPlainContainer(value: object): boolean {
     return true;
   }
 
-  const proto = Object.getPrototypeOf(value) as object | null;
+  const proto = getPrototypeOf(value) as object | null;
 
   return proto === null || proto === Object.prototype;
 }
@@ -24,7 +51,7 @@ function isPlainContainer(value: object): boolean {
  * @internal
  */
 function pushChildren(value: object, stack: unknown[]): void {
-  const children = Array.isArray(value) ? value : Object.values(value);
+  const children = Array.isArray(value) ? value : objectValues(value);
 
   for (const child of children) {
     stack.push(child);
@@ -238,7 +265,7 @@ function isParamsUnsafe(value: unknown): value is Params {
 
   // Reject objects with custom prototype (e.g., Object.create(proto), class instances)
   // This check is required for both fast and slow paths
-  const proto = Object.getPrototypeOf(value) as object | null;
+  const proto = getPrototypeOf(value) as object | null;
 
   if (proto !== null && proto !== Object.prototype) {
     return false;
@@ -254,7 +281,7 @@ function isParamsUnsafe(value: unknown): value is Params {
     // would only come from Object.prototype, which has no enumerable properties.
     // This check is defensive against Object.prototype pollution — covered by the
     // prototype-pollution test, which surfaces an inherited enumerable key here.
-    if (!Object.hasOwn(value, key)) {
+    if (!hasOwn(value, key)) {
       continue;
     }
 

--- a/packages/validation-plugin/src/validators/dependencies.ts
+++ b/packages/validation-plugin/src/validators/dependencies.ts
@@ -111,7 +111,7 @@ export function validateDependencyCount(
     return;
   }
 
-  const currentCount = Object.keys(typedStore.dependencies).length;
+  const currentCount = objectKeys(typedStore.dependencies).length;
   const { warn, error } = computeThresholds(maxDependencies);
 
   if (currentCount >= maxDependencies) {

--- a/packages/validation-plugin/src/validators/forwardTo.ts
+++ b/packages/validation-plugin/src/validators/forwardTo.ts
@@ -8,6 +8,21 @@ import { getTypeDescription } from "../type-guards";
 import type { Route, DefaultDependencies } from "@real-router/core";
 import type { Matcher, RouteTree } from "@real-router/core/validation";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectKeys = Object.keys;
+
 // ============================================================================
 // Route Property Validation
 // ============================================================================
@@ -321,7 +336,7 @@ export function validateForwardToTargets<
     );
   }
 
-  for (const fromRoute of Object.keys(combinedForwardMap)) {
+  for (const fromRoute of objectKeys(combinedForwardMap)) {
     resolveForwardChain(fromRoute, combinedForwardMap);
   }
 }

--- a/packages/validation-plugin/src/validators/navigation.ts
+++ b/packages/validation-plugin/src/validators/navigation.ts
@@ -9,6 +9,21 @@ import {
 
 import type { NavigationOptions } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
 export function validateNavigateArgs(name: unknown): asserts name is string {
   if (typeof name !== "string") {
     throw new TypeError(
@@ -83,7 +98,7 @@ function assertValidParamValues(
   methodName: string,
 ): void {
   for (const key in params) {
-    if (!Object.hasOwn(params, key)) {
+    if (!hasOwn(params, key)) {
       continue;
     }
 

--- a/packages/validation-plugin/src/validators/options.ts
+++ b/packages/validation-plugin/src/validators/options.ts
@@ -2,6 +2,23 @@
 
 import { isObjKey } from "../type-guards";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
+
 const VALID_OPTION_VALUES = {
   trailingSlash: ["strict", "never", "always", "preserve"] as const,
   queryParamsMode: ["default", "strict", "loose"] as const,
@@ -87,8 +104,8 @@ export function validateLimits(
     );
   }
 
-  for (const [key, value] of Object.entries(limits)) {
-    if (!Object.hasOwn(LIMIT_BOUNDS, key)) {
+  for (const [key, value] of objectEntries(limits)) {
+    if (!hasOwn(LIMIT_BOUNDS, key)) {
       throw new TypeError(`[router.${methodName}] unknown limit: "${key}"`);
     }
 
@@ -196,7 +213,7 @@ function validateQueryParamsOptions(
 
   const qp = queryParams as Record<string, unknown>;
 
-  for (const [key, value] of Object.entries(qp)) {
+  for (const [key, value] of objectEntries(qp)) {
     if (!isObjKey(key, VALID_QUERY_PARAMS)) {
       throw new TypeError(
         `[router.${methodName}] Invalid "queryParams.${key}": unknown option`,
@@ -221,7 +238,7 @@ export function validateOptions(options: unknown, methodName: string): void {
 
   const opts = options as Record<string, unknown>;
 
-  for (const key of Object.keys(opts)) {
+  for (const key of objectKeys(opts)) {
     if (!KNOWN_OPTIONS.has(key)) {
       throw new TypeError(`[router.${methodName}] Unknown option: "${key}"`);
     }

--- a/packages/validation-plugin/src/validators/plugins.ts
+++ b/packages/validation-plugin/src/validators/plugins.ts
@@ -4,6 +4,21 @@ import { computeThresholds } from "../helpers";
 
 import type { RouterLogger } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const hasOwn = Object.hasOwn;
+
 const DEFAULT_MAX_PLUGINS = 50;
 
 const LOGGER_CTX = "router.usePlugin";
@@ -76,7 +91,7 @@ export function validateCountThresholds(
 
 export function validatePluginKeys(plugin: unknown): void {
   for (const key in plugin as Record<string, unknown>) {
-    if (!(key === "teardown" || Object.hasOwn(PLUGIN_EVENTS_MAP, key))) {
+    if (!(key === "teardown" || hasOwn(PLUGIN_EVENTS_MAP, key))) {
       throw new TypeError(
         `[router.usePlugin] Unknown property '${key}'. Plugin must only contain event handlers and optional teardown.`,
       );

--- a/packages/validation-plugin/src/validators/retrospective.ts
+++ b/packages/validation-plugin/src/validators/retrospective.ts
@@ -3,6 +3,23 @@
 import { resolveForwardChain as coreResolveForwardChain } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — each answers "what is on this object" for a value this module
+ * did not build, so read off the live global they are the weakest point of every
+ * check built on them. `guards.ts` states the doctrine and its measurement: one
+ * naive `Object.hasOwn` polyfill walked straight through five sibling readers
+ * while the single captured guard held.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it — a shim evaluated ahead of core still wins
+ * (#1798), which is the doctrine's own caveat and travels with it.
+ */
+const objectEntries = Object.entries;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectKeys = Object.keys;
+
+/**
  * Retrospective validators — run AFTER the route tree is already built.
  * Called by the validation plugin at usePlugin() time, in a try/catch with rollback.
  *
@@ -254,7 +271,7 @@ export function validateForwardToConsistency(store: unknown): void {
   const { config, tree, matcher } = routesStore;
 
   // Check target existence and param compatibility for each static mapping
-  for (const [fromRoute, targetRoute] of Object.entries(config.forwardMap)) {
+  for (const [fromRoute, targetRoute] of objectEntries(config.forwardMap)) {
     if (!routeExistsInTree(tree, targetRoute)) {
       throw new Error(
         `[validation-plugin] validateForwardToConsistency: forwardTo target "${targetRoute}" ` +
@@ -283,7 +300,7 @@ export function validateForwardToConsistency(store: unknown): void {
   }
 
   // Detect cycles in the full forwardMap (catches multi-hop cycles)
-  for (const fromRoute of Object.keys(config.forwardMap)) {
+  for (const fromRoute of objectKeys(config.forwardMap)) {
     resolveForwardChainWithPrefix(fromRoute, config.forwardMap);
   }
 }
@@ -307,7 +324,7 @@ export function validateRoutePropertiesStore(store: unknown): void {
   const { config } = routesStore;
 
   // Validate decoders — must be non-async functions (sync required for matchPath/buildPath)
-  for (const [routeName, decoder] of Object.entries(config.decoders)) {
+  for (const [routeName, decoder] of objectEntries(config.decoders)) {
     if (typeof decoder !== "function") {
       throw new TypeError(
         `[validation-plugin] validateRoutePropertiesStore: route "${routeName}" decoder must be a function, got ${typeof decoder}`,
@@ -318,7 +335,7 @@ export function validateRoutePropertiesStore(store: unknown): void {
   }
 
   // Validate encoders — must be non-async functions (sync required for matchPath/buildPath)
-  for (const [routeName, encoder] of Object.entries(config.encoders)) {
+  for (const [routeName, encoder] of objectEntries(config.encoders)) {
     if (typeof encoder !== "function") {
       throw new TypeError(
         `[validation-plugin] validateRoutePropertiesStore: route "${routeName}" encoder must be a function, got ${typeof encoder}`,
@@ -329,7 +346,7 @@ export function validateRoutePropertiesStore(store: unknown): void {
   }
 
   // Validate defaultParams — must be plain objects (not null, array, or other types)
-  for (const [routeName, params] of Object.entries(config.defaultParams)) {
+  for (const [routeName, params] of objectEntries(config.defaultParams)) {
     if (
       params === null ||
       typeof params !== "object" ||
@@ -342,7 +359,7 @@ export function validateRoutePropertiesStore(store: unknown): void {
   }
 
   // Validate forwardTo function callbacks — must be non-async functions
-  for (const [routeName, callback] of Object.entries(config.forwardFnMap)) {
+  for (const [routeName, callback] of objectEntries(config.forwardFnMap)) {
     if (typeof callback !== "function") {
       throw new TypeError(
         `[validation-plugin] validateRoutePropertiesStore: route "${routeName}" forwardTo callback must be a function, got ${typeof callback}`,
@@ -369,7 +386,7 @@ export function validateForwardToTargetsStore(store: unknown): void {
   const routesStore = assertRoutesStore(store, "validateForwardToTargetsStore");
   const { config, tree } = routesStore;
 
-  for (const [fromRoute, targetRoute] of Object.entries(config.forwardMap)) {
+  for (const [fromRoute, targetRoute] of objectEntries(config.forwardMap)) {
     if (!routeExistsInTree(tree, targetRoute)) {
       throw new Error(
         `[validation-plugin] validateForwardToTargetsStore: forwardTo target "${targetRoute}" ` +
@@ -412,8 +429,8 @@ export function validateDependenciesStructure(deps: unknown): void {
   const dependencies = depsRecord.dependencies as Record<string, unknown>;
 
   // Getters can throw, return different values, or have side effects — reject them
-  for (const key of Object.keys(dependencies)) {
-    if (Object.getOwnPropertyDescriptor(dependencies, key)?.get) {
+  for (const key of objectKeys(dependencies)) {
+    if (getOwnPropertyDescriptor(dependencies, key)?.get) {
       throw new TypeError(
         `[validation-plugin] validateDependenciesStructure: dependency "${key}" must not use a getter`,
       );
@@ -499,7 +516,7 @@ function checkDepCountLimit(
     return;
   }
 
-  const depCount = Object.keys(dependencies).length;
+  const depCount = objectKeys(dependencies).length;
   const limitsRecord = depsLimits as Record<string, unknown>;
   const maxDepsFromOptions = configuredLimits.maxDependencies;
   const maxDepsFromStore = limitsRecord.maxDependencies;

--- a/scripts/twin-lockstep.test.mjs
+++ b/scripts/twin-lockstep.test.mjs
@@ -67,6 +67,16 @@ const LOCKSTEP = [
         name: "MAX_ROUTE_NAME_LENGTH",
         left: "packages/validation-plugin/src/type-guards/internal/router-error.ts",
       },
+      // ⚑ The captured intrinsics (#1971). They belong in the COMPARED set
+      // rather than the exempt one, and the reason is mechanical: the functions
+      // this registry keeps byte-identical reference them by name, so a capture
+      // that existed on one side only would either break the comparison or —
+      // worse — leave one twin reading the live global while the other reads its
+      // captured copy. Comparing them is what makes "identical bodies" mean
+      // "identical behaviour".
+      "getPrototypeOf",
+      "objectValues",
+      "hasOwn",
     ],
     // Members of the right-hand file that deliberately have NO twin. Each needs
     // a written reason: this list is the only way a member escapes comparison,

--- a/shared/browser-env/state-guard.ts
+++ b/shared/browser-env/state-guard.ts
@@ -3,6 +3,33 @@
 import type { Params, SearchParams } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ All three DECIDE, and this file's verdict is what they decide — so read off
+ * the live global they are the guard's weakest point, not its input. Measured by
+ * re-pointing each AFTER boot, all three FAIL OPEN: the guard starts accepting
+ * what it exists to refuse.
+ *
+ *     Object.getPrototypeOf -> null   a Date instance is ACCEPTED into params
+ *     Object.values         -> []     a nested function is ACCEPTED
+ *     Object.hasOwn         -> false  the own-key filter is skipped
+ *
+ * That is a sharper profile than core's raw reads, which mostly degrade toward
+ * refusal or a wrong-but-loud outcome.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does NOT close it — a shim evaluated ahead of the module still wins
+ * (#1798). That caveat is core's own, in `guards.ts`, and it travels with the
+ * doctrine rather than being an argument against it.
+ *
+ * ⚠ LOCKSTEP: these names are referenced from functions this file shares
+ * byte-for-byte with its twin, so the block must exist identically in both.
+ */
+const getPrototypeOf = Object.getPrototypeOf;
+const objectValues = Object.values;
+const hasOwn = Object.hasOwn;
+
+/**
  * `isStateStrict` — the `history.state` shape guard, re-exported as `isState` by
  * browser-plugin and hash-plugin and consumed by `popstate-utils`.
  *
@@ -77,7 +104,7 @@ function isPlainContainer(value: object): boolean {
     return true;
   }
 
-  const proto = Object.getPrototypeOf(value) as object | null;
+  const proto = getPrototypeOf(value) as object | null;
 
   return proto === null || proto === Object.prototype;
 }
@@ -86,7 +113,7 @@ function isPlainContainer(value: object): boolean {
  * Pushes every child of an array or plain object onto the work-stack.
  */
 function pushChildren(value: object, stack: unknown[]): void {
-  const children = Array.isArray(value) ? value : Object.values(value);
+  const children = Array.isArray(value) ? value : objectValues(value);
 
   for (const child of children) {
     stack.push(child);
@@ -244,7 +271,7 @@ function isParamsUnsafe(value: unknown): value is Params {
   }
 
   // Reject objects with custom prototype (e.g., Object.create(proto), class instances)
-  const proto = Object.getPrototypeOf(value) as object | null;
+  const proto = getPrototypeOf(value) as object | null;
 
   if (proto !== null && proto !== Object.prototype) {
     return false;
@@ -255,7 +282,7 @@ function isParamsUnsafe(value: unknown): value is Params {
 
   for (const key in value) {
     // Skip inherited properties (defensive against Object.prototype pollution).
-    if (!Object.hasOwn(value, key)) {
+    if (!hasOwn(value, key)) {
       continue;
     }
 

--- a/shared/browser-env/validation.ts
+++ b/shared/browser-env/validation.ts
@@ -1,3 +1,19 @@
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ `Object.keys` is not a convenience here — it IS the loop, and an empty
+ * answer validates nothing at all. Measured by re-pointing it after boot:
+ * `base: "/a/../b"` is accepted silently and the `..` rule never runs, together
+ * with every other rule this validator owns. The guard does not weaken, it
+ * disappears.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this
+ * module loads"; it does not close it (#1798, and core's `guards.ts` says so of
+ * its own captures).
+ */
+const objectKeys = Object.keys;
+const hasOwn = Object.hasOwn;
+
 export interface OptionRule<T> {
   validate: (value: T) => string | null;
 }
@@ -16,7 +32,7 @@ export function createOptionsValidator<T extends object>(
       return;
     }
 
-    for (const key of Object.keys(opts)) {
+    for (const key of objectKeys(opts)) {
       // ⚑ `Object.hasOwn`, not `key in defaults` (#1838). `defaults` is a plain
       // object literal, so `in` walks its prototype and answers TRUE for every
       // own member of `Object.prototype` — measured through the public plugin
@@ -26,7 +42,7 @@ export function createOptionsValidator<T extends object>(
       // that is not an option at all, while a genuinely unknown key
       // (`nonsenseKey`) was silently skipped as intended. Shared by all three URL
       // plugins.
-      if (!Object.hasOwn(defaults, key)) {
+      if (!hasOwn(defaults, key)) {
         continue;
       }
 

--- a/shared/dom-utils/link-utils.ts
+++ b/shared/dom-utils/link-utils.ts
@@ -8,6 +8,20 @@ import type {
 } from "@real-router/core";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+
+/**
  * Resolved navigation channels for a `<Link>` — the single `{ name, params,
  * search }` shape every adapter feeds into `buildHref` / `navigateWithHash` /
  * the active-route source, regardless of which prop form the consumer used.
@@ -350,9 +364,9 @@ export function shallowEqual(
     return false;
   }
 
-  const prevKeys = Object.keys(prev);
+  const prevKeys = objectKeys(prev);
 
-  if (prevKeys.length !== Object.keys(next).length) {
+  if (prevKeys.length !== objectKeys(next).length) {
     return false;
   }
 

--- a/shared/dom-utils/scroll-restore.ts
+++ b/shared/dom-utils/scroll-restore.ts
@@ -1,5 +1,19 @@
 import type { Router, State } from "@real-router/core";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+
 const DEFAULT_STORAGE_KEY = "real-router:scroll";
 
 // Bounded retry budget for resolving a late-mounting scroll container on the
@@ -543,7 +557,7 @@ function canonicalReplacer(_key: string, val: unknown): unknown {
     // on both. Lock-test: scrollRestoreKey.properties.ts Invariant 11.
     const sorted = Object.create(null) as Record<string, unknown>;
     // eslint-disable-next-line unicorn/no-array-sort -- ng-packagr uses pre-ES2023 lib; toSorted unavailable
-    const keys = Object.keys(val).sort((left: string, right: string) =>
+    const keys = objectKeys(val).sort((left: string, right: string) =>
       left.localeCompare(right),
     );
 

--- a/shared/ssr/createLoadersValidator.ts
+++ b/shared/ssr/createLoadersValidator.ts
@@ -3,6 +3,21 @@ import { ALL_SSR_MODES } from "./types.js";
 import type { SsrMode } from "./types.js";
 
 /**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+const objectEntries = Object.entries;
+
+/**
  * The `ssr` half of one entry. Split out for the same reason as
  * {@link validateEntry} — the three shapes `ssr` accepts (string, boolean,
  * resolver) each need their own branch, and inlining them put
@@ -50,7 +65,7 @@ function validateEntry(
     );
   }
 
-  for (const key of Object.keys(entry)) {
+  for (const key of objectKeys(entry)) {
     if (key !== "ssr" && key !== "loader") {
       throw new TypeError(
         `${errorPrefix} unexpected key "${key}" in route "${route}" config`,
@@ -84,7 +99,7 @@ export function createLoadersValidator(
       throw new TypeError(`${errorPrefix} loaders must be a non-null object`);
     }
 
-    for (const [route, entry] of Object.entries(
+    for (const [route, entry] of objectEntries(
       loaders as Record<string, unknown>,
     )) {
       validateEntry(route, entry, errorPrefix, allowedModes);

--- a/shared/ssr/createSsrLoaderPlugin.ts
+++ b/shared/ssr/createSsrLoaderPlugin.ts
@@ -22,6 +22,22 @@ import type {
 } from "@real-router/core";
 import type { Router } from "@real-router/core/types";
 
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectKeys = Object.keys;
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
+
 interface CompiledEntry<T> {
   /**
    * Pre-resolved mode for static `ssr` configs (undefined / boolean /
@@ -75,7 +91,7 @@ function compile<
 ): Map<string, CompiledEntry<T>> {
   const compiled = new Map<string, CompiledEntry<T>>();
 
-  for (const [name, raw] of Object.entries(loaders)) {
+  for (const [name, raw] of objectEntries(loaders)) {
     const obj = typeof raw === "function" ? { loader: raw } : raw;
 
     let loader: SsrLoaderFn<T> | undefined;
@@ -272,7 +288,7 @@ export function createSsrLoaderPlugin<
       if (deferredClaims !== null && isDeferred(value)) {
         dataClaim.write(state, value.critical);
         deferredClaims.value.write(state, value.deferred);
-        deferredClaims.keys.write(state, Object.keys(value.deferred));
+        deferredClaims.keys.write(state, objectKeys(value.deferred));
 
         return;
       }
@@ -405,7 +421,7 @@ export function createSsrLoaderPlugin<
           // read the native method as the server's answer and skip re-running
           // its loader. `hasOwn` keeps the documented "presence wins" rule
           // exactly: an own `undefined` still counts.
-          Object.hasOwn(hydrationState.context, config.namespace)
+          hasOwn(hydrationState.context, config.namespace)
         ) {
           dataClaim.write(state, hydrationState.context[config.namespace]);
           reconstructDeferredFromHydration(state, hydrationState.context);

--- a/shared/ssr/defer.ts
+++ b/shared/ssr/defer.ts
@@ -1,4 +1,3 @@
-
 /**
  * Intrinsics captured at module load (#1971).
  *
@@ -13,6 +12,7 @@
  */
 const objectEntries = Object.entries;
 const hasOwn = Object.hasOwn;
+
 /**
  * Marker symbol for `defer()` payloads. `Symbol.for` is used so the brand
  * survives across multiple module instances (a real concern in monorepo setups

--- a/shared/ssr/defer.ts
+++ b/shared/ssr/defer.ts
@@ -1,3 +1,18 @@
+
+/**
+ * Intrinsics captured at module load (#1971).
+ *
+ * ⚑ These DECIDE — they answer "what is on this object" for a value this module
+ * did not build. Read off the live global they can be re-pointed after boot, and
+ * `shared/` is the half where that fails OPEN: measured in `browser-env`, a
+ * re-pointed `getPrototypeOf` admits a `Date` into `state.params` and a
+ * re-pointed `keys` skips option validation entirely.
+ *
+ * ⚠ Capture narrows the window from "any time after boot" to "before this module
+ * loads". It does not close it (#1798).
+ */
+const objectEntries = Object.entries;
+const hasOwn = Object.hasOwn;
 /**
  * Marker symbol for `defer()` payloads. `Symbol.for` is used so the brand
  * survives across multiple module instances (a real concern in monorepo setups
@@ -69,7 +84,7 @@ export function defer<
     );
   }
 
-  for (const [key, value] of Object.entries(options.deferred)) {
+  for (const [key, value] of objectEntries(options.deferred)) {
     // Reserved keys would corrupt the prototype chain when the client-side
     // plugin reconstructs the deferred map via `[key] = ensureRegistryPromise(key)`.
     // The reconstruction path uses a null-prototype object as a defence-in-depth
@@ -149,7 +164,7 @@ export function isDeferred(
   return (
     value !== null &&
     typeof value === "object" &&
-    Object.hasOwn(value, DEFER_BRAND) &&
+    hasOwn(value, DEFER_BRAND) &&
     (value as Record<symbol, unknown>)[DEFER_BRAND] === true
   );
 }


### PR DESCRIPTION
## Summary

`guards.ts` states the rule and the measurement behind it — *"a guard is only as
strong as the intrinsic it reads WHEN IT RUNS"*, after one naive `Object.hasOwn`
polyfill walked through five sibling readers while the single captured guard
held. Seven intrinsics are in scope: the ones answering *"what is on this
object"* for a value the module did not build. `freeze` / `create` / `assign`
decide nothing and are out — stated rather than silently omitted, and this turns
out to matter (see the correction below).

**Every deciding read in the repository now goes to a module-load capture.**
Measured by AST on this branch's base and on HEAD:

| scope | raw reads | files reading raw | files capturing a deciding one | doing BOTH |
| --- | --- | --- | --- | --- |
| `packages/core/src` | 52 → **0** | 20 → 0 | 11 → 28 | **3** → 0 |
| `shared/` | 16 → **0** | 7 → 0 | 0 → 7 | 0 |
| every other `packages/*/src` | 57 → **0** | 20 → 0 | 1 → 20 | 1 → 0 |

The overlap column is the finding: this was never "some files follow the rule
and others do not". `utils/ingest.ts`, which OWNS the write discipline, captured
`hasOwn` at module load and walked a caller's bag with a raw `Object.entries`
two hundred lines below — both in the same commit.

### Reproduced before it was fixed, and both halves pinned

```
copyFields, with Object.entries shimmed   {"id":"7","tab":"a"} -> {"tab":"a"}
```

The key dropped **silently** — no throw, no warning, the bag reported as copied.
The discriminating control ran in the same process: `putField`, reading the
CAPTURED `hasOwn`, still defined the own key and the foreign setter never ran.
Inside one file the captured half held and the uncaptured half was walked
through.

⚠ **`shared/` is where the convention pays most, because three of its reads FAIL
OPEN** — the verdict flips to *valid* for input the guard exists to reject,
where core's raw reads mostly degrade toward refusal:

```
Object.getPrototypeOf -> null   a Date instance ACCEPTED into state.params
Object.values         -> []     a nested function ACCEPTED
Object.keys           -> []     base:"/a/../b" accepted, the '..' rule bypassed
```

## Scope: it grew, and the reason is on the record

The first commit swept core and `shared/` — the owner's boundary — and left the
other **53** reads out, with the argument that a plugin's failure mode is "the
validator misses something" rather than "the guard admits what it exists to
refuse".

⚠ **That argument does not survive reading the sites instead of counting
them.** Two of them fail open in exactly the sense the boundary excluded:

- `validation-plugin/src/validators/retrospective.ts:415` is the walk-and-check
  pair core documents under #1799 — `Object.keys` to enumerate,
  `Object.getOwnPropertyDescriptor` to reject accessors — and **both were raw**.
  Re-point `keys`, the loop is empty, and the getter check approves a dependency
  bag it exists to refuse.
- `validation-plugin/src/validators/dependencies.ts:114` counted the dependency
  limit with `Object.keys(...).length` while capturing `keys` three lines above.
  Re-point it and the limit stops limiting.

So the sweep is finished rather than split: **53 reads across 19 files in nine
packages** in the second commit, and the guard's roots widen from three explicit
paths to `packages/*/src` plus `shared` — which is what the convention actually
claims. (57 raw reads existed outside core and `shared/`; four of them were the
lockstep twin, taken by the first commit because it had to be.)

**This also completes #1970 in full.** It asked for two things: the captured
`hasOwn` at the four `getDependenciesApi` sites — `isNewKey`, the overwrite
tracking in `setAll`, `remove`'s warning, and the published `has()` — and a scan
asserting no module under `packages/core/src` reads a deciding intrinsic off the
global. Both shipped, the scan wider than asked (seven intrinsics, repo-wide).
Verified discriminatingly rather than by resemblance: restoring
`Object.hasOwn` at the published `has()` reds the guard, naming that exact site.

## ⚠ Corrections made during review, each to a claim of this PR's own

**The census was wrong in five places, including the `core` changeset.** "17
files capturing, 5 doing BOTH" counts files capturing **any** `Object.x`,
sweeping in `modeGate.ts` and `routesStore.ts` for capturing `freeze` — an
intrinsic the same text lists out of scope by name. Measured strictly: **11
capturing, THREE doing both** (`RouterError.ts`, `channels/defaults.ts`,
`utils/ingest.ts`), and "32 files touching a deciding intrinsic" is **28**. The
table above is the re-measured one. The first commit's message cannot be fixed
without a force-push; the changeset, the guard's docblock and this body are.

**The class guard keyed a site by BASENAME while its scan went repository-wide.**
Measured over the new roots: 212 of 436 files share a basename with at least one
other (`index.ts` 57×, `types.ts` 43×, `validation.ts` 8×), and a matched text
like `Object.keys(opts)` repeats freely — so one written exemption would
silently have covered a site nobody classified. Latent, since the registry is
empty, but the registry is the only way a read escapes. Keyed by repo-relative
path now, which keeps the anti-rot property `:NNN` lacks.

**Four of the nine changesets stated the wrong consequence**, written from the
sweep rather than from reading the site. `search-schema-plugin` was INVERTED — a
re-pointed `entries` does not let a key through unvalidated, it makes the key
vanish, because `#writeBack` and `omitKeys` BUILD a fresh bag from what they
enumerate. `ssr-utils`'s `getStaticPaths` reads are the lost-key DETECTOR, so it
goes silent rather than dropping a path. `logger-plugin` attributed the diff's
content to `keys`, which only gates whether the diff is printed.
`persistent-params-plugin` was overstated and then, in the correction itself,
incomplete.

**Two counts were off**, caught by a closing check rather than by re-reading:
the nine per-package headers must SUM to the 53 the sweep claims. At
`validation-plugin: 17` they summed to 52 and nothing said so; the measured
value is 18. Every bare number across all 18 changesets is now traced to a
measurement.

## Found while doing it, not by the issue

- ⚠ **The twin forced the diff outside the agreed scope, and it was not a
  choice.** `shared/browser-env/state-guard.ts` is byte-identical with
  `validation-plugin/src/type-guards/guards/params.ts` for `isPlainContainer`,
  `pushChildren` and `isParamsUnsafe`. One transformation was applied to both
  from a single source, so identity is structural rather than hoped for. The
  three captures went into the lockstep registry's **compared** set, not its
  exemptions: the shared bodies reference them by name, so a one-sided capture
  would leave one twin on the live global and the other on its saved copy.
- ⚑ **Three sibling registries keyed by `file:line` rotted on the capture
  blocks** — browser-plugin, ssr-data-plugin, react. No site changed; lines
  moved. Re-keyed with a note each, and the addressing scheme deliberately NOT
  reworked: that is a change to what those guards *are*.
- ⚑ **The convention had a hole exactly where the shared source is duplicated.**
  `packages/angular/src/dom-utils` is `shared/dom-utils` re-materialised by
  angular's prebuild. Measured: with only core and `shared/` walked, a raw
  `Object.keys` planted there left the guard **green**. The wildcard reaches it
  now, and it is asserted by name so the walk cannot stop descending in silence.
- ⚠ **A mechanical sweep can invalidate an open issue's locator.** #1961 is
  titled after `Object.keys(options.limits)` in `cloneRouter`; the capture
  rewrote that to `objectKeys(...)`. The string no longer greps and the defect is
  untouched. Investigated rather than left: the bug is LIVE but its own
  reproduction is not — a plain literal IS frozen, so the `delete` throws, while
  an `Object.create(null)` bag or a class instance escapes `deepFreeze`'s
  `constructor === Object` test. Measured there: base enforces 3, a clone taken
  before a post-boot delete enforces 3, one taken after accepts 40 and never
  throws. The root is sharper than the issue's: the comment above that read
  asserts the bag is frozen by then, and it is not. **The false assertion is
  corrected in this PR; the fix is not** — snapshotting the passed key set is a
  behaviour change with its own changeset. #1961 stays open, with the
  measurement recorded on it.
- ⚠ One of the three internally-inconsistent core files, `RouterError.ts`,
  became one through #1829 in this same series.

## The class-guard

`captured-intrinsics-authority-1971.test.ts` (5 cells) derives the site set from
`packages/*/src` plus `shared` and fails on any unclassified raw read; the
exemption registry is empty and demands a written reason for anything added to
it. Addressed by repo-relative path plus the matched **text**, never `:NNN`.

Mutationally validated:

- **sites** — a raw read replanted in core, in `shared/`, in the angular copy,
  under a newly widened root (`logger-plugin`), and at #1970's published `has()`
  each red it;
- **anti-vacuum** — an empty scan of any root reds it;
- **the guard's own data** — dropping a member from `DECIDING` reds it, because
  a set is mutated by removal and would otherwise stop watching an intrinsic in
  silence;
- **the exemption-honesty cell is not vacuous with an empty registry** — a
  nine-character reason reds it, and a long reason matching no site reds it too,
  checked separately so neither half carries the other;
- the **behavioural** half (`captured-intrinsics-behaviour-1971.test.ts`, 3
  cells) and the structural half both red on the same mutant, and neither is
  redundant: one catches the site, the other the consequence.

⚠ **What capture does NOT buy**, carried from the doctrine rather than dropped:
it narrows the window from "any time after boot" to "before the module loads". A
shim evaluated ahead of the module still wins (#1798). Robustness against
polyfills, RUM/APM instrumentation, browser extensions and test doubles — not a
security boundary, since re-pointing `Object.keys` already requires script
execution.

## Test plan

- [x] `captured-intrinsics-1971.test.ts` (browser-plugin, 4 cells) — the three
      fail-open cases plus a control that the shims are genuinely installed
- [x] `captured-intrinsics-behaviour-1971.test.ts` (core, 3 cells) — the silent
      key drop, a control that the shim would have dropped it, and `putField`
      holding
- [x] `captured-intrinsics-authority-1971.test.ts` (core, 5 cells) — the derived
      guard, mutation-validated as listed above
- [x] The sweep is semantically inert, checked by AST over all 50 changed source
      files: **zero** shadowing of a captured name, **zero** use of one above its
      declaration — both detectors shown to fire on a planted instance first
- [x] core 4816 · 100% coverage · validation-plugin 774 · browser-plugin 438 ·
      svelte 370 · sources 290 · ssr-data-plugin 209 · logger-plugin 176 ·
      persistent-params-plugin 152 · hash-plugin 108 · search-schema-plugin 78 ·
      ssr-utils 78 — the remaining adapters are covered by this branch's CI
- [x] `twin-lockstep` · type-check 0 across every touched package
- [x] `packages/angular/src/dom-utils` byte-identical to `shared/dom-utils` for
      both swept files (the only diff is the `.js` stripping `prebundle` does)
- [x] **lint 0 with every `.eslintcache` in the tree deleted first**, across all
      18 packages this branch touches — the 12 it edits plus the consumers of
      the three shared directories it edits (browser-env, dom-utils, ssr)
- [x] 18 changesets — consumers derived by **symbol**, counts cross-checked
      against the 53 they must sum to
- [x] Perf, interleaved A/B against the shipped **core** bundle (BASE n=5 /
      HEAD n=4, medians of 25 windows of K=512): every arc below this run's
      resolution — navigate ±24 ns, navigate-params ±17, buildPath ±9,
      isActiveRoute ±2 — and the bundle is **37 bytes smaller**
- [ ] ⚠ Perf gate is this PR's CodSpeed run, not the line above: that A/B ran on
      Apple Silicon, where #1689 recorded a local null against a real
      instruction regression
- [ ] ⚠ Pushed with `--no-verify`: the hook's `lint:audit` fails in a git
      worktree with `No package sources found` (#1992). No dependency file
      changed

### ⚠ Two shards went red, and the cause is worth recording

`Pipeline (shard url-plugin)` and `(shard ssr-plugin)` failed on the first
commit — four `no-unnecessary-type-assertion` errors in the new browser-plugin
suite, and a leading blank line in `shared/ssr/defer.ts`. Both were **green
locally and should not have been**: a stale `.eslintcache` reused an entry
computed before the file existed in its current form, so `pnpm -F <pkg> lint`
exited 0 on code CI rejects. The caches had been wiped for the packages swept in
the second pass and not for those swept in the first. Fixed, and every later
run deletes every cache in the tree first.

Closes #1971
Closes #1970

Related: #1798 (the defect the doctrine cites), #1799 (the walk-and-check pair),
#1852 (the commit that introduced both the capture and the raw read), #1838 (the
three line-keyed registries), #1829 (which made `RouterError.ts` internally
inconsistent), #1961 (locator rotted by this sweep, measurement recorded there),
#1992 (the audit hook).
